### PR TITLE
Attempt to handle asynchronous rig output data in Icom backend

### DIFF
--- a/rigs/icom/frame.c
+++ b/rigs/icom/frame.c
@@ -346,6 +346,7 @@ read_another_frame:
         RETURNFUNC(-RIG_EPROTO);
     }
 
+    // TODO: Does ctrlid (detected by icom_is_async_frame) vary (seeing some code above using 0x80 for non-full-duplex)?
     if (icom_is_async_frame(rig, frm_len, buf))
     {
         int elapsed_ms;

--- a/rigs/icom/frame.h
+++ b/rigs/icom/frame.h
@@ -28,6 +28,7 @@
  * helper functions
  */
 int make_cmd_frame(char frame[], char re_id, char ctrl_id, char cmd, int subcmd, const unsigned char *data, int data_len);
+int icom_frame_fix_preamble(int frame_len, unsigned char *frame);
 
 int icom_transaction (RIG *rig, int cmd, int subcmd, const unsigned char *payload, int payload_len, unsigned char *data, int *data_len);
 int read_icom_frame(hamlib_port_t *p, unsigned char rxbuffer[], int rxbuffer_len);

--- a/rigs/icom/icom.c
+++ b/rigs/icom/icom.c
@@ -8061,9 +8061,6 @@ static int icom_parse_spectrum_frame(RIG *rig, int length, const unsigned char *
 
 int icom_is_async_frame(RIG *rig, int frame_len, const unsigned char *frame)
 {
-    struct rig_state *rs = &rig->state;
-    struct icom_priv_data *priv = (struct icom_priv_data *) rs->priv;
-
     if (frame_len < ACKFRMLEN)
     {
         return 0;
@@ -8167,7 +8164,7 @@ int icom_decode_event(RIG *rig)
 
     if (frm_len < 1)
     {
-        RETURNFUNC(0);
+        RETURNFUNC(RIG_OK);
     }
 
     retval = icom_frame_fix_preamble(frm_len, buf);

--- a/rigs/icom/icom.h
+++ b/rigs/icom/icom.h
@@ -387,6 +387,8 @@ int icom_set_custom_parm_time(RIG *rig, int parmbuflen, unsigned char *parmbuf,
 int icom_get_custom_parm_time(RIG *rig, int parmbuflen, unsigned char *parmbuf,
                               int *seconds);
 int icom_get_freq_range(RIG *rig);
+int icom_is_async_frame(RIG *rig, int frame_len, const unsigned char *frame);
+int icom_process_async_frame(RIG *rig, int frame_len, const unsigned char *frame);
 
 extern const struct confparams icom_cfg_params[];
 extern const struct confparams icom_ext_levels[];

--- a/src/misc.c
+++ b/src/misc.c
@@ -1904,7 +1904,7 @@ int HAMLIB_API parse_hoststr(char *hoststr, char host[256], char port[6])
     return -1;
 }
 
-#undef RIG_FLUSH_REMOVE
+#define RIG_FLUSH_REMOVE
 int HAMLIB_API rig_flush(hamlib_port_t *port)
 {
 #ifndef RIG_FLUSH_REMOVE


### PR DESCRIPTION
This is an attempt to handle asynchronous (transceive/spectrum) data in Icom backend. The basic detection of async CI-V frames in `icom_one_transaction()` works properly and it delivers these frames to `icom_process_async_frame()` while waiting for the actual command response.

I was trying to make async data handling work with the SIGIO (`set_trn RIG`) signals, but having two routines read the serial port data does not work reliably, so that part of the code has to be rewritten. Without `set_trn RIG` active, the code still works correctly.
