### PR TITLE
The -M option needs an argument like its long version "multicast-addr"

### DIFF
--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -86,7 +86,7 @@
  *      keep up to date SHORT_OPTIONS, usage()'s output and man page. thanks.
  * TODO: add an option to read from a file
  */
-#define SHORT_OPTIONS "m:r:p:d:P:D:s:c:T:t:C:W:x:z:lLuovhVZM"
+#define SHORT_OPTIONS "m:r:p:d:P:D:s:c:T:t:C:W:x:z:lLuovhVZM:"
 static struct option long_options[] =
 {
     {"model",           1, 0, 'm'},


### PR DESCRIPTION
This PR adds the missing ':'.