### PR TITLE
Fix install instructions on README.

### DIFF
--- a/README
+++ b/README
@@ -78,6 +78,7 @@ Recompiling
 Hamlib is entirely developed using GNU tools, under various Linux systems.
 The library may be recompiled by the familiar "three step":
 
+        ./bootstrap
         ./configure
         make
         sudo make install


### PR DESCRIPTION
I had to run the bootstrap script for the configure script to exist then the rest of the process could be followed.