### PR TITLE
Yaesu cmnd indirection removal

### DIFF
--- a/rigs/yaesu/ft100.c
+++ b/rigs/yaesu/ft100.c
@@ -386,19 +386,12 @@ int ft100_close(RIG *rig)
 
 static int ft100_send_priv_cmd(RIG *rig, unsigned char cmd_index)
 {
-
-    struct rig_state *rig_s;
-    unsigned char *cmd;       /* points to sequence to send */
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called (%d)\n", __func__, cmd_index);
 
     if (!rig) { return -RIG_EINVAL; }
 
-    rig_s = &rig->state;
-
-    cmd = (unsigned char *) &ncmd[cmd_index].nseq; /* get native sequence */
-
-    return write_block(&rig_s->rigport, (char *) cmd, YAESU_CMD_LENGTH);
+    return write_block(&rig->state.rigport, (char *) &ncmd[cmd_index].nseq,
+            YAESU_CMD_LENGTH);
 }
 
 static int ft100_read_status(RIG *rig)
@@ -463,13 +456,10 @@ static int ft100_read_flags(RIG *rig)
 
 int ft100_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-    struct rig_state *rig_s;
     unsigned char p_cmd[YAESU_CMD_LENGTH];
     unsigned char cmd_index;  /* index of sequence to send */
 
     if (!rig) { return -RIG_EINVAL; }
-
-    rig_s = &rig->state;
 
     rig_debug(RIG_DEBUG_VERBOSE, "ft100: requested freq = %"PRIfreq" Hz \n", freq);
 
@@ -481,7 +471,7 @@ int ft100_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     freq = (int)freq / 10;
     to_bcd(p_cmd, freq, 8); /* store bcd format in in p_cmd */
 
-    return write_block(&rig_s->rigport, (char *) p_cmd, YAESU_CMD_LENGTH);
+    return write_block(&rig->state.rigport, (char *) p_cmd, YAESU_CMD_LENGTH);
 }
 
 int ft100_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
@@ -1045,12 +1035,9 @@ int ft100_get_rptr_shift(RIG *rig, vfo_t vfo, rptr_shift_t *shift)
  */
 int ft100_set_dcs_code(RIG *rig, vfo_t vfo, tone_t code)
 {
-    struct rig_state *rig_s;
     unsigned char p_cmd[YAESU_CMD_LENGTH];
     unsigned char cmd_index;  /* index of sequence to send */
     int pcode;
-
-    rig_s = &rig->state;
 
     for (pcode = 0; pcode < 104 && ft100_dcs_list[pcode] != 0; pcode++)
     {
@@ -1075,7 +1062,7 @@ int ft100_set_dcs_code(RIG *rig, vfo_t vfo, tone_t code)
 
     p_cmd[3] = (char)pcode;
 
-    return write_block(&rig_s->rigport, (char *) p_cmd, YAESU_CMD_LENGTH);
+    return write_block(&rig->state.rigport, (char *) p_cmd, YAESU_CMD_LENGTH);
 }
 
 int ft100_get_dcs_code(RIG *rig, vfo_t vfo, tone_t *code)
@@ -1102,7 +1089,6 @@ int ft100_get_dcs_code(RIG *rig, vfo_t vfo, tone_t *code)
  */
 int ft100_set_ctcss_tone(RIG *rig, vfo_t vfo, tone_t tone)
 {
-    struct rig_state *rig_s;
     unsigned char p_cmd[YAESU_CMD_LENGTH];
     unsigned char cmd_index;  /* index of sequence to send */
     int ptone;
@@ -1121,8 +1107,6 @@ int ft100_set_ctcss_tone(RIG *rig, vfo_t vfo, tone_t tone)
         return -RIG_EINVAL;
     }
 
-    rig_s = &rig->state;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s = %.1f Hz, n=%d\n", __func__,
               (float)tone / 10, ptone);
 
@@ -1132,7 +1116,7 @@ int ft100_set_ctcss_tone(RIG *rig, vfo_t vfo, tone_t tone)
 
     p_cmd[3] = (char)ptone;
 
-    return write_block(&rig_s->rigport, (char *) p_cmd, YAESU_CMD_LENGTH);
+    return write_block(&rig->state.rigport, (char *) p_cmd, YAESU_CMD_LENGTH);
 }
 
 int ft100_get_ctcss_tone(RIG *rig, vfo_t vfo, tone_t *tone)

--- a/rigs/yaesu/ft1000d.c
+++ b/rigs/yaesu/ft1000d.c
@@ -2332,7 +2332,6 @@ int ft1000d_get_vfo(RIG *rig, vfo_t *vfo)
 int ft1000d_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *value)
 {
     struct ft1000d_priv_data *priv;
-    struct rig_state *rig_s;
     unsigned char mdata[YAESU_CMD_LENGTH];
     int err;
 
@@ -2375,8 +2374,7 @@ int ft1000d_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *value)
         return err;
     }
 
-    rig_s = &rig->state;
-    err = read_block(&rig_s->rigport, (char *) mdata, FT1000D_READ_METER_LENGTH);
+    err = read_block(&rig->state.rigport, (char *) mdata, FT1000D_READ_METER_LENGTH);
 
     if (err < 0)
     {
@@ -3267,7 +3265,7 @@ int ft1000d_get_update_data(RIG *rig, unsigned char ci, unsigned short ch)
             return -RIG_EINVAL;
         }
 
-        n = read_block(&rig_s->rigport, p, rl);
+        n = read_block(&rig->state.rigport, p, rl);
 
     }
     while (n < 0 && retry-- >= 0);
@@ -3300,7 +3298,6 @@ int ft1000d_get_update_data(RIG *rig, unsigned char ci, unsigned short ch)
  */
 int ft1000d_send_static_cmd(RIG *rig, unsigned char ci)
 {
-    struct rig_state *rig_s;
     int err;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
@@ -3311,8 +3308,6 @@ int ft1000d_send_static_cmd(RIG *rig, unsigned char ci)
         return -RIG_EINVAL;
     }
 
