### PR TITLE
Fix unnecessary rig re-open cycles by refactoring rigctl_parse return values

### DIFF
--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -141,6 +141,15 @@ enum rig_errcode_e {
 };
 
 /**
+ * \brief Determines if the given error code indicates a "soft" error
+ * Soft errors are caused by invalid parameters and software/hardware features
+ * and cannot be fixed by retries or by re-initializing hardware.
+ */
+#define RIG_IS_SOFT_ERRCODE(errcode) (errcode == RIG_EINVAL || errcode == RIG_ENIMPL || errcode == RIG_ERJCTED \
+    || errcode == RIG_ETRUNC || errcode == RIG_ENAVAIL || errcode == RIG_ENTARGET \
+    || errcode == RIG_EVFO || errcode == RIG_EDOM)
+
+/**
  * \brief Token in the netrigctl protocol for returning error code
  */
 #define NETRIGCTL_RET "RPRT "

--- a/rigs/icom/icom.c
+++ b/rigs/icom/icom.c
@@ -6532,20 +6532,6 @@ int icom_get_powerstat(RIG *rig, powerstat_t *status)
             RETURNFUNC(retval);
         }
 
-        if ((ack_len >= 1 && ackbuf[0] != ACK) && (ack_len >= 2 && ackbuf[1] != NAK))
-        {
-            //  if we don't get ACK/NAK some serial corruption occurred
-            // so we'll call it a timeout for retry purposes
-            RETURNFUNC(-RIG_ETIMEOUT);
-        }
-
-        if (ack_len != 1 || (ack_len >= 1 && ackbuf[0] != ACK))
-        {
-            rig_debug(RIG_DEBUG_ERR, "%s: ack NG (%#.2x), len=%d\n", __func__,
-                      ackbuf[0], ack_len);
-            RETURNFUNC(-RIG_ERJCTED);
-        }
-
         *status = ackbuf[1] == S_PWR_ON ? RIG_POWER_ON : RIG_POWER_OFF;
     }
 
@@ -7384,13 +7370,6 @@ int icom_get_raw_buf(RIG *rig, int cmd, int subcmd, int subcmdbuflen,
 
     cmdhead += (subcmd == -1) ? 1 : 2;
     ack_len -= cmdhead;
-
-    if ((ack_len >= 1 && ackbuf[0] != ACK) && (ack_len >= 2 && ackbuf[1] != NAK))
-    {
-        //  if we don't get ACK/NAK some serial corruption occurred
-        // so we'll call it a timeout for retry purposes
-        RETURNFUNC(-RIG_ETIMEOUT);
-    }
 
     rig_debug(RIG_DEBUG_TRACE, "%s: %d\n", __func__, ack_len);
 

--- a/tests/rigctl.c
+++ b/tests/rigctl.c
@@ -611,14 +611,9 @@ int main(int argc, char *argv[])
                                interactive, prompt, &vfo_opt, send_cmd_term,
                                &ext_resp, &resp_sep);
 
-        if (retcode == 2)
-        {
-            exitcode = 2;
-        }
-
         // if we get a hard error we try to reopen the rig again
         // this should cover short dropouts that can occur
-        if (retcode == -RIG_EIO || retcode == 2)
+        if (retcode < 0 && !RIG_IS_SOFT_ERRCODE(-retcode))
         {
             int retry = 3;
             rig_debug(RIG_DEBUG_ERR, "%s: i/o error\n", __func__)
@@ -632,10 +627,9 @@ int main(int argc, char *argv[])
                 rig_debug(RIG_DEBUG_ERR, "%s: rig_open retcode=%d\n", __func__, retcode);
             }
             while (retry-- > 0 && retcode != RIG_OK);
-
         }
     }
