### PR TITLE
Fix rig_get_ant NULL check

### DIFF
--- a/src/rig.c
+++ b/src/rig.c
@@ -5087,7 +5087,7 @@ int HAMLIB_API rig_get_ant(RIG *rig, vfo_t vfo, ant_t ant, value_t *option,
         RETURNFUNC(-RIG_EIO);
     }
 
-    if (ant_curr)
+    if (ant_curr == NULL)
     {
         RETURNFUNC(-RIG_EINVAL);
     }


### PR DESCRIPTION
The `rig_get_ant` function doesn't work currently, as there is a typo in the code. This fixes it.

However, I'm wondering if there should be null checks for `ant_tx` and `ant_rx` too? Now the code simply sets value to those pointers without any checks.