-    rig_s = &rig->state;
-
     if (!ncmd[ci].ncomp)
     {
         rig_debug(RIG_DEBUG_TRACE,
@@ -3320,7 +3315,7 @@ int ft1000d_send_static_cmd(RIG *rig, unsigned char ci)
         return -RIG_EINVAL;
     }
 
-    err = write_block(&rig_s->rigport, (char *) ncmd[ci].nseq,
+    err = write_block(&rig->state.rigport, (char *) ncmd[ci].nseq,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -3328,7 +3323,7 @@ int ft1000d_send_static_cmd(RIG *rig, unsigned char ci)
         return err;
     }
 
-    hl_usleep(rig_s->rigport.write_delay * 1000);
+    hl_usleep(rig->state.rigport.write_delay * 1000);
     return RIG_OK;
 }
 
@@ -3349,7 +3344,6 @@ int ft1000d_send_dynamic_cmd(RIG *rig, unsigned char ci,
                              unsigned char p1, unsigned char p2,
                              unsigned char p3, unsigned char p4)
 {
-    struct rig_state *rig_s;
     struct ft1000d_priv_data *priv;
     int err;
 
@@ -3375,7 +3369,6 @@ int ft1000d_send_dynamic_cmd(RIG *rig, unsigned char ci,
         return -RIG_EINVAL;
     }
 
-    rig_s = &rig->state;
     memcpy(&priv->p_cmd, &ncmd[ci].nseq, YAESU_CMD_LENGTH);
 
     priv->p_cmd[3] = p1;
@@ -3383,7 +3376,7 @@ int ft1000d_send_dynamic_cmd(RIG *rig, unsigned char ci,
     priv->p_cmd[1] = p3;
     priv->p_cmd[0] = p4;
 
-    err = write_block(&rig_s->rigport, (char *) &priv->p_cmd,
+    err = write_block(&rig->state.rigport, (char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -3391,7 +3384,7 @@ int ft1000d_send_dynamic_cmd(RIG *rig, unsigned char ci,
         return err;
     }
 
-    hl_usleep(rig_s->rigport.write_delay * 1000);
+    hl_usleep(rig->state.rigport.write_delay * 1000);
     return RIG_OK;
 }
 
@@ -3409,7 +3402,6 @@ int ft1000d_send_dynamic_cmd(RIG *rig, unsigned char ci,
  */
 int ft1000d_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
 {
-    struct rig_state *rig_s;
     struct ft1000d_priv_data *priv;
     int err;
     // cppcheck-suppress *
@@ -3434,8 +3426,6 @@ int ft1000d_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
         return -RIG_EINVAL;
     }
 
-    rig_s = &rig->state;
-
     /* Copy native cmd freq_set to private cmd storage area */
     memcpy(&priv->p_cmd, &ncmd[ci].nseq, YAESU_CMD_LENGTH);
 
@@ -3445,7 +3435,7 @@ int ft1000d_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
     rig_debug(RIG_DEBUG_TRACE, fmt, __func__, (int64_t)from_bcd(priv->p_cmd,
               FT1000D_BCD_DIAL) * 10);
 
-    err = write_block(&rig_s->rigport, (char *) &priv->p_cmd,
+    err = write_block(&rig->state.rigport, (char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -3453,7 +3443,7 @@ int ft1000d_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
         return err;
     }
 
-    hl_usleep(rig_s->rigport.write_delay * 1000);
+    hl_usleep(rig->state.rigport.write_delay * 1000);
     return RIG_OK;
 }
 
@@ -3471,7 +3461,6 @@ int ft1000d_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
 int ft1000d_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
 {
     struct ft1000d_priv_data *priv;
-    struct rig_state *rig_s;
     int err;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
@@ -3485,7 +3474,6 @@ int ft1000d_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
     rig_debug(RIG_DEBUG_TRACE, "%s: passed rit = %li Hz\n", __func__, rit);
 
     priv = (struct ft1000d_priv_data *) rig->state.priv;
-    rig_s = &rig->state;
 
     if (ncmd[ci].ncomp)
     {
@@ -3513,7 +3501,7 @@ int ft1000d_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
     // Store bcd format into privat command storage area
     to_bcd(priv->p_cmd, labs(rit) / 10, FT1000D_BCD_RIT);
 
-    err = write_block(&rig_s->rigport, (char *) &priv->p_cmd,
+    err = write_block(&rig->state.rigport, (char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -3521,7 +3509,7 @@ int ft1000d_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
         return err;
     }
 
-    hl_usleep(rig_s->rigport.write_delay * 1000);
+    hl_usleep(rig->state.rigport.write_delay * 1000);
     return RIG_OK;
 }
 

--- a/rigs/yaesu/ft1000mp.c
+++ b/rigs/yaesu/ft1000mp.c
@@ -206,7 +206,6 @@ struct ft1000mp_priv_data
     unsigned int read_update_delay;           /* depends on pacing value */
     unsigned char
     p_cmd[YAESU_CMD_LENGTH];    /* private copy of 1 constructed CAT cmd */
-    yaesu_cmd_set_t pcs[FT1000MP_NATIVE_SIZE];  /* private cmd set */
     unsigned char update_data[2 *
                                 FT1000MP_STATUS_UPDATE_LENGTH]; /* returned data--max value, some are less */
 };
@@ -641,11 +640,6 @@ int ft1000mp_init(RIG *rig)
     }
 
     priv = rig->state.priv;
-
-    /*
-     * Copy native cmd set to private cmd storage area
-     */
-    memcpy(priv->pcs, ncmd, sizeof(ncmd));
 
     /* TODO: read pacing from preferences */
     priv->pacing =
@@ -1601,25 +1595,23 @@ static int ft1000mp_get_update_data(RIG *rig, unsigned char ci,
 static int ft1000mp_send_priv_cmd(RIG *rig, unsigned char ci)
 {
     struct rig_state *rig_s;
-    struct ft1000mp_priv_data *p;
     unsigned char *cmd;           /* points to sequence to send */
     unsigned char cmd_index;      /* index of sequence to send */
 
     ENTERFUNC;
 
-    p = (struct ft1000mp_priv_data *)rig->state.priv;
     rig_s = &rig->state;
 
     cmd_index = ci;               /* get command */
 
-    if (! p->pcs[cmd_index].ncomp)
+    if (! ncmd[cmd_index].ncomp)
     {
         rig_debug(RIG_DEBUG_TRACE, "%s: attempt to send incomplete sequence\n",
                   __func__);
         RETURNFUNC(-RIG_EINVAL);
     }
 
-    cmd = (unsigned char *) p->pcs[cmd_index].nseq; /* get native sequence */
+    cmd = (unsigned char *) ncmd[cmd_index].nseq; /* get native sequence */
     rig_flush(&rig_s->rigport);
     write_block(&rig_s->rigport, (char *) cmd, YAESU_CMD_LENGTH);
 

--- a/rigs/yaesu/ft1000mp.c
+++ b/rigs/yaesu/ft1000mp.c
@@ -703,7 +703,7 @@ int ft1000mp_open(RIG *rig)
 
     /* send PACING cmd to rig  */
     cmd = p->p_cmd;
-    write_block(&rig_s->rigport, (char *) cmd, YAESU_CMD_LENGTH);
+    write_block(&rig->state.rigport, (char *) cmd, YAESU_CMD_LENGTH);
 
     ft1000mp_get_vfo(rig, &rig->state.current_vfo);
     /* TODO */
@@ -715,7 +715,6 @@ int ft1000mp_open(RIG *rig)
 
 int ft1000mp_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-    struct rig_state *rig_s;
     struct ft1000mp_priv_data *p;
     unsigned char *cmd;           /* points to sequence to send */
     int cmd_index = 0;
@@ -723,8 +722,6 @@ int ft1000mp_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     ENTERFUNC;
 
     p = (struct ft1000mp_priv_data *)rig->state.priv;
-
-    rig_s = &rig->state;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: requested freq = %"PRIfreq" Hz \n", __func__,
               freq);
@@ -768,7 +765,7 @@ int ft1000mp_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
               (freq_t)from_bcd(p->p_cmd, 8) * 10);
 
     cmd = p->p_cmd;               /* get native sequence */
-    write_block(&rig_s->rigport, (char *) cmd, YAESU_CMD_LENGTH);
+    write_block(&rig->state.rigport, (char *) cmd, YAESU_CMD_LENGTH);
 
     RETURNFUNC(RIG_OK);
 }
@@ -1560,21 +1557,19 @@ int ft1000mp_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 static int ft1000mp_get_update_data(RIG *rig, unsigned char ci,
                                     unsigned char rl)
 {
-    struct rig_state *rig_s;
     struct ft1000mp_priv_data *p;
     int n;                        /* for read_  */
 
     ENTERFUNC;
 
     p = (struct ft1000mp_priv_data *)rig->state.priv;
-    rig_s = &rig->state;
 
     // timeout retries are done in read_block now
     // based on rig backed retry value
     /* send UPDATE command to fetch data*/
     ft1000mp_send_priv_cmd(rig, ci);
 
-    n = read_block(&rig_s->rigport, (char *) p->update_data, rl);
+    n = read_block(&rig->state.rigport, (char *) p->update_data, rl);
 
     if (n == -RIG_ETIMEOUT)
     {
@@ -1594,26 +1589,15 @@ static int ft1000mp_get_update_data(RIG *rig, unsigned char ci,
 
 static int ft1000mp_send_priv_cmd(RIG *rig, unsigned char ci)
 {
-    struct rig_state *rig_s;
-    unsigned char *cmd;           /* points to sequence to send */
-    unsigned char cmd_index;      /* index of sequence to send */
-
     ENTERFUNC;
 
-    rig_s = &rig->state;
-
-    cmd_index = ci;               /* get command */
-
-    if (! ncmd[cmd_index].ncomp)
+    if (! ncmd[ci].ncomp)
     {
         rig_debug(RIG_DEBUG_TRACE, "%s: attempt to send incomplete sequence\n",
                   __func__);
         RETURNFUNC(-RIG_EINVAL);
     }
-
-    cmd = (unsigned char *) ncmd[cmd_index].nseq; /* get native sequence */
-    rig_flush(&rig_s->rigport);
-    write_block(&rig_s->rigport, (char *) cmd, YAESU_CMD_LENGTH);
+    write_block(&rig->state.rigport, (char *) ncmd[ci].nseq, YAESU_CMD_LENGTH);
 
     RETURNFUNC(RIG_OK);
 

--- a/rigs/yaesu/ft600.c
+++ b/rigs/yaesu/ft600.c
@@ -298,19 +298,11 @@ int ft600_close(RIG *rig)
 
 static int ft600_send_priv_cmd(RIG *rig, unsigned char cmd_index)
 {
-
-    struct rig_state *rig_s;
-    unsigned char *cmd;       /* points to sequence to send */
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called (%d)\n", __func__, cmd_index);
 
     if (!rig) { return -RIG_EINVAL; }
 
-    rig_s = &rig->state;
-
-    cmd = (unsigned char *) &ncmd[cmd_index].nseq; /* get native sequence */
-
-    return write_block(&rig_s->rigport, (char *) cmd, YAESU_CMD_LENGTH);
+    return write_block(&rig->state.rigport, (char *) &ncmd[cmd_index].nseq, YAESU_CMD_LENGTH);
 }
 
 static int ft600_read_status(RIG *rig)
@@ -386,13 +378,10 @@ int ft600_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 
 int ft600_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-    struct rig_state *rig_s;
     unsigned char p_cmd[YAESU_CMD_LENGTH];
     unsigned char cmd_index;  /* index of sequence to send */
 
     if (!rig) { return -RIG_EINVAL; }
-
-    rig_s = &rig->state;
 
     rig_debug(RIG_DEBUG_VERBOSE, "ft600: requested freq = %"PRIfreq" Hz \n", freq);
 
@@ -403,7 +392,7 @@ int ft600_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     freq = (int)freq / 10;
     to_bcd(p_cmd, freq, 8); /* store bcd format in in p_cmd */
 
-    return write_block(&rig_s->rigport, (char *) p_cmd, YAESU_CMD_LENGTH);
+    return write_block(&rig->state.rigport, (char *) p_cmd, YAESU_CMD_LENGTH);
 }
 
 int ft600_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)

--- a/rigs/yaesu/ft747.c
+++ b/rigs/yaesu/ft747.c
@@ -372,7 +372,7 @@ int ft747_open(RIG *rig)
 
     /* send PACING cmd to rig, once for all */
 
-    ret = write_block(&rig_s->rigport, (char *)p->p_cmd, YAESU_CMD_LENGTH);
+    ret = write_block(&rig->state.rigport, (char *)p->p_cmd, YAESU_CMD_LENGTH);
 
     if (ret < 0)
     {
@@ -407,15 +407,12 @@ int ft747_close(RIG *rig)
 
 int ft747_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-    struct rig_state *rig_s;
     struct ft747_priv_data *p;
     unsigned char *cmd;       /* points to sequence to send */
     // cppcheck-suppress *
     char *fmt = "%s: requested freq after conversion = %"PRIll" Hz \n";
 
     p = (struct ft747_priv_data *)rig->state.priv;
-
-    rig_s = &rig->state;
 
     rig_debug(RIG_DEBUG_VERBOSE, "ft747: requested freq = %"PRIfreq" Hz \n", freq);
 
@@ -435,7 +432,7 @@ int ft747_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     rig_force_cache_timeout(&p->status_tv);
 
     cmd = p->p_cmd; /* get native sequence */
-    return write_block(&rig_s->rigport, (char *) cmd, YAESU_CMD_LENGTH);
+    return write_block(&rig->state.rigport, (char *) cmd, YAESU_CMD_LENGTH);
 }
 
 
@@ -909,24 +906,14 @@ static int ft747_get_update_data(RIG *rig)
 
 static int ft747_send_priv_cmd(RIG *rig, unsigned char ci)
 {
-
-    struct rig_state *rig_s;
-    unsigned char *cmd;       /* points to sequence to send */
-    unsigned char cmd_index;  /* index of sequence to send */
-
-    rig_s = &rig->state;
-
-    cmd_index = ci;       /* get command */
-
-    if (! ft747_ncmd[cmd_index].ncomp)
+    if (! ft747_ncmd[ci].ncomp)
     {
         rig_debug(RIG_DEBUG_VERBOSE, "%s: attempt to send incomplete sequence\n",
                   __func__);
         return -RIG_EINVAL;
     }
 
-    cmd = (unsigned char *) ft747_ncmd[cmd_index].nseq; /* get native sequence */
-    return write_block(&rig_s->rigport, (char *) cmd, YAESU_CMD_LENGTH);
+    return write_block(&rig->state.rigport, (char *) ft747_ncmd[ci].nseq, YAESU_CMD_LENGTH);
 
 }
 

--- a/rigs/yaesu/ft840.c
+++ b/rigs/yaesu/ft840.c
@@ -1697,7 +1697,6 @@ static int ft840_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op)
 
 static int ft840_get_update_data(RIG *rig, unsigned char ci, unsigned char rl)
 {
-    struct rig_state *rig_s;
     struct ft840_priv_data *priv;
     int n, err;                       /* for read_  */
 
@@ -1709,7 +1708,6 @@ static int ft840_get_update_data(RIG *rig, unsigned char ci, unsigned char rl)
     }
 
     priv = (struct ft840_priv_data *)rig->state.priv;
-    rig_s = &rig->state;
 
     err = ft840_send_static_cmd(rig, ci);
 
@@ -1718,7 +1716,7 @@ static int ft840_get_update_data(RIG *rig, unsigned char ci, unsigned char rl)
         return err;
     }
 
-    n = read_block(&rig_s->rigport, (char *) priv->update_data, rl);
+    n = read_block(&rig->state.rigport, (char *) priv->update_data, rl);
 
     if (n < 0)
     {
@@ -1745,7 +1743,6 @@ static int ft840_get_update_data(RIG *rig, unsigned char ci, unsigned char rl)
 
 static int ft840_send_static_cmd(RIG *rig, unsigned char ci)
 {
-    struct rig_state *rig_s;
     int err;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
@@ -1755,8 +1752,6 @@ static int ft840_send_static_cmd(RIG *rig, unsigned char ci)
         return -RIG_EINVAL;
     }
 
-    rig_s = &rig->state;
-
     if (!ncmd[ci].ncomp)
     {
         rig_debug(RIG_DEBUG_TRACE,
@@ -1764,7 +1759,7 @@ static int ft840_send_static_cmd(RIG *rig, unsigned char ci)
         return -RIG_EINVAL;
     }
 
-    err = write_block(&rig_s->rigport, (char *) ncmd[ci].nseq,
+    err = write_block(&rig->state.rigport, (char *) ncmd[ci].nseq,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -1794,7 +1789,6 @@ static int ft840_send_dynamic_cmd(RIG *rig, unsigned char ci,
                                   unsigned char p1, unsigned char p2,
                                   unsigned char p3, unsigned char p4)
 {
-    struct rig_state *rig_s;
     struct ft840_priv_data *priv;
     int err;
 
@@ -1819,7 +1813,6 @@ static int ft840_send_dynamic_cmd(RIG *rig, unsigned char ci,
         return -RIG_EINVAL;
     }
 
-    rig_s = &rig->state;
     memcpy(&priv->p_cmd, &ncmd[ci].nseq, YAESU_CMD_LENGTH);
 
     priv->p_cmd[P1] = p1;         /* ick */
@@ -1827,7 +1820,7 @@ static int ft840_send_dynamic_cmd(RIG *rig, unsigned char ci,
     priv->p_cmd[P3] = p3;
     priv->p_cmd[P4] = p4;
 
-    err = write_block(&rig_s->rigport, (char *) &priv->p_cmd,
+    err = write_block(&rig->state.rigport, (char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -1855,7 +1848,6 @@ static int ft840_send_dynamic_cmd(RIG *rig, unsigned char ci,
 
 static int ft840_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
 {
-    struct rig_state *rig_s;
     struct ft840_priv_data *priv;
     int err;
     // cppcheck-suppress *
@@ -1880,8 +1872,6 @@ static int ft840_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
         return -RIG_EINVAL;
     }
 
-    rig_s = &rig->state;
-
     /* Copy native cmd freq_set to private cmd storage area */
     memcpy(&priv->p_cmd, &ncmd[ci].nseq, YAESU_CMD_LENGTH);
 
@@ -1891,7 +1881,7 @@ static int ft840_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
     rig_debug(RIG_DEBUG_TRACE, fmt, __func__, (int64_t)from_bcd(priv->p_cmd,
               FT840_BCD_DIAL) * 10);
 
-    err = write_block(&rig_s->rigport, (char *) &priv->p_cmd,
+    err = write_block(&rig->state.rigport, (char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -1924,7 +1914,6 @@ static int ft840_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
 #ifdef USE_FT840_SET_RIT
 static int ft840_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
 {
-    struct rig_state *rig_s;
     struct ft840_priv_data *priv;
     unsigned char p1;
     unsigned char p2;
@@ -1948,8 +1937,6 @@ static int ft840_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
                   "%s: Attempt to modify complete sequence\n", __func__);
         return -RIG_EINVAL;
     }
-
-    rig_s = &rig->state;
 
     p1 = CLAR_SET_FREQ;
 
@@ -1976,7 +1963,7 @@ static int ft840_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
     priv->p_cmd[P1] = p1;         /* ick */
     priv->p_cmd[P2] = p2;
 
-    err = write_block(&rig_s->rigport, (char *) &priv->p_cmd,
+    err = write_block(&rig->state.rigport, (char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)

--- a/rigs/yaesu/ft847.c
+++ b/rigs/yaesu/ft847.c
@@ -645,15 +645,6 @@ int ft847_close(RIG *rig)
 
 static int ft847_send_priv_cmd(RIG *rig, int cmd_index)
 {
-
-    struct rig_state *rig_s;
-    unsigned char *cmd;       /* points to sequence to send */
-
-    if (!rig)
-    {
-        return -RIG_EINVAL;
-    }
-
     if (! ncmd[cmd_index].ncomp)
     {
         rig_debug(RIG_DEBUG_VERBOSE, "%s: attempt to send incomplete sequence\n",
@@ -661,11 +652,7 @@ static int ft847_send_priv_cmd(RIG *rig, int cmd_index)
         return -RIG_EINVAL;
     }
 
-    rig_s = &rig->state;
-
-    cmd = (unsigned char *) ncmd[cmd_index].nseq; /* get native sequence */
-
-    return write_block(&rig_s->rigport, (char *) cmd, YAESU_CMD_LENGTH);
+    return write_block(&rig->state.rigport, (char *) ncmd[cmd_index].nseq, YAESU_CMD_LENGTH);
 }
 
 
@@ -717,7 +704,6 @@ static int opcode_vfo(RIG *rig, unsigned char *cmd, int cmd_index, vfo_t vfo)
 
 int ft847_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-    struct rig_state *rig_s;
     unsigned char p_cmd[YAESU_CMD_LENGTH]; /* sequence to send */
     int ret;
     // cppcheck-suppress *
@@ -727,8 +713,6 @@ int ft847_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     {
         return -RIG_EINVAL;
     }
-
-    rig_s = &rig->state;
 
     rig_debug(RIG_DEBUG_VERBOSE, "ft847: requested freq = %"PRIfreq" Hz, vfo=%s\n",
               freq, rig_strvfo(vfo));
@@ -761,7 +745,7 @@ int ft847_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
         }
     }
 
-    return write_block(&rig_s->rigport, (char *)p_cmd, YAESU_CMD_LENGTH);
+    return write_block(&rig->state.rigport, (char *)p_cmd, YAESU_CMD_LENGTH);
 }
 
 #define MD_LSB  0x00

--- a/rigs/yaesu/ft857.c
+++ b/rigs/yaesu/ft857.c
@@ -76,8 +76,6 @@
 
 struct ft857_priv_data
 {
-    yaesu_cmd_set_t pcs[FT857_NATIVE_SIZE];  /* TODO:  why? */
-
     /* rx status */
     struct timeval rx_status_tv;
     unsigned char rx_status;
@@ -316,19 +314,12 @@ const struct rig_caps ft857_caps =
 
 int ft857_init(RIG *rig)
 {
-    struct ft857_priv_data *priv;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s: called \n", __func__);
 
     if ((rig->state.priv = calloc(1, sizeof(struct ft857_priv_data))) == NULL)
     {
         return -RIG_ENOMEM;
     }
-
-    priv = rig->state.priv;
-
-    /* Copy complete native cmd set to private cmd storage area */
-    memcpy(priv->pcs, ncmd, sizeof(ncmd));
 
     return RIG_OK;
 }
@@ -400,12 +391,11 @@ static int check_cache_timeout(struct timeval *tv)
 
 static int ft857_read_eeprom(RIG *rig, unsigned short addr, unsigned char *out)
 {
-    struct ft857_priv_data *p = (struct ft857_priv_data *) rig->state.priv;
     unsigned char data[YAESU_CMD_LENGTH];
     int n;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: called \n", __func__);
-    memcpy(data, (char *)p->pcs[FT857_NATIVE_CAT_EEPROM_READ].nseq,
+    memcpy(data, (char *)ncmd[FT857_NATIVE_CAT_EEPROM_READ].nseq,
            YAESU_CMD_LENGTH);
 
     data[0] = addr >> 8;
@@ -465,7 +455,7 @@ static int ft857_get_status(RIG *rig, int status)
 
     rig_flush(&rig->state.rigport);
 
-    write_block(&rig->state.rigport, (char *) p->pcs[status].nseq,
+    write_block(&rig->state.rigport, (char *) ncmd[status].nseq,
                 YAESU_CMD_LENGTH);
 
     if ((n = read_block(&rig->state.rigport, (char *) data, len)) < 0)
@@ -499,17 +489,15 @@ static int ft857_get_status(RIG *rig, int status)
  */
 static int ft857_send_cmd(RIG *rig, int index)
 {
-    struct ft857_priv_data *p = (struct ft857_priv_data *) rig->state.priv;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s: called \n", __func__);
 
-    if (p->pcs[index].ncomp == 0)
+    if (ncmd[index].ncomp == 0)
     {
         rig_debug(RIG_DEBUG_VERBOSE, "%s: incomplete sequence\n", __func__);
         return -RIG_EINTERNAL;
     }
 
-    write_block(&rig->state.rigport, (char *) p->pcs[index].nseq, YAESU_CMD_LENGTH);
+    write_block(&rig->state.rigport, (char *) ncmd[index].nseq, YAESU_CMD_LENGTH);
     return ft817_read_ack(rig);
 }
 
@@ -518,18 +506,17 @@ static int ft857_send_cmd(RIG *rig, int index)
  */
 static int ft857_send_icmd(RIG *rig, int index, unsigned char *data)
 {
-    struct ft857_priv_data *p = (struct ft857_priv_data *) rig->state.priv;
     unsigned char cmd[YAESU_CMD_LENGTH];
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: called \n", __func__);
 
-    if (p->pcs[index].ncomp == 1)
+    if (ncmd[index].ncomp == 1)
     {
         rig_debug(RIG_DEBUG_VERBOSE, "%s: complete sequence\n", __func__);
         return -RIG_EINTERNAL;
     }
 
-    cmd[YAESU_CMD_LENGTH - 1] = p->pcs[index].nseq[YAESU_CMD_LENGTH - 1];
+    cmd[YAESU_CMD_LENGTH - 1] = ncmd[index].nseq[YAESU_CMD_LENGTH - 1];
     memcpy(cmd, data, YAESU_CMD_LENGTH - 1);
 
     write_block(&rig->state.rigport, (char *) cmd, YAESU_CMD_LENGTH);

--- a/rigs/yaesu/ft890.c
+++ b/rigs/yaesu/ft890.c
@@ -1636,7 +1636,6 @@ static int ft890_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op)
 
 static int ft890_get_update_data(RIG *rig, unsigned char ci, unsigned char rl)
 {
-    struct rig_state *rig_s;
     struct ft890_priv_data *priv;
     int n, err;                       /* for read_  */
 
@@ -1648,7 +1647,6 @@ static int ft890_get_update_data(RIG *rig, unsigned char ci, unsigned char rl)
     }
 
     priv = (struct ft890_priv_data *)rig->state.priv;
-    rig_s = &rig->state;
 
     err = ft890_send_static_cmd(rig, ci);
 
@@ -1657,7 +1655,7 @@ static int ft890_get_update_data(RIG *rig, unsigned char ci, unsigned char rl)
         return err;
     }
 
-    n = read_block(&rig_s->rigport, (char *) priv->update_data, rl);
+    n = read_block(&rig->state.rigport, (char *) priv->update_data, rl);
 
     if (n < 0)
     {
@@ -1684,7 +1682,6 @@ static int ft890_get_update_data(RIG *rig, unsigned char ci, unsigned char rl)
 
 static int ft890_send_static_cmd(RIG *rig, unsigned char ci)
 {
-    struct rig_state *rig_s;
     int err;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
@@ -1694,8 +1691,6 @@ static int ft890_send_static_cmd(RIG *rig, unsigned char ci)
         return -RIG_EINVAL;
     }
 
-    rig_s = &rig->state;
-
     if (!ncmd[ci].ncomp)
     {
         rig_debug(RIG_DEBUG_TRACE,
@@ -1703,7 +1698,7 @@ static int ft890_send_static_cmd(RIG *rig, unsigned char ci)
         return -RIG_EINVAL;
     }
 
-    err = write_block(&rig_s->rigport, (char *) ncmd[ci].nseq,
+    err = write_block(&rig->state.rigport, (char *) ncmd[ci].nseq,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -1733,7 +1728,6 @@ static int ft890_send_dynamic_cmd(RIG *rig, unsigned char ci,
                                   unsigned char p1, unsigned char p2,
                                   unsigned char p3, unsigned char p4)
 {
-    struct rig_state *rig_s;
     struct ft890_priv_data *priv;
     int err;
 
@@ -1758,7 +1752,6 @@ static int ft890_send_dynamic_cmd(RIG *rig, unsigned char ci,
         return -RIG_EINVAL;
     }
 
-    rig_s = &rig->state;
     memcpy(&priv->p_cmd, &ncmd[ci].nseq, YAESU_CMD_LENGTH);
 
     priv->p_cmd[P1] = p1;         /* ick */
@@ -1766,7 +1759,7 @@ static int ft890_send_dynamic_cmd(RIG *rig, unsigned char ci,
     priv->p_cmd[P3] = p3;
     priv->p_cmd[P4] = p4;
 
-    err = write_block(&rig_s->rigport, (char *) &priv->p_cmd,
+    err = write_block(&rig->state.rigport, (char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -1794,7 +1787,6 @@ static int ft890_send_dynamic_cmd(RIG *rig, unsigned char ci,
 
 static int ft890_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
 {
-    struct rig_state *rig_s;
     struct ft890_priv_data *priv;
     int err;
     // cppcheck-suppress *
@@ -1819,8 +1811,6 @@ static int ft890_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
         return -RIG_EINVAL;
     }
 
-    rig_s = &rig->state;
-
     /* Copy native cmd freq_set to private cmd storage area */
     memcpy(&priv->p_cmd, &ncmd[ci].nseq, YAESU_CMD_LENGTH);
 
@@ -1830,7 +1820,7 @@ static int ft890_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
     rig_debug(RIG_DEBUG_TRACE, fmt, __func__, (int64_t)from_bcd(priv->p_cmd,
               FT890_BCD_DIAL) * 10);
 
-    err = write_block(&rig_s->rigport, (char *) &priv->p_cmd,
+    err = write_block(&rig->state.rigport, (char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -1862,7 +1852,6 @@ static int ft890_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
 
 static int ft890_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
 {
-    struct rig_state *rig_s;
     struct ft890_priv_data *priv;
     unsigned char p1;
     unsigned char p2;
@@ -1886,8 +1875,6 @@ static int ft890_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
                   "%s: Attempt to modify complete sequence\n", __func__);
         return -RIG_EINVAL;
     }
-
-    rig_s = &rig->state;
 
     p1 = CLAR_SET_FREQ;
 
@@ -1914,7 +1901,7 @@ static int ft890_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
     priv->p_cmd[P1] = p1;         /* ick */
     priv->p_cmd[P2] = p2;
 
-    err = write_block(&rig_s->rigport, (char *) &priv->p_cmd,
+    err = write_block(&rig->state.rigport, (char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)

--- a/rigs/yaesu/ft890.c
+++ b/rigs/yaesu/ft890.c
@@ -139,7 +139,6 @@ struct ft890_priv_data
     vfo_t current_vfo;                        /* active VFO from last cmd */
     unsigned char
     p_cmd[YAESU_CMD_LENGTH];    /* private copy of 1 constructed CAT cmd */
-    yaesu_cmd_set_t pcs[FT890_NATIVE_SIZE];   /* private cmd set */
     unsigned char
     update_data[FT890_ALL_DATA_LENGTH]; /* returned data--max value, some are less */
     unsigned char current_mem;                   /* private memory channel number */
@@ -301,11 +300,6 @@ static int ft890_init(RIG *rig)
     }
 
     priv = rig->state.priv;
-
-    /*
-     * Copy native cmd set to private cmd storage area
-     */
-    memcpy(priv->pcs, ncmd, sizeof(ncmd));
 
     /* TODO: read pacing from preferences */
     priv->pacing = FT890_PACING_DEFAULT_VALUE; /* set pacing to minimum for now */
@@ -1682,7 +1676,7 @@ static int ft890_get_update_data(RIG *rig, unsigned char ci, unsigned char rl)
  * TODO: place variant of this in yaesu.c
  *
  * Arguments:   *rig    Valid RIG instance
- *              ci      Command index of the pcs struct
+ *              ci      Command index of the ncmd table
  *
  * Returns:     RIG_OK if all called functions are successful,
  *              otherwise returns error from called functiion
@@ -1691,7 +1685,6 @@ static int ft890_get_update_data(RIG *rig, unsigned char ci, unsigned char rl)
 static int ft890_send_static_cmd(RIG *rig, unsigned char ci)
 {
     struct rig_state *rig_s;
-    struct ft890_priv_data *priv;
     int err;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
@@ -1701,17 +1694,16 @@ static int ft890_send_static_cmd(RIG *rig, unsigned char ci)
         return -RIG_EINVAL;
     }
 
-    priv = (struct ft890_priv_data *)rig->state.priv;
     rig_s = &rig->state;
 
-    if (!priv->pcs[ci].ncomp)
+    if (!ncmd[ci].ncomp)
     {
         rig_debug(RIG_DEBUG_TRACE,
                   "%s: Attempt to send incomplete sequence\n", __func__);
         return -RIG_EINVAL;
     }
 
-    err = write_block(&rig_s->rigport, (char *) priv->pcs[ci].nseq,
+    err = write_block(&rig_s->rigport, (char *) ncmd[ci].nseq,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -1730,7 +1722,7 @@ static int ft890_send_static_cmd(RIG *rig, unsigned char ci)
  * TODO: place variant of this in yaesu.c
  *
  * Arguments:   *rig    Valid RIG instance
- *              ci      Command index of the pcs struct
+ *              ci      Command index of the ncmd table
  *              p1-p4   Command parameters
  *
  * Returns:     RIG_OK if all called functions are successful,
@@ -1759,7 +1751,7 @@ static int ft890_send_dynamic_cmd(RIG *rig, unsigned char ci,
 
     priv = (struct ft890_priv_data *)rig->state.priv;
 
-    if (priv->pcs[ci].ncomp)
+    if (ncmd[ci].ncomp)
     {
         rig_debug(RIG_DEBUG_TRACE,
                   "%s: Attempt to modify complete sequence\n", __func__);
@@ -1793,7 +1785,7 @@ static int ft890_send_dynamic_cmd(RIG *rig, unsigned char ci,
  * TODO: place variant of this in yaesu.c
  *
  * Arguments:   *rig    Valid RIG instance
- *              ci      Command index of the pcs struct
+ *              ci      Command index of the ncmd table
  *              freq    freq_t frequency value
  *
  * Returns:     RIG_OK if all called functions are successful,
@@ -1820,7 +1812,7 @@ static int ft890_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
 
     priv = (struct ft890_priv_data *)rig->state.priv;
 
-    if (priv->pcs[ci].ncomp)
+    if (ncmd[ci].ncomp)
     {
         rig_debug(RIG_DEBUG_TRACE,
                   "%s: Attempt to modify complete sequence\n", __func__);
@@ -1857,7 +1849,7 @@ static int ft890_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
  * TODO: place variant of this in yaesu.c
  *
  * Arguments:   *rig    Valid RIG instance
- *              ci      Command index of the pcs struct
+ *              ci      Command index of the ncmd table
  *              rit     shortfreq_t frequency value
  *              p1      P1 value -- CLAR_SET_FREQ
  *              p2      P2 value -- CLAR_OFFSET_PLUS || CLAR_OFFSET_MINUS
@@ -1888,7 +1880,7 @@ static int ft890_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
 
     priv = (struct ft890_priv_data *)rig->state.priv;
 
-    if (priv->pcs[ci].ncomp)
+    if (ncmd[ci].ncomp)
     {
         rig_debug(RIG_DEBUG_TRACE,
                   "%s: Attempt to modify complete sequence\n", __func__);

--- a/rigs/yaesu/ft900.c
+++ b/rigs/yaesu/ft900.c
@@ -1638,10 +1638,9 @@ static int ft900_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op)
 
 static int ft900_get_update_data(RIG *rig, unsigned char ci, unsigned char rl)
 {
-    struct rig_state *rig_s;
     struct ft900_priv_data *priv;
-    int n, err;                       /* for read_  */
-
+    int err;
+    int n;
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
     if (!rig)
@@ -1650,7 +1649,6 @@ static int ft900_get_update_data(RIG *rig, unsigned char ci, unsigned char rl)
     }
 
     priv = (struct ft900_priv_data *)rig->state.priv;
-    rig_s = &rig->state;
 
     err = ft900_send_static_cmd(rig, ci);
 
@@ -1659,7 +1657,7 @@ static int ft900_get_update_data(RIG *rig, unsigned char ci, unsigned char rl)
         return err;
     }
 
-    n = read_block(&rig_s->rigport, (char *) priv->update_data, rl);
+    n = read_block(&rig->state.rigport, (char *) priv->update_data, rl);
 
     if (n < 0)
     {
@@ -1686,7 +1684,6 @@ static int ft900_get_update_data(RIG *rig, unsigned char ci, unsigned char rl)
 
 static int ft900_send_static_cmd(RIG *rig, unsigned char ci)
 {
-    struct rig_state *rig_s;
     int err;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
@@ -1696,8 +1693,6 @@ static int ft900_send_static_cmd(RIG *rig, unsigned char ci)
         return -RIG_EINVAL;
     }
 
-    rig_s = &rig->state;
-
     if (!ncmd[ci].ncomp)
     {
         rig_debug(RIG_DEBUG_TRACE,
@@ -1705,7 +1700,7 @@ static int ft900_send_static_cmd(RIG *rig, unsigned char ci)
         return -RIG_EINVAL;
     }
 
-    err = write_block(&rig_s->rigport, (char *) ncmd[ci].nseq,
+    err = write_block(&rig->state.rigport, (char *) ncmd[ci].nseq,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -1735,7 +1730,6 @@ static int ft900_send_dynamic_cmd(RIG *rig, unsigned char ci,
                                   unsigned char p1, unsigned char p2,
                                   unsigned char p3, unsigned char p4)
 {
-    struct rig_state *rig_s;
     struct ft900_priv_data *priv;
     int err;
 
@@ -1760,7 +1754,6 @@ static int ft900_send_dynamic_cmd(RIG *rig, unsigned char ci,
         return -RIG_EINVAL;
     }
 
-    rig_s = &rig->state;
     memcpy(&priv->p_cmd, &ncmd[ci].nseq, YAESU_CMD_LENGTH);
 
     priv->p_cmd[P1] = p1;         /* ick */
@@ -1768,7 +1761,7 @@ static int ft900_send_dynamic_cmd(RIG *rig, unsigned char ci,
     priv->p_cmd[P3] = p3;
     priv->p_cmd[P4] = p4;
 
-    err = write_block(&rig_s->rigport, (char *) &priv->p_cmd,
+    err = write_block(&rig->state.rigport, (char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -1796,7 +1789,6 @@ static int ft900_send_dynamic_cmd(RIG *rig, unsigned char ci,
 
 static int ft900_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
 {
-    struct rig_state *rig_s;
     struct ft900_priv_data *priv;
     int err;
     // cppcheck-suppress *
@@ -1821,8 +1813,6 @@ static int ft900_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
         return -RIG_EINVAL;
     }
 
-    rig_s = &rig->state;
-
     /* Copy native cmd freq_set to private cmd storage area */
     memcpy(&priv->p_cmd, &ncmd[ci].nseq, YAESU_CMD_LENGTH);
 
@@ -1832,7 +1822,7 @@ static int ft900_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
     rig_debug(RIG_DEBUG_TRACE, fmt, __func__, (int64_t)from_bcd(priv->p_cmd,
               FT900_BCD_DIAL) * 10);
 
-    err = write_block(&rig_s->rigport, (char *) &priv->p_cmd,
+    err = write_block(&rig->state.rigport, (char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -1864,7 +1854,6 @@ static int ft900_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
 
 static int ft900_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
 {
-    struct rig_state *rig_s;
     struct ft900_priv_data *priv;
     unsigned char p1;
     unsigned char p2;
@@ -1888,8 +1877,6 @@ static int ft900_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
                   "%s: Attempt to modify complete sequence\n", __func__);
         return -RIG_EINVAL;
     }
-
-    rig_s = &rig->state;
 
     p1 = CLAR_SET_FREQ;
 
@@ -1916,7 +1903,7 @@ static int ft900_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
     priv->p_cmd[P1] = p1;         /* ick */
     priv->p_cmd[P2] = p2;
 
-    err = write_block(&rig_s->rigport, (char *) &priv->p_cmd,
+    err = write_block(&rig->state.rigport, (char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)

--- a/rigs/yaesu/ft920.c
+++ b/rigs/yaesu/ft920.c
@@ -453,7 +453,7 @@ static int ft920_open(RIG *rig)
 
     rig_debug(RIG_DEBUG_TRACE, "%s: read pacing = %i\n", __func__, priv->pacing);
 
-    err = write_block(&rig_s->rigport, (char *) priv->p_cmd, YAESU_CMD_LENGTH);
+    err = write_block(&rig->state.rigport, (char *) priv->p_cmd, YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
     {
@@ -2350,7 +2350,6 @@ static int ft920_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
 
 static int ft920_get_update_data(RIG *rig, unsigned char ci, unsigned char rl)
 {
-    struct rig_state *rig_s;
     struct ft920_priv_data *priv;
     int n;                              /* for read_  */
     int err;
@@ -2363,7 +2362,6 @@ static int ft920_get_update_data(RIG *rig, unsigned char ci, unsigned char rl)
     }
 
     priv = (struct ft920_priv_data *)rig->state.priv;
-    rig_s = &rig->state;
 
     err = ft920_send_static_cmd(rig, ci);
 
@@ -2372,7 +2370,7 @@ static int ft920_get_update_data(RIG *rig, unsigned char ci, unsigned char rl)
         return err;
     }
 
-    n = read_block(&rig_s->rigport, (char *)priv->update_data, rl);
+    n = read_block(&rig->state.rigport, (char *)priv->update_data, rl);
 
     if (n < 0)
     {
@@ -2399,7 +2397,6 @@ static int ft920_get_update_data(RIG *rig, unsigned char ci, unsigned char rl)
 
 static int ft920_send_static_cmd(RIG *rig, unsigned char ci)
 {
-    struct rig_state *rig_s;
     int err;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
@@ -2409,7 +2406,6 @@ static int ft920_send_static_cmd(RIG *rig, unsigned char ci)
         return -RIG_EINVAL;
     }
 
-    rig_s = &rig->state;
     /*
      * If we've been passed a command index (ci) that is marked
      * as dynamic (0), then bail out.
@@ -2421,7 +2417,7 @@ static int ft920_send_static_cmd(RIG *rig, unsigned char ci)
         return -RIG_EINVAL;
     }
 
-    err = write_block(&rig_s->rigport, (char *) ncmd[ci].nseq,
+    err = write_block(&rig->state.rigport, (char *) ncmd[ci].nseq,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -2451,7 +2447,6 @@ static int ft920_send_dynamic_cmd(RIG *rig, unsigned char ci,
                                   unsigned char p1, unsigned char p2,
                                   unsigned char p3, unsigned char p4)
 {
-    struct rig_state *rig_s;
     struct ft920_priv_data *priv;
     int err;
 
@@ -2481,7 +2476,6 @@ static int ft920_send_dynamic_cmd(RIG *rig, unsigned char ci,
         return -RIG_EINVAL;
     }
 
-    rig_s = &rig->state;
     memcpy(&priv->p_cmd, &ncmd[ci].nseq, YAESU_CMD_LENGTH);
 
     priv->p_cmd[P1] = p1;               /* ick */
@@ -2489,7 +2483,7 @@ static int ft920_send_dynamic_cmd(RIG *rig, unsigned char ci,
     priv->p_cmd[P3] = p3;
     priv->p_cmd[P4] = p4;
 
-    err = write_block(&rig_s->rigport, (char *) &priv->p_cmd, YAESU_CMD_LENGTH);
+    err = write_block(&rig->state.rigport, (char *) &priv->p_cmd, YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
     {
@@ -2516,7 +2510,6 @@ static int ft920_send_dynamic_cmd(RIG *rig, unsigned char ci,
 
 static int ft920_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
 {
-    struct rig_state *rig_s;
     struct ft920_priv_data *priv;
     int err;
     // cppcheck-suppress *
@@ -2545,8 +2538,6 @@ static int ft920_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
         return -RIG_EINVAL;
     }
 
-    rig_s = &rig->state;
-
     /* Copy native cmd freq_set to private cmd storage area */
     memcpy(&priv->p_cmd, &ncmd[ci].nseq, YAESU_CMD_LENGTH);
 
@@ -2556,7 +2547,7 @@ static int ft920_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
     rig_debug(RIG_DEBUG_TRACE, fmt, __func__, (int64_t)from_bcd(priv->p_cmd,
               FT920_BCD_DIAL) * 10);
 
-    err = write_block(&rig_s->rigport, (char *) &priv->p_cmd, YAESU_CMD_LENGTH);
+    err = write_block(&rig->state.rigport, (char *) &priv->p_cmd, YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
     {
@@ -2587,7 +2578,6 @@ static int ft920_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
 
 static int ft920_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
 {
-    struct rig_state *rig_s;
     struct ft920_priv_data *priv;
     unsigned char p1;
     unsigned char p2;
@@ -2616,8 +2606,6 @@ static int ft920_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
         return -RIG_EINVAL;
     }
 
-    rig_s = &rig->state;
-
     p1 = CLAR_SET_FREQ;
 
     if (rit < 0)
@@ -2642,7 +2630,7 @@ static int ft920_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
     priv->p_cmd[P1] = p1;               /* ick */
     priv->p_cmd[P2] = p2;
 
-    err = write_block(&rig_s->rigport, (char *) &priv->p_cmd, YAESU_CMD_LENGTH);
+    err = write_block(&rig->state.rigport, (char *) &priv->p_cmd, YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
     {

--- a/rigs/yaesu/ft990.c
+++ b/rigs/yaesu/ft990.c
@@ -125,7 +125,6 @@ struct ft990_priv_data
     unsigned int read_update_delay;           /* depends on pacing value */
     vfo_t current_vfo;                        /* active VFO from last cmd */
     unsigned char p_cmd[YAESU_CMD_LENGTH];    /* private copy of CAT cmd */
-    yaesu_cmd_set_t pcs[FT990_NATIVE_SIZE];   /* private cmd set */
     ft990_update_data_t update_data;          /* returned data */
 };
 
@@ -309,9 +308,6 @@ int ft990_init(RIG *rig)
     }
 
     priv = rig->state.priv;
-
-// Copy native cmd set to private cmd storage area
-    memcpy(priv->pcs, ncmd, sizeof(ncmd));
 
     // Set default pacing value
     priv->pacing = FT990_PACING_DEFAULT_VALUE;
@@ -3221,7 +3217,7 @@ int ft990_get_update_data(RIG *rig, unsigned char ci, unsigned short ch)
  * TODO: place variant of this in yaesu.c
  *
  * Arguments:   *rig    Valid RIG instance
- *              ci      Command index of the pcs struct
+ *              ci      Command index of the ncmd table
  *
  * Returns:     RIG_OK if all called functions are successful,
  *              otherwise returns error from called functiion
@@ -3229,7 +3225,6 @@ int ft990_get_update_data(RIG *rig, unsigned char ci, unsigned short ch)
 int ft990_send_static_cmd(RIG *rig, unsigned char ci)
 {
     struct rig_state *rig_s;
-    struct ft990_priv_data *priv;
     int err;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
@@ -3239,17 +3234,16 @@ int ft990_send_static_cmd(RIG *rig, unsigned char ci)
         return -RIG_EINVAL;
     }
 
-    priv = (struct ft990_priv_data *)rig->state.priv;
     rig_s = &rig->state;
 
-    if (!priv->pcs[ci].ncomp)
+    if (!ncmd[ci].ncomp)
     {
         rig_debug(RIG_DEBUG_TRACE,
                   "%s: Attempt to send incomplete sequence\n", __func__);
         return -RIG_EINVAL;
     }
 
-    err = write_block(&rig_s->rigport, (char *) priv->pcs[ci].nseq,
+    err = write_block(&rig_s->rigport, (char *) ncmd[ci].nseq,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -3267,7 +3261,7 @@ int ft990_send_static_cmd(RIG *rig, unsigned char ci)
  * TODO: place variant of this in yaesu.c
  *
  * Arguments:   *rig    Valid RIG instance
- *              ci      Command index of the pcs struct
+ *              ci      Command index of the ncmd table
  *              p1-p4   Command parameters
  *
  * Returns:     RIG_OK if all called functions are successful,
@@ -3295,7 +3289,7 @@ int ft990_send_dynamic_cmd(RIG *rig, unsigned char ci,
 
     priv = (struct ft990_priv_data *)rig->state.priv;
 
-    if (priv->pcs[ci].ncomp)
+    if (ncmd[ci].ncomp)
     {
         rig_debug(RIG_DEBUG_TRACE,
                   "%s: Attempt to modify complete sequence\n", __func__);
@@ -3328,7 +3322,7 @@ int ft990_send_dynamic_cmd(RIG *rig, unsigned char ci,
  * TODO: place variant of this in yaesu.c
  *
  * Arguments:   *rig    Valid RIG instance
- *              ci      Command index of the pcs struct
+ *              ci      Command index of the ncmd table
  *              freq    freq_t frequency value
  *
  * Returns:     RIG_OK if all called functions are successful,
@@ -3354,7 +3348,7 @@ int ft990_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
 
     priv = (struct ft990_priv_data *)rig->state.priv;
 
-    if (priv->pcs[ci].ncomp)
+    if (ncmd[ci].ncomp)
     {
         rig_debug(RIG_DEBUG_TRACE,
                   "%s: Attempt to modify complete sequence\n", __func__);
@@ -3388,7 +3382,7 @@ int ft990_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
  * change the rit frequency.
  *
  * Arguments:   *rig    Valid RIG instance
- *              ci      Command index of the pcs struct
+ *              ci      Command index of the ncmd table
  *              rit    shortfreq_t frequency value
  *
  * Returns:     RIG_OK if all called functions are successful,
@@ -3413,7 +3407,7 @@ int ft990_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
     priv = (struct ft990_priv_data *) rig->state.priv;
     rig_s = &rig->state;
 
-    if (priv->pcs[ci].ncomp)
+    if (ncmd[ci].ncomp)
     {
         rig_debug(RIG_DEBUG_TRACE, "%s: Attempt to modify complete sequence\n",
                   __func__);

--- a/rigs/yaesu/ft990.c
+++ b/rigs/yaesu/ft990.c
@@ -2281,7 +2281,6 @@ int ft990_get_vfo(RIG *rig, vfo_t *vfo)
 int ft990_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *value)
 {
     struct ft990_priv_data *priv;
-    struct rig_state *rig_s;
     unsigned char mdata[YAESU_CMD_LENGTH];
     int err;
 
@@ -2324,8 +2323,7 @@ int ft990_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *value)
         return err;
     }
 
-    rig_s = &rig->state;
-    err = read_block(&rig_s->rigport, (char *) mdata, FT990_READ_METER_LENGTH);
+    err = read_block(&rig->state.rigport, (char *) mdata, FT990_READ_METER_LENGTH);
 
     if (err < 0)
     {
@@ -3124,7 +3122,6 @@ int ft990_get_channel(RIG *rig, vfo_t vfo, channel_t *chan, int read_only)
  */
 int ft990_get_update_data(RIG *rig, unsigned char ci, unsigned short ch)
 {
-    struct rig_state *rig_s;
     struct ft990_priv_data *priv;
     int n;
     int err;
@@ -3142,7 +3139,6 @@ int ft990_get_update_data(RIG *rig, unsigned char ci, unsigned short ch)
     }
 
     priv = (struct ft990_priv_data *)rig->state.priv;
-    rig_s = &rig->state;
 
     if (ci == FT990_NATIVE_UPDATE_MEM_CHNL_DATA)
         // P4 = 0x01 to 0x5a for channel 1 - 90
@@ -3194,7 +3190,7 @@ int ft990_get_update_data(RIG *rig, unsigned char ci, unsigned short ch)
         return -RIG_EINVAL;
     }
 
-    n = read_block(&rig_s->rigport, p, rl);
+    n = read_block(&rig->state.rigport, p, rl);
 
     if (n < 0)
     {
@@ -3224,7 +3220,6 @@ int ft990_get_update_data(RIG *rig, unsigned char ci, unsigned short ch)
  */
 int ft990_send_static_cmd(RIG *rig, unsigned char ci)
 {
-    struct rig_state *rig_s;
     int err;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
@@ -3234,8 +3229,6 @@ int ft990_send_static_cmd(RIG *rig, unsigned char ci)
         return -RIG_EINVAL;
     }
 
-    rig_s = &rig->state;
-
     if (!ncmd[ci].ncomp)
     {
         rig_debug(RIG_DEBUG_TRACE,
@@ -3243,7 +3236,7 @@ int ft990_send_static_cmd(RIG *rig, unsigned char ci)
         return -RIG_EINVAL;
     }
 
-    err = write_block(&rig_s->rigport, (char *) ncmd[ci].nseq,
+    err = write_block(&rig->state.rigport, (char *) ncmd[ci].nseq,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -3271,7 +3264,6 @@ int ft990_send_dynamic_cmd(RIG *rig, unsigned char ci,
                            unsigned char p1, unsigned char p2,
                            unsigned char p3, unsigned char p4)
 {
-    struct rig_state *rig_s;
     struct ft990_priv_data *priv;
     int err;
 
@@ -3296,7 +3288,6 @@ int ft990_send_dynamic_cmd(RIG *rig, unsigned char ci,
         return -RIG_EINVAL;
     }
 
-    rig_s = &rig->state;
     memcpy(&priv->p_cmd, &ncmd[ci].nseq, YAESU_CMD_LENGTH);
 
     priv->p_cmd[3] = p1;
@@ -3304,7 +3295,7 @@ int ft990_send_dynamic_cmd(RIG *rig, unsigned char ci,
     priv->p_cmd[1] = p3;
     priv->p_cmd[0] = p4;
 
-    err = write_block(&rig_s->rigport, (char *) &priv->p_cmd,
+    err = write_block(&rig->state.rigport, (char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -3330,7 +3321,6 @@ int ft990_send_dynamic_cmd(RIG *rig, unsigned char ci,
  */
 int ft990_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
 {
-    struct rig_state *rig_s;
     struct ft990_priv_data *priv;
     int err;
     // cppcheck-suppress *
@@ -3355,8 +3345,6 @@ int ft990_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
         return -RIG_EINVAL;
     }
 
-    rig_s = &rig->state;
-
     /* Copy native cmd freq_set to private cmd storage area */
     memcpy(&priv->p_cmd, &ncmd[ci].nseq, YAESU_CMD_LENGTH);
 
@@ -3366,7 +3354,7 @@ int ft990_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
     rig_debug(RIG_DEBUG_TRACE, fmt, __func__, (int64_t)from_bcd(priv->p_cmd,
               FT990_BCD_DIAL) * 10);
 
-    err = write_block(&rig_s->rigport, (char *) &priv->p_cmd,
+    err = write_block(&rig->state.rigport, (char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -3391,7 +3379,6 @@ int ft990_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
 int ft990_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
 {
     struct ft990_priv_data *priv;
-    struct rig_state *rig_s;
     int err;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
@@ -3405,7 +3392,6 @@ int ft990_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
     rig_debug(RIG_DEBUG_TRACE, "%s: passed rit = %li Hz\n", __func__, rit);
 
     priv = (struct ft990_priv_data *) rig->state.priv;
-    rig_s = &rig->state;
 
     if (ncmd[ci].ncomp)
     {
@@ -3433,7 +3419,7 @@ int ft990_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
     // Store bcd format into privat command storage area
     to_bcd(priv->p_cmd, labs(rit) / 10, FT990_BCD_RIT);
 
-    err = write_block(&rig_s->rigport, (char *) &priv->p_cmd,
+    err = write_block(&rig->state.rigport, (char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)

--- a/rigs/yaesu/vx1700.c
+++ b/rigs/yaesu/vx1700.c
@@ -288,7 +288,7 @@ static int vx1700_do_transaction(RIG *rig,
  * TODO: place variant of this in yaesu.c
  *
  * Arguments:   *rig    Valid RIG instance
- *              ci      Command index of the ncmd struct
+ *              ci      Command index of the ncmd table
  *
  * Returns:     RIG_OK if all called functions are successful,
  *              otherwise returns error from called functiion
@@ -314,7 +314,7 @@ static int vx1700_do_static_cmd(RIG *rig, unsigned char ci)
  * TODO: place variant of this in yaesu.c
  *
  * Arguments:   *rig    Valid RIG instance
- *              ci      Command index of the ncmd struct
+ *              ci      Command index of the cmd struct
  *              p1-p4   Command parameters
  *
  * Returns:     RIG_OK if all called functions are successful,


### PR DESCRIPTION
Most Yaesu rigs have a private command table, which they pointlessly copy to their private structure where it is never written.
So drop the copy step and use the table direct; much easier to read and understand.
Also drop single use variable rig_s in most the of the same function already touched.