### PR TITLE
Correctly compare response strings #319

### DIFF
--- a/rigs/uniden/uniden.c
+++ b/rigs/uniden/uniden.c
@@ -187,7 +187,7 @@ transaction_write:
         goto transaction_quit;
     }
 
-    if (strcmp(data, "OK"EOM))
+    if (strcmp(data, "OK"EOM) == 0)
     {
         /* everything is fine */
         retval = RIG_OK;
@@ -198,7 +198,7 @@ transaction_write:
      *  in the right mode or using the correct parameters. ERR indicates
      *  an INVALID Command.
      */
-    if (strcmp(data, "NG"EOM) || strcmp(data, "ORER"EOM))
+    if (strcmp(data, "NG"EOM) == 0 || strcmp(data, "ORER"EOM) == 0)
     {
         /* Invalid command */
         rig_debug(RIG_DEBUG_VERBOSE, "%s: NG/Overflow for '%s'\n", __func__, cmdstr);
@@ -206,7 +206,7 @@ transaction_write:
         goto transaction_quit;
     }
 
-    if (strcmp(data, "ERR"EOM))
+    if (strcmp(data, "ERR"EOM) == 0)
     {
         /*  Command format error */
         rig_debug(RIG_DEBUG_VERBOSE, "%s: Error for '%s'\n", __func__, cmdstr);


### PR DESCRIPTION
I was able to set the frequency on a bc780xlt without any error

```bash
./rigctl -m 801 -r /dev/dtyU0 -s 9600 -vvvvv
rigctl, Hamlib 3.3
Report bugs to <hamlib-developer@lists.sourceforge.net>

rig_init called
uniden: _init called
rig_register called
rig_register: rig_register (803)
rig_register called
rig_register: rig_register (812)
rig_register called
rig_register: rig_register (802)
rig_register called
rig_register: rig_register (801)
rig_register called
rig_register: rig_register (806)
rig_register called
rig_register: rig_register (804)
rig_register called
rig_register: rig_register (810)
rig_register called
rig_register: rig_register (811)
rig_open called
port_open called
serial_open called
serial_setup called
rig_get_vfo called
Opened rig model 801, 'BC780xlt'
rig_strstatus called
Backend version: 0.3, Status: Stable

Rig command: f
rigctl_parse: input_line: f
rig_get_freq called
serial_flush called
write_block called
write_block(): TX 3 bytes
0000    53 47 0d                                            SG.
read_string called
read_string(): RX 15 characters
0000    53 30 35 32 20 46 30 30 30 30 30 30 30 30 0d        S052 F00000000.
Frequency: 0

Rig command: F
rigctl_parse: input_line: F
Frequency: 102300000
rig_set_freq called
serial_flush called
write_block called
write_block(): TX 11 bytes
0000    52 46 30 31 30 32 33 30 30 30 0d                    RF01023000.
read_string called
read_string(): RX 3 characters
0000    4f 4b 0d                                            OK.

Rig command: f
rigctl_parse: input_line: f
rig_get_freq called
serial_flush called
write_block called
write_block(): TX 3 bytes
0000    53 47 0d                                            SG.
read_string called
read_string(): RX 15 characters
0000    53 31 32 33 20 46 30 31 30 32 33 30 30 30 0d        S123 F01023000.
Frequency: 102300000

Rig command:
```