### PR TITLE
icom.c can now power up icom rigs and determine USB echo status

### DIFF
--- a/icom/icom.h
+++ b/icom/icom.h
@@ -30,7 +30,7 @@
 #include <sys/time.h>
 #endif
 
-#define BACKEND_VER "0.21"
+#define BACKEND_VER "0.22"
 
 /*
  * defines used by comp_cal_str in rig.c


### PR DESCRIPTION
Next step is to add icom_rig_open to other icom rigs
This routine should work on any icom rig -- those that don't have
the ability to power up will just be ignored and should produce error if not
power up already.  USB echo test should work on all icom rigs.