### PR TITLE
Move priv_data structs of ft100, ft600, ft817, ft857, ft897 to the C file

### DIFF
--- a/rigs/yaesu/ft100.c
+++ b/rigs/yaesu/ft100.c
@@ -41,6 +41,13 @@
 #include "misc.h"
 #include "bandplan.h"
 
+struct ft100_priv_data {
+  /* TODO: make use of cached data */
+  FT100_STATUS_INFO status;
+  FT100_FLAG_INFO flags;
+};
+
+
 /* prototypes */
 
 static int ft100_send_priv_cmd(RIG *rig, unsigned char cmd_index);

--- a/rigs/yaesu/ft100.h
+++ b/rigs/yaesu/ft100.h
@@ -127,13 +127,6 @@ typedef struct
 FT100_FLAG_INFO;
 
 
-struct ft100_priv_data {
-  /* TODO: make use of cached data */
-  FT100_STATUS_INFO status;
-  FT100_FLAG_INFO flags;
-};
-
-
 static int ft100_init(RIG *rig);
 static int ft100_open(RIG *rig);
 static int ft100_cleanup(RIG *rig);

--- a/rigs/yaesu/ft600.c
+++ b/rigs/yaesu/ft600.c
@@ -41,6 +41,14 @@
 #include "misc.h"
 #include "bandplan.h"
 
+struct ft600_priv_data {
+  FT600_STATUS_INFO status;
+  FT600_FLAG_INFO flags;
+  unsigned char s_meter;
+
+};
+
+
 /* prototypes */
 static int ft600_send_priv_cmd(RIG *rig, unsigned char cmd_index);
 

--- a/rigs/yaesu/ft600.h
+++ b/rigs/yaesu/ft600.h
@@ -112,14 +112,6 @@ typedef struct
 FT600_FLAG_INFO;
 
 
-struct ft600_priv_data {
-  FT600_STATUS_INFO status;
-  FT600_FLAG_INFO flags;
-  unsigned char s_meter;
-
-};
-
-
 static int ft600_init(RIG *rig);
 static int ft600_open(RIG *rig);
 static int ft600_cleanup(RIG *rig);

--- a/rigs/yaesu/ft817.c
+++ b/rigs/yaesu/ft817.c
@@ -73,8 +73,6 @@
 
 struct ft817_priv_data
 {
-    yaesu_cmd_set_t pcs[FT817_NATIVE_SIZE];  /* TODO:  why? */
-
     /* rx status */
     struct timeval rx_status_tv;
     unsigned char rx_status;
@@ -497,8 +495,6 @@ const struct rig_caps ft818_caps =
 
 int ft817_init(RIG *rig)
 {
-    struct ft817_priv_data *priv;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s: called, version %s\n", __func__,
               rig->caps->version);
 
@@ -508,9 +504,6 @@ int ft817_init(RIG *rig)
     }
 
     priv = rig->state.priv;
-
-    /* Copy complete native cmd set to private cmd storage area */
-    memcpy(priv->pcs, ncmd, sizeof(ncmd));
 
     return RIG_OK;
 }
