### PR TITLE
Fix spurious writes when no RT-21 second port

### DIFF
--- a/rotators/rotorez/rotorez.c
+++ b/rotators/rotorez/rotorez.c
@@ -493,15 +493,14 @@ static int rt21_rot_set_position(ROT *rot, azimuth_t azimuth,
     {
         sprintf(cmdstr, "AP1%05.1f\r;",
                 elevation);    /* Total field width of 5 chars */
+
+        err = rotorez_send_priv_cmd2(rot, cmdstr);
+
+        if (err != RIG_OK)
+        {
+            return err;
+        }
     }
-
-    err = rotorez_send_priv_cmd2(rot, cmdstr);
-
-    if (err != RIG_OK)
-    {
-        return err;
-    }
-
     return RIG_OK;
 }
 
@@ -1101,3 +1100,4 @@ DECLARE_INITROT_BACKEND(rotorez)
 
     return RIG_OK;
 }
+


### PR DESCRIPTION
The if condition for whether there actually is a second port is only
covering the sprintf for the elevation command, and not the write
attempt. So we call rotorez_send_priv_cmd2 whether rotport2 is valid or
not. When it's not, we try to write the command to fd 0 (stdin). When
running on the console, this results in trash on the console. When
runnning under something else (e.g. systemd) this results in errors or
other wierd behavior (e.g. EBADF because stdin isn't connected, causing
the command to fail with RIG_EIO).