### PR TITLE
Icom fixes: CW keyer speed and pitch

### DIFF
--- a/icom/ic7000.c
+++ b/icom/ic7000.c
@@ -179,6 +179,8 @@ const struct rig_caps ic7000_caps = {
 .level_gran = {
 	[LVL_RAWSTR] = { .min = { .i = 0 }, .max = { .i = 255 } },
 	[LVL_VOXDELAY] = { .min = { .i = 0 }, .max = { .i = 20 }, .step = { .i = 1 } },
+	[LVL_KEYSPD] = { .min = { .i = 6 }, .max = { .i = 48 }, .step = { .i = 1 } },
+	[LVL_CWPITCH] = { .min = { .i = 300 }, .max = { .i = 900 }, .step = { .i = 1 } },
 },
 .parm_gran =  {},
 .ctcss_list =  common_ctcss_list,

--- a/icom/ic7100.c
+++ b/icom/ic7100.c
@@ -203,6 +203,8 @@ const struct rig_caps ic7100_caps = {
 .level_gran = {
 	[LVL_RAWSTR] = { .min = { .i = 0 }, .max = { .i = 255 } },
 	[LVL_VOXDELAY] = { .min = { .i = 0 }, .max = { .i = 20 }, .step = { .i = 1 } },
+	[LVL_KEYSPD] = { .min = { .i = 6 }, .max = { .i = 48 }, .step = { .i = 1 } },
+	[LVL_CWPITCH] = { .min = { .i = 300 }, .max = { .i = 900 }, .step = { .i = 1 } },
 },
 .parm_gran =  {},
 .ctcss_list =  common_ctcss_list,

--- a/icom/ic7200.c
+++ b/icom/ic7200.c
@@ -143,6 +143,8 @@ const struct rig_caps ic7200_caps = {
 .level_gran = {
 	[LVL_RAWSTR] = { .min = { .i = 0 }, .max = { .i = 255 } },
 	[LVL_VOXDELAY] = { .min = { .i = 0 }, .max = { .i = 20 }, .step = { .i = 1 } },
+	[LVL_KEYSPD] = { .min = { .i = 6 }, .max = { .i = 48 }, .step = { .i = 1 } },
+	[LVL_CWPITCH] = { .min = { .i = 300 }, .max = { .i = 900 }, .step = { .i = 1 } },
 },
 .parm_gran =  {},
 .ctcss_list =  NULL,

--- a/icom/ic7300.c
+++ b/icom/ic7300.c
@@ -246,8 +246,10 @@ const struct rig_caps ic7300_caps = {
 .has_get_parm =  IC7300_PARMS,
 .has_set_parm =  RIG_PARM_SET(IC7300_PARMS),
 .level_gran = {
-  [LVL_RAWSTR] = { .min = { .i = 0 }, .max = { .i = 255 } },
-  [LVL_VOXDELAY] = { .min = { .i = 0 }, .max = { .i = 20 }, .step = { .i = 1 } },
+        [LVL_RAWSTR] = {.min = {.i = 0}, .max = {.i = 255}},
+        [LVL_VOXDELAY] = {.min = {.i = 0}, .max = {.i = 20}, .step = {.i = 1}},
+        [LVL_KEYSPD] = {.min = {.i = 6}, .max = {.i = 48}, .step = {.i = 1}},
+        [LVL_CWPITCH] = {.min = {.i = 300}, .max = {.i = 900}, .step = {.i = 1}},
 },
 .parm_gran =  {},
 .extlevels = NULL,

--- a/icom/ic7300.c
+++ b/icom/ic7300.c
@@ -426,6 +426,8 @@ const struct rig_caps ic9700_caps = {
 .level_gran = {
 	[LVL_RAWSTR] = { .min = { .i = 0 }, .max = { .i = 255 } },
 	[LVL_VOXDELAY] = { .min = { .i = 0 }, .max = { .i = 20 }, .step = { .i = 1 } },
+	[LVL_KEYSPD] = {.min = {.i = 6}, .max = {.i = 48}, .step = {.i = 1}},
+	[LVL_CWPITCH] = {.min = {.i = 300}, .max = {.i = 900}, .step = {.i = 1}},
 },
 .parm_gran =  {},
 .extlevels = NULL,

--- a/icom/ic7410.c
+++ b/icom/ic7410.c
@@ -137,6 +137,8 @@ const struct rig_caps ic7410_caps = {
 .level_gran = {
 	[LVL_RAWSTR] = { .min = { .i = 0 }, .max = { .i = 255 } },
 	[LVL_VOXDELAY] = { .min = { .i = 0 }, .max = { .i = 20 }, .step = { .i = 1 } },
+	[LVL_KEYSPD] = { .min = { .i = 6 }, .max = { .i = 48 }, .step = { .i = 1 } },
+	[LVL_CWPITCH] = { .min = { .i = 300 }, .max = { .i = 900 }, .step = { .i = 1 } },
 },
 .parm_gran =  {},
 .ctcss_list =  common_ctcss_list,

--- a/icom/ic746.c
+++ b/icom/ic746.c
@@ -203,7 +203,9 @@ const struct rig_caps ic746_caps = {
 .has_set_parm =  RIG_PARM_ANN,
 .level_gran = {
 	[LVL_RAWSTR] = { .min = { .i = 0 }, .max = { .i = 255 } },
-	},
+	[LVL_KEYSPD] = { .min = { .i = 6 }, .max = { .i = 48 }, .step = { .i = 1 } },
+	[LVL_CWPITCH] = { .min = { .i = 300 }, .max = { .i = 900 }, .step = { .i = 1 } },
+},
 .parm_gran =  {},
 .ctcss_list =  common_ctcss_list,
 .dcs_list =  NULL,

--- a/icom/ic756.c
+++ b/icom/ic756.c
@@ -311,7 +311,9 @@ const struct rig_caps ic756pro_caps = {
 .has_set_parm =  RIG_PARM_NONE,	/* FIXME: parms */
 .level_gran = {
 	[LVL_RAWSTR] = { .min = { .i = 0 }, .max = { .i = 255 } },
-	},
+	[LVL_KEYSPD] = { .min = { .i = 6 }, .max = { .i = 48 }, .step = { .i = 1 } },
+	[LVL_CWPITCH] = { .min = { .i = 300 }, .max = { .i = 900 }, .step = { .i = 1 } },
+},
 .parm_gran =  {},
 .ctcss_list =  common_ctcss_list,
 .dcs_list =  NULL,
@@ -529,6 +531,8 @@ const struct rig_caps ic756pro2_caps = {
 .level_gran = {
 	[LVL_RAWSTR] = { .min = { .i = 0 }, .max = { .i = 255 } },
 	[LVL_VOXDELAY] = { .min = { .i = 0 }, .max = { .i = 20 }, .step = { .i = 1 } },
+	[LVL_KEYSPD] = { .min = { .i = 6 }, .max = { .i = 48 }, .step = { .i = 1 } },
+	[LVL_CWPITCH] = { .min = { .i = 300 }, .max = { .i = 900 }, .step = { .i = 1 } },
 },
 .parm_gran =  {},
 .extparms =  ic756pro2_ext_parms,
@@ -900,6 +904,8 @@ const struct rig_caps ic756pro3_caps = {
 .level_gran = {
 	[LVL_RAWSTR] = { .min = { .i = 0 }, .max = { .i = 255 } },
 	[LVL_VOXDELAY] = { .min = { .i = 0 }, .max = { .i = 20 }, .step = { .i = 1 } },
+	[LVL_KEYSPD] = { .min = { .i = 6 }, .max = { .i = 48 }, .step = { .i = 1 } },
+	[LVL_CWPITCH] = { .min = { .i = 300 }, .max = { .i = 900 }, .step = { .i = 1 } },
 },
 .parm_gran =  {},
 .extparms =  ic756pro2_ext_parms,

--- a/icom/ic7600.c
+++ b/icom/ic7600.c
@@ -181,6 +181,8 @@ const struct rig_caps ic7600_caps = {
 .level_gran = {
 	[LVL_RAWSTR] = { .min = { .i = 0 }, .max = { .i = 255 } },
 	[LVL_VOXDELAY] = { .min = { .i = 0 }, .max = { .i = 20 }, .step = { .i = 1 } },
+	[LVL_KEYSPD] = { .min = { .i = 6 }, .max = { .i = 48 }, .step = { .i = 1 } },
+	[LVL_CWPITCH] = { .min = { .i = 300 }, .max = { .i = 900 }, .step = { .i = 1 } },
 },
 .parm_gran =  {},
 .extlevels = ic7600_ext_levels,

--- a/icom/ic7610.c
+++ b/icom/ic7610.c
@@ -186,6 +186,8 @@ const struct rig_caps ic7610_caps = {
 .level_gran = {
 	[LVL_RAWSTR] = { .min = { .i = 0 }, .max = { .i = 255 } },
 	[LVL_VOXDELAY] = { .min = { .i = 0 }, .max = { .i = 20 }, .step = { .i = 1 } },
+	[LVL_KEYSPD] = { .min = { .i = 6 }, .max = { .i = 48 }, .step = { .i = 1 } },
+	[LVL_CWPITCH] = { .min = { .i = 300 }, .max = { .i = 900 }, .step = { .i = 1 } },
 },
 .parm_gran =  {},
 .extlevels = ic7610_ext_levels,

--- a/icom/ic7700.c
+++ b/icom/ic7700.c
@@ -171,6 +171,8 @@ const struct rig_caps ic7700_caps = {
 .level_gran = {
 	[LVL_RAWSTR] = { .min = { .i = 0 }, .max = { .i = 255 } },
 	[LVL_VOXDELAY] = { .min = { .i = 0 }, .max = { .i = 20 }, .step = { .i = 1 } },
+	[LVL_KEYSPD] = { .min = { .i = 6 }, .max = { .i = 48 }, .step = { .i = 1 } },
+	[LVL_CWPITCH] = { .min = { .i = 300 }, .max = { .i = 900 }, .step = { .i = 1 } },
 },
 .parm_gran =  {},
 .extlevels = ic7700_ext_levels,

--- a/icom/ic7800.c
+++ b/icom/ic7800.c
@@ -171,6 +171,8 @@ const struct rig_caps ic7800_caps = {
 .level_gran = {
 	[LVL_RAWSTR] = { .min = { .i = 0 }, .max = { .i = 255 } },
 	[LVL_VOXDELAY] = { .min = { .i = 0 }, .max = { .i = 20 }, .step = { .i = 1 } },
+	[LVL_KEYSPD] = { .min = { .i = 6 }, .max = { .i = 48 }, .step = { .i = 1 } },
+	[LVL_CWPITCH] = { .min = { .i = 300 }, .max = { .i = 900 }, .step = { .i = 1 } },
 },
 .parm_gran =  {},
 .extlevels = ic7800_ext_levels,

--- a/icom/ic785x.c
+++ b/icom/ic785x.c
@@ -176,6 +176,8 @@ const struct rig_caps ic785x_caps = {
 .level_gran = {
 	[LVL_RAWSTR] = { .min = { .i = 0 }, .max = { .i = 255 } },
 	[LVL_VOXDELAY] = { .min = { .i = 0 }, .max = { .i = 20 }, .step = { .i = 1 } },
+	[LVL_KEYSPD] = { .min = { .i = 6 }, .max = { .i = 48 }, .step = { .i = 1 } },
+	[LVL_CWPITCH] = { .min = { .i = 300 }, .max = { .i = 900 }, .step = { .i = 1 } },
 },
 .parm_gran =  {},
 .extlevels = ic785x_ext_levels,

--- a/icom/icom.c
+++ b/icom/icom.c
@@ -1275,22 +1275,26 @@ int icom_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 		}
 	}
 
-	switch (level) {
-		case RIG_LEVEL_KEYSPD:
-			if (val.i < 6) val.i = 6;
-			if (val.i > 48) val.i = 48;
-			icom_val = (val.i-6)*(255/42.0)+.99;
-	  case RIG_LEVEL_CWPITCH:
-	    if (val.i < 300) {
-	      icom_val = 300;
-	    } else if (val.i >= 900) {
-	      icom_val = 900;
-	    }
-	    icom_val = (icom_val - 300) * (255.0f / 600.0f);
-	    break;
-	  default:
-	    break;
-	}
+    switch (level) {
+        case RIG_LEVEL_KEYSPD:
+            if (val.i < 6) {
+                icom_val = 6;
+            } else if (val.i > 48) {
+                icom_val = 48;
+            }
+            icom_val = (int) lroundf(((float) icom_val - 6.0f) * (255.0f / 42.0f));
+            break;
+        case RIG_LEVEL_CWPITCH:
+            if (val.i < 300) {
+                icom_val = 300;
+            } else if (val.i >= 900) {
+                icom_val = 900;
+            }
+            icom_val = (int) lroundf(((float) icom_val - 300) * (255.0f / 600.0f));
+            break;
+        default:
+            break;
+    }
 
 	/*
 	 * Most of the time, the data field is a 3 digit BCD,
@@ -1764,10 +1768,10 @@ int icom_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
       }
       break;
     case RIG_LEVEL_CWPITCH:
-      val->i = 300 + (icom_val * 600.0f / 255.0f);
-      break;
+        val->i = (int) lroundf(300.0f + ((float) icom_val * 600.0f / 255.0f));
+        break;
     case RIG_LEVEL_KEYSPD:
-        val->i = icom_val * (42.0 / 255) + 6 + .5;
+        val->i = (int) lroundf((float) icom_val * (42.0f / 255.0f) + 6.0f);
         break;
 	case RIG_LEVEL_PREAMP:
 		if (icom_val == 0) {


### PR DESCRIPTION
The previous commit I made broke key speed setting (missing `break` keyword). In addition to fixing that, this PR provides better rounding of level values for CW keyer speed and CW pitch and sets the level value ranges for many Icom rigs.