### PR TITLE
Fixing #48 "Create new rig for Raspberry Pi GPIO pins"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,7 +24,7 @@ SUBDIRS = macros include lib \
 ## assigned by 'configure' so list rig backends statically.
 DIST_SUBDIRS = macros include lib src c++ bindings tests doc android scripts\
 	adat alinco aor barrett drake dorji dummy elad flexradio icom icmarine jrc\
-	kachina kenwood kit lowe pcr prm80 racal rft rs skanti tapr tentec\
+	kachina kenwood kit lowe pcr prm80 racal rft rpi rs skanti tapr tentec\
 	tuner uniden wj yaesu winradio\
 	$(ROT_BACKEND_LIST) $(AMP_BACKEND_LIST)
 

--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,7 @@ dnl added to AC_CONFIG_FILES near the end of this file.  See README.developer
 dnl Beware of duplication should a backend directory include both rig and
 dnl rotor definitions, e.g. "dummy".  Optional backends will not be listed
 dnl here but will be added later, e.g. "winradio".
-BACKEND_LIST="adat alinco aor barrett dorji drake dummy elad flexradio icom icmarine jrc kachina kenwood kit lowe pcr prm80 racal rft rs skanti tapr tentec tuner uniden wj yaesu"
+BACKEND_LIST="adat alinco aor barrett dorji drake dummy elad flexradio icom icmarine jrc kachina kenwood kit lowe pcr prm80 racal rft rpi rs skanti tapr tentec tuner uniden wj yaesu"
 ROT_BACKEND_LIST="amsat ars celestron cnctrk easycomm ether6 fodtrack gs232a heathkit m2 meade rotorez sartek spid ts7400 prosistel ioptron"
 # Amplifiers are all in the amplifiers directory
 AMP_BACKEND_LIST="amplifiers/elecraft"
@@ -770,6 +770,7 @@ jrc/Makefile
 drake/Makefile
 lowe/Makefile
 rft/Makefile
