### PR TITLE
Propagate variable read_only value to rig implementation of get_channel

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -853,7 +853,7 @@ int HAMLIB_API rig_get_channel(RIG *rig, channel_t *chan, int read_only)
 
     if (rc->get_channel)
     {
-        return rc->get_channel(rig, chan, 0);
+        return rc->get_channel(rig, chan, read_only);
     }
 
     /*


### PR DESCRIPTION
The value of `read_only` parameter for `get_channel` command is not propagated to the rig function actually implementing the feature.