### PR TITLE
Fix compile-time errors in Android NDK environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ tests/rotctld
 src/hamlibdatetime.h
 .gdbinit
 build/
+libs/
+obj/

--- a/Android.mk
+++ b/Android.mk
@@ -48,3 +48,4 @@ include $(TOP_PATH)/rotators/sartek/Android.mk
 include $(TOP_PATH)/rotators/satel/Android.mk
 include $(TOP_PATH)/rotators/spid/Android.mk
 include $(TOP_PATH)/rotators/ts7400/Android.mk
+include $(TOP_PATH)/rotators/radant/Android.mk

--- a/android/README.android
+++ b/android/README.android
@@ -1,3 +1,6 @@
+Update Note:
+These Android NDK scripts can compile the 4.3 version of hamlib normally, but they may be corrupted as the master branch code is updated. If you encounter compile-time errors, please try to fix them, or choose to recompile with version 4.3.
+
 This is android port of hamlib
 (C) 2012 Ladislav Vaiz <ok1zia@nagano.cz>
 

--- a/rigs/kenwood/Android.mk
+++ b/rigs/kenwood/Android.mk
@@ -8,7 +8,7 @@ LOCAL_SRC_FILES := ts850.c ts870s.c ts570.c ts450s.c ts950.c ts50s.c \
 		ts440.c ts940.c ts711.c ts811.c r5000.c \
 		thd7.c thf7.c thg71.c tmd700.c tmv7.c thf6a.c thd72.c tmd710.c \
 		kenwood.c th.c ic10.c elecraft.c transfox.c flex6xxx.c ts990s.c \
-		xg3.c thd74.c flex.c pihpsdr.c
+		xg3.c thd74.c flex.c pihpsdr.c ts890s.c
 LOCAL_MODULE := kenwood
 
 LOCAL_CFLAGS := -DHAVE_CONFIG_H

--- a/rotators/radant/Android.mk
+++ b/rotators/radant/Android.mk
@@ -1,0 +1,12 @@
+LOCAL_PATH:= $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_SRC_FILES := radant.c
+LOCAL_MODULE := radant
+
+LOCAL_CFLAGS := -DHAVE_CONFIG_H
+LOCAL_C_INCLUDES := android include src
+LOCAL_LDLIBS := -lhamlib -Lobj/local/armeabi
+
+include $(BUILD_STATIC_LIBRARY)

--- a/src/Android.mk
+++ b/src/Android.mk
@@ -23,11 +23,12 @@ LOCAL_SRC_FILES := \
         parallel.c \
         debug.c \
         network.c \
-	sleep.c \
-	gpio.c \
-	microham.c \
-	rot_ext.c \
-        cm108.c
+        sleep.c \
+        gpio.c \
+        microham.c \
+        rot_ext.c \
+        cm108.c \
+        sprintflst.c
 
 
 LOCAL_MODULE := libhamlib
@@ -38,7 +39,7 @@ LOCAL_STATIC_LIBRARIES := adat alinco amsat aor ars barrett celestron cnctrk \
         gs232a heathkit icmarine icom ioptron jrc kachina kenwood kit \
         lowe m2 meade pcr prm80 prosistel racal rft \
         rotorez rs sartek satel skanti spid tapr tentec ts7400 tuner \
-        uniden wj yaesu
+        uniden wj yaesu radant
 
 LOCAL_LDLIBS := -llog
 


### PR DESCRIPTION
Fixed some errors. It seems that the NDK files are outdated and are not synchronized with the code of the master branch.