### PR TITLE
ic7610: Re-add send_morse

### DIFF
--- a/rigs/icom/ic7610.c
+++ b/rigs/icom/ic7610.c
@@ -475,6 +475,7 @@ const struct rig_caps ic7610_caps =
     .get_split_vfo =  icom_get_split_vfo,
     .set_powerstat = icom_set_powerstat,
     .get_powerstat = icom_get_powerstat,
+    .send_morse = icom_send_morse,
     .stop_morse = icom_stop_morse,
     .wait_morse = rig_wait_morse
 };


### PR DESCRIPTION
Commit 28b7543de660c432b22d0035b250d32fb91797e4 mistakenly removed
send_morse from ic7610, add it back.