### PR TITLE
prm80: fix on musl

### DIFF
--- a/rigs/prm80/prm80.h
+++ b/rigs/prm80/prm80.h
@@ -22,6 +22,7 @@
 #ifndef _PRM80_H
 #define _PRM80_H 1
 
+#include <sys/time.h>
 #include <hamlib/rig.h>
 #include "misc.h"
 


### PR DESCRIPTION
to use timeval with musl libc, sys/time.h must be included
