### PR TITLE
Use GNU Source-highlight for documentation build

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,51 +7,52 @@ Copyright (C) 2000-2021  Michael Black W9MDB, and others
 Please send Hamlib bug reports to hamlib-developer@lists.sourceforge.net
 
 Version 4.3
-    * 2021-??-??
+        * 2021-??-??
+        * Generating documentation now requires GNU source-highlighter.
 
 Version 4.2
-    * 2021-05-17
-    * New rig_get_mode_bandwidths -- returns token set for bandwidths for given mode
-        Rig command: \get_mode_bandwidths CW
-        Mode=CW
-        Normal=500Hz
-        Narrow=50Hz
-        Wide=2400Hz
-    * New rig_get_info  -- returns token set for all vfos where order does not matter
-      This is a string return to allow for easy future expansion without changing the API
-      New tokens may be introduced and can be skipped if not used by clients
-        Rig command: \get_rig_info
-        VFO=Main Freq=145000000 Mode=None Width=0 RX=1 TX=1
-        VFO=VFOB Freq=145000000 Mode=FM Width=15000 RX=0 TX=0
-        Split=0 SatMode=0
-        Rig=Dummy
-        App=Hamlib
-        Version=20210429
-        CRC=0xf49f4708
-    * New rig_get_vfo_info
-        Rig command: \get_vfo_info VFOA
-        Freq: 145000000
-        Mode: None
-        Width: 0
-        Split: 0
-        SatMode: 0
+        * 2021-05-17
+        * New rig_get_mode_bandwidths -- returns token set for bandwidths for given mode
+              Rig command: \get_mode_bandwidths CW
+              Mode=CW
+              Normal=500Hz
+              Narrow=50Hz
+              Wide=2400Hz
+        * New rig_get_info  -- returns token set for all vfos where order does not matter
+          This is a string return to allow for easy future expansion without changing the API
+          New tokens may be introduced and can be skipped if not used by clients
+              Rig command: \get_rig_info
+              VFO=Main Freq=145000000 Mode=None Width=0 RX=1 TX=1
+              VFO=VFOB Freq=145000000 Mode=FM Width=15000 RX=0 TX=0
+              Split=0 SatMode=0
+              Rig=Dummy
+              App=Hamlib
+              Version=20210429
+              CRC=0xf49f4708
+        * New rig_get_vfo_info
+              Rig command: \get_vfo_info VFOA
+              Freq: 145000000
+              Mode: None
+              Width: 0
+              Split: 0
+              SatMode: 0
 
-    * FILPATHLEN has changed to HAMLIB_FILPATHLEN
+        * FILPATHLEN has changed to HAMLIB_FILPATHLEN
 
-    * USRP lib and gnuradio are deprecated and will be removed in 5.0
-    * Added Radan rotator
-    * Added Malachite SDR
-    * Major rework for PRM80
-    * Add twiddle_timeout and twiddle_rit --set-conf options
-        rigctld --set-conf=twiddle_timeout=5,twiddle_rit=1
-        This will set the twiddle timeout to 5 seconds and turn on twiddle_rit
-        For twiddle timeout VFOB will not be polled for 5 seconds after VFO twiddling
-	is detected
-    * rigctld --twiddle is deprecated and will be removed in 5.0 along with
-      get_twiddle and set_twiddle
-    * Rework Doxygen manual including default layout for Doxygen 1.9.1.  So far
-      the amplifier, rotator, and utilities API sections have been updated.  The
-      rig (radio) section remains to be updated.
+        * USRP lib and gnuradio are deprecated and will be removed in 5.0
+        * Added Radan rotator
+        * Added Malachite SDR
+        * Major rework for PRM80
+        * Add twiddle_timeout and twiddle_rit --set-conf options
+              rigctld --set-conf=twiddle_timeout=5,twiddle_rit=1
+              This will set the twiddle timeout to 5 seconds and turn on twiddle_rit
+              For twiddle timeout VFOB will not be polled for 5 seconds after VFO twiddling
+	      is detected
+        * rigctld --twiddle is deprecated and will be removed in 5.0 along with
+          get_twiddle and set_twiddle
+        * Rework Doxygen manual including default layout for Doxygen 1.9.1.  So far
+          the amplifier, rotator, and utilities API sections have been updated.  The
+          rig (radio) section remains to be updated.
 
 Version 4.1
         2021-01-31

--- a/README.developer
+++ b/README.developer
@@ -269,6 +269,7 @@ backend.  The older version of libusb 0.1.x is no longer supported.
 
 Documentation:
 * Doxygen
+* GNU Source-highlight
 
 N.B.:  Some systems can have several versions of the autotools installed. In
 that case, autoconf may be called "autoconf2.59", autoheader

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -8,5 +8,16 @@ dist_man_MANS = man1/ampctl.1 man1/ampctld.1 \
 SRCDOCLST = ../src/rig.c ../src/rotator.c ../src/tones.c ../src/locator.c \
 	../src/event.c ../src/conf.c ../src/mem.c ../src/settings.c
 
+SCRIPTSLST = build-w32.sh build-w64.sh
+
+
+# Use GNU source-highlight to generate highlighted shell scripts for the
+# Doxygen manual.
 doc: hamlib.cfg $(SRCDOCLST)
+	for script in $(SCRIPTSLST) ; do \
+		source-highlight -n -i $(top_srcdir)/scripts/$${script} -o $(top_builddir)/scripts/$${script}.html ; \
+	done ; \
 	doxygen hamlib.cfg
+
+clean-local:
+	-rm -rf $(top_builddir)/doc/html $(top_builddir)/scripts/build-w*.sh.html

--- a/doc/hamlib.cfg.in
+++ b/doc/hamlib.cfg.in
@@ -30,8 +30,8 @@ INCLUDE_PATH     = @top_srcdir@/include
 EXAMPLE_PATH     = @top_srcdir@/tests/testrig.c \
                    @top_srcdir@ \
                    @top_srcdir@/scripts/README.build-Windows \
-                   @top_srcdir@/scripts/build-w32.sh \
-                   @top_srcdir@/scripts/build-w64.sh
+                   @top_builddir@/scripts/build-w32.sh.html \
+                   @top_builddir@/scripts/build-w64.sh.html
 
 
 QUIET            = YES

--- a/doc/index.doxygen
+++ b/doc/index.doxygen
@@ -87,9 +87,9 @@ GNU/Linux.
 \section Build README.build-Windows
 \verbinclude README.build-Windows
 \subsection W32 The build-w32.sh script
-\include{lineno} build-w32.sh
+\htmlinclude build-w32.sh.html
 \subsection W64 The build-w64.sh script
-\include{lineno} build-w64.sh
+\htmlinclude build-w64.sh.html
 */
 
 /*! \page Rdmeosx README.osx


### PR DESCRIPTION
Generate highlighted and line numbered files for the Windows build
scripts to be included in the generated documentation.

Add clean-local target to doc/Makefile.am to clean generated document
files.

Document requirement for GNU Source-highlight.