### PR TITLE
WIP: Add lo_freq setting to allow use with transverters

### DIFF
--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -1597,6 +1597,8 @@ struct rig_state {
     int transmit;               /*!< rig should be transmitting i.e. hard
                                      wired PTT asserted - used by rigs that
                                      don't do CAT while in Tx */
+    freq_t lo_freq;             /*!< Local oscillator frequency of any
+				     transverter */
 };
 
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -113,6 +113,11 @@ static const struct confparams frontend_cfg_params[] =
         "Path name to the device file of the Data Carrier Detect (or squelch)",
         "/dev/rig", RIG_CONF_STRING,
     },
+    {
+	TOK_LO_FREQ, "lo_freq", "LO Frequency",
+	"Frequency to add to the VFO frequency for use with a transverter",
+	"0", RIG_CONF_NUMERIC, { .n = {0.0, 1e9, .1}}
+    },
 
     { RIG_CONF_END, NULL, }
 };
@@ -510,6 +515,9 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
     case TOK_POLL_INTERVAL:
         rs->poll_interval = atof(val);
         break;
+    case TOK_LO_FREQ:
+	rs->lo_freq = atof(val);
+	break;
 
 
     default:

--- a/src/rig.c
+++ b/src/rig.c
@@ -406,6 +406,7 @@ RIG * HAMLIB_API rig_init(rig_model_t rig_model)
     rs->poll_interval = 500;
     /* should it be a parameter to rig_init ? --SF */
     rs->itu_region = RIG_ITU_REGION2;
+    rs->lo_freq = 0;
 
     switch (rs->itu_region)
     {
@@ -1092,6 +1093,11 @@ int HAMLIB_API rig_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     }
 
     caps = rig->caps;
+    if (rig->state.lo_freq != 0.0)
+    {
+	freq -= rig->state.lo_freq;
+    }
+	    
 
     if (rig->state.vfo_comp != 0.0)
     {
@@ -1223,7 +1229,10 @@ int HAMLIB_API rig_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
     {
         rig->state.current_freq = *freq;
     }
-
+    if (rig->state.lo_freq != 0.0)
+    {
+	*freq += rig->state.lo_freq;
+    }
     return retcode;
 }
 

--- a/src/token.h
+++ b/src/token.h
@@ -96,6 +96,8 @@
 #define TOK_VFO_COMP    TOKEN_FRONTEND(110)
 /** \brief rig: polling interval (units?) */
 #define TOK_POLL_INTERVAL   TOKEN_FRONTEND(111)
+/** \brief rig: lo frequency of any transverters */
+#define TOK_LO_FREQ         TOKEN_FRONTEND(112)
 /** \brief rig: International Telecommunications Union region no. */
 #define TOK_ITU_REGION  TOKEN_FRONTEND(120)
 /*


### PR DESCRIPTION
This PR allows software using rigctld with radio that has a transverter connected to display the true tx frequency of the radio instead of the IF frequency. 

To use, invoke rigctld with -C lo_freq=xxxx, where xxxx is the lo_frequency of the transverter in Hz. 