### PR TITLE
Rshfiq aug2021

### DIFF
--- a/rigs/kit/rs_hfiq.c
+++ b/rigs/kit/rs_hfiq.c
@@ -38,6 +38,8 @@
 
 #define RSHFIQ_INIT_RETRY 5
 
+#define RSHFIQ_LEVEL_ALL (RIG_LEVEL_RFPOWER_METER)
+
 static int rshfiq_open(RIG *rig)
 {
     int retval;
@@ -166,6 +168,8 @@ static int rshfiq_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
         return retval;
     }
 
+    rig_debug(RIG_DEBUG_TRACE, "%s: reply = %s\n", __func__, cmdstr);
+
     cmdstr[retval] = 0;
     *freq = atoi(cmdstr);
 
@@ -202,24 +206,77 @@ static int rshfiq_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
     return retval;
 }
 
-static int rsfhiq_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
+static int rshfiq_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
-    switch (level)
-    {
-        case RIG_LEVEL_TEMP_METER:
-            return -RIG_ENIMPL;
-            break;
-    }
-    return -RIG_ENIMPL;
-}
+    rig_debug(RIG_DEBUG_VERBOSE, "%s called. level type =%qd\n", __func__, level);
 
+    char cmdstr[15];
+    char stopset[2];
+    int retval;
+
+    if (!val)
+    {
+        return -RIG_EINVAL;
+    }
+
+        switch (level)
+        {
+            //Requires RS-HFIQ firmware version 4 or later
+            case RIG_LEVEL_RFPOWER_METER:
+
+                rig_flush(&rig->state.rigport);
+
+                snprintf(cmdstr, sizeof(cmdstr), "*L\r");
+
+                rig_debug(RIG_DEBUG_TRACE, "RIG_LEVEL_RFPOWER_METER command=%s\n", cmdstr);
+
+                retval = write_block(&rig->state.rigport, cmdstr, strlen(cmdstr));
+
+                if (retval != RIG_OK)
+                {
+                    return retval;
+                }
+
+                stopset[0] = '\r';
+                stopset[1] = '\n';
+
+                retval = read_string(&rig->state.rigport, cmdstr, 9, stopset, 2);
+
+                rig_debug(RIG_DEBUG_TRACE, "RIG_LEVEL_RFPOWER_METER reply=%s\n", cmdstr);
+
+                if (retval <= 0)
+                {
+                    return retval;
+                }
+
+                cmdstr[retval] = 0;
+
+                //Range is 0-110. Unit is percent
+                val->i = atoi(cmdstr);
+                val->f = (float)(val->i) / 100;
+
+                rig_debug(RIG_DEBUG_TRACE, "RIG_LEVEL_RFPOWER_METER val=%f\n", val->f);
+
+                return RIG_OK;
+                break;
+
+            case RIG_LEVEL_TEMP_METER:
+                return -RIG_ENIMPL;
+                break;
+        break;
+    default:
+        rig_debug(RIG_DEBUG_TRACE, "%s: Unrecognized RIG_LEVEL_* enum: %qu\n", __func__, level);
+        break;
+    }
+    return -RIG_EINVAL;
+}
 
 const struct rig_caps rshfiq_caps =
 {
     RIG_MODEL(RIG_MODEL_RSHFIQ),
     .model_name =     "RS-HFIQ",
     .mfg_name =       "HobbyPCB",
-    .version =        "20210802.0",
+    .version =        "20210803.0",
     .copyright =      "LGPL",
     .status =         RIG_STATUS_STABLE,
     .rig_type =       RIG_TYPE_TRANSCEIVER,
@@ -236,6 +293,8 @@ const struct rig_caps rshfiq_caps =
     .post_write_delay =  1,
     .timeout =  1000,
     .retry =  3,
+
+    .has_get_level = RSHFIQ_LEVEL_ALL,
 
     .rx_range_list1 =  { {.startf = kHz(3500), .endf = MHz(30), .modes = RIG_MODE_NONE, .low_power = -1, .high_power = -1, RIG_VFO_A},
         RIG_FRNG_END,
@@ -258,8 +317,7 @@ const struct rig_caps rshfiq_caps =
     .get_freq =     rshfiq_get_freq,
     .set_freq =     rshfiq_set_freq,
     .set_ptt  =     rshfiq_set_ptt,
-    .has_get_level =      RIG_LEVEL_TEMP_METER,
-    .get_level =          rsfhiq_get_level,
+    .get_level=     rshfiq_get_level,
 
 };
 

--- a/rigs/kit/rs_hfiq.c
+++ b/rigs/kit/rs_hfiq.c
@@ -40,6 +40,8 @@
 
 #define RSHFIQ_LEVEL_ALL (RIG_LEVEL_RFPOWER_METER|RIG_LEVEL_TEMP_METER)
 
+int rshfiq_version_major, rshfiq_version_minor;
+
 static int rshfiq_open(RIG *rig)
 {
     int retval;
@@ -113,6 +115,17 @@ static int rshfiq_open(RIG *rig)
         rig_debug(RIG_DEBUG_WARN, "%s: Invalid Rigversion: %s\n", __func__, versionstr);
         return -RIG_ECONF;
     }
+
+    retval = sscanf(versionstr, "RS-HFIQ FW %d.%d", &rshfiq_version_major, &rshfiq_version_minor);
+    
+    if (retval <= 0)
+    {
+        rig_debug(RIG_DEBUG_WARN, "%s: Failed to parse RS-HFIQ firmware version string. Defaulting to 2.0.\n", __func__);
+        rshfiq_version_major = 2;
+        rshfiq_version_minor = 0;
+    }
+
+    rig_debug(RIG_DEBUG_VERBOSE, "RS-HFIQ returned firmware version major=%d minor=%d\n", rshfiq_version_major, rshfiq_version_minor);
 
     return RIG_OK;
 }


### PR DESCRIPTION
Implements TX drive level query, board temperature query to rs_hfiq.c.

Also gathers the RS-HFIQ's major/minor firmware version.

The RIG_LEVEL_RFPOWER_METER implementation uses undocumented commands found in v4 of the firmware's source code. v3 has the same *L command but with different behavior. RIG_LEVEL_RFPOWER_METER query will return -RIG_ENAVAIL if firmware is below 4.x. The firmware behavior may change again in later versions and I will keep an eye on it to add more version clauses to handle the different behaviors if feasible.

**Note to end-users:** The RS-HFIQ's internally-measured TX power level fluctuates. A good strategy in practice would be to poll about twice per second and watch the readings. Driving below readings of 0.9 seems to be a good balance between drive and clip avoidance.