### PR TITLE
Add method to build inside docker

### DIFF
--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,0 +1,21 @@
+# Idea from https://github.com/ok2cqr/cqrlog
+
+FROM ubuntu:latest
+
+RUN apt-get update && apt-get -y upgrade
+
+ENV DEBIAN_FRONTEND="noninteractive" TZ="Europe/London"
+
+RUN apt-get install -y git build-essential automake libtool
+
+RUN mkdir -p /usr/local/hamlib-alpha /home/hamlib/build
+
+# Mount point for the git repository:
+VOLUME ["/home/hamlib/build"]
+
+# Mount point for the result of the build:
+VOLUME ["/usr/local/hamlib-alpha"]
+
+WORKDIR /home/hamlib/build
+
+ENTRYPOINT rm -rf build && mkdir -p build && cd build && ../bootstrap && ../configure --prefix=/usr/local/hamlib-alpha && make clean && make && make install

--- a/docker-build/README.docker
+++ b/docker-build/README.docker
@@ -1,0 +1,13 @@
+This is all about building hamlib inside docker contariner - so that you do not need to install dependencied on your local machine.
+
+1. Build docker container
+
+(cd docker-build && docker build --no-cache -t this.registry.is.invalid/hamlib-build .)
+
+2. Build hamlib
+
+docker run -ti -u root -v $(pwd):/home/hamlib/build -v /usr/local/hamlib-alpha:/usr/local/hamlib-alpha this.registry.is.invalid/hamlib-build
+
+3. Execute hamlib
+
+/usr/local/hamlib-alpha/bin/rigctl <your options here>


### PR DESCRIPTION
This does not influence core hamlib but add capability to build hamlib on local linux without making mess with dependencies on local computer.
