### PR TITLE
Fix Prosistel rotator control backend

### DIFF
--- a/include/hamlib/rotlist.h
+++ b/include/hamlib/rotlist.h
@@ -424,15 +424,31 @@
 
 
 /**
- *  \def ROT_MODEL_PROSISTEL
- *  \brief A macro that returns the model number of the PROSISTEL backend.
+ *  \def ROT_MODEL_PROSISTEL_AZ
+ *  \brief A macro that returns the model number of the PROSISTEL azimuth backend.
  *
  */
 //! @cond Doxygen_Suppress
 #define ROT_PROSISTEL 17
 #define ROT_BACKEND_PROSISTEL "prosistel"
 //! @endcond
-#define ROT_MODEL_PROSISTEL ROT_MAKE_MODEL(ROT_PROSISTEL, 1)
+#define ROT_MODEL_PROSISTEL_AZ ROT_MAKE_MODEL(ROT_PROSISTEL, 1)
+
+
+/**
+ *  \def ROT_MODEL_PROSISTEL_EL
+ *  \brief A macro that returns the model number of the PROSISTEL elevation backend.
+ *
+ */
+#define ROT_MODEL_PROSISTEL_EL ROT_MAKE_MODEL(ROT_PROSISTEL, 2)
+
+
+/**
+ *  \def ROT_MODEL_PROSISTEL_AZEL_COMBO
+ *  \brief A macro that returns the model number of the PROSISTEL azimuth + elevation combo backend.
+ *
+ */
+#define ROT_MODEL_PROSISTEL_AZEL_COMBO ROT_MAKE_MODEL(ROT_PROSISTEL, 3)
 
 
 /**

--- a/include/hamlib/rotlist.h
+++ b/include/hamlib/rotlist.h
@@ -424,31 +424,31 @@
 
 
 /**
- *  \def ROT_MODEL_PROSISTEL_AZ
- *  \brief A macro that returns the model number of the PROSISTEL azimuth backend.
+ *  \def ROT_MODEL_PROSISTEL_D_AZ
+ *  \brief A macro that returns the model number of the PROSISTEL D azimuth backend.
  *
  */
 //! @cond Doxygen_Suppress
 #define ROT_PROSISTEL 17
 #define ROT_BACKEND_PROSISTEL "prosistel"
 //! @endcond
-#define ROT_MODEL_PROSISTEL_AZ ROT_MAKE_MODEL(ROT_PROSISTEL, 1)
+#define ROT_MODEL_PROSISTEL_D_AZ ROT_MAKE_MODEL(ROT_PROSISTEL, 1)
 
 
 /**
- *  \def ROT_MODEL_PROSISTEL_EL
- *  \brief A macro that returns the model number of the PROSISTEL elevation backend.
+ *  \def ROT_MODEL_PROSISTEL_D_EL
+ *  \brief A macro that returns the model number of the PROSISTEL D elevation backend.
  *
  */
-#define ROT_MODEL_PROSISTEL_EL ROT_MAKE_MODEL(ROT_PROSISTEL, 2)
+#define ROT_MODEL_PROSISTEL_D_EL ROT_MAKE_MODEL(ROT_PROSISTEL, 2)
 
 
 /**
  *  \def ROT_MODEL_PROSISTEL_AZEL_COMBO
- *  \brief A macro that returns the model number of the PROSISTEL azimuth + elevation combo backend.
+ *  \brief A macro that returns the model number of the PROSISTEL Combi-Track azimuth + elevation combo backend.
  *
  */
-#define ROT_MODEL_PROSISTEL_AZEL_COMBO ROT_MAKE_MODEL(ROT_PROSISTEL, 3)
+#define ROT_MODEL_PROSISTEL_COMBI_TRACK_AZEL ROT_MAKE_MODEL(ROT_PROSISTEL, 3)
 
 
 /**

--- a/rotators/prosistel/prosistel.c
+++ b/rotators/prosistel/prosistel.c
@@ -360,9 +360,9 @@ static const struct prosistel_rot_priv_caps prosistel_rot_combitrack_priv_caps =
 /*
  * Prosistel rotator capabilities
  */
-const struct rot_caps prosistel_az_rot_caps =
+const struct rot_caps prosistel_d_az_rot_caps =
 {
-    ROT_MODEL(ROT_MODEL_PROSISTEL_AZ),
+    ROT_MODEL(ROT_MODEL_PROSISTEL_D_AZ),
     .model_name =     "D azimuth",
     .mfg_name =       "Prosistel",
     .version =        "20201215.0",
@@ -395,9 +395,9 @@ const struct rot_caps prosistel_az_rot_caps =
 };
 
 
-const struct rot_caps prosistel_el_rot_caps =
+const struct rot_caps prosistel_d_el_rot_caps =
 {
-    ROT_MODEL(ROT_MODEL_PROSISTEL_EL),
+    ROT_MODEL(ROT_MODEL_PROSISTEL_D_EL),
     .model_name =     "D elevation",
     .mfg_name =       "Prosistel",
     .version =        "20201215.0",
@@ -430,9 +430,9 @@ const struct rot_caps prosistel_el_rot_caps =
 };
 
 
