### PR TITLE
ic746.c: fix ic746pro_get_channel() and implement ic746pro_set_channel()

### DIFF
--- a/tests/memcsv.c
+++ b/tests/memcsv.c
@@ -548,11 +548,6 @@ void dump_csv_name(const channel_cap_t *mem_caps, FILE *f)
         fprintf(f, "flags%c", csv_sep);
     }
 
-    if (mem_caps->channel_desc)
-    {
-        fprintf(f, "channel_desc%c", csv_sep);
-    }
-
     fprintf(f, "\n");
 }
 
@@ -706,11 +701,6 @@ int dump_csv_chan(RIG *rig,
     if (mem_caps->flags)
     {
         fprintf(f, "%x%c", chan.flags, csv_sep);
-    }
-
-    if (mem_caps->channel_desc)
-    {
-        fprintf(f, "%s", chan.channel_desc);
     }
 
     fprintf(f, "\n");

--- a/tests/memsave.c
+++ b/tests/memsave.c
@@ -285,12 +285,6 @@ int dump_xml_chan(RIG *rig,
         xmlNewProp(node, (unsigned char *) "flags", (unsigned char *) attrbuf);
     }
 
-    if (mem_caps->channel_desc)
-    {
-        sprintf(attrbuf, "%s", chan.channel_desc);
-        xmlNewProp(node, (unsigned char *) "channel_desc", (unsigned char *) attrbuf);
-    }
-
     return 0;
 }
 #endif


### PR DESCRIPTION
for ic746pro_get_channel()
- pb variable is signed
- fix struct length enabling dcs.pol (fix description)
- add split correct configuration
- remove duplicated name description on csv

for ic746pro_set_channel()
- implement the function to re-write the saved csv
- tested with IC-7400 (aka IC-746Pro)
- if in the line the frequency or mode is empty or 0 the memory will be cleared

Closes: https://github.com/Hamlib/Hamlib/issues/125