### PR TITLE
Fix Icom repeater shift + split and add tuning steps for IC-9700

### DIFF
--- a/rigs/icom/ic7300.c
+++ b/rigs/icom/ic7300.c
@@ -247,7 +247,7 @@ static const struct icom_priv_caps IC9700_priv_caps =
     0xA2,   /* default address */
     0,      /* 731 mode */
     1,      /* no XCHG to avoid display flickering */
-    ic7300_ts_sc_list,
+    ic9700_ts_sc_list,
     .serial_USB_echo_check = 1,  /* USB CI-V may not echo */
     .agc_levels_present = 1,
     .agc_levels = {

--- a/rigs/icom/icom.c
+++ b/rigs/icom/icom.c
@@ -369,11 +369,25 @@ const struct ts_sc_list ic705_ts_sc_list[] =
     {kHz(25), 0x11},
     {kHz(50), 0x12},
     {kHz(100), 0x13},
-    {0, 0x13},            /* programmable tuning step not supported */
     {0, 0},
 };
 
-
+const struct ts_sc_list ic9700_ts_sc_list[] =
+{
+    {10, 0x00},
+    {100, 0x01},
+    {500, 0x02},
+    {kHz(1), 0x03},
+    {kHz(5), 0x04},
+    {kHz(6.25), 0x05},
+    {kHz(10), 0x06},
+    {kHz(12.5), 0x07},
+    {kHz(20), 0x08},
+    {kHz(25), 0x09},
+    {kHz(50), 0x10},
+    {kHz(100), 0x11},
+    {0, 0},
+};
 
 /* rtty filter list for some DSP rigs ie PRO */
 #define RTTY_FIL_NB 5
@@ -3639,6 +3653,7 @@ int icom_get_rptr_shift(RIG *rig, vfo_t vfo, rptr_shift_t *rptr_shift)
     switch (rptrbuf[1])
     {
     case S_DUP_OFF:
+    case S_DUP_DD_RPS:
         *rptr_shift = RIG_RPT_SHIFT_NONE; /* Simplex mode */
         break;
 
@@ -3648,6 +3663,12 @@ int icom_get_rptr_shift(RIG *rig, vfo_t vfo, rptr_shift_t *rptr_shift)
 
     case S_DUP_P:
         *rptr_shift = RIG_RPT_SHIFT_PLUS; /* Duplex + mode */
+        break;
+
+    // The same command indicates split state, which means simplex mode
+    case S_SPLT_OFF:
+    case S_SPLT_ON:
+        *rptr_shift = RIG_RPT_SHIFT_NONE; /* Simplex mode */
         break;
 
     default:
@@ -4965,6 +4986,13 @@ int icom_get_split_vfo(RIG *rig, vfo_t vfo, split_t *split, vfo_t *tx_vfo)
 
     case S_SPLT_ON:
         *split = RIG_SPLIT_ON;
+        break;
+
+    // The same command indicates repeater shift state, which means that split is off
+    case S_DUP_M:
+    case S_DUP_P:
+    case S_DUP_DD_RPS:
+        *split = RIG_SPLIT_OFF;
         break;
 
     default:

--- a/rigs/icom/icom.h
+++ b/rigs/icom/icom.h
@@ -218,6 +218,7 @@ extern const struct ts_sc_list ic7000_ts_sc_list[];
 extern const struct ts_sc_list ic7100_ts_sc_list[];
 extern const struct ts_sc_list ic7200_ts_sc_list[];
 extern const struct ts_sc_list ic7300_ts_sc_list[];
+extern const struct ts_sc_list ic9700_ts_sc_list[];
 extern const struct ts_sc_list ic910_ts_sc_list[];
 extern const struct ts_sc_list ic718_ts_sc_list[];
 extern const struct ts_sc_list x108g_ts_sc_list[];

--- a/rigs/icom/icom_defs.h
+++ b/rigs/icom/icom_defs.h
@@ -207,6 +207,7 @@
 #define S_DUP_OFF	0x10		/* Simplex mode */
 #define S_DUP_M 	0x11		/* Duplex - mode */
 #define S_DUP_P		0x12		/* Duplex + mode */
+#define S_DUP_DD_RPS	0x13		/* DD Repeater Simplex mode (RPS) */
 
 /*
  * Set Attenuator (C_CTL_ATT) subcommands


### PR DESCRIPTION
This PR includes:

* fixes for handling of Icom repeater shift and split command responses. Both use the same command and should handle all responses (duplex + split), depending on which one is in use.
* tuning step definitions for IC-9700

I've tested the changes on an IC-9700.
