### PR TITLE
Remove security page as it is for GitHub only

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,8 @@ pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = hamlib.pc
 
 EXTRA_DIST = PLAN LICENSE hamlib.m4 hamlib.pc.in README.developer \
-	README.betatester README.win32 Android.mk
+	README.betatester README.freqranges README.multicast README.osx \
+	Android.mk
 
 doc_DATA = ChangeLog COPYING COPYING.LIB LICENSE \
 	README README.betatester README.developer

--- a/doc/index.doxygen
+++ b/doc/index.doxygen
@@ -24,7 +24,6 @@ These text files are distributed with the Hamlib package.
 \subpage Rdmeosx "Mac OS X";
 \subpage Rdmefrq "Frequency range changes";
 \subpage Rdmemulti "Multicast support";
-\subpage Security "Security policy";
 
 \li Other files: \subpage INSTALL;
 \subpage AUTHORS;
@@ -102,11 +101,6 @@ GNU/Linux.
 
 /*! \page Rdmemulti README.multicast
 \verbinclude README.multicast
-*/
-
-/* FIXME: figure out how to include Markdown for HTML output. */
-/*! \page Security SECURITY.md
-\include SECURITY.md
 */
 
 /*! \page INSTALL INSTALL


### PR DESCRIPTION
Distribute other files ommitted from the 4.2 release for documentation
generation.  Caveat--don't rush!