-    while (retcode == 0 || retcode == 2 || retcode == -RIG_ENAVAIL);
+    while (retcode == RIG_OK || RIG_IS_SOFT_ERRCODE(-retcode));
 
     if (interactive && prompt)
     {

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -65,7 +65,6 @@ extern int read_history();
 #include <hamlib/rig.h>
 #include "misc.h"
 #include "iofunc.h"
-#include "serial.h"
 #include "sprintflst.h"
 
 #include "rigctl_parse.h"
@@ -662,7 +661,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 {
                     rig_debug(RIG_DEBUG_WARN, "%s: nothing to scan#1? retcode=%d\n", __func__,
                               retcode);
-                    RETURNFUNC(-1);
+                    RETURNFUNC(RIGCTL_PARSE_ERROR);
                 }
 
                 if (cmd != 0xa)
@@ -681,12 +680,12 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                     if (scanfc(fin, "%c", &cmd) < 1)
                     {
                         rig_debug(RIG_DEBUG_WARN, "%s: nothing to scan#2?\n", __func__);
-                        RETURNFUNC(-1);
+                        RETURNFUNC(RIGCTL_PARSE_ERROR);
                     }
                 }
                 else if (cmd == '+' && prompt)
                 {
-                    RETURNFUNC(0);
+                    RETURNFUNC(RIG_OK);
                 }
 
                 if (cmd != '\\'
@@ -704,7 +703,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                     if (scanfc(fin, "%c", &cmd) < 1)
                     {
                         rig_debug(RIG_DEBUG_WARN, "%s: nothing to scan#3?\n", __func__);
-                        RETURNFUNC(-1);
+                        RETURNFUNC(RIGCTL_PARSE_ERROR);
                     }
                 }
                 else if (cmd != '\\'
@@ -717,7 +716,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                          && prompt)
                 {
 
-                    RETURNFUNC(0);
+                    RETURNFUNC(RIG_OK);
                 }
 
                 /* command by name */
@@ -728,7 +727,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                     if (scanfc(fin, "%c", pcmd) < 1)
                     {
                         rig_debug(RIG_DEBUG_WARN, "%s: nothing to scan#4?\n", __func__);
-                        RETURNFUNC(-1);
+                        RETURNFUNC(RIGCTL_PARSE_ERROR);
                     }
 
                     retcode = fscanf(fin, "%s", ++pcmd);
@@ -755,7 +754,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                             fprintf_flush(fout, "\nRig command: ");
                         }
 
-                        RETURNFUNC(0);
+                        RETURNFUNC(RIG_OK);
                     }
 
                     last_was_ret = 1;
@@ -773,11 +772,11 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                     if (scanfc(fin, "%c", &cmd) < 1)
                     {
                         rig_debug(RIG_DEBUG_WARN, "%s: nothing to scan#6?\n", __func__);
-                        RETURNFUNC(-1);
+                        RETURNFUNC(RIGCTL_PARSE_ERROR);
                     }
                 }
 
-                RETURNFUNC(0);
+                RETURNFUNC(RIG_OK);
             }
 
             my_rig->state.vfo_opt = *vfo_opt;
@@ -790,14 +789,14 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 if (interactive && !prompt) { fprintf(fout, "%s0\n", NETRIGCTL_RET); }
 
                 fflush(fout);
-                RETURNFUNC(1);
+                RETURNFUNC(RIGCTL_PARSE_END);
             }
 
             if (cmd == '?')
             {
                 usage_rig(fout);
                 fflush(fout);
-                RETURNFUNC(0);
+                RETURNFUNC(RIG_OK);
             }
         }
         else
@@ -807,11 +806,11 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
 
             if (EOF == retcode)
             {
-                RETURNFUNC(1);
+                RETURNFUNC(RIGCTL_PARSE_END);
             }
             else if (retcode < 0)
             {
-                RETURNFUNC(retcode);
+                RETURNFUNC(RIGCTL_PARSE_ERROR);
             }
             else if ('\0' == command[1])
             {
@@ -832,7 +831,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 fprintf(stderr, "Command '%c' not found!\n", cmd);
             }
 
-            RETURNFUNC(0);
+            RETURNFUNC(RIG_OK);
         }
 
         if (!(cmd_entry->flags & ARG_NOVFO) && *vfo_opt)
