### PR TITLE
easycomm: Fix futile check of speed range

### DIFF
--- a/easycomm/easycomm.c
+++ b/easycomm/easycomm.c
@@ -212,7 +212,7 @@ easycomm_rot_move_velocity(ROT *rot, int direction, int speed)
     char cmdstr[24], ackbuf[32];
     int retval;
     rig_debug(RIG_DEBUG_TRACE, "%s called\n", __FUNCTION__);
-    if(speed<0 && speed>9999) {
+    if(speed<0 || speed>9999) {
        rig_debug(RIG_DEBUG_ERR,"%s: Invalid speed value!(0-9999) (%d)\n", __FUNCTION__, speed);
        return -RIG_EINVAL;
     }


### PR DESCRIPTION
The conditional expression in which the speed parameter is validated
is such that it can never become true. This looks like an error
inadvertently introduced.

Signed-off-by: Vasilis Tsiligiannis <acinonyx@openwrt.gr>