### PR TITLE
Add support for CM108AH chipsets

### DIFF
--- a/src/cm108.c
+++ b/src/cm108.c
@@ -115,7 +115,8 @@ int cm108_open(hamlib_port_t *port)
              && ((hiddevinfo.product >= 0x0008
                   && hiddevinfo.product <= 0x000f)
                  || hiddevinfo.product == 0x0012
-                 || hiddevinfo.product == 0x013a))
+                 || hiddevinfo.product == 0x013a
+                 || hiddevinfo.product == 0x013c))
             // SSS1621/23
             || (hiddevinfo.vendor == 0x0c76
                 && (hiddevinfo.product == 0x1605


### PR DESCRIPTION
CM108 uses PID of 0x13c which needs to be added. Tests with rigctl showed it is working fine.