### PR TITLE
Fix max macro. Added missing > operator.

### DIFF
--- a/kenwood/kenwood.c
+++ b/kenwood/kenwood.c
@@ -43,7 +43,7 @@
 #include "ts990s.h"
 
 #ifndef max
-#define max(a,b) (((a) (b)) ? (a) : (b))
+#define max(a,b) (((a) > (b)) ? (a) : (b))
 #define min(a,b) (((a) < (b)) ? (a) : (b))
 #endif
 


### PR DESCRIPTION
Not sure why my gcc wasn't able to find this error. I couldn't find any tests for this lib, to check if this macro is used anywhere.