### PR TITLE
get_dcd responds without crashing #323

### DIFF
--- a/rigs/uniden/uniden.c
+++ b/rigs/uniden/uniden.c
@@ -229,8 +229,8 @@ transaction_write:
 #endif
 
     /* Special case for SQuelch */
-    if (replystr && !memcmp(cmdstr, "SQ", 2) && (replystr[0] == '-'
-            || replystr[0] == '+'))
+    if (replystr && !memcmp(cmdstr, "SQ", 2) && (data[0] == '-'
+            || data[0] == '+'))
     {
         retval = RIG_OK;
         goto transaction_quit;


### PR DESCRIPTION
Getting DCD from bc780xlt

```bash
# rigctl -m 801 -r /dev/dtyU0 -s 9600 -vvvvv
rigctl, Hamlib 3.3
Report bugs to <hamlib-developer@lists.sourceforge.net>

rig_init called
uniden: _init called
rig_register called
rig_register: rig_register (803)
rig_register called
rig_register: rig_register (812)
rig_register called
rig_register: rig_register (802)
rig_register called
rig_register: rig_register (801)
rig_register called
rig_register: rig_register (806)
rig_register called
rig_register: rig_register (804)
rig_register called
rig_register: rig_register (810)
rig_register called
rig_register: rig_register (811)
rig_open called
port_open called
serial_open called
serial_setup called
rig_get_vfo called
Opened rig model 801, 'BC780xlt'
rig_strstatus called
Backend version: 0.3, Status: Stable

Rig command: \get_dcd
rigctl_parse: input_line: \get_dcd
rig_get_dcd called
serial_flush called
write_block called
write_block(): TX 3 bytes
0000    53 51 0d                                            SQ.
read_string called
read_string(): RX 2 characters
0000    2d 0d                                               -.
DCD: 0

Rig command:
```