### PR TITLE
Fix macros not defined in man pages

### DIFF
--- a/doc/man1/rigctl.1
+++ b/doc/man1/rigctl.1
@@ -27,7 +27,7 @@ rigctl \- control radio transceivers and receivers
 .OP \-c id
 .OP \-t char
 .OP \-C parm=val
-.RG \-Y
+.RB \-Y
 .RB [ \-v [ \-Z ]]
 .RB [ command | \- ]
 .YS

--- a/doc/man1/rotctld.1
+++ b/doc/man1/rotctld.1
@@ -642,7 +642,7 @@ Example get position (Perl code):
 "135"
 "10"
 .EE
-.IN
+.in
 .
 .PP
 Most


### PR DESCRIPTION
This PR fixes two warnings raised by Lintian.

The first commit makes the -Y option visible in the man page.
Before:
![image](https://user-images.githubusercontent.com/1055635/152649071-a1621708-a878-4a96-a83b-914ca6c5504f.png)
After:
![image](https://user-images.githubusercontent.com/1055635/152649120-edade866-0047-48cd-bfe3-b56dc88f1484.png)


The second commit has no visible changes because there is an empty line after the macro, so it makes no difference if the indent is reset or no.