### PR TITLE
ft817: adding delay before next retry after returning from tx to rx

### DIFF
--- a/yaesu/ft817.c
+++ b/yaesu/ft817.c
@@ -886,7 +886,7 @@ int ft817_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 		}
 
 		if (ptt_response != ptt) {
-			usleep(100000l); // Before next try wait for 0.1 seconds. Helps with slower rigs cloning FT817 protocol (e.g. MCHF)
+			usleep(1000l * FT817_RETRY_DELAY); // Wait before next try. Helps with slower rigs cloning FT817 protocol (e.g. MCHF)
 		}
 
 	} while (ptt_response != ptt && retries-- > 0);

--- a/yaesu/ft817.c
+++ b/yaesu/ft817.c
@@ -885,6 +885,10 @@ int ft817_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 			ptt_response = -1;
 		}
 
+		if (ptt_response != ptt) {
+			usleep(100000l); // Before next try wait for 0.1 seconds. Helps with slower rigs cloning FT817 protocol (e.g. MCHF)
+		}
+
 	} while (ptt_response != ptt && retries-- > 0);
 
 	if (retries >=0) {

--- a/yaesu/ft817.h
+++ b/yaesu/ft817.h
@@ -53,6 +53,13 @@
 #define FT817_TIMEOUT			3000
 
 /*
+ * Return from TX to RX may have a delay. If status is not changed
+ * on the first attempt, wait this amount of milliseconds before
+ * each next next attempts.
+ */
+#define FT817_RETRY_DELAY		100
+
+/*
  * The time the TX, RX and FREQ/MODE status are cached (in millisec).
  * This optimises the common case of doing eg. rig_get_freq() and
  * rig_get_mode() in a row.


### PR DESCRIPTION
My previous commit added checking of actual status change after coming from tx to rx and retrying in case the status had not changed. Apparently, it is much more useful if there is a delay between retries as my rig (MCHF) takes some time (<.1s) to actually change the state. For original FT817 this should work the same as before as delay is only after first attempt.