### PR TITLE
Fixes for the piHPSDR backend.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ build-aux/
 doc/hamlib.cfg
 doc/hamlib.info
 doc/stamp-vti
+doc/hamlib.html
 doc/version.texi
 hamlib-*.tar.gz
 include/config.h

--- a/kenwood/kenwood.c
+++ b/kenwood/kenwood.c
@@ -1427,7 +1427,7 @@ int kenwood_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         }
     }
 
-  if (priv->is_emulation)
+  if (priv->is_emulation || rig->caps->rig_model == RIG_MODEL_HPSDR)
     {
       /* emulations like PowerSDR and SmartSDR normally hijack the
          RTTY modes for SSB-DATA AFSK modes */
@@ -1624,7 +1624,7 @@ int kenwood_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
       kmode = modebuf[offs] - 'A' + 10;
     }
   *mode = kenwood2rmode(kmode, caps->mode_table);
-  if (priv->is_emulation)
+  if (priv->is_emulation || rig->caps->rig_model == RIG_MODEL_HPSDR)
     {
       /* emulations like PowerSDR and SmartSDR normally hijack the
          RTTY modes for SSB-DATA AFSK modes */

--- a/kenwood/pihpsdr.c
+++ b/kenwood/pihpsdr.c
@@ -656,7 +656,8 @@ int pihpsdr_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
   switch (level) {
   case RIG_LEVEL_RFPOWER:
-    /* XXX check level range */
+    /* level is float between 0.0 and 1.0, maps to 0 ... 100 */
+    kenwood_val = val.f * 100;
     sprintf(levelbuf, "PC%03d", kenwood_val);
     break;
 


### PR DESCRIPTION
Two issues:
a) fix setting RFPOWER level: the value in the PC command must be max. 100

b) Allow hijacking two RTTY modes for PKTUSB and PKTLSB, piHPSDR uses these for
    DIGU and DIGL ("digital" versions of USB and LSB).