-const struct rot_caps prosistel_azel_combo_rot_caps =
+const struct rot_caps prosistel_combi_track_azel_rot_caps =
 {
-    ROT_MODEL(ROT_MODEL_PROSISTEL_AZEL_COMBO),
+    ROT_MODEL(ROT_MODEL_PROSISTEL_COMBI_TRACK_AZEL),
     .model_name =     "Combi-Track az+el",
     .mfg_name =       "Prosistel",
     .version =        "20201215.0",
@@ -468,9 +468,9 @@ DECLARE_INITROT_BACKEND(prosistel)
 {
     rig_debug(RIG_DEBUG_VERBOSE, "%s: _init called\n", __func__);
 
-    rot_register(&prosistel_az_rot_caps);
-    rot_register(&prosistel_el_rot_caps);
-    rot_register(&prosistel_azel_combo_rot_caps);
+    rot_register(&prosistel_d_az_rot_caps);
+    rot_register(&prosistel_d_el_rot_caps);
+    rot_register(&prosistel_combi_track_azel_rot_caps);
 
     return RIG_OK;
 }

--- a/rotators/prosistel/prosistel.c
+++ b/rotators/prosistel/prosistel.c
@@ -252,6 +252,10 @@ static int prosistel_rot_get_position(ROT *rot, azimuth_t *az, elevation_t *el)
 
         *az = (azimuth_t) posval;
     }
+    else
+    {
+        *az = 0;
+    }
 
     // Query elevation only if the rotator has the capability to do so
     // It is an error to query for elevation if it's not supported by the rotator controller
@@ -284,6 +288,10 @@ static int prosistel_rot_get_position(ROT *rot, azimuth_t *az, elevation_t *el)
                 __func__, data, posval);
 
         *el = (elevation_t) posval;
+    }
+    else
+    {
+        *el = 0;
     }
 
     return retval;

--- a/rotators/prosistel/prosistel.c
+++ b/rotators/prosistel/prosistel.c
@@ -363,7 +363,7 @@ static const struct prosistel_rot_priv_caps prosistel_rot_combitrack_priv_caps =
 const struct rot_caps prosistel_az_rot_caps =
 {
     ROT_MODEL(ROT_MODEL_PROSISTEL_AZ),
-    .model_name =     "Prosistel D azimuth",
+    .model_name =     "D azimuth",
     .mfg_name =       "Prosistel",
     .version =        "20201215.0",
     .copyright =      "LGPL",
@@ -398,7 +398,7 @@ const struct rot_caps prosistel_az_rot_caps =
 const struct rot_caps prosistel_el_rot_caps =
 {
     ROT_MODEL(ROT_MODEL_PROSISTEL_EL),
-    .model_name =     "Prosistel D elevation",
+    .model_name =     "D elevation",
     .mfg_name =       "Prosistel",
     .version =        "20201215.0",
     .copyright =      "LGPL",
@@ -433,7 +433,7 @@ const struct rot_caps prosistel_el_rot_caps =
 const struct rot_caps prosistel_azel_combo_rot_caps =
 {
     ROT_MODEL(ROT_MODEL_PROSISTEL_AZEL_COMBO),
-    .model_name =     "Prosistel Combi-Track az+el",
+    .model_name =     "Combi-Track az+el",
     .mfg_name =       "Prosistel",
     .version =        "20201215.0",
     .copyright =      "LGPL",

--- a/rotators/prosistel/prosistel.h
+++ b/rotators/prosistel/prosistel.h
@@ -23,6 +23,8 @@
 #define _ROT_PROSISTEL_H 1
 
 
-extern const struct rot_caps prosistel_rot_caps;
+extern const struct rot_caps prosistel_az_rot_caps;
+extern const struct rot_caps prosistel_el_rot_caps;
+extern const struct rot_caps prosistel_azel_combo_rot_caps;
 
 #endif /* _ROT_PROSISTEL_H */

--- a/rotators/prosistel/prosistel.h
+++ b/rotators/prosistel/prosistel.h
@@ -22,9 +22,8 @@
 #ifndef _ROT_PROSISTEL_H
 #define _ROT_PROSISTEL_H 1
 
-
-extern const struct rot_caps prosistel_az_rot_caps;
-extern const struct rot_caps prosistel_el_rot_caps;
-extern const struct rot_caps prosistel_azel_combo_rot_caps;
+extern const struct rot_caps prosistel_d_az_rot_caps;
+extern const struct rot_caps prosistel_d_el_rot_caps;
+extern const struct rot_caps prosistel_combi_track_azel_rot_caps;
 
 #endif /* _ROT_PROSISTEL_H */


### PR DESCRIPTION
The Prosistel backend is now a bit broken, as it follows the Prosistel Combi-Track (az+el) protocol, which is slightly different from the Prosistel D (azimuth/elevation only) controllers. The az/el-only controllers also do not accept queries for the unsupported angle, e.g. it's an error to query elevation on an azimuth-only controller.

I contacted Prosistel and they actually have all the protocol documentation available here: https://www.prosistel.it/download/download.htm

The documentation reveals that there are three "product families", namely the "D" series, the PRO series and the Combi-Track (az+el) combos.

Of these three, the D and the PRO series seem to use the same protocol with angle in degrees and A/E identifiers for azimuth and elevation. These rotator controllers support either azimuth or elevation, but not both.

The Combi-Track controllers are combined azimuth+elevation controllers and these represent angles in 1/10ths of degrees and use A/B identifiers for unit A and B (which can be thought of as azimuth and elevation).

I've rewritten the backends for Prosistel allowing user to choose between the az, el or az+er models.

I've tested the D azimuth (model 1701) backend on PST-61D rotator and it seems to work now, the other 2 backends need testing.
