### PR TITLE
Width pointer check removal

### DIFF
--- a/rigs/yaesu/ft600.c
+++ b/rigs/yaesu/ft600.c
@@ -467,10 +467,7 @@ int ft600_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
         return -RIG_EINVAL;
     }
 
-    if (width != NULL)
-    {
-        *width = RIG_PASSBAND_NORMAL;
-    }
+    *width = RIG_PASSBAND_NORMAL;
 
     ret = ft600_read_status(rig);
 

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -10080,16 +10080,13 @@ rmode_t newcat_rmode_width(RIG *rig, vfo_t vfo, char mode, pbwidth_t *width)
 
     ENTERFUNC;
 
-    if (width != NULL)
-    {
-        *width = RIG_PASSBAND_NORMAL;
-    }
+    *width = RIG_PASSBAND_NORMAL;
 
     for (i = 0; i < sizeof(newcat_mode_conv) / sizeof(newcat_mode_conv[0]); i++)
     {
         if (newcat_mode_conv[i].modechar == mode)
         {
-            if (newcat_mode_conv[i].chk_width == TRUE && width != NULL)
+            if (newcat_mode_conv[i].chk_width == TRUE)
             {
                 if (newcat_is_rig(rig, RIG_MODEL_FT991)
                         && mode == 'E') // crude fix because 991 hangs on NA0; command while in C4FM

--- a/src/rig.c
+++ b/src/rig.c
@@ -2297,6 +2297,9 @@ int HAMLIB_API rig_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
  *  The value stored at \a mode location equals RIG_MODE_NONE when the current
  *  mode of the VFO is not defined (e.g. blank memory).
  *
+ *  Note that if either \a mode or \a width is NULL, -RIG_EINVAL is returned.
+ *  Both must be given even if only one is actually wanted.
+ *
  * \RETURNFUNC(RIG_OK) if the operation has been successful, otherwise
  * a negative value if an error occurred (in which case, cause is
  * set appropriately).


### PR DESCRIPTION
Only 3 rigs check for existence of width pointers, the rest silently assumes it is.
From my quick grepping and cscope inspection all call sites check width before it is passed on to the function pointer.
For icom.c the diff seems larger then it is. It is just the removal of one level of indenting.