### PR TITLE
Fix Yaesu and Adat detect

### DIFF
--- a/rigs/adat/adat.c
+++ b/rigs/adat/adat.c
@@ -3706,7 +3706,7 @@ DECLARE_PROBERIG_BACKEND(adat)
     }
 
     port->write_delay = port->post_write_delay = 10;
-    port->parm.serial.stop_bits = 0;
+    port->parm.serial.stop_bits = 2;
     port->retry = 1;
 
 

--- a/rigs/yaesu/yaesu.c
+++ b/rigs/yaesu/yaesu.c
@@ -134,7 +134,7 @@ DECLARE_PROBERIG_BACKEND(yaesu)
     static const unsigned char cmd[YAESU_CMD_LENGTH] = { 0x00, 0x00, 0x00, 0x00, 0xfa};
     int id_len = -1, i, id1, id2;
     int retval = -1;
-    int rates[] = { 4800, 57600, 9600, 38400, 0 };  /* possible baud rates */
+    static const int rates[] = { 4800, 57600, 9600, 38400, 0 };  /* possible baud rates */
     int rates_idx;
 
     if (!port)
@@ -159,6 +159,7 @@ DECLARE_PROBERIG_BACKEND(yaesu)
         port->parm.serial.rate = rates[rates_idx];
         port->timeout = 2 * 1000 / rates[rates_idx] + 50;
 
+        printf("Yaesu trying rate = %d\n", rates[rates_idx]);
         retval = serial_open(port);
 
         if (retval != RIG_OK)
@@ -172,9 +173,9 @@ DECLARE_PROBERIG_BACKEND(yaesu)
 
         close(port->fd);
 
-        if (retval != RIG_OK || id_len < 0)
+        if (retval == RIG_OK && id_len > 0)
         {
-            continue;
+            break;
         }
     }
 

--- a/rigs/yaesu/yaesu.c
+++ b/rigs/yaesu/yaesu.c
@@ -159,7 +159,6 @@ DECLARE_PROBERIG_BACKEND(yaesu)
         port->parm.serial.rate = rates[rates_idx];
         port->timeout = 2 * 1000 / rates[rates_idx] + 50;
 
-        printf("Yaesu trying rate = %d\n", rates[rates_idx]);
         retval = serial_open(port);
 
         if (retval != RIG_OK)


### PR DESCRIPTION
Yaesu probe function did not exit the loop if it found something. So it never worked properly.
Adat used stop_bits = 0, which is interesting but not supported, the code does say probe is untested.