### PR TITLE
Allow async I/O for Icom SDR rigs

### DIFF
--- a/rigs/icom/ic7300.c
+++ b/rigs/icom/ic7300.c
@@ -1016,6 +1016,11 @@ const struct rig_caps ic9700_caps =
         },
     },
 
+    .async_data_supported = 1,
+    .read_frame_direct = icom_read_frame_direct,
+    .is_async_frame = icom_is_async_frame,
+    .process_async_frame = icom_process_async_frame,
+
     .cfgparams =  icom_cfg_params,
     .set_conf =  icom_set_conf,
     .get_conf =  icom_get_conf,
@@ -1272,6 +1277,11 @@ const struct rig_caps ic705_caps =
             .name = "4",
         },
     },
+
+    .async_data_supported = 1,
+    .read_frame_direct = icom_read_frame_direct,
+    .is_async_frame = icom_is_async_frame,
+    .process_async_frame = icom_process_async_frame,
 
     .cfgparams =  icom_cfg_params,
     .set_conf =  icom_set_conf,

--- a/rigs/icom/ic7610.c
+++ b/rigs/icom/ic7610.c
@@ -526,6 +526,11 @@ const struct rig_caps ic7610_caps =
         },
     },
 
+    .async_data_supported = 1,
+    .read_frame_direct = icom_read_frame_direct,
+    .is_async_frame = icom_is_async_frame,
+    .process_async_frame = icom_process_async_frame,
+
     .cfgparams =  icom_cfg_params,
     .set_conf =  icom_set_conf,
     .get_conf =  icom_get_conf,

--- a/rigs/icom/ic785x.c
+++ b/rigs/icom/ic785x.c
@@ -418,6 +418,11 @@ const struct rig_caps ic785x_caps =
     },
     .spectrum_attenuator = { 10, 20, 30, RIG_DBLST_END, },
 
+    .async_data_supported = 1,
+    .read_frame_direct = icom_read_frame_direct,
+    .is_async_frame = icom_is_async_frame,
+    .process_async_frame = icom_process_async_frame,
+
     .cfgparams =  icom_cfg_params,
     .set_conf =  icom_set_conf,
     .get_conf =  icom_get_conf,

--- a/rigs/icom/icr8600.c
+++ b/rigs/icom/icr8600.c
@@ -285,6 +285,11 @@ const struct rig_caps icr8600_caps =
         },
     },
 
+    .async_data_supported = 1,
+    .read_frame_direct = icom_read_frame_direct,
+    .is_async_frame = icom_is_async_frame,
+    .process_async_frame = icom_process_async_frame,
+
     .cfgparams = icom_cfg_params,
 
     .set_conf = icom_set_conf,


### PR DESCRIPTION
Allow async I/O for Icom SDR rigs, mainly for waterfall spectrum data support. Async I/O is still turned off by default and needs to be enabled via a conf option, so this doesn't change existing (default) behavior.
