### PR TITLE
Re-enable Yaesu question mark handling and fix newcat_get_cmd retries in case of question mark response

### DIFF
--- a/rigs/yaesu/newcat.h
+++ b/rigs/yaesu/newcat.h
@@ -50,7 +50,7 @@
 typedef char ncboolean;
 
 /* shared function version */
-#define NEWCAT_VER "20210111"
+#define NEWCAT_VER "20210112"
 
 /* Hopefully large enough for future use, 128 chars plus '\0' */
 #define NEWCAT_DATA_LEN                 129


### PR DESCRIPTION
This should fix #505 -- the `rc = -RIG_BUSBUSY;` was missing in `newcat_get_cmd`.