### PR TITLE
dummy/dummy.c: Fix unaligned access in dummy_get_level()

### DIFF
--- a/rigs/dummy/dummy.c
+++ b/rigs/dummy/dummy.c
@@ -1123,7 +1123,7 @@ static int dummy_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         break;
     }
 
-    *val = curr->levels[idx];
+    memcpy (val, &curr->levels[idx], sizeof(value_t));
     rig_debug(RIG_DEBUG_VERBOSE, "%s called: %s\n", __func__,
               rig_strlevel(level));
 


### PR DESCRIPTION
This fixes an unaligned access in dummy/dummy.c in the function
dummy_get_level() which resulted in crashes (Bus Error) on systems
with stricter alignment requirements such as SPARC.

On x86_64 (and any other architecture with less strict alignment
requirements), the compiler automatically optimizes the memcpy()
out if necessary such that there are no performance issues.

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=950950