### PR TITLE
Small bugfixes

### DIFF
--- a/rigs/icom/icom.c
+++ b/rigs/icom/icom.c
@@ -6926,6 +6926,7 @@ int icom_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
         {
             fct_cn = C_SET_VFO;
             fct_sc = status ? S_DUAL_ON : S_DUAL_OFF;
+            fct_len = 0;
         }
 
         break;

--- a/tests/rotctl_parse.c
+++ b/tests/rotctl_parse.c
@@ -275,7 +275,7 @@ struct mod_lst
     char model_name[32];    /* caps->model_name */
     char version[32];       /* caps->version */
     char status[32];        /* caps->status */
-    char macro_name[32];    /* caps->macro_name */
+    char macro_name[64];    /* caps->macro_name */
     UT_hash_handle hh;      /* makes this structure hashable */
 };
 


### PR DESCRIPTION
* Fix Icom dual watch set command -- how did this even ever work?
* Make rotator macro name buffer larger, as the macro names are longer than the space allocated
