### PR TITLE
prm80: fix RX frequencies on VHF

### DIFF
--- a/rigs/prm80/prm80.h
+++ b/rigs/prm80/prm80.h
@@ -24,7 +24,7 @@
 
 #include <hamlib/rig.h>
 
-#define BACKEND_VER "20210315"
+#define BACKEND_VER "20210416"
 
 #define PRM80_MEM_CAP {    \
         .freq = 1,  \


### PR DESCRIPTION
The RX IF shift on VHF is the opposite than on UHF.

Tested-by: Claus <claus.moessner@web.de>