@@ -850,7 +849,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 if (scanfc(fin, "%s", arg1) < 1)
                 {
                     rig_debug(RIG_DEBUG_WARN, "%s: nothing to scan#7?\n", __func__);
-                    RETURNFUNC(-1);
+                    RETURNFUNC(RIGCTL_PARSE_ERROR);
                 }
 
                 vfo = rig_parse_vfo(arg1);
@@ -866,7 +865,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 }
                 else if (retcode < 0)
                 {
-                    RETURNFUNC(retcode);
+                    RETURNFUNC(RIGCTL_PARSE_ERROR);
                 }
 
                 vfo = rig_parse_vfo(arg1);
@@ -889,7 +888,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
 
                 if (fgets(arg1, MAXARGSZ, fin) == NULL)
                 {
-                    RETURNFUNC(-1);
+                    RETURNFUNC(RIGCTL_PARSE_ERROR);
                 }
 
                 if (arg1[0] == 0xa)
@@ -903,7 +902,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
 
                     if (fgets(arg1, MAXARGSZ, fin) == NULL)
                     {
-                        RETURNFUNC(-1);
+                        RETURNFUNC(RIGCTL_PARSE_ERROR);
                     }
                 }
 
@@ -931,11 +930,11 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 {
                     fprintf(stderr, "Invalid arg for command '%s'\n",
                             cmd_entry->name);
-                    RETURNFUNC(1);
+                    RETURNFUNC(RIGCTL_PARSE_END);
                 }
                 else if (retcode < 0)
                 {
-                    RETURNFUNC(retcode);
+                    RETURNFUNC(RIGCTL_PARSE_ERROR);
                 }
 
                 p1 = arg1;
@@ -959,7 +958,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 if (scanfc(fin, "%s", arg1) < 1)
                 {
                     rig_debug(RIG_DEBUG_WARN, "%s: nothing to scan#8?\n", __func__);
-                    RETURNFUNC(-1);
+                    RETURNFUNC(RIGCTL_PARSE_ERROR);
                 }
 
                 p1 = arg1;
@@ -976,7 +975,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 }
                 else if (retcode < 0)
                 {
-                    RETURNFUNC(retcode);
+                    RETURNFUNC(RIGCTL_PARSE_ERROR);
                 }
 
                 p1 = arg1;
@@ -1005,7 +1004,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 if (scanfc(fin, "%s", arg2) < 1)
                 {
                     rig_debug(RIG_DEBUG_WARN, "%s: nothing to scan#9?\n", __func__);
-                    RETURNFUNC(-1);
+                    RETURNFUNC(RIGCTL_PARSE_ERROR);
                 }
 
                 p2 = arg2;
@@ -1019,11 +1018,11 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 {
                     fprintf(stderr, "Invalid arg for command '%s'\n",
                             cmd_entry->name);
-                    RETURNFUNC(1);
+                    RETURNFUNC(RIGCTL_PARSE_END);
                 }
                 else if (retcode < 0)
                 {
-                    RETURNFUNC(retcode);
+                    RETURNFUNC(RIGCTL_PARSE_ERROR);
                 }
 
                 p2 = arg2;
@@ -1052,7 +1051,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 if (scanfc(fin, "%s", arg3) < 1)
                 {
                     rig_debug(RIG_DEBUG_WARN, "%s: nothing to scan#10?\n", __func__);
-                    RETURNFUNC(-1);
+                    RETURNFUNC(RIGCTL_PARSE_ERROR);
                 }
 
                 p3 = arg3;
@@ -1067,11 +1066,11 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                     fprintf(stderr,
                             "Invalid arg for command '%s'\n",
                             cmd_entry->name);
-                    RETURNFUNC(1);
+                    RETURNFUNC(RIGCTL_PARSE_END);
                 }
                 else if (retcode < 0)
                 {
-                    RETURNFUNC(retcode);
+                    RETURNFUNC(RIGCTL_PARSE_ERROR);
                 }
 
                 p3 = arg3;
