### PR TITLE
Allow \send_voice_mem to be used over network and tested in dummy rig

### DIFF
--- a/rigs/dummy/dummy.c
+++ b/rigs/dummy/dummy.c
@@ -2104,6 +2104,13 @@ static int dummy_send_morse(RIG *rig, vfo_t vfo, const char *msg)
     RETURNFUNC(RIG_OK);
 }
 
+static int dummy_send_voice_mem(RIG *rig, vfo_t vfo, int ch)
+{
+    ENTERFUNC;
+
+    RETURNFUNC(RIG_OK);
+}
+
 static int dummy_power2mW(RIG *rig, unsigned int *mwpower, float power,
                           freq_t freq, rmode_t mode)
 {
@@ -2458,6 +2465,7 @@ struct rig_caps dummy_caps =
     .send_dtmf =  dummy_send_dtmf,
     .recv_dtmf =  dummy_recv_dtmf,
     .send_morse =  dummy_send_morse,
+    .send_voice_mem =  dummy_send_voice_mem,
     .set_channel =    dummy_set_channel,
     .get_channel =    dummy_get_channel,
     .set_trn =    dummy_set_trn,
@@ -2625,6 +2633,7 @@ struct rig_caps dummy_no_vfo_caps =
     .send_dtmf =  dummy_send_dtmf,
     .recv_dtmf =  dummy_recv_dtmf,
     .send_morse =  dummy_send_morse,
+    .send_voice_mem =  dummy_send_voice_mem,
     .set_channel =    dummy_set_channel,
     .get_channel =    dummy_get_channel,
     .set_trn =    dummy_set_trn,

--- a/rigs/dummy/netrigctl.c
+++ b/rigs/dummy/netrigctl.c
@@ -2421,6 +2421,28 @@ static int netrigctl_recv_dtmf(RIG *rig, vfo_t vfo, char *digits, int *length)
     return RIG_OK;
 }
 
+static int netrigctl_send_voice_mem(RIG *rig, vfo_t vfo, int ch)
+{
+    int ret, len;
+    char cmd[CMD_MAX];
+    char buf[BUF_MAX];
+
+    rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
+
+    len = sprintf(cmd, "\\send_voice_mem %d\n", ch);
+
+    ret = netrigctl_transaction(rig, cmd, len, buf);
+
+    if (ret > 0)
+    {
+        return -RIG_EPROTO;
+    }
+    else
+    {
+        return ret;
+    }
+}
+
 static int netrigctl_send_morse(RIG *rig, vfo_t vfo, const char *msg)
 {
     int ret, len;
@@ -2694,6 +2716,7 @@ struct rig_caps netrigctl_caps =
     .send_dtmf =  netrigctl_send_dtmf,
     .recv_dtmf =  netrigctl_recv_dtmf,
     .send_morse =  netrigctl_send_morse,
+    .send_voice_mem =  netrigctl_send_voice_mem,
     .stop_morse =  netrigctl_stop_morse,
     .set_channel =    netrigctl_set_channel,
     .get_channel =    netrigctl_get_channel,


### PR DESCRIPTION
Allow \send_voice_mem to be used over network and tested in dummy rig