### PR TITLE
Enable "stop" command for RT-21 rotator.

### DIFF
--- a/rotators/rotorez/rotorez.c
+++ b/rotators/rotorez/rotorez.c
@@ -338,7 +338,7 @@ const struct rot_caps rt21_rot_caps =
     .rot_cleanup =      rotorez_rot_cleanup,
     .set_position =     rt21_rot_set_position,
     .get_position =     rt21_rot_get_position,
-//  .stop =             rotorez_rot_stop,
+    .stop =             rotorez_rot_stop,
 //  .set_conf =         rotorez_rot_set_conf,
 //  .get_info =         rotorez_rot_get_info,
 

--- a/rotators/rotorez/rotorez.c
+++ b/rotators/rotorez/rotorez.c
@@ -310,7 +310,7 @@ const struct rot_caps rt21_rot_caps =
     ROT_MODEL(ROT_MODEL_RT21),
     .model_name =       "RT-21",
     .mfg_name =     "Green Heron",
-    .version =      "20210801.0",
+    .version =      "20220104.0",
     .copyright =        "LGPL",
     .status =       RIG_STATUS_STABLE,
     .rot_type =     ROT_TYPE_OTHER,


### PR DESCRIPTION
I got a request from G0GJV to see about why the RT-21 driver doesn't support the "stop" command. It looks like it was commented out when the RT-21 caps were added back in 2014, and hasn't been touched since. I uncommented it and it works 100% fine with my unit (and the manual agrees that sending a bare `;` is the stop command). Might as well enable it?