@@ -582,12 +575,11 @@ static int check_cache_timeout(struct timeval *tv)
 
 static int ft817_read_eeprom(RIG *rig, unsigned short addr, unsigned char *out)
 {
-    struct ft817_priv_data *p = (struct ft817_priv_data *) rig->state.priv;
     unsigned char data[YAESU_CMD_LENGTH];
     int n;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: called\n", __func__);
-    memcpy(data, (char *)p->pcs[FT817_NATIVE_CAT_EEPROM_READ].nseq,
+    memcpy(data, ncmd[FT817_NATIVE_CAT_EEPROM_READ].nseq,
            YAESU_CMD_LENGTH);
 
     data[0] = addr >> 8;
@@ -649,7 +641,7 @@ static int ft817_get_status(RIG *rig, int status)
     do
     {
         rig_flush(&rig->state.rigport);
-        write_block(&rig->state.rigport, (char *) p->pcs[status].nseq,
+        write_block(&rig->state.rigport, (char *) ncmd[status].nseq,
                     YAESU_CMD_LENGTH);
         n = read_block(&rig->state.rigport, (char *) data, len);
     }
@@ -1082,18 +1074,16 @@ int ft817_read_ack(RIG *rig)
  */
 static int ft817_send_cmd(RIG *rig, int index)
 {
-    struct ft817_priv_data *p = (struct ft817_priv_data *) rig->state.priv;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s: called\n", __func__);
 
-    if (p->pcs[index].ncomp == 0)
+    if (ncmd[index].ncomp == 0)
     {
         rig_debug(RIG_DEBUG_VERBOSE, "%s: Incomplete sequence\n", __func__);
         return -RIG_EINTERNAL;
     }
 
     rig_flush(&rig->state.rigport);
-    write_block(&rig->state.rigport, (char *) p->pcs[index].nseq, YAESU_CMD_LENGTH);
+    write_block(&rig->state.rigport, (char *) ncmd[index].nseq, YAESU_CMD_LENGTH);
     return ft817_read_ack(rig);
 }
 
@@ -1102,18 +1092,17 @@ static int ft817_send_cmd(RIG *rig, int index)
  */
 static int ft817_send_icmd(RIG *rig, int index, unsigned char *data)
 {
-    struct ft817_priv_data *p = (struct ft817_priv_data *) rig->state.priv;
     unsigned char cmd[YAESU_CMD_LENGTH];
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: called\n", __func__);
 
-    if (p->pcs[index].ncomp == 1)
+    if (ncmd[index].ncomp == 1)
     {
         rig_debug(RIG_DEBUG_VERBOSE, "%s: Complete sequence\n", __func__);
         return -RIG_EINTERNAL;
     }
 
-    cmd[YAESU_CMD_LENGTH - 1] = p->pcs[index].nseq[YAESU_CMD_LENGTH - 1];
+    cmd[YAESU_CMD_LENGTH - 1] = ncmd[index].nseq[YAESU_CMD_LENGTH - 1];
     memcpy(cmd, data, YAESU_CMD_LENGTH - 1);
 
     write_block(&rig->state.rigport, (char *) cmd, YAESU_CMD_LENGTH);
@@ -1512,8 +1501,6 @@ int ft817_set_rit(RIG *rig, vfo_t vfo, shortfreq_t rit)
 
 int ft817_set_powerstat(RIG *rig, powerstat_t status)
 {
-    struct ft817_priv_data *p = (struct ft817_priv_data *) rig->state.priv;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s: called\n", __func__);
 
     switch (status)
@@ -1524,9 +1511,9 @@ int ft817_set_powerstat(RIG *rig, powerstat_t status)
     case RIG_POWER_ON:
         // send 5 bytes first, snooze a bit, then PWR_ON
         write_block(&rig->state.rigport,
-                    (char *) p->pcs[FT817_NATIVE_CAT_PWR_WAKE].nseq, YAESU_CMD_LENGTH);
+                    (char *) ncmd[FT817_NATIVE_CAT_PWR_WAKE].nseq, YAESU_CMD_LENGTH);
         hl_usleep(200 * 1000);
-        write_block(&rig->state.rigport, (char *) p->pcs[FT817_NATIVE_CAT_PWR_ON].nseq,
+        write_block(&rig->state.rigport, (char *) ncmd[FT817_NATIVE_CAT_PWR_ON].nseq,
                     YAESU_CMD_LENGTH);
         return RIG_OK;
 

--- a/rigs/yaesu/ft817.c
+++ b/rigs/yaesu/ft817.c
@@ -71,6 +71,22 @@
 #include "bandplan.h"
 #include "cal.h"
 
+struct ft817_priv_data
+{
+    yaesu_cmd_set_t pcs[FT817_NATIVE_SIZE];  /* TODO:  why? */
+
+    /* rx status */
+    struct timeval rx_status_tv;
+    unsigned char rx_status;
+
+    /* tx status */
+    struct timeval tx_status_tv;
+    unsigned char tx_status;
+
+    /* freq & mode status */
+    struct timeval fm_status_tv;
+    unsigned char fm_status[YAESU_CMD_LENGTH + 1];
+};
 
 /* Native ft817 cmd set prototypes. These are READ ONLY as each */
 /* rig instance will copy from these and modify if required . */

--- a/rigs/yaesu/ft817.h
+++ b/rigs/yaesu/ft817.h
@@ -122,23 +122,6 @@ enum ft817_native_cmd_e
 typedef enum ft817_native_cmd_e ft817_native_cmd_t;
 
 
-struct ft817_priv_data
-{
-    yaesu_cmd_set_t pcs[FT817_NATIVE_SIZE];  /* TODO:  why? */
-
-    /* rx status */
-    struct timeval rx_status_tv;
-    unsigned char rx_status;
-
-    /* tx status */
-    struct timeval tx_status_tv;
-    unsigned char tx_status;
-
-    /* freq & mode status */
-    struct timeval fm_status_tv;
-    unsigned char fm_status[YAESU_CMD_LENGTH + 1];
-};
-
 /* fixme: why declare static? it has no effect */
 static int ft817_init(RIG *rig);
 static int ft817_open(RIG *rig);

--- a/rigs/yaesu/ft847.c
+++ b/rigs/yaesu/ft847.c
@@ -60,8 +60,26 @@
 #include "bandplan.h"
 #include "tones.h"
 
-/* prototypes */
+/*
+ * ft847 instance - private data
+ *
+ */
 
+struct ft847_priv_data {
+  split_t sat_mode;
+
+  unsigned char rx_status;	/* tx returned data */
+  unsigned char tx_status;	/* rx returned data */
+  /* for early ft847's we keep our own memory items */
+  /* Early rigs are one-way com to the rig */
+  freq_t freqA,freqB;
+  mode_t mode;
+  pbwidth_t width;
+  ptt_t ptt;
+};
+
+
+/* prototypes */
 static int ft847_send_priv_cmd(RIG *rig, int cmd_index);
 
 

--- a/rigs/yaesu/ft847.h
+++ b/rigs/yaesu/ft847.h
@@ -145,26 +145,6 @@ typedef enum ft847_native_cmd_e ft847_native_cmd_t;
 
 
 /*
- * ft847 instance - private data
- *
- */
-
-struct ft847_priv_data {
-  split_t sat_mode;
-
-  unsigned char rx_status;	/* tx returned data */
-  unsigned char tx_status;	/* rx returned data */
-  /* for early ft847's we keep our own memory items */
-  /* Early rigs are one-way com to the rig */
-  freq_t freqA,freqB;
-  mode_t mode;
-  pbwidth_t width;
-  ptt_t ptt;
-};
-
-
-
-/*
  * API local implementation
  */
 

--- a/rigs/yaesu/ft857.c
+++ b/rigs/yaesu/ft857.c
@@ -74,6 +74,24 @@
 #include "tones.h"
 #include "bandplan.h"
 
+struct ft857_priv_data {
+  yaesu_cmd_set_t pcs[FT857_NATIVE_SIZE];  /* TODO:  why? */
+
+  /* rx status */
+  struct timeval rx_status_tv;
+  unsigned char rx_status;
+
+  /* tx status */
+  struct timeval tx_status_tv;
+  unsigned char tx_status;
+
+  /* freq & mode status */
+  struct timeval fm_status_tv;
+  unsigned char fm_status[YAESU_CMD_LENGTH+1];
+};
+
+
+
 /* Native ft857 cmd set prototypes. These are READ ONLY as each */
 /* rig instance will copy from these and modify if required . */
 /* Complete sequences (1) can be read and used directly as a cmd sequence . */

--- a/rigs/yaesu/ft857.h
+++ b/rigs/yaesu/ft857.h
@@ -118,23 +118,6 @@ enum ft857_native_cmd_e {
 typedef enum ft857_native_cmd_e ft857_native_cmd_t;
 
 
-struct ft857_priv_data {
-  yaesu_cmd_set_t pcs[FT857_NATIVE_SIZE];  /* TODO:  why? */
-
-  /* rx status */
-  struct timeval rx_status_tv;
-  unsigned char rx_status;
-
-  /* tx status */
-  struct timeval tx_status_tv;
-  unsigned char tx_status;
-
-  /* freq & mode status */
-  struct timeval fm_status_tv;
-  unsigned char fm_status[YAESU_CMD_LENGTH+1];
-};
-
-
 static int ft857_init(RIG *rig);
 static int ft857_open(RIG *rig);
 static int ft857_cleanup(RIG *rig);

--- a/rigs/yaesu/ft897.c
+++ b/rigs/yaesu/ft897.c
@@ -79,6 +79,23 @@
 #include "tones.h"
 #include "bandplan.h"
 
+struct ft897_priv_data {
+  yaesu_cmd_set_t pcs[FT897_NATIVE_SIZE];  /* TODO:  why? */
+
+  /* rx status */
+  struct timeval rx_status_tv;
+  unsigned char rx_status;
+
+  /* tx status */
+  struct timeval tx_status_tv;
+  unsigned char tx_status;
+
+  /* freq & mode status */
+  struct timeval fm_status_tv;
+  unsigned char fm_status[YAESU_CMD_LENGTH+1];
+};
+
+
 
 static int ft897_init(RIG *rig);
 static int ft897_open(RIG *rig);

--- a/rigs/yaesu/ft897.h
+++ b/rigs/yaesu/ft897.h
@@ -115,22 +115,4 @@ enum ft897_native_cmd_e {
 
 typedef enum ft897_native_cmd_e ft897_native_cmd_t;
 
-
-struct ft897_priv_data {
-  yaesu_cmd_set_t pcs[FT897_NATIVE_SIZE];  /* TODO:  why? */
-
-  /* rx status */
-  struct timeval rx_status_tv;
-  unsigned char rx_status;
-
-  /* tx status */
-  struct timeval tx_status_tv;
-  unsigned char tx_status;
-
-  /* freq & mode status */
-  struct timeval fm_status_tv;
-  unsigned char fm_status[YAESU_CMD_LENGTH+1];
-};
-
-
 #endif /* _FT897_H */


### PR DESCRIPTION
Note that is already so for all other Yaesu device.
Leave private data in newcat; it is used by multiple rigs.