### PR TITLE
Simplify get_ant by setting ant to 'unknown' by default.

### DIFF
--- a/rigs/drake/drake.c
+++ b/rigs/drake/drake.c
@@ -512,8 +512,6 @@ int drake_get_ant(RIG *rig, vfo_t vfo, ant_t dummy, value_t *option,
     char mdbuf[BUFSZ];
     char cant;
 
-    *ant_tx = *ant_rx = RIG_ANT_UNKNOWN;
-
     retval = drake_transaction(rig, "RM" EOM, 3, mdbuf, &mdbuf_len);
 
     if (retval != RIG_OK)
@@ -542,7 +540,6 @@ int drake_get_ant(RIG *rig, vfo_t vfo, ant_t dummy, value_t *option,
         rig_debug(RIG_DEBUG_ERR,
                   "drake_get_ant: unsupported antenna %c\n",
                   cant);
-        *ant_curr = RIG_ANT_UNKNOWN;
         return -RIG_EINVAL;
     }
 

--- a/rigs/dummy/dummy.c
+++ b/rigs/dummy/dummy.c
@@ -482,7 +482,7 @@ static int dummy_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
     case RIG_VFO_SUB:
     case RIG_VFO_B:  *freq = priv->vfo_b.freq; break;
-    case RIG_VFO_SUB_A:  *freq = priv->vfo_suba.freq;break; 
+    case RIG_VFO_SUB_A:  *freq = priv->vfo_suba.freq;break;
     case RIG_VFO_SUB_B:  *freq = priv->vfo_subb.freq;break;
 
     case RIG_VFO_C:  *freq = priv->vfo_c.freq; break;
@@ -1670,8 +1670,6 @@ static int dummy_get_ant(RIG *rig, vfo_t vfo, ant_t ant, value_t *option,
     ENTERFUNC;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called, ant=0x%02x\n", __func__, ant);
-
-    *ant_tx = *ant_rx = RIG_ANT_UNKNOWN;
 
     switch (ant)
     {

--- a/rigs/dummy/netrigctl.c
+++ b/rigs/dummy/netrigctl.c
@@ -673,7 +673,7 @@ static int netrigctl_open(RIG *rig)
             // setting targetable_vfo this way breaks WSJTX in rig split with rigctld
             // Ends up putting VFOB freq on VFOA
             // Have to figure out why but disabling this fixes it for now
-#if 0 
+#if 0
             else if (strcmp(setting, "targetable_vfo") == 0)
             {
                 rig->caps->targetable_vfo = strtol(value, NULL, 0);
@@ -2111,8 +2111,6 @@ static int netrigctl_get_ant(RIG *rig, vfo_t vfo, ant_t ant, value_t *option,
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    *ant_tx = *ant_rx = RIG_ANT_UNKNOWN;
-
     ret = netrigctl_vfostr(rig, vfostr, sizeof(vfostr), vfo);
 
     if (ret != RIG_OK) { return ret; }
@@ -2557,7 +2555,7 @@ struct rig_caps netrigctl_caps =
     .dcd_type =       RIG_DCD_RIG,
     .port_type =      RIG_PORT_NETWORK,
     .timeout = 10000,  /* enough for the worst rig we have */
-    .retry =   5,     
+    .retry =   5,
 
     /* following fields updated in rig_state at opening time */
     .has_get_func =   RIG_FUNC_NONE,

--- a/rigs/icom/icom.c
+++ b/rigs/icom/icom.c
@@ -7663,8 +7663,6 @@ int icom_get_ant(RIG *rig, vfo_t vfo, ant_t ant, value_t *option,
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called, ant=0x%02x\n", __func__, ant);
 
-    *ant_tx = *ant_rx = RIG_ANT_UNKNOWN;
-
     if (ant != RIG_ANT_CURR)
     {
         ant = rig_setting2idx(ant);

--- a/rigs/kenwood/ic10.c
+++ b/rigs/kenwood/ic10.c
@@ -505,7 +505,6 @@ int ic10_get_ant(RIG *rig, vfo_t vfo, ant_t dummy, value_t *option,
     char infobuf[50];
     int info_len, retval;
 
-    *ant_tx = *ant_rx = RIG_ANT_UNKNOWN;
     info_len = 4;
     retval = ic10_transaction(rig, "AN;", 3, infobuf, &info_len);
 

--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -1299,8 +1299,8 @@ int kenwood_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t txvfo)
     priv->tx_vfo = txvfo;
 
     /* do not attempt redundant split change commands on Elecraft as
-       they impact output power when transmitting 
-       and all other rigs don't need to set it if it's already set correctly 
+       they impact output power when transmitting
+       and all other rigs don't need to set it if it's already set correctly
     */
     if (RIG_OK == (retval = kenwood_safe_transaction(rig, "FT", cmdbuf,
                             sizeof(cmdbuf), 3)))
@@ -4187,8 +4187,6 @@ int kenwood_get_ant(RIG *rig, vfo_t vfo, ant_t dummy, value_t *option,
     int retval;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
-
-    *ant_tx = *ant_rx = RIG_ANT_UNKNOWN;
 
     if (!ant_curr)
     {

--- a/rigs/kenwood/th.c
+++ b/rigs/kenwood/th.c
@@ -2532,8 +2532,6 @@ int th_get_ant(RIG *rig, vfo_t vfo, ant_t dummy, value_t *option,
 
     rig_debug(RIG_DEBUG_TRACE, "%s\n", __func__);
 
-    *ant_tx = *ant_rx = RIG_ANT_UNKNOWN;
-
     retval = kenwood_safe_transaction(rig, "ANT", buf, sizeof(buf), 5);
 
     if (retval != RIG_OK)

--- a/rigs/racal/ra37xx.c
+++ b/rigs/racal/ra37xx.c
@@ -760,8 +760,6 @@ int ra37xx_get_ant(RIG *rig, vfo_t vfo, ant_t dummy, value_t *option,
     char buf[BUFSZ];
     int retval, buflen, ra_ant;
 
-    *ant_tx = *ant_rx = RIG_ANT_UNKNOWN;
-
     retval = ra37xx_transaction(rig, "QANT", buf, &buflen);
 
     if (retval != RIG_OK)

--- a/rigs/tentec/orion.c
+++ b/rigs/tentec/orion.c
@@ -2125,8 +2125,6 @@ int tt565_get_ant(RIG *rig, vfo_t vfo, ant_t dummy, value_t *option,
     char respbuf[TT565_BUFSIZE];
     int resp_len, retval;
 
-    *ant_tx = *ant_rx = RIG_ANT_UNKNOWN;
-
     resp_len = sizeof(respbuf);
     retval = tt565_transaction(rig, "?KA" EOM, 4, respbuf, &resp_len);
 

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -3383,8 +3383,6 @@ int newcat_get_ant(RIG *rig, vfo_t vfo, ant_t dummy, value_t *option,
 
     ENTERFUNC;
 
-    option->i = 0;  // default to no options
-
     if (!newcat_valid_command(rig, command))
     {
         RETURNFUNC(-RIG_ENAVAIL);
@@ -3437,7 +3435,6 @@ int newcat_get_ant(RIG *rig, vfo_t vfo, ant_t dummy, value_t *option,
         break;
 
     default:
-        *ant_curr = RIG_ANT_UNKNOWN;
         RETURNFUNC(-RIG_EPROTO);
     }
 

--- a/src/rig.c
+++ b/src/rig.c
@@ -5188,15 +5188,18 @@ int HAMLIB_API rig_set_ant(RIG *rig, vfo_t vfo, ant_t ant, value_t option)
  * \brief get the current antenna
  * \param rig   The rig handle
  * \param vfo   The target VFO
- * \param ant   The location where to store the current antenna
- * \param option  The option value for the antenna
+ * \param ant   The antenna to query option for
+ * \param option  The option value for the antenna, rig specific.
  * \param ant_curr  The currently selected antenna
  * \param ant_tx  The currently selected TX antenna
  * \param ant_rx  The currently selected RX antenna
  *
  *  Retrieves the current antenna.
  *
- * \RETURNFUNC(RIG_OK) if the operation has been successful, otherwise
+ *  If \a ant_tx and/or \a ant_rx are unused by the rig they will be set to
+ *  RIG_ANT_UNKNOWN and only \a ant_curr will be set.
+ *
+ * \return RIG_OK if the operation has been successful, otherwise
  * a negative value if an error occurred (in which case, cause is
  * set appropriately).
  *
@@ -5224,14 +5227,17 @@ int HAMLIB_API rig_get_ant(RIG *rig, vfo_t vfo, ant_t ant, value_t *option,
         RETURNFUNC(-RIG_EINVAL);
     }
 
-    *ant_tx = *ant_rx = RIG_ANT_UNKNOWN;
-
     caps = rig->caps;
 
     if (caps->get_ant == NULL)
     {
         RETURNFUNC(-RIG_ENAVAIL);
     }
+
+    /* Set antenna default to unknown and clear option.
+     * So we have sane defaults for all backends */
+    *ant_tx = *ant_rx = *ant_curr = RIG_ANT_UNKNOWN;
+    option->i = 0;
 
     if ((caps->targetable_vfo & RIG_TARGETABLE_ANT)
             || vfo == RIG_VFO_CURR


### PR DESCRIPTION
There was no guarantee documented on what rx/tx ant would contain. So I added it and added sane defaults in place.

Drop setting rx/tx_ant to default in rigs backends; they are already set and some rigs did not set defaults.

Add some documentation on get_ant.
get_ant could still use more documentation but I am not comfortable writing that.