### PR TITLE
Fix a [missingInclude] when running cppcheck --check-config

### DIFF
--- a/rotators/amsat/if100.c
+++ b/rotators/amsat/if100.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
+#include <math.h>
 
 #ifdef HAVE_SYS_IOCTL_H
 #  include <sys/ioctl.h>
@@ -35,7 +36,6 @@
 #include "parallel.h"
 #include "misc.h"
 #include "register.h"
-#include "math.h"
 
 static int
 if100_set_position(ROT *rot, azimuth_t az, elevation_t el)


### PR DESCRIPTION
This is for consistency with other source fils, but gcc finds the include
file anyway (see https://gcc.gnu.org/onlinedocs/cpp/Search-Path.html)

Fixes:
rotators/amsat/if100.c:38:0: information: Include file: "math.h" not found. [missingInclude]