### PR TITLE
bindings: Fix tcl build with slibtool

### DIFF
--- a/bindings/Makefile.am
+++ b/bindings/Makefile.am
@@ -149,8 +149,9 @@ PKG_VER = $(ABI_VERSION).$(ABI_REVISION)
 DLL = hamlibtcl-$(PKG_VER)$(TCL_SHLIB_SUFFIX)
 
 nodist_hamlibtcl_la_SOURCES = hamlibtcl_wrap.c
+hamlibtcl_la_CFLAGS = $(TCL_CFLAGS)
 hamlibtcl_la_LDFLAGS = -no-undefined -module -release $(PKG_VER) -avoid-version
-hamlibtcl_la_LIBADD = $(top_builddir)/src/libhamlib.la $(TCL_LIB_SPEC)
+hamlibtcl_la_LIBADD = $(top_builddir)/src/libhamlib.la $(TCL_LIB_SPEC) $(TCL_LIBS)
 
 hamlibtcl_ladir = $(tcldir)
 hamlibtcl_la_DATA = pkgIndex.tcl

--- a/configure.ac
+++ b/configure.ac
@@ -602,6 +602,10 @@ AS_IF([test x"${build_tcl}" = "xyes"],[
 	[AC_MSG_ERROR([Unable to find Tcl headers])])
     CPPFLAGS=$tcl_save_CPPFLAGS
 
+    PKG_CHECK_MODULES([TCL], [tcl],
+	[],
+	[AC_MSG_ERROR([Unable to find Tcl pkgconfig])])
+
     BINDING_LIST="${BINDING_LIST} tcl"
     BINDING_ALL="${BINDING_ALL} all-tcl"
     BINDING_CHECK="${BINDING_CHECK} check-tcl"
@@ -617,6 +621,9 @@ AC_SUBST([TCL_VERSION])
 AC_SUBST([TCL_LIB_SPEC])
 AC_SUBST([TCL_INCLUDE_SPEC])
 AC_SUBST([TCL_SHLIB_SUFFIX])
+dnl These variables are set once tcl.pc is found.
+AC_SUBST([TCL_LIBS])
+AC_SUBST([TCL_CFLAGS])
 
 
 dnl Check for lua availability, so we can enable HamlibLua


### PR DESCRIPTION
Gentoo issue: https://bugs.gentoo.org/798273

When building hamlib with `--with-tcl-binding` and slibtool (https://dev.midipix.org/cross/slibtool) it will fail with many undefined references for tcl.

This is because the `TCL_LIBS` is never set correctly and it uses `-no-undefined` during the build. GNU libtool does not reveal this problem because it will silently ignore `-no-undefined`. This patch will use `PKG_CHECK_MODULES` to find the linker flags and sets them where needed.

Full build log: [hamlib.slibtool.log](https://github.com/Hamlib/Hamlib/files/8644100/hamlib.slibtool.log)
