### PR TITLE
uniden_get_freq_2 to use SG<cr> instead of RF<cr> for bc780xlt #313

### DIFF
--- a/rigs/uniden/bc780.c
+++ b/rigs/uniden/bc780.c
@@ -129,7 +129,7 @@ const struct rig_caps bc780_caps =
     .priv =  NULL,
 
     .set_freq =  uniden_set_freq,
-    .get_freq =  uniden_get_freq,
+    .get_freq =  uniden_get_freq_2,
     .set_mode =  uniden_set_mode,
     .get_mode =  uniden_get_mode,
     .set_mem =  uniden_set_mem,

--- a/rigs/uniden/uniden.c
+++ b/rigs/uniden/uniden.c
@@ -318,6 +318,35 @@ int uniden_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
     return RIG_OK;
 }
 
+/*
+ * uniden_get_freq
+ * Assumes rig!=NULL
+ */
+int uniden_get_freq_2(RIG *rig, vfo_t vfo, freq_t *freq)
+{
+    char freqbuf[BUFSZ];
+    size_t freq_len = BUFSZ;
+    int ret;
+
+    ret = uniden_transaction(rig, "SG" EOM, 3, "S", freqbuf, &freq_len);
+
+    if (ret != RIG_OK)
+    {
+        return ret;
+    }
+
+    if (freq_len < 10)
+    {
+        return -RIG_EPROTO;
+    }
+
+    sscanf(freqbuf + 6, "%"SCNfreq, freq);
+    /* returned freq in hundreds of Hz */
+    *freq *= 100;
+
+    return RIG_OK;
+}
+
 int uniden_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
     const char *modebuf;

--- a/rigs/uniden/uniden.h
+++ b/rigs/uniden/uniden.h
@@ -58,6 +58,7 @@ int uniden_transaction (RIG *rig, const char *cmdstr, int cmd_len,
 		const char *replystr, char *data, size_t *datasize);
 int uniden_set_freq(RIG *rig, vfo_t vfo, freq_t freq);
 int uniden_get_freq(RIG *rig, vfo_t vfo, freq_t *freq);
+int uniden_get_freq_2(RIG *rig, vfo_t vfo, freq_t *freq);
 int uniden_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width);
 int uniden_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width);
 int uniden_set_mem(RIG *rig, vfo_t vfo, int ch);


### PR DESCRIPTION
- RF<cr> responds NG on bc780xlt
- SG<cr> responds with the gain + the current frequency
- SG<cr> is valid in manual mode, scan mode and search mode