### PR TITLE
Removed redundant RETURNFUNC() call

### DIFF
--- a/src/rig.c
+++ b/src/rig.c
@@ -3823,7 +3823,6 @@ int HAMLIB_API rig_get_split_freq(RIG *rig, vfo_t vfo, freq_t *tx_freq)
         TRACE;
         retcode = caps->get_freq(rig, tx_vfo, tx_freq);
         RETURNFUNC(retcode);
-        RETURNFUNC(retcode);
     }
 
 


### PR DESCRIPTION
I assume this was an oversight?