### PR TITLE
Automatically detect CI-V echo state

### DIFF
--- a/icom/frame.c
+++ b/icom/frame.c
@@ -127,7 +127,7 @@ int icom_one_transaction (RIG *rig, int cmd, int subcmd, const unsigned char *pa
 			return retval;
 	}
 
-	if (priv_caps->serial_full_duplex == 0) {
+	if (!priv_caps->serial_full_duplex && !priv->serial_USB_echo_off) {
 
 		/*
 		 * read what we just sent, because TX and RX are looped,
@@ -335,7 +335,7 @@ int rig2icom_mode(RIG *rig, rmode_t mode, pbwidth_t width,
 	case RIG_MODE_RTTY:	icmode = S_RTTY; break;
 	case RIG_MODE_RTTYR:	icmode = S_RTTYR; break;
 	case RIG_MODE_FM:	icmode = S_FM; break;
-	case RIG_MODE_FMN:	icmode = S_FMN; break;
+    case RIG_MODE_FMN:  icmode = S_FMN; break;
 	case RIG_MODE_WFM:	icmode = S_WFM; break;
 	case RIG_MODE_P25:	icmode = S_P25; break;
 	case RIG_MODE_DSTAR:	icmode = S_DSTAR; break;
@@ -380,11 +380,11 @@ void icom2rig_mode(RIG *rig, unsigned char md, int pd, rmode_t *mode, pbwidth_t 
 	*width = RIG_PASSBAND_NORMAL;
 
 	switch (md) {
-	case S_AM:	if (rig->caps->rig_model == RIG_MODEL_ICR30 && pd == 0x02) {
-                                *mode = RIG_MODE_AMN;
-			} else {
-				*mode = RIG_MODE_AM;
-			}  break;
+    case S_AM:  if (rig->caps->rig_model == RIG_MODEL_ICR30 && pd == 0x02) {
+                    *mode = RIG_MODE_AMN;
+                } else {
+                    *mode = RIG_MODE_AM;
+                }  break;
 	case S_AMS:	*mode = RIG_MODE_AMS; break;
 	case S_CW:	*mode = RIG_MODE_CW; break;
 	case S_CWR:	*mode = RIG_MODE_CWR; break;
@@ -393,24 +393,24 @@ void icom2rig_mode(RIG *rig, unsigned char md, int pd, rmode_t *mode, pbwidth_t 
 				*mode = RIG_MODE_USB;
 				*width = rig_passband_normal(rig, RIG_MODE_USB);
 				return;
-			} else if (rig->caps->rig_model == RIG_MODEL_ICR30 && pd == 0x02) {
-                                *mode = RIG_MODE_FMN;
-                        } else {
-				*mode = RIG_MODE_FM;
-			} break;
-	case S_WFM:	*mode = RIG_MODE_WFM; break;
-	case S_USB:	*mode = RIG_MODE_USB; break;
-	case S_LSB:	*mode = RIG_MODE_LSB; break;
+                } else if (rig->caps->rig_model == RIG_MODEL_ICR30 && pd == 0x02) {
+                    *mode = RIG_MODE_FMN;
+                } else {
+    				*mode = RIG_MODE_FM;
+			    } break;
+	case S_WFM:	    *mode = RIG_MODE_WFM; break;
+	case S_USB:	    *mode = RIG_MODE_USB; break;
+	case S_LSB:	    *mode = RIG_MODE_LSB; break;
 	case S_RTTY:	*mode = RIG_MODE_RTTY; break;
 	case S_RTTYR:	*mode = RIG_MODE_RTTYR; break;
-	case S_PSK:	*mode = RIG_MODE_PKTUSB; break;	/* IC-7800 */
+	case S_PSK:     *mode = RIG_MODE_PKTUSB; break;	/* IC-7800 */
 	case S_PSKR:	*mode = RIG_MODE_PKTLSB; break;
-	case S_DSTAR:	*mode = RIG_MODE_DSTAR; break;
-	case S_P25:	*mode = RIG_MODE_P25; break;
-	case S_DPMR:	*mode = RIG_MODE_DPMR; break;
-	case S_NXDNVN:	*mode = RIG_MODE_NXDNVN; break;
-	case S_NXDN_N:	*mode = RIG_MODE_NXDN_N; break;
-	case S_DCR:	*mode = RIG_MODE_DCR; break;
+    case S_DSTAR:   *mode = RIG_MODE_DSTAR; break;
+    case S_P25:     *mode = RIG_MODE_P25; break;
+    case S_DPMR:    *mode = RIG_MODE_DPMR; break;
+    case S_NXDNVN:  *mode = RIG_MODE_NXDNVN; break;
+    case S_NXDN_N:  *mode = RIG_MODE_NXDN_N; break;
+    case S_DCR: *mode = RIG_MODE_DCR; break;
 	case 0xff:	*mode = RIG_MODE_NONE; break;	/* blank mem channel */
 
 	default:

--- a/icom/icom.h
+++ b/icom/icom.h
@@ -113,6 +113,7 @@ struct icom_priv_caps {
 	int serial_full_duplex; /*!< Whether RXD&TXD are not tied together */
 	unsigned char civ_version; // default to 0, 1=IC7200,IC7300,etc differences
 	int offs_len; /* Number of bytes in offset frequency field. 0 defaults to 3 */
+	int serial_USB_echo_check; /* Flag to test USB echo state */
 };
 
 
@@ -124,6 +125,7 @@ struct icom_priv_data {
 	int split_on;									/* record split state */
 	pltstate_t *pltstate;	/* only on optoscan */
 	unsigned char civ_version; /* 0=default, 1=new commands for IC7200,IC7300, etc */
+	int serial_USB_echo_off; /* USB is not set to echo */
 };
 
 extern const struct ts_sc_list r8500_ts_sc_list[];
@@ -149,6 +151,7 @@ extern const pbwidth_t rtty_fil[];	/* rtty filter passband width; available on 7
 pbwidth_t icom_get_dsp_flt(RIG *rig, rmode_t mode);
 
 int icom_init(RIG *rig);
+int icom_rig_open(RIG *rig);
 int icom_cleanup(RIG *rig);
 int icom_set_freq(RIG *rig, vfo_t vfo, freq_t freq);
 int icom_get_freq(RIG *rig, vfo_t vfo, freq_t *freq);


### PR DESCRIPTION
Some Icom rigs use USB for the CI-V connection. This can be set to echo or not. This mod permits a check of the echo state on start-up & flags the frame handling accordingly.

A new member of the icom_priv_caps is defined to flag that this check should be done. A new icom_rig_open function performs this check & sets a flag in priv_data which frame.c then uses to process the input accordingly.