### PR TITLE
easycomm: Return the correct value of pointer val

### DIFF
--- a/easycomm/easycomm.c
+++ b/easycomm/easycomm.c
@@ -314,8 +314,8 @@ static int easycomm_rot_get_conf(ROT *rot, token_t token, char *val) {
 
    
     rig_debug(RIG_DEBUG_TRACE, "%s got response: %s\n", __FUNCTION__, ackbuf);
-     /* Return given string at correct position*/
-		val = &ackbuf[2]; /* CCxxxxxx */
+    /* Return given string at correct position*/
+    memcpy(val, ackbuf + 2, sizeof(ackbuf) - 2); /* CCxxxxxx */
     return RIG_OK;
 }
 


### PR DESCRIPTION
Add value of ackbuf into value of val instead of
the address, because isn't the same after the call
of function easycomm_rot_get_conf().

Signed-off-by: Agis Zisimatos <agzisim@gmail.com>