### PR TITLE
Add support for extlevels in rig_token_foreach()

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -1129,6 +1129,14 @@ int HAMLIB_API rig_token_foreach(RIG *rig,
             return RIG_OK;
         }
     }
+    
+    for (cfp = rig->caps->extlevels; cfp && cfp->name; cfp ++)
+    {
+        if ((*cfunc)(cfp, data) == 0)
+        {
+            return RIG_OK;
+        }
+    }
 
     return RIG_OK;
 }


### PR DESCRIPTION
Adding support for extlevels in rig_token_foreach() so these tokens can be searched/looked up.  New to Hamlib development, comments welcome!  73 de K1AY