### PR TITLE
bindings: Fix tcl build with slibtool

### DIFF
--- a/bindings/Makefile.am
+++ b/bindings/Makefile.am
@@ -149,8 +149,9 @@ PKG_VER = $(ABI_VERSION).$(ABI_REVISION)
 DLL = hamlibtcl-$(PKG_VER)$(TCL_SHLIB_SUFFIX)
 
 nodist_hamlibtcl_la_SOURCES = hamlibtcl_wrap.c
+hamlibtcl_la_CFLAGS = $(TCL_CFLAGS)
 hamlibtcl_la_LDFLAGS = -no-undefined -module -release $(PKG_VER) -avoid-version
-hamlibtcl_la_LIBADD = $(top_builddir)/src/libhamlib.la $(TCL_LIB_SPEC)
+hamlibtcl_la_LIBADD = $(top_builddir)/src/libhamlib.la $(TCL_LIB_SPEC) $(TCL_LIBS)
 
 hamlibtcl_ladir = $(tcldir)
 hamlibtcl_la_DATA = pkgIndex.tcl

--- a/configure.ac
+++ b/configure.ac
@@ -589,11 +589,16 @@ AC_ARG_WITH([tcl-binding],
     [build_tcl=no])
 AC_MSG_RESULT([$build_tcl])
 
-dnl SC_PATH_TCLCONFIG and SC_LOAD_TCLCONFIG from macros/tcl.m4
+dnl tcl.pc or SC_PATH_TCLCONFIG and SC_LOAD_TCLCONFIG from macros/tcl.m4
 AS_IF([test x"${build_tcl}" = "xyes"],[
-    dnl Search for and load tclConfig.sh.
-    SC_PATH_TCLCONFIG
-    SC_LOAD_TCLCONFIG
+    dnl Search for and load tcl.pc or tclConfig.sh.
+    PKG_CHECK_MODULES([TCL], [tcl],
+        [],
+        [
+            AC_MSG_WARN([Unable to find Tcl pkgconfig])
+            SC_PATH_TCLCONFIG
+            SC_LOAD_TCLCONFIG
+        ])
 
     tcl_save_CPPFLAGS=$CPPFLAGS
     CPPFLAGS="$CPPFLAGS $TCL_INCLUDE_SPEC"
@@ -617,6 +622,9 @@ AC_SUBST([TCL_VERSION])
 AC_SUBST([TCL_LIB_SPEC])
 AC_SUBST([TCL_INCLUDE_SPEC])
 AC_SUBST([TCL_SHLIB_SUFFIX])
+dnl These variables are set once tcl.pc is found.
+AC_SUBST([TCL_LIBS])
+AC_SUBST([TCL_CFLAGS])
 
 
 dnl Check for lua availability, so we can enable HamlibLua

--- a/macros/tcl.m4
+++ b/macros/tcl.m4
@@ -130,6 +130,7 @@ AC_DEFUN([SC_LOAD_TCLCONFIG], [
 	. $TCL_BIN_DIR/tclConfig.sh
     else
         AC_MSG_RESULT([file not found])
+        AC_MSG_ERROR([failed to load tclConfig.sh])
     fi
 
     #


### PR DESCRIPTION
This is the second attempt at PR https://github.com/Hamlib/Hamlib/pull/1022, please confirm it works for you.

Gentoo issue: https://bugs.gentoo.org/798273

When building hamlib with `--with-tcl-binding` and slibtool (https://dev.midipix.org/cross/slibtool) it will fail with many undefined references for tcl.

This is because the `TCL_LIBS` is never set correctly and it uses `-no-undefined` during the build. GNU libtool does not reveal this problem because it will silently ignore `-no-undefined`. This patch will use `PKG_CHECK_MODULES` to find the linker flags and sets them where needed.

The difference with the original PR is that instead of an error when `tcl.pc` is not found it will then check for `tclConfig.sh` instead. I also added an error for when the `SC_LOAD_TCLCONFIG` macro fails to load the config file in case both the pkgconfig file and `tclConfig.sh` are missing while the `tcl.h` header is present.

Full build log: [hamlib.slibtool.log](https://github.com/Hamlib/Hamlib/files/8644100/hamlib.slibtool.log)
