### PR TITLE
Fix rig_cookie: use lock for reads and write.

### DIFF
--- a/tests/testcookie.c
+++ b/tests/testcookie.c
@@ -1,7 +1,7 @@
 #include <hamlib/rig.h>
 
 // GET tests
-int test1()
+static int test1()
 {
     int retcode;
     // Normal get
@@ -45,7 +45,7 @@ int test1()
 }
 
 // RENEW tests
-int test2()
+static int test2()
 {
     int retcode;
     char cookie[HAMLIB_COOKIE_SIZE];
@@ -72,9 +72,61 @@ int test2()
     if (retcode != RIG_OK) { printf("Test#2d OK\n"); }
     else {printf("Test#2d Failed cookie=%s\n", cookie); return 1;}
 
+// release cookie2 again to clean up test
+    retcode = rig_cookie(NULL, RIG_COOKIE_RELEASE, cookie2, sizeof(cookie2));
+
+    if (retcode == RIG_OK) { printf("Test#2e OK\n"); }
+    else {printf("Test#2e Failed\n"); return 1;}
     return 0;
 }
 
+// Input sanity checks
+static int test3_invalid_input()
+{
+    int retcode;
+    char cookie[HAMLIB_COOKIE_SIZE];
+    /* Make sure any value smaller then HAMLIB_COOKIE_SIZE is rejected */
+    for(unsigned int i = 0; i < HAMLIB_COOKIE_SIZE; i++)
+    {
+        retcode = rig_cookie(NULL, RIG_COOKIE_GET, cookie, i);
+        if (retcode == -RIG_EINVAL) { printf("Test#3a OK\n"); }
+        else {printf("Test#3a Failed\n"); return 1;}
+    }
+
+    /* Make sure a NULL cookie is ignored */
+    retcode = rig_cookie(NULL, RIG_COOKIE_GET, NULL, sizeof(cookie));
+    if (retcode == -RIG_EINVAL) { printf("Test#3b OK\n"); }
+    else {printf("Test#3b Failed\n"); return 1;}
+
+    /* Make sure an invalid command is dropped with proto error */
+    retcode = rig_cookie(NULL, RIG_COOKIE_RENEW + 1, cookie, sizeof(cookie));
+    if (retcode == -RIG_EPROTO) { printf("Test#3c OK\n"); }
+    else {printf("Test#3c Failed\n"); return 1;}
+
+    return 0;
+}
+
+static int test4_large_cookie_size()
+{
+    int retcode;
+    char cookie[HAMLIB_COOKIE_SIZE * 2];
+
+    /* Using a larger cookie should also work */
+    retcode = rig_cookie(NULL, RIG_COOKIE_GET, cookie, sizeof(cookie));
+    if (retcode == RIG_OK) { printf("Test#4a OK\n"); }
+    else {printf("Test#4a Failed\n"); return 1;}
+
+    /* Cookie should be smaller the maximum specified by lib */
+    if (strlen(cookie) < HAMLIB_COOKIE_SIZE) { printf("Test#4b OK\n"); }
+    else {printf("Test#4b Failed\n"); return 1;}
+
+    /* Release the cookie again to clean up */
+    retcode = rig_cookie(NULL, RIG_COOKIE_RELEASE, cookie, sizeof(cookie));
+    if (retcode == RIG_OK) { printf("Test#4c OK\n"); }
+    else {printf("Test#4c Failed\n"); return 1;}
+
+    return 0;
+}
 
 int main()
 {
@@ -83,6 +135,10 @@ int main()
     if (test1()) { return 1; }
 
     if (test2()) { return 1; }
+
+    if (test3_invalid_input()) { return 1; }
+
+    if (test4_large_cookie_size()) { return 1; }
 
     return 0;
 }


### PR DESCRIPTION
Ensure we never print more then HAMLIB_COOKIE_SIZE otherwise we read out-of-bounds.
Drop stray printf.
Add tests for invalid input and overly large input.
Fix test2 to release the cookie.

This fixes #802