### PR TITLE
uniden_get_channel correctly parses rig's response #315

### DIFF
--- a/rigs/uniden/uniden.c
+++ b/rigs/uniden/uniden.c
@@ -619,12 +619,12 @@ int uniden_get_channel(RIG *rig, channel_t *chan, int read_only)
      */
     if (mem_len < 30 ||
             membuf[5] != 'F' ||
-            membuf[25] != 'T' ||
-            membuf[28] != 'D' ||
-            membuf[31] != 'L' ||
-            membuf[34] != 'A' ||
-            membuf[37] != 'R' ||
-            membuf[40] != 'N')
+            membuf[15] != 'T' ||
+            membuf[18] != 'D' ||
+            membuf[21] != 'L' ||
+            membuf[24] != 'A' ||
+            membuf[27] != 'R' ||
+            membuf[30] != 'N')
     {
         return -RIG_EPROTO;
     }


### PR DESCRIPTION
Tested on bc780xlt

```bash
./rigctl -m 801 -r /dev/dtyU0 -s 9600 -vvvvv
rigctl, Hamlib 3.3
Report bugs to <hamlib-developer@lists.sourceforge.net>

rig_init called
uniden: _init called
rig_register called
rig_register: rig_register (803)
rig_register called
rig_register: rig_register (812)
rig_register called
rig_register: rig_register (802)
rig_register called
rig_register: rig_register (801)
rig_register called
rig_register: rig_register (806)
rig_register called
rig_register: rig_register (804)
rig_register called
rig_register: rig_register (810)
rig_register called
rig_register: rig_register (811)
rig_open called
port_open called
serial_open called
serial_setup called
rig_get_vfo called
Opened rig model 801, 'BC780xlt'
rig_strstatus called
Backend version: 0.3, Status: Untested

Rig command: h
rigctl_parse: input_line: h
Channel: 1
rig_get_channel called
serial_flush called
write_block called
write_block(): TX 6 bytes
0000    50 4d 30 30 31 0d                                   PM001.
read_string called
read_string(): RX 35 characters
0000    43 30 30 31 20 46 30 31 31 38 33 35 30 30 20 54     C001 F01183500 T
0010    46 20 44 4e 20 4c 46 20 41 46 20 52 46 20 4e 30     F DN LF AF RF N0
0020    30 30 0d                                            00.
serial_flush called
write_block called
write_block(): TX 9 bytes
0000    54 41 20 43 20 30 30 31 0d                          TA C 001.
read_string called
read_string(): RX 10 characters
0000    54 41 20 43 20 30 30 31 20 0d                       TA C 001 .
'hannel: 1, Name: '
rig_strvfo called
VFO: MEM, Antenna: 0, Split: OFF
sprintf_freq called
sprintf_freq called
rig_strrmode called
Freq:   118.35 MHz      Mode:           Width:   0 Hz
sprintf_freq called
sprintf_freq called
rig_strrmode called
txFreq: 0 Hz    txMode:         txWidth: 0 Hz
sprintf_freq called
rig_strptrshift called
sprintf_freq called
sprintf_freq called
sprintf_freq called
Shift: None, Offset: 0 Hz, Step: 0 Hz, RIT: 0 Hz, XIT: 0 Hz
CTCSS: 0.0Hz, CTCSSsql: 0.0Hz, DCS: 0.0, DCSsql: 0.0
Functions:
rig_has_set_level called
rig_has_get_level called
rig_has_set_level called
rig_strlevel called
rig_has_set_level called
(...)
rig_has_set_level called
Levels: ATT: 0

Rig command: