### PR TITLE
Re-enable Yaesu question mark handling and fix newcat_get_cmd retries in case of question mark response (2nd attempt)

### DIFF
--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -4090,14 +4090,32 @@ int newcat_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         snprintf(priv->cmd_str, sizeof(priv->cmd_str), "KS%c", cat_term);
         break;
 
-    case RIG_LEVEL_MICGAIN:
+    case RIG_LEVEL_MICGAIN: {
+        pbwidth_t width;
+        rmode_t mode = 0;
+
         if (!newcat_valid_command(rig, "MG"))
         {
             return -RIG_ENAVAIL;
         }
 
+        if (is_ft991 || is_ftdx5000 || is_ftdx101)
+        {
+            newcat_get_mode(rig, vfo, &mode, &width);
+        }
+
         snprintf(priv->cmd_str, sizeof(priv->cmd_str), "MG%c", cat_term);
+
+        // Some Yaesu rigs reject this command in RTTY modes
+        if (is_ft991 || is_ftdx5000 || is_ftdx101)
+        {
+            if (mode & RIG_MODE_RTTY || mode & RIG_MODE_RTTYR)
+            {
+                priv->question_mark_response_means_rejected = 1;
+            }
+        }
         break;
+    }
 
     case RIG_LEVEL_METER:
         if (!newcat_valid_command(rig, "MS"))

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -9085,19 +9085,17 @@ int newcat_get_cmd(RIG *rig)
         rc = RIG_OK;              /* received something */
 
         /* Check that command termination is correct - alternative is
-           response is longer that the buffer */
+           response is longer than the buffer */
         if (cat_term  != priv->ret_data[strlen(priv->ret_data) - 1])
         {
             rig_debug(RIG_DEBUG_ERR, "%s: Command is not correctly terminated '%s'\n",
                       __func__, priv->ret_data);
-            // we were using BUSBUSY but microham devices need retries
-            //rc = -RIG_BUSBUSY;    /* don't write command again */
-            // rc = -RIG_EPROTO;
+            rc = -RIG_EPROTO; /* retry */
             /* we could decrement retry_count
                here but there is a danger of
                infinite looping so we just use up
                a retry for safety's sake */
-            continue;             /* retry */
+            continue;
         }
 
         /* check for error codes */
@@ -9158,7 +9156,7 @@ int newcat_get_cmd(RIG *rig)
                 rig_debug(RIG_DEBUG_WARN, "%s: Rig busy - retrying: '%s'\n", __func__,
                         priv->cmd_str);
 
-                rc = -RIG_BUSBUSY; /* retry */
+                rc = -RIG_ERJCTED; /* retry */
                 break;
             }
 

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -3304,7 +3304,17 @@ int newcat_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
         }
 
         // Some Yaesu rigs reject this command in AM/FM modes
-        priv->question_mark_response_means_rejected = 1;
+        if (is_ft991 || is_ftdx5000 || is_ftdx101)
+        {
+            pbwidth_t width;
+            rmode_t mode;
+            err = newcat_get_mode(rig, vfo, &mode, &width);
+
+            if (mode & RIG_MODE_AM || mode & RIG_MODE_FM || mode & RIG_MODE_AMN || mode & RIG_MODE_FMN)
+            {
+                priv->question_mark_response_means_rejected = 1;
+            }
+        }
         break;
 
     case RIG_LEVEL_CWPITCH:
@@ -3371,7 +3381,17 @@ int newcat_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
         snprintf(priv->cmd_str, sizeof(priv->cmd_str), "MG%03d%c", fpf, cat_term);
 
         // Some Yaesu rigs reject this command in RTTY modes
-        priv->question_mark_response_means_rejected = 1;
+        if (is_ft991 || is_ftdx5000 || is_ftdx101)
+        {
+            pbwidth_t width;
+            rmode_t mode;
+            err = newcat_get_mode(rig, vfo, &mode, &width);
+
+            if (mode & RIG_MODE_RTTY || mode & RIG_MODE_RTTYR)
+            {
+                priv->question_mark_response_means_rejected = 1;
+            }
+        }
         break;
 
     case RIG_LEVEL_METER:
@@ -3577,9 +3597,6 @@ int newcat_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
                 priv->cmd_str[2] = main_sub_vfo;
             }
         }
-
-        // Some Yaesu rigs reject this command in AM/FM modes
-        priv->question_mark_response_means_rejected = 1;
         break;
 
     case RIG_LEVEL_COMP:
@@ -4026,6 +4043,18 @@ int newcat_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
             priv->cmd_str[2] = main_sub_vfo;
         }
 
+        // Some Yaesu rigs reject this command in FM mode
+        if (is_ft991 || is_ftdx5000 || is_ftdx101)
+        {
+            pbwidth_t width;
+            rmode_t mode;
+            err = newcat_get_mode(rig, vfo, &mode, &width);
+
+            if (mode & RIG_MODE_FM || mode & RIG_MODE_FMN)
+            {
+                priv->question_mark_response_means_rejected = 1;
+            }
+        }
         break;
 
     case RIG_LEVEL_CWPITCH:
@@ -4310,6 +4339,9 @@ int newcat_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     }
 
     err = newcat_get_cmd(rig);
+
+    // Clear flag after executing command
+    priv->question_mark_response_means_rejected = 0;
 
     if (err != RIG_OK)
     {
@@ -4867,8 +4899,18 @@ int newcat_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
             priv->cmd_str[2] = main_sub_vfo;
         }
 
-        // Some Yaesu rigs reject this command in AM/FM modes
-        priv->question_mark_response_means_rejected = 1;
+        // Some Yaesu rigs reject this command in FM mode
+        if (is_ft991 || is_ftdx5000 || is_ftdx101)
+        {
+            pbwidth_t width;
+            rmode_t mode;
+            err = newcat_get_mode(rig, vfo, &mode, &width);
+
+            if (mode & RIG_MODE_FM || mode & RIG_MODE_FMN)
+            {
+                priv->question_mark_response_means_rejected = 1;
+            }
+        }
         break;
 
     case RIG_FUNC_MN:
@@ -4885,8 +4927,18 @@ int newcat_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
             priv->cmd_str[2] = main_sub_vfo;
         }
 
-        // Some Yaesu rigs reject this command in AM/FM modes
-        priv->question_mark_response_means_rejected = 1;
+        // Some Yaesu rigs reject this command in FM mode
+        if (is_ft991 || is_ftdx5000 || is_ftdx101)
+        {
+            pbwidth_t width;
+            rmode_t mode;
+            err = newcat_get_mode(rig, vfo, &mode, &width);
+
+            if (mode & RIG_MODE_FM || mode & RIG_MODE_FMN)
+            {
+                priv->question_mark_response_means_rejected = 1;
+            }
+        }
         break;
 
     case RIG_FUNC_FBKIN:
@@ -4991,8 +5043,18 @@ int newcat_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
             priv->cmd_str[2] = main_sub_vfo;
         }
 
-        // Some Yaesu rigs reject this command in AM/FM modes
-        priv->question_mark_response_means_rejected = 1;
+        // Some Yaesu rigs reject this command in FM mode
+        if (is_ft991 || is_ftdx5000 || is_ftdx101)
+        {
+            pbwidth_t width;
+            rmode_t mode;
+            err = newcat_get_mode(rig, vfo, &mode, &width);
+
+            if (mode & RIG_MODE_FM || mode & RIG_MODE_FMN)
+            {
+                priv->question_mark_response_means_rejected = 1;
+            }
+        }
         break;
 
     case RIG_FUNC_COMP:
@@ -5100,6 +5162,18 @@ int newcat_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
             priv->cmd_str[2] = main_sub_vfo;
         }
 
+        // Some Yaesu rigs reject this command in FM mode
+        if (is_ft991 || is_ftdx5000 || is_ftdx101)
+        {
+            pbwidth_t width;
+            rmode_t mode;
+            err = newcat_get_mode(rig, vfo, &mode, &width);
+
+            if (mode & RIG_MODE_FM || mode & RIG_MODE_FMN)
+            {
+                priv->question_mark_response_means_rejected = 1;
+            }
+        }
         break;
 
     case RIG_FUNC_MN:
@@ -5261,7 +5335,12 @@ int newcat_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
         return -RIG_EINVAL;
     }
 
-    if (RIG_OK != (err = newcat_get_cmd(rig)))
+    err = newcat_get_cmd(rig);
+
+    // Clear flag after executing command
+    priv->question_mark_response_means_rejected = 0;
+
+    if (err != RIG_OK)
     {
         return err;
     }

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -4061,10 +4061,10 @@ int newcat_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
             priv->cmd_str[2] = main_sub_vfo;
         }
 
-        // Some Yaesu rigs reject this command in FM mode
+        // Some Yaesu rigs reject this command in AM/FM modes
         if (is_ft991 || is_ftdx5000 || is_ftdx101)
         {
-            if (mode & RIG_MODE_FM || mode & RIG_MODE_FMN)
+            if (mode & RIG_MODE_AM || mode & RIG_MODE_FM || mode & RIG_MODE_AMN || mode & RIG_MODE_FMN)
             {
                 priv->question_mark_response_means_rejected = 1;
             }

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -3261,10 +3261,18 @@ int newcat_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
         break;
 
-    case RIG_LEVEL_IF:
+    case RIG_LEVEL_IF: {
+        pbwidth_t width;
+        rmode_t mode = 0;
+
         if (!newcat_valid_command(rig, "IS"))
         {
             return -RIG_ENAVAIL;
+        }
+
+        if (is_ft991 || is_ftdx5000 || is_ftdx101)
+        {
+            newcat_get_mode(rig, vfo, &mode, &width);
         }
 
         rig_debug(RIG_DEBUG_TRACE, "%s: LEVEL_IF val.i=%d\n", __func__, val.i);
@@ -3306,16 +3314,13 @@ int newcat_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
         // Some Yaesu rigs reject this command in AM/FM modes
         if (is_ft991 || is_ftdx5000 || is_ftdx101)
         {
-            pbwidth_t width;
-            rmode_t mode;
-            err = newcat_get_mode(rig, vfo, &mode, &width);
-
             if (mode & RIG_MODE_AM || mode & RIG_MODE_FM || mode & RIG_MODE_AMN || mode & RIG_MODE_FMN)
             {
                 priv->question_mark_response_means_rejected = 1;
             }
         }
         break;
+    }
 
     case RIG_LEVEL_CWPITCH:
     {
@@ -3362,10 +3367,18 @@ int newcat_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
         snprintf(priv->cmd_str, sizeof(priv->cmd_str), "KS%03d%c", val.i, cat_term);
         break;
 
-    case RIG_LEVEL_MICGAIN:
+    case RIG_LEVEL_MICGAIN: {
+        pbwidth_t width;
+        rmode_t mode = 0;
+
         if (!newcat_valid_command(rig, "MG"))
         {
             return -RIG_ENAVAIL;
+        }
+
+        if (is_ft991 || is_ftdx5000 || is_ftdx101)
+        {
+            newcat_get_mode(rig, vfo, &mode, &width);
         }
 
         if (is_ftdx1200 || is_ftdx3000 || is_ft891 || is_ft991 || is_ftdx101
@@ -3383,16 +3396,13 @@ int newcat_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
         // Some Yaesu rigs reject this command in RTTY modes
         if (is_ft991 || is_ftdx5000 || is_ftdx101)
         {
-            pbwidth_t width;
-            rmode_t mode;
-            err = newcat_get_mode(rig, vfo, &mode, &width);
-
             if (mode & RIG_MODE_RTTY || mode & RIG_MODE_RTTYR)
             {
                 priv->question_mark_response_means_rejected = 1;
             }
         }
         break;
+    }
 
     case RIG_LEVEL_METER:
         if (!newcat_valid_command(rig, "MS"))
@@ -4029,10 +4039,18 @@ int newcat_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
                  cat_term);
         break;
 
-    case RIG_LEVEL_IF:
+    case RIG_LEVEL_IF: {
+        pbwidth_t width;
+        rmode_t mode = 0;
+
         if (!newcat_valid_command(rig, "IS"))
         {
             return -RIG_ENAVAIL;
+        }
+
+        if (is_ft991 || is_ftdx5000 || is_ftdx101)
+        {
+            newcat_get_mode(rig, vfo, &mode, &width);
         }
 
         snprintf(priv->cmd_str, sizeof(priv->cmd_str), "IS%c%c", main_sub_vfo,
@@ -4046,16 +4064,13 @@ int newcat_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         // Some Yaesu rigs reject this command in FM mode
         if (is_ft991 || is_ftdx5000 || is_ftdx101)
         {
-            pbwidth_t width;
-            rmode_t mode;
-            err = newcat_get_mode(rig, vfo, &mode, &width);
-
             if (mode & RIG_MODE_FM || mode & RIG_MODE_FMN)
             {
                 priv->question_mark_response_means_rejected = 1;
             }
         }
         break;
+    }
 
     case RIG_LEVEL_CWPITCH:
         if (!newcat_valid_command(rig, "KP"))
@@ -4885,10 +4900,18 @@ int newcat_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
 
     switch (func)
     {
-    case RIG_FUNC_ANF:
+    case RIG_FUNC_ANF: {
+        pbwidth_t width;
+        rmode_t mode = 0;
+
         if (!newcat_valid_command(rig, "BC"))
         {
             return -RIG_ENAVAIL;
+        }
+
+        if (is_ft991 || is_ftdx5000 || is_ftdx101)
+        {
+            err = newcat_get_mode(rig, vfo, &mode, &width);
         }
 
         snprintf(priv->cmd_str, sizeof(priv->cmd_str), "BC0%d%c", status ? 1 : 0,
@@ -4902,21 +4925,26 @@ int newcat_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
         // Some Yaesu rigs reject this command in FM mode
         if (is_ft991 || is_ftdx5000 || is_ftdx101)
         {
-            pbwidth_t width;
-            rmode_t mode;
-            err = newcat_get_mode(rig, vfo, &mode, &width);
-
             if (mode & RIG_MODE_FM || mode & RIG_MODE_FMN)
             {
                 priv->question_mark_response_means_rejected = 1;
             }
         }
         break;
+        }
 
-    case RIG_FUNC_MN:
+    case RIG_FUNC_MN: {
+        pbwidth_t width;
+        rmode_t mode = 0;
+
         if (!newcat_valid_command(rig, "BP"))
         {
             return -RIG_ENAVAIL;
+        }
+
+        if (is_ft991 || is_ftdx5000 || is_ftdx101)
+        {
+            newcat_get_mode(rig, vfo, &mode, &width);
         }
 
         snprintf(priv->cmd_str, sizeof(priv->cmd_str), "BP00%03d%c", status ? 1 : 0,
@@ -4930,16 +4958,13 @@ int newcat_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
         // Some Yaesu rigs reject this command in FM mode
         if (is_ft991 || is_ftdx5000 || is_ftdx101)
         {
-            pbwidth_t width;
-            rmode_t mode;
-            err = newcat_get_mode(rig, vfo, &mode, &width);
-
             if (mode & RIG_MODE_FM || mode & RIG_MODE_FMN)
             {
                 priv->question_mark_response_means_rejected = 1;
             }
         }
         break;
+    }
 
     case RIG_FUNC_FBKIN:
         if (!newcat_valid_command(rig, "BI"))
@@ -5029,12 +5054,19 @@ int newcat_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
 
         break;
 
-    case RIG_FUNC_NR:
+    case RIG_FUNC_NR: {
+        pbwidth_t width;
+        rmode_t mode = 0;
+
         if (!newcat_valid_command(rig, "NR"))
         {
             return -RIG_ENAVAIL;
         }
 
+        if (is_ft991 || is_ftdx5000 || is_ftdx101)
+        {
+            newcat_get_mode(rig, vfo, &mode, &width);
+        }
         snprintf(priv->cmd_str, sizeof(priv->cmd_str), "NR0%d%c", status ? 1 : 0,
                  cat_term);
 
@@ -5046,16 +5078,13 @@ int newcat_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
         // Some Yaesu rigs reject this command in FM mode
         if (is_ft991 || is_ftdx5000 || is_ftdx101)
         {
-            pbwidth_t width;
-            rmode_t mode;
-            err = newcat_get_mode(rig, vfo, &mode, &width);
-
             if (mode & RIG_MODE_FM || mode & RIG_MODE_FMN)
             {
                 priv->question_mark_response_means_rejected = 1;
             }
         }
         break;
+    }
 
     case RIG_FUNC_COMP:
         if (!newcat_valid_command(rig, "PR"))
@@ -5149,10 +5178,18 @@ int newcat_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
 
     switch (func)
     {
-    case RIG_FUNC_ANF:
+    case RIG_FUNC_ANF: {
+        pbwidth_t width;
+        rmode_t mode = 0;
+
         if (!newcat_valid_command(rig, "BC"))
         {
             return -RIG_ENAVAIL;
+        }
+
+        if (is_ft991 || is_ftdx5000 || is_ftdx101)
+        {
+            err = newcat_get_mode(rig, vfo, &mode, &width);
         }
 
         snprintf(priv->cmd_str, sizeof(priv->cmd_str), "BC0%c", cat_term);
@@ -5165,16 +5202,13 @@ int newcat_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
         // Some Yaesu rigs reject this command in FM mode
         if (is_ft991 || is_ftdx5000 || is_ftdx101)
         {
-            pbwidth_t width;
-            rmode_t mode;
-            err = newcat_get_mode(rig, vfo, &mode, &width);
-
             if (mode & RIG_MODE_FM || mode & RIG_MODE_FMN)
             {
                 priv->question_mark_response_means_rejected = 1;
             }
         }
         break;
+    }
 
     case RIG_FUNC_MN:
         if (!newcat_valid_command(rig, "BP"))

--- a/rigs/yaesu/newcat.h
+++ b/rigs/yaesu/newcat.h
@@ -50,7 +50,7 @@
 typedef char ncboolean;
 
 /* shared function version */
-#define NEWCAT_VER "20210111"
+#define NEWCAT_VER "20210112"
 
 /* Hopefully large enough for future use, 128 chars plus '\0' */
 #define NEWCAT_DATA_LEN                 129


### PR DESCRIPTION
@mdblack98 Another attempt at fixing #505 -- please check if the retries work now. I can also add conditions for the question_mark flag for particular rig, so please don't close this PR yet as invalid. I just wish to verify that the logic works correctly for all rigs now. Regular set/get VFO/mode/IF etc commands should not be affected by the flag in ANY case.