@@ -1098,13 +1097,13 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
         if (!input_line)
         {
             fprintf_flush(fout, "\n");
-            RETURNFUNC(1);
+            RETURNFUNC(RIGCTL_PARSE_END);
         }
 
         /* Q or q to quit */
         if (!(strncasecmp(input_line, "q", 1)))
         {
-            RETURNFUNC(1);
+            RETURNFUNC(RIGCTL_PARSE_END);
         }
 
         /* '?' for help */
@@ -1112,13 +1111,13 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
         {
             usage_rig(fout);
             fflush(fout);
-            RETURNFUNC(0);
+            RETURNFUNC(RIG_OK);
         }
 
         /* '#' for comment */
         if (!(strncmp(input_line, "#", 1)))
         {
-            RETURNFUNC(0);
+            RETURNFUNC(RIG_OK);
         }
 
         /* Blank line entered */
@@ -1126,7 +1125,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
         {
             fprintf(fout, "? for help, q to quit.\n");
             fflush(fout);
-            RETURNFUNC(0);
+            RETURNFUNC(RIG_OK);
         }
 
         rig_debug(RIG_DEBUG_TRACE, "%s: input_line: %s\n", __func__, input_line);
@@ -1149,7 +1148,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
         {
             /* Oops!  Invoke GDB!! */
             fprintf_flush(fout, "\n");
-            RETURNFUNC(1);
+            RETURNFUNC(RIGCTL_PARSE_END);
         }
 
         /* At this point parsed_input contains the typed text of the command
@@ -1208,7 +1207,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 {
                     fprintf(stderr,
                             "Valid multiple character command names contain alphanumeric characters plus '_'\n");
-                    RETURNFUNC(0);
+                    RETURNFUNC(RIG_OK);
                 }
             }
 
@@ -1217,13 +1216,13 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
         /* Single '\' entered, prompt again */
         else if ((*parsed_input[0] == '\\') && (strlen(parsed_input[0]) == 1))
         {
-            RETURNFUNC(0);
+            RETURNFUNC(RIG_OK);
         }
         /* Multiple characters but no leading '\' */
         else
         {
             fprintf(stderr, "Precede multiple character command names with '\\'\n");
-            RETURNFUNC(0);
+            RETURNFUNC(RIG_OK);
         }
 
         cmd_entry = find_cmd_entry(cmd);
@@ -1239,7 +1238,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 fprintf(stderr, "Command '%c' not found!\n", cmd);
             }
 
-            RETURNFUNC(0);
+            RETURNFUNC(RIG_OK);
         }
 
         /* If vfo_opt is enabled (-o|--vfo) check if already given
@@ -1264,7 +1263,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 if (!input_line)
                 {
                     fprintf_flush(fout, "\n");
-                    RETURNFUNC(1);
+                    RETURNFUNC(RIGCTL_PARSE_END);
                 }
 
                 /* Blank line entered */
@@ -1272,7 +1271,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 {
                     fprintf(fout, "? for help, q to quit.\n");
                     fflush(fout);
-                    RETURNFUNC(0);
+                    RETURNFUNC(RIG_OK);
                 }
 
                 /* Get the first token of input, the rest, if any, will be
@@ -1287,7 +1286,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 else
                 {
                     fprintf_flush(fout, "\n");
-                    RETURNFUNC(1);
+                    RETURNFUNC(RIGCTL_PARSE_END);
                 }
             }
 
@@ -1366,7 +1365,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 {
                     fprintf(fout, "? for help, q to quit.\n");
                     fflush(fout);
-                    RETURNFUNC(0);
+                    RETURNFUNC(RIG_OK);
                 }
 
                 if (input_line)
@@ -1376,7 +1375,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 else
                 {
                     fprintf_flush(fout, "\n");
-                    RETURNFUNC(1);
+                    RETURNFUNC(RIGCTL_PARSE_END);
                 }
             }
 
@@ -1428,7 +1427,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 {
                     fprintf(fout, "? for help, q to quit.\n");
                     fflush(fout);
-                    RETURNFUNC(0);
+                    RETURNFUNC(RIG_OK);
                 }
 
                 result = strtok(input_line, " ");
@@ -1440,7 +1439,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 else
                 {
                     fprintf_flush(fout, "\n");
-                    RETURNFUNC(1);
+                    RETURNFUNC(RIGCTL_PARSE_END);
                 }
             }
 
@@ -1494,7 +1493,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 {
                     fprintf(fout, "? for help, q to quit.\n");
                     fflush(fout);
-                    RETURNFUNC(0);
+                    RETURNFUNC(RIG_OK);
                 }
 
                 result = strtok(input_line, " ");
@@ -1506,7 +1505,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 else
                 {
                     fprintf_flush(fout, "\n");
-                    RETURNFUNC(1);
+                    RETURNFUNC(RIGCTL_PARSE_END);
                 }
             }
 
@@ -1560,7 +1559,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 {
                     fprintf(fout, "? for help, q to quit.\n");
                     fflush(fout);
-                    RETURNFUNC(0);
+                    RETURNFUNC(RIG_OK);
                 }
 
                 result = strtok(input_line, " ");
@@ -1572,7 +1571,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                 else
                 {
                     fprintf_flush(fout, "\n");
-                    RETURNFUNC(1);
+                    RETURNFUNC(RIGCTL_PARSE_END);
                 }
             }
 
@@ -1669,7 +1668,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
 
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo_opt=%d\n", __func__, *vfo_opt);
 
-    if (retcode == RIG_EIO)
+    if (retcode == -RIG_EIO)
     {
         rig_debug(RIG_DEBUG_ERR, "%s: RIG_EIO?\n", __func__);
 
@@ -1727,12 +1726,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
 
     if (sync_cb) { sync_cb(0); }    /* unlock if necessary */
 
-    if (retcode == -RIG_ENAVAIL)
-    {
-        RETURNFUNC(retcode);
-    }
-
-    RETURNFUNC(retcode != RIG_OK ? 2 : 0);
+    RETURNFUNC(retcode);
 }
 
 

--- a/tests/rigctl_parse.h
+++ b/tests/rigctl_parse.h
@@ -28,6 +28,9 @@
 #include <stdio.h>
 #include <hamlib/rig.h>
 
+#define RIGCTL_PARSE_END 1
+#define RIGCTL_PARSE_ERROR 2
+
 /*
  * external prototype
  */


### PR DESCRIPTION
The current command loop in both `rigctl` and the `rigctld` server perform rig close/open cycles in case of hardware or I/O errors. However, the logic to detect these errors is not very accurate, as `rigctl_parse` returns value `2` (indicating re-open is required) for all `RIG_E*` errors from `rig_` commands. There are many errors, e.g. "invalid parameter", which do not indicate an issue in the rig communication and re-opening the rig is totally unnecessary in this case.

Re-opening the rig causes real trouble when there are multiple clients connected to `rigctld` server and one of the clients issues a command resulting in "invalid parameter" error, for example. This will lead to the rig being unavailable for some time all other clients. See #612 for a more detailed explanation.

This PR includes:

1) New, more deterministic return values in `rigctl_prase` function. The function returns the negative `RIG_E*` errors as they are, uses `RIG_OK` for indicating a successful command and two positive integers `RIGCTL_PARSE_END` (1) and `RIGCTL_PARSE_ERROR` (2) to indicate end-of-stream and other internal parsing errors -- both of which will make the command loop exit.

2) New macro `RIG_IS_SOFT_ERRCODE` for determining if a particular error code is a "soft error", indicating it is not a hardware or I/O fault and cannot be potentially fixed by re-opening the rig. The soft errcodes are: RIG_EINVAL, RIG_ENIMPL, RIG_ERJCTED, RIG_ETRUNC, RIG_ENAVAIL, RIG_ENTARGET, RIG_EVFO and RIG_EDOM.

3) Some fixes to Icom backend to remove ACK/NAK detection in commands that get/read data from the rig, as the ACK/NAK bytes are present in responses to commands that set/change the rig state only.