+rpi/Makefile
 rs/Makefile
 kit/Makefile
 tapr/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -695,6 +695,32 @@ AS_IF([test x"${cf_with_usrp}" = "xyes"],[
 
 AM_CONDITIONAL([HAVE_USRP], [test x"${cf_with_usrp}" = "xyes"])
 
+dnl check for wiringPi (for RPi backend)
+AC_ARG_WITH([wiringpi],
+    [AS_HELP_STRING([--without-wiringpi],
+        [disable (RPi-specific) wiringPi dependent backends @<:@default=yes@:>@])],
+        [cf_with_wiringpi=no],
+        [cf_with_wiringpi=yes]
+    )
+
+AS_IF([test x"${cf_with_wiringpi}" = "xyes"],[
+    AC_CHECK_HEADERS([wiringPi.h],[
+        AC_CHECK_LIB([wiringPi], [wiringPiSetup], [
+            WIRINGPI_LIBS="-lwiringPi"
+            AC_DEFINE([HAVE_WIRINGPI],[1],[Define if wiringPi is available])
+        ], [
+            AC_MSG_WARN([found defunct wiringPi])
+            cf_with_wiringpi="no"
+        ])
+    ], [
+        cf_with_wiringpi="no"
+    ])
+], [
+    cf_with_wiringpi="no"
+])
+AM_CONDITIONAL(RPI_WIRINGPI, [test x"${cf_with_wiringpi}" = "xyes"])
+AC_MSG_CHECKING([for wiringPi])
+AC_MSG_RESULT([$cf_with_wiringpi])
 
 ## -------------------------------- ##
 ## Prepare rig backend dependencies ##

--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,7 @@ dnl added to AC_CONFIG_FILES near the end of this file.  See README.developer
 dnl Beware of duplication should a backend directory include both rig and
 dnl rotor definitions, e.g. "dummy".  Optional backends will not be listed
 dnl here but will be added later, e.g. "winradio".
-BACKEND_LIST="adat alinco aor barrett dorji drake dummy elad flexradio icom icmarine jrc kachina kenwood kit lowe pcr prm80 racal rft rpi rs skanti tapr tentec tuner uniden wj yaesu"
+BACKEND_LIST="adat alinco aor barrett dorji drake dummy elad flexradio icom icmarine jrc kachina kenwood kit lowe pcr prm80 racal rft rs skanti tapr tentec tuner uniden wj yaesu"
 ROT_BACKEND_LIST="amsat ars celestron cnctrk easycomm ether6 fodtrack gs232a heathkit m2 meade rotorez sartek spid ts7400 prosistel ioptron"
 # Amplifiers are all in the amplifiers directory
 AMP_BACKEND_LIST="amplifiers/elecraft"
@@ -708,6 +708,7 @@ AS_IF([test x"${cf_with_wiringpi}" = "xyes"],[
         AC_CHECK_LIB([wiringPi], [wiringPiSetup], [
             WIRINGPI_LIBS="-lwiringPi"
             AC_DEFINE([HAVE_WIRINGPI],[1],[Define if wiringPi is available])
+            BACKEND_LIST="$BACKEND_LIST rpi"
         ], [
             AC_MSG_WARN([found defunct wiringPi])
             cf_with_wiringpi="no"
@@ -718,6 +719,7 @@ AS_IF([test x"${cf_with_wiringpi}" = "xyes"],[
 ], [
     cf_with_wiringpi="no"
 ])
+AC_SUBST([WIRINGPI_LIBS])
 AM_CONDITIONAL(RPI_WIRINGPI, [test x"${cf_with_wiringpi}" = "xyes"])
 AC_MSG_CHECKING([for wiringPi])
 AC_MSG_RESULT([$cf_with_wiringpi])
@@ -862,6 +864,7 @@ echo \
     Enable HTML rig feature matrix  ${cf_enable_html_matrix}
     Enable WinRadio                 ${cf_with_winradio}
     Enable USRP                     ${cf_with_usrp}
+    Enable wiringPi                 ${cf_with_wiringpi}
     Enable USB backends             ${cf_with_libusb}
     Enable shared libs              ${enable_shared}
     Enable static libs              ${enable_static}

--- a/hamlib.pc.in
+++ b/hamlib.pc.in
@@ -10,4 +10,4 @@ Version: @PACKAGE_VERSION@
 Requires.private: @LIBUSB@
 Cflags: -I${includedir} @PTHREAD_CFLAGS@
 Libs: -L${libdir} -lhamlib
-Libs.private: @MATH_LIBS@ @DL_LIBS@ @NET_LIBS@ @PTHREAD_LIBS@
+Libs.private: @MATH_LIBS@ @DL_LIBS@ @NET_LIBS@ @PTHREAD_LIBS@ @WIRINGPI_LIBS@

--- a/include/hamlib/riglist.h
+++ b/include/hamlib/riglist.h
@@ -616,6 +616,12 @@
     etc.
 */
 
+/*
+ * Raspberry PI GPIO
+ */
+#define RIG_RPI 34
+#define RIG_BACKEND_RPI "rpi"
+#define RIG_MODEL_RPI_WIRINGPI RIG_MAKE_MODEL(RIG_RPI, 1)
 
 /*! \typedef typedef int rig_model_t
     \brief Convenience type definition for rig model.

--- a/include/hamlib/riglist.h
+++ b/include/hamlib/riglist.h
@@ -616,12 +616,14 @@
     etc.
 */
 
+#ifdef HAVE_WIRINGPI
 /*
  * Raspberry PI GPIO
  */
 #define RIG_RPI 34
 #define RIG_BACKEND_RPI "rpi"
 #define RIG_MODEL_RPI_WIRINGPI RIG_MAKE_MODEL(RIG_RPI, 1)
+#endif
 
 /*! \typedef typedef int rig_model_t
     \brief Convenience type definition for rig model.

--- a/rpi/Makefile.am
+++ b/rpi/Makefile.am
@@ -1,0 +1,5 @@
+RPISRC = rpi.c rpi.h
+
+noinst_LTLIBRARIES = libhamlib-rpi.la
+libhamlib_rpi_la_SOURCES = $(RPISRC)
+

--- a/rpi/Makefile.am
+++ b/rpi/Makefile.am
@@ -1,5 +1,7 @@
+if RPI_WIRINGPI
 RPISRC = rpi.c rpi.h
 
+libhamlib_rpi_la_LIBADD = $(WIRINGPI_LIBS)
 noinst_LTLIBRARIES = libhamlib-rpi.la
 libhamlib_rpi_la_SOURCES = $(RPISRC)
-
+endif

--- a/rpi/rpi.c
+++ b/rpi/rpi.c
@@ -86,3 +86,25 @@ const struct rig_caps rpi_caps = {
     .get_ptt = rpi_get_ptt,
     .get_dcd = rpi_get_dcd,
 };
+
+/*
+ * proberigs_rpi
+ * rig_model_t probeallrigs_rpi(port_t *port, rig_probe_func_t cfunc, rig_ptr_t data)
+ */
+DECLARE_PROBERIG_BACKEND(rpi)
+{
+  rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
+  return RIG_MODEL_RPI_WIRINGPI;
+}
+
+/*
+ * initrigs_rpi is called by rig_backend_load
+ */
+DECLARE_INITRIG_BACKEND(rpi)
+{
+  rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
+
+  rig_register(&rpi_caps);
+
+  return RIG_OK;
+}

--- a/rpi/rpi.c
+++ b/rpi/rpi.c
@@ -27,6 +27,7 @@
 #include <wiringPi.h>
 
 #include "rpi.h"
+#include "register.h"
 
 int rpi_init(RIG* rig){
     if(wiringPiSetup() == -1)
@@ -40,7 +41,7 @@ int rpi_cleanup(RIG* rig){
 
 int rpi_open(RIG* rig){
     pinMode(PIN_PTT, OUTPUT);
-    pinMode(PIN_DCD, OUTPUT);
+    pinMode(PIN_DCD, INPUT);
     return RIG_OK;
 }
 
@@ -73,8 +74,8 @@ const struct rig_caps rpi_caps = {
     .copyright = "LGPL",
     .status = RIG_STATUS_ALPHA,
     .rig_type = RIG_TYPE_TRANSCEIVER,
-    .ptt_type = RIG_PTT_GPIO,
-    .dcd_type = RIG_DCD_GPIO,
+    .ptt_type = RIG_PTT_RIG,
+    .dcd_type = RIG_DCD_RIG,
     .port_type = RIG_PORT_NONE,
     .transceive = RIG_TRN_OFF,
     .rig_init = rpi_init,

--- a/rpi/rpi.c
+++ b/rpi/rpi.c
@@ -1,0 +1,93 @@
+/*
+ i  Hamlib Raspberry Pi backend - main file
+ *  Copyright (c) 2019 by HA5KFU ham radio club
+ *
+ *
+ *   This library is free software; you can redistribute it and/or
+ *   modify it under the terms of the GNU Lesser General Public
+ *   License as published by the Free Software Foundation; either
+ *   version 2.1 of the License, or (at your option) any later version.
+ *
+ *   This library is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *   Lesser General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public
+ *   License along with this library; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <hamlib/rig.h>
+
+#include <wiringPi.h>
+#define PIN_PTT 0
+#define PIN_DCD 2
+
+#include "rpi.h"
+
+int rpi_init(RIG* rig){
+    if(wiringPiSetup() == -1)
+        return -RIG_ECONF;
+    return RIG_OK;
+}
+
+int rpi_cleanup(RIG* rig){
+    return RIG_OK;
+}
+
+int rpi_open(RIG* rig){
+    pinMode(PIN_PTT, OUTPUT);
+    pinMode(PIN_DCD, OUTPUT);
+    return RIG_OK;
+}
+
+int rpi_close(RIG* rig){
+    return RIG_OK;
+}
+
+int rpi_set_ptt(RIG* rig, vfo_f vfo, ptt_t ptt){
+    digitalWrite(PIN_PTT, ptt);
+    return RIG_OK;
+}
+
+int rpi_get_ptt(RIG* rig, vfo_f vfo, ptt_t *ptt){
+    if(ptt)
+        *ptt = digitalRead(PIN_PTT);
+    return RIG_OK;
+}
+
+int rpi_get_dcd(RIG* rig, vfo_f vfo, dcd_t *dcd){
+    if(dcd)
+        *dcd = digitalRead(PIN_DCD);
+    return RIG_OK;
+}
+
+extern const struct rig_caps rpi_caps = {
+    .rig_model = RIG_MODEL_RPI_WIRINGPI,
+    .model_name = "WiringPI",
+    .mfg_name = "Raspberry PI",
+    .version = "0.1",
+    .copyright = "LGPL",
+    .status = RIG_STATUS_ALPHA,
+    .rig_type = RIG_TYPE_TRANSCEIVER,
+    .ptt_type = RIG_PTT_GPIO,
+    .dcd_type = RIG_DCD_GPIO,
+    .port_type = RIG_PORT_NONE,
+    .ctcss_list = common_ctcss_list,
+    .dcs_list = full_dcs_list,
+    .chan_list = {},
+    .transceive = RIG_TRN_OFF,
+    .rig_init = rpi_init,
+    .rig_cleanup = rpi_cleanup,
+    .rig_open = rpi_open,
+    .rig_close = rpi_close,
+
+    .rig_set_ptt = rpi_set_ptt,
+    .rig_get_ptt = rpi_get_ptt,
+    .rig_get_dcd = rpi_get_dcd,
+};

--- a/rpi/rpi.c
+++ b/rpi/rpi.c
@@ -25,8 +25,6 @@
 #include <hamlib/rig.h>
 
 #include <wiringPi.h>
-#define PIN_PTT 0
-#define PIN_DCD 2
 
 #include "rpi.h"
 
@@ -50,24 +48,24 @@ int rpi_close(RIG* rig){
     return RIG_OK;
 }
 
-int rpi_set_ptt(RIG* rig, vfo_f vfo, ptt_t ptt){
+int rpi_set_ptt(RIG* rig, vfo_t vfo, ptt_t ptt){
     digitalWrite(PIN_PTT, ptt);
     return RIG_OK;
 }
 
-int rpi_get_ptt(RIG* rig, vfo_f vfo, ptt_t *ptt){
+int rpi_get_ptt(RIG* rig, vfo_t vfo, ptt_t *ptt){
     if(ptt)
         *ptt = digitalRead(PIN_PTT);
     return RIG_OK;
 }
 
-int rpi_get_dcd(RIG* rig, vfo_f vfo, dcd_t *dcd){
+int rpi_get_dcd(RIG* rig, vfo_t vfo, dcd_t *dcd){
     if(dcd)
         *dcd = digitalRead(PIN_DCD);
     return RIG_OK;
 }
 
-extern const struct rig_caps rpi_caps = {
+const struct rig_caps rpi_caps = {
     .rig_model = RIG_MODEL_RPI_WIRINGPI,
     .model_name = "WiringPI",
     .mfg_name = "Raspberry PI",
@@ -78,16 +76,13 @@ extern const struct rig_caps rpi_caps = {
     .ptt_type = RIG_PTT_GPIO,
     .dcd_type = RIG_DCD_GPIO,
     .port_type = RIG_PORT_NONE,
-    .ctcss_list = common_ctcss_list,
-    .dcs_list = full_dcs_list,
-    .chan_list = {},
     .transceive = RIG_TRN_OFF,
     .rig_init = rpi_init,
     .rig_cleanup = rpi_cleanup,
     .rig_open = rpi_open,
     .rig_close = rpi_close,
 
-    .rig_set_ptt = rpi_set_ptt,
-    .rig_get_ptt = rpi_get_ptt,
-    .rig_get_dcd = rpi_get_dcd,
+    .set_ptt = rpi_set_ptt,
+    .get_ptt = rpi_get_ptt,
+    .get_dcd = rpi_get_dcd,
 };

--- a/rpi/rpi.h
+++ b/rpi/rpi.h
@@ -1,0 +1,29 @@
+/*
+ *  Hamlib RPi backend - main header
+ *  Copyright (c) 2019 by HA5KFU ham radio club
+ *
+ *
+ *   This library is free software; you can redistribute it and/or
+ *   modify it under the terms of the GNU Lesser General Public
+ *   License as published by the Free Software Foundation; either
+ *   version 2.1 of the License, or (at your option) any later version.
+ *
+ *   This library is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *   Lesser General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public
+ *   License along with this library; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef _RPI_H
+#define _RPI_H 1
+
+#include "hamlib/rig.h"
+
+extern const struct rig_caps rpi_caps;
+
+#endif /* _RPI_H */

--- a/rpi/rpi.h
+++ b/rpi/rpi.h
@@ -24,6 +24,9 @@
 
 #include "hamlib/rig.h"
 
+#define PIN_PTT 0
+#define PIN_DCD 2
+
 extern const struct rig_caps rpi_caps;
 
 #endif /* _RPI_H */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,7 +12,7 @@ libhamlib_la_SOURCES = $(RIGSRC)
 libhamlib_la_LDFLAGS = $(WINLDFLAGS) $(OSXLDFLAGS) -no-undefined -version-info $(ABI_VERSION):$(ABI_REVISION):$(ABI_AGE)
 
 libhamlib_la_LIBADD = $(top_builddir)/lib/libmisc.la \
-	$(BACKENDEPS) $(ROT_BACKENDEPS) $(AMP_BACKENDEPS) $(NET_LIBS) $(MATH_LIBS) $(LIBUSB_LIBS)
+	$(BACKENDEPS) $(ROT_BACKENDEPS) $(AMP_BACKENDEPS) $(NET_LIBS) $(MATH_LIBS) $(LIBUSB_LIBS) $(WIRINGPI_LIBS)
 
 libhamlib_la_DEPENDENCIES = $(top_builddir)/lib/libmisc.la $(BACKENDEPS) $(ROT_BACKENDEPS) $(AMP_BACKENDEPS)
 

--- a/src/register.c
+++ b/src/register.c
@@ -93,6 +93,9 @@ DEFINE_INITRIG_BACKEND(elad);
 DEFINE_INITRIG_BACKEND(winradio);
 #endif
 
+#ifdef HAVE_WIRINGPI
+DEFINE_INITRIG_BACKEND(rpi);
+#endif
 
 /**
  *  \def rig_backend_list
@@ -135,6 +138,9 @@ static struct
     { RIG_RFT, RIG_BACKEND_RFT, RIG_FUNCNAMA(rft) },
     { RIG_KIT, RIG_BACKEND_KIT, RIG_FUNCNAMA(kit) },
     { RIG_TUNER, RIG_BACKEND_TUNER, RIG_FUNCNAMA(tuner) },
+    #ifdef HAVE_WIRINGPI
+    { RIG_RPI, RIG_BACKEND_RPI, RIG_FUNCNAM(rpi) },
+    #endif /* HAVE_WIRINGPI */
     { RIG_RS, RIG_BACKEND_RS, RIG_FUNCNAMA(rs) },
     { RIG_PRM80, RIG_BACKEND_PRM80, RIG_FUNCNAMA(prm80) },
     { RIG_ADAT, RIG_BACKEND_ADAT, RIG_FUNCNAM(adat) },


### PR DESCRIPTION
Added a new backend for controlling the PTT via a Raspberry Pi pin, using the wiringPi library. If you don't have it (ex. you're building on a PC and not a RPi or compatible), Autoconf should disable it, so this PR shouldn't affect you negatively (yes, I did test it on PC too).

It was tested on a RPi v2 B, revision 1.1 board running Raspbian Jessie (Linux 4.1.7-v7) and wiringPi 2.24, confirmed working with `rigctl`.

You can change the pin numbers in `rpi/rpi.h`, by default it is pin 0 for PTT out and pin 2 for DCD in. (On my board, those are the 6th and 7th pins from the left on the bottom row, if you hold the device so that you can read the "Raspberry Pi 2 Model..." label. For more info, see [wiringPi's website](http://wiringpi.com/pins/).)

73 de [HA5KFU](https://ha5kfu.sch.bme.hu/about/) amateur radio club