### PR TITLE
Fix issues with EasyComm II in rotctl

### DIFF
--- a/easycomm/easycomm.c
+++ b/easycomm/easycomm.c
@@ -131,12 +131,11 @@ easycomm_rot_get_position(ROT *rot, azimuth_t *az, elevation_t *el)
 static int
 easycomm_rot_stop(ROT *rot)
 {
-    char ackbuf[32];
     int retval;
 
     rig_debug(RIG_DEBUG_TRACE, "%s called\n", __FUNCTION__);
 
-    retval = easycomm_transaction(rot, "SA SE \n", ackbuf, sizeof(ackbuf));
+    retval = easycomm_transaction(rot, "SA SE \n", NULL, 0);
 	if (retval != RIG_OK)
 		return retval;
 
@@ -148,11 +147,10 @@ easycomm_rot_stop(ROT *rot)
 static int
 easycomm_rot_reset(ROT *rot, rot_reset_t rst)
 {
-    char ackbuf[32];
     int retval;
     rig_debug(RIG_DEBUG_TRACE, "%s called\n", __FUNCTION__);
 
-    retval = easycomm_transaction(rot, "RESET\n", ackbuf, sizeof(ackbuf));
+    retval = easycomm_transaction(rot, "RESET\n", NULL, 0);
     if (retval != RIG_OK)   /* Custom command (not in Easycomm) */
 		return retval;
 
@@ -162,11 +160,10 @@ easycomm_rot_reset(ROT *rot, rot_reset_t rst)
 static int
 easycomm_rot_park(ROT *rot)
 {
-    char ackbuf[32];
     int retval;
     rig_debug(RIG_DEBUG_TRACE, "%s called\n", __FUNCTION__);
 
-    retval = easycomm_transaction(rot, "PARK\n", ackbuf, sizeof(ackbuf));
+    retval = easycomm_transaction(rot, "PARK\n", NULL, 0);
     if (retval != RIG_OK)   /* Custom command (not in Easycomm) */
 		return retval;
 
@@ -176,7 +173,7 @@ easycomm_rot_park(ROT *rot)
 static int
 easycomm_rot_move(ROT *rot, int direction, int speed)
 {
-    char cmdstr[24], ackbuf[32];
+    char cmdstr[24];
     int retval;
     rig_debug(RIG_DEBUG_TRACE, "%s called\n", __FUNCTION__);
 
@@ -199,7 +196,7 @@ easycomm_rot_move(ROT *rot, int direction, int speed)
         return -RIG_EINVAL;
     }
 
-    retval = easycomm_transaction(rot, cmdstr, ackbuf, sizeof(ackbuf));
+    retval = easycomm_transaction(rot, cmdstr, NULL, 0);
     if (retval != RIG_OK)
         return retval;
 
@@ -209,7 +206,7 @@ easycomm_rot_move(ROT *rot, int direction, int speed)
 static int
 easycomm_rot_move_velocity(ROT *rot, int direction, int speed)
 {
-    char cmdstr[24], ackbuf[32];
+    char cmdstr[24];
     int retval;
     rig_debug(RIG_DEBUG_TRACE, "%s called\n", __FUNCTION__);
     if(speed<0 || speed>9999) {
@@ -236,7 +233,7 @@ easycomm_rot_move_velocity(ROT *rot, int direction, int speed)
         return -RIG_EINVAL;
     }
 
-    retval = easycomm_transaction(rot, cmdstr, ackbuf, sizeof(ackbuf));
+    retval = easycomm_transaction(rot, cmdstr, NULL, 0);
     if (retval != RIG_OK)
         return retval;
 
@@ -327,7 +324,7 @@ static int easycomm_rot_get_conf(ROT *rot, token_t token, char *val) {
  */
 
 static int easycomm_rot_set_conf(ROT *rot, token_t token, const char *val) {
-	char cmdstr[16], ackbuf[32];
+	char cmdstr[16];
 	int retval;
 
 	rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
@@ -345,7 +342,7 @@ static int easycomm_rot_set_conf(ROT *rot, token_t token, const char *val) {
 	}
 	rig_debug(RIG_DEBUG_TRACE, "%s: cmdstr = %s, *val = %c\n", __func__, cmdstr, *val);
 
-	retval = easycomm_transaction(rot, cmdstr, ackbuf, sizeof(ackbuf));
+	retval = easycomm_transaction(rot, cmdstr, NULL, 0);
 	
 	if (retval != RIG_OK) {
 	  rig_debug(RIG_DEBUG_TRACE, "%s got error: %d\n", __FUNCTION__, retval);

--- a/easycomm/easycomm.c
+++ b/easycomm/easycomm.c
@@ -93,7 +93,12 @@ easycomm_rot_set_position(ROT *rot, azimuth_t az, elevation_t el)
     int retval;
 	rig_debug(RIG_DEBUG_TRACE, "%s called: %f %f\n", __FUNCTION__, az, el);
 
-    sprintf(cmdstr, "AZ%.1f EL%.1f UP000 XXX DN000 XXX\n", az, el);
+    if (rot->caps->rot_model == ROT_MODEL_EASYCOMM1) {
+        sprintf(cmdstr, "AZ%.1f EL%.1f UP000 XXX DN000 XXX\n", az, el);
+    }
+    else { // for easycomm 2 & 3 and upwards
+        sprintf(cmdstr, "AZ%.1f EL%.1f\n", az, el);
+    }
     retval = easycomm_transaction(rot, cmdstr, NULL, 0);
 	if (retval != RIG_OK) {
 		return retval;


### PR DESCRIPTION
This pull request addresses the issues brought up in e-mail regarding (a) commands that have no response timing out when waiting for one, and (b) an EasyComm I command sequence being sent to EasyComm II controllers. The fixes for (a) and (b) are in separate commits for convenience in tracking.