### PR TITLE
Allow rigctld to reopen after error

### DIFF
--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -929,6 +929,10 @@ void * handle_socket(void *arg)
         {
           retcode = 1;
         }
+      if (retcode == 1) 
+        {
+          retcode = rig_open(my_rig);
+        }
     }
     while (retcode == 0 || retcode == 2 || retcode == -RIG_ENAVAIL);
 


### PR DESCRIPTION
To test
Run rigctld to connect to socket client like FLRig
Run rigctl -m 2 to connect to rigctld
Kill FLRig
Execute command from rigctl to read Freq...quits on error as expected.
Start rigctl again and it can't connect
This patch fixes this behavior