### PR TITLE
Set FILPATHLEN to 512 instead to support longer device file names

### DIFF
--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -147,7 +147,7 @@ typedef struct rig RIG;
 
 #define RIGNAMSIZ 30
 #define RIGVERSIZ 8
-#define FILPATHLEN 100
+#define FILPATHLEN 512
 #define FRQRANGESIZ 30
 #define MAXCHANDESC 30      /* describe channel eg: "WWV 5Mhz" */
 #define TSLSTSIZ 20         /* max tuning step list size, zero ended */

--- a/kylix/hamlib_rigapi.pas
+++ b/kylix/hamlib_rigapi.pas
@@ -54,7 +54,7 @@ type
 const
     RIGNAMSIZ = 30;
     RIGVERSIZ = 8;
-    FILPATHLEN = 100;
+    FILPATHLEN = 512;
     FRQRANGESIZ = 30;
     MAXCHANDESC = 30;		{* describe channel eg: "WWV 5Mhz" *}
     TSLSTSIZ = 20;			{* max tuning step list size, zero ended *}


### PR DESCRIPTION
Set FILPATHLEN to 512 instead of 100 to support longer device file names.

In some cases, static serial port device file names (for USB devices) generated by udev may be longer than 100 chars.
