### PR TITLE
Add split freq control to Kenwood TMD710

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ tests/rigsmtr
 tests/rigswr
 tests/rotctl
 tests/rotctld
+.vscode/settings.json
+.vscode/c_cpp_properties.json
+.gitignore

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -344,6 +344,8 @@ const struct rig_caps tmd710_caps = {
     .rig_cleanup = kenwood_cleanup,
     .set_freq =  tmd710_set_freq,
     .get_freq =  tmd710_get_freq,
+    .set_split_freq =  tmd710_set_split_freq,
+    .get_split_freq =  tmd710_get_split_freq,
     .set_mode =  tmd710_set_mode,
     .get_mode =  tmd710_get_mode,
     .set_vfo =  tmd710_set_vfo,
@@ -970,6 +972,26 @@ int tmd710_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
   }
 
   return retval;
+}
+
+/*
+ * tmd710_get_split_freq
+ * Assumes rig!=NULL, freq!=NULL
+ */
+int tmd710_set_split_freq(RIG *rig, vfo_t vfo, freq_t freq) {
+	 
+	 rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
+	 return tmd710_set_freq(*rig, vfo^1, freq);
+}
+
+/*
+ * tmd710_get_split_freq
+ * Assumes rig!=NULL, freq!=NULL
+ */
+int tmd710_get_split_freq(RIG *rig, vfo_t vfo, freq_t *freq) {
+	 
+	 rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
+	 return tmd710_get_freq(*rig, vfo^1, *freq);
 }
 
 static int tmd710_find_ctcss_index(RIG *rig, tone_t tone, int *ctcss_index) {

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -513,7 +513,7 @@ static int tmd710_get_vfo_num(RIG *rig, int *vfonum, vfo_t *vfo) {
     *vfonum = ctrlnum;
   }
 
-  rig_debug(RIG_DEBUG_ERR, "VFO assignments: VFO_A: %s\nVFO_B: %s\n", RIG_VFO_A, RIG_VFO_B);
+  rig_debug(RIG_DEBUG_ERR, "VFO assignments: VFO_A: %d\nVFO_B: %d\n", RIG_VFO_A, RIG_VFO_B);
 
   return RIG_OK;
 }

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -1005,7 +1005,7 @@ int tmd710_set_freq(RIG *rig, vfo_t vfo, freq_t freq) {
 
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 	
-	return tmd710_set_freq(rig, RIG_VFO_A, freq);
+	return tmd710_do_set_freq(rig, RIG_VFO_A, freq);
 }
 
 /*
@@ -1016,7 +1016,7 @@ int tmd710_get_freq(RIG *rig, vfo_t vfo, freq_t *freq) {
 	 
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 
-	return tmd710_get_freq(rig, RIG_VFO_A, freq);
+	return tmd710_do_get_freq(rig, RIG_VFO_A, freq);
 }
 
 /*
@@ -1027,7 +1027,7 @@ int tmd710_set_split_freq(RIG *rig, vfo_t vfo, freq_t freq) {
 
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 	
-	return tmd710_set_freq(rig, RIG_VFO_B, freq);
+	return tmd710_do_set_freq(rig, RIG_VFO_B, freq);
 }
 
 /*
@@ -1038,7 +1038,7 @@ int tmd710_get_split_freq(RIG *rig, vfo_t vfo, freq_t *freq) {
 	 
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 
-	return tmd710_get_freq(rig, RIG_VFO_B, freq);
+	return tmd710_do_get_freq(rig, RIG_VFO_B, freq);
 }
 
 static int tmd710_find_ctcss_index(RIG *rig, tone_t tone, int *ctcss_index) {

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -59,7 +59,7 @@ static int tmd710_set_split_freq(RIG *rig, vfo_t vfo, freq_t freq);
 static int tmd710_set_vfo (RIG *rig, vfo_t vfo);
 static int tmd710_get_vfo(RIG *rig, vfo_t *vfo);
 static int tmd710_set_split_vfo (RIG *rig, vfo_t vfo, split_t split, vfo_t txvfo);
-static int tmd710_get_split_vfo (RIG *rig, vfo_t vfo, split_t *split, vfo_t *txvfo)
+static int tmd710_get_split_vfo (RIG *rig, vfo_t vfo, split_t *split, vfo_t *txvfo);
 static int tmd710_set_ts(RIG *rig, vfo_t vfo, shortfreq_t ts);
 static int tmd710_get_ts(RIG *rig, vfo_t vfo, shortfreq_t *ts);
 static int tmd710_set_ctcss_tone(RIG *rig, vfo_t vfo, tone_t tone);

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -90,11 +90,6 @@ static int tmd710_set_parm(RIG *rig, setting_t parm, value_t val);
 static int tmd710_get_ext_level(RIG *rig, vfo_t vfo, token_t token, value_t *val);
 static int tmd710_set_ext_level(RIG *rig, vfo_t vfo, token_t token, value_t val);
 
-static struct tmd710_vfo_assignment = {
-	vfo_t vfoTx,
-	vfo_t vfoRx
-};
-
 #define TMD710_MODES     (RIG_MODE_FM|RIG_MODE_FMN|RIG_MODE_AM)
 #define TMD710_MODES_FM  (RIG_MODE_FM|RIG_MODE_FMN)
 #define TMD710_MODES_TX  (RIG_MODE_FM|RIG_MODE_FMN)
@@ -230,11 +225,6 @@ static rmode_t tmd710_mode_table[KENWOOD_MODE_TABLE_MAX] = {
     [0] = RIG_MODE_FM,
     [1] = RIG_MODE_FMN,
     [2] = RIG_MODE_AM,
-};
-
-static struct tmd710_vfo_assignment tmd710_split_vfos = {
-	.vfoTx = RIG_VFO_A,
-	.vfoRx = RIG_VFO_B,
 };
 
 static struct kenwood_priv_caps  tmd710_priv_caps  = {

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -980,7 +980,7 @@ int tmd710_do_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
   tmd710_fo fo_struct;
   int retval;
 
-  rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
+  rig_debug(RIG_DEBUG_TRACE, "%s: called for vfo: %n(%d)\n", __func__, rig_strvfo(vfo), vfo);
 
   retval = tmd710_pull_fo(rig, vfo, &fo_struct);
 
@@ -999,7 +999,9 @@ int tmd710_set_freq(RIG *rig, vfo_t vfo, freq_t freq) {
 
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 	
-	vfo = rig->state.tx_vfo == RIG_VFO_A ? RIG_VFO_B : RIG_VFO_A;
+	rig_debug(RIG_DEBUG_TRACE, "tx_vfo: %n(%d)\n", __func__, rig_strvfo(rig->state.tx_vfo), rig->state.tx_vfo);
+
+  	vfo = rig->state.tx_vfo == RIG_VFO_A ? RIG_VFO_B : RIG_VFO_A;
 
 	return tmd710_do_set_freq(rig, vfo, freq);
 }

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -485,6 +485,10 @@ static int tmd710_open(RIG *rig) {
 	
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 
+	rig->state.tx_vfo = RIG_VFO_A;
+	rig_debug(RIG_DEBUG_TRACE, "rig->state.tx_vfo: %d\n", __func__, rig->state.tx_vfo)
+
+
 	return 0;
 }
 
@@ -999,6 +1003,8 @@ int tmd710_set_freq(RIG *rig, vfo_t vfo, freq_t freq) {
 
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 	
+	rig_debug(RIG_DEBUG_TRACE, "rig->state.tx_vfo: %d\n", __func__, rig->state.tx_vfo)
+
 	rig_debug(RIG_DEBUG_TRACE, "tx_vfo: %n(%d)\n", __func__, rig_strvfo(rig->state.tx_vfo), rig->state.tx_vfo);
 
   	vfo = rig->state.tx_vfo == RIG_VFO_A ? RIG_VFO_B : RIG_VFO_A;
@@ -1630,6 +1636,8 @@ int tmd710_set_split_vfo (RIG *rig, vfo_t vfo, split_t split, vfo_t txvfo)
 	
     
 	rig->state.tx_vfo = txvfo;
+
+	rig_debug(RIG_DEBUG_TRACE, "rig->state.tx_vfo: %d\n", __func__, rig->state.tx_vfo)
 
 	int txVfoIndex = txvfo == RIG_VFO_A ? 0 : 1;
 

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -982,8 +982,15 @@ int tmd710_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
  */
 int tmd710_set_split_freq(RIG *rig, vfo_t vfo, freq_t freq) {
 	 
-	 rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
-	 return tmd710_set_freq(rig, vfo^1, freq);
+	 if( vfo == RIG_VFO_A) {
+		vfo = RIG_VFO_B;
+	}
+	else {
+		vfo = RIG_VFO_A;
+	}
+
+	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
+	 return tmd710_set_freq(rig, vfo, freq);
 }
 
 /*
@@ -992,8 +999,15 @@ int tmd710_set_split_freq(RIG *rig, vfo_t vfo, freq_t freq) {
  */
 int tmd710_get_split_freq(RIG *rig, vfo_t vfo, freq_t *freq) {
 	 
-	 rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
-	 return tmd710_get_freq(rig, vfo^1, freq);
+	if( vfo == RIG_VFO_A) {
+		vfo = RIG_VFO_B;
+	}
+	else {
+		vfo = RIG_VFO_A;
+	}
+
+	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
+	return tmd710_get_freq(rig, vfo, freq);
 }
 
 static int tmd710_find_ctcss_index(RIG *rig, tone_t tone, int *ctcss_index) {

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -483,8 +483,6 @@ typedef struct {
 
 static int tmd710_open(RIG *rig) {
 	
-	int retval;
-
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 
 	return 0;
@@ -1001,7 +999,7 @@ int tmd710_set_freq(RIG *rig, vfo_t vfo, freq_t freq) {
 
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 	
-	vfo_t vfo = rig->state.tx_vfo == RIG_VFO_A ? RIG_VFO_B : RIG_VFO_A;
+	vfo = rig->state.tx_vfo == RIG_VFO_A ? RIG_VFO_B : RIG_VFO_A;
 
 	return tmd710_do_set_freq(rig, vfo, freq);
 }
@@ -1014,7 +1012,7 @@ int tmd710_get_freq(RIG *rig, vfo_t vfo, freq_t *freq) {
 	 
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 
-	vfo_t vfo = rig->state.tx_vfo == RIG_VFO_A ? RIG_VFO_B : RIG_VFO_A;
+	vfo = rig->state.tx_vfo == RIG_VFO_A ? RIG_VFO_B : RIG_VFO_A;
 
 	return tmd710_do_get_freq(rig, vfo, freq);
 }
@@ -1027,9 +1025,9 @@ int tmd710_set_split_freq(RIG *rig, vfo_t vfo, freq_t freq) {
 
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 	
-	vfo_t vfo = rig->state.tx_vfo == RIG_VFO_B ? RIG_VFO_A : RIG_VFO_B;
+	vfo = rig->state.tx_vfo == RIG_VFO_B ? RIG_VFO_A : RIG_VFO_B;
 
-	return tmd710_do_set_freq(rig, RIG_VFO_B, freq);
+	return tmd710_do_set_freq(rig, vfo, freq);
 }
 
 /*
@@ -1040,9 +1038,9 @@ int tmd710_get_split_freq(RIG *rig, vfo_t vfo, freq_t *freq) {
 	 
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 
-	vfo_t vfo = rig->state.tx_vfo == RIG_VFO_B ? RIG_VFO_A : RIG_VFO_B;
+	vfo = rig->state.tx_vfo == RIG_VFO_B ? RIG_VFO_A : RIG_VFO_B;
 	
-	return tmd710_do_get_freq(rig, RIG_VFO_B, freq);
+	return tmd710_do_get_freq(rig, vfo, freq);
 }
 
 static int tmd710_find_ctcss_index(RIG *rig, tone_t tone, int *ctcss_index) {
@@ -1622,7 +1620,6 @@ int tmd710_set_vfo(RIG *rig, vfo_t vfo)
 int tmd710_set_split_vfo (RIG *rig, vfo_t vfo, split_t split, vfo_t txvfo)
 {
     char vfobuf[16];
-    int vfonum, txvfonum;
     int retval;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: called %s\n", __func__, rig_strvfo(vfo));
@@ -1659,7 +1656,7 @@ int tmd710_get_split_vfo (RIG *rig, vfo_t vfo, split_t *split, vfo_t *txvfo)
 			return -RIG_EPROTO;
 	}
 
-    rig->state.tx_vfo = txvfo;
+    rig->state.tx_vfo = *txvfo;
 
 	return RIG_OK;
 }

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -513,7 +513,7 @@ static int tmd710_get_vfo_num(RIG *rig, int *vfonum, vfo_t *vfo) {
     *vfonum = ctrlnum;
   }
 
-  rig_debug(RIG_DEBUG_ERR, "VFO assignments: VFO_A: %d\nVFO_B: %d\n", RIG_VFO_A, RIG_VFO_B);
+  rig_debug(RIG_DEBUG_ERR, "VFO assignments: VFO_A: %d\tVFO_B: %d\n", RIG_VFO_A, RIG_VFO_B);
 
   return RIG_OK;
 }
@@ -703,12 +703,15 @@ int tmd710_pull_fo(RIG *rig, vfo_t vfo, tmd710_fo *fo_struct)
   int vfonum;
   int retval;
 
+  rig_debug(RIG_DEBUG_ERR, "VFO assignments at %s.a: VFO_A: %d\tVFO_B: %d\n", __func__, RIG_VFO_A, RIG_VFO_B);
   rig_debug(RIG_DEBUG_TRACE, "%s: called with VFO %08X\n", __func__, vfo);
 
   retval = tmd710_resolve_vfo(rig, vfo, NULL, &vfonum);
   if (retval != RIG_OK) {
     return retval;
   }
+
+  rig_debug(RIG_DEBUG_ERR, "VFO assignments at %s.b: VFO_A: %d\tVFO_B: %d\n", __func__, RIG_VFO_A, RIG_VFO_B);
 
   snprintf(cmdbuf, sizeof(cmdbuf), "FO %1d", vfonum);
   retval = kenwood_safe_transaction(rig, cmdbuf, buf, sizeof(buf), 48);

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -984,7 +984,7 @@ int tmd710_do_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
   tmd710_fo fo_struct;
   int retval;
 
-  rig_debug(RIG_DEBUG_TRACE, "%s: called for vfo: %n(%d)\n", __func__, rig_strvfo(vfo), vfo);
+  rig_debug(RIG_DEBUG_TRACE, "%s: called for vfo: %s(%d)\n", __func__, rig_strvfo(vfo), vfo);
 
   retval = tmd710_pull_fo(rig, vfo, &fo_struct);
 

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -953,7 +953,8 @@ int tmd710_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
   fo_struct.step = freq_sent >= MHz(470) ? 4 : step;
   fo_struct.freq = freq_sent >= MHz(470) ? (round(freq_sent / 10000) * 10000) : freq_sent;
 
-  return tmd710_push_fo(rig, vfo, &fo_struct);
+  //return tmd710_push_fo(rig, vfo, &fo_struct);
+  return tmd710_push_fo(rig, RIG_VFO_A, &fo_struct);
 }
 
 /*

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -486,7 +486,7 @@ static int tmd710_open(RIG *rig) {
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 
 	rig->state.tx_vfo = RIG_VFO_A;
-	rig_debug(RIG_DEBUG_TRACE, "rig->state.tx_vfo: %d\n", __func__, *rig->state.tx_vfo);
+	rig_debug(RIG_DEBUG_TRACE, "RIG_VFO_A: %d\trig->state.tx_vfo: %d\n", RIG_VFO_A, rig->state.tx_vfo);
 
 
 	return 0;
@@ -1003,9 +1003,9 @@ int tmd710_set_freq(RIG *rig, vfo_t vfo, freq_t freq) {
 
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 	
-	rig_debug(RIG_DEBUG_TRACE, "rig->state.tx_vfo: %d\n", __func__, rig->state.tx_vfo);
+	rig_debug(RIG_DEBUG_TRACE, "rig->state.tx_vfo: %d\n", rig->state.tx_vfo);
 
-	rig_debug(RIG_DEBUG_TRACE, "tx_vfo: %n(%d)\n", __func__, rig_strvfo(rig->state.tx_vfo), rig->state.tx_vfo);
+	rig_debug(RIG_DEBUG_TRACE, "tx_vfo: %n(%d)\n", rig_strvfo(rig->state.tx_vfo), rig->state.tx_vfo);
 
   	vfo = rig->state.tx_vfo == RIG_VFO_A ? RIG_VFO_B : RIG_VFO_A;
 
@@ -1637,7 +1637,7 @@ int tmd710_set_split_vfo (RIG *rig, vfo_t vfo, split_t split, vfo_t txvfo)
     
 	rig->state.tx_vfo = txvfo;
 
-	rig_debug(RIG_DEBUG_TRACE, "rig->state.tx_vfo: %d\n", __func__, rig->state.tx_vfo);
+	rig_debug(RIG_DEBUG_TRACE, "rig->state.tx_vfo: %d\n", rig->state.tx_vfo);
 
 	int txVfoIndex = txvfo == RIG_VFO_A ? 0 : 1;
 

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -513,6 +513,8 @@ static int tmd710_get_vfo_num(RIG *rig, int *vfonum, vfo_t *vfo) {
     *vfonum = ctrlnum;
   }
 
+  rig_debug(RIG_DEBUG_ERR, "VFO assignments: VFO_A: %s\nVFO_B: %s\n", RIG_VFO_A, RIG_VFO_B);
+
   return RIG_OK;
 }
 

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -1001,11 +1001,7 @@ int tmd710_do_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
  */
 int tmd710_set_freq(RIG *rig, vfo_t vfo, freq_t freq) {
 
-	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
-	
-	rig_debug(RIG_DEBUG_TRACE, "rig->state.tx_vfo: %d\n", rig->state.tx_vfo);
-
-	rig_debug(RIG_DEBUG_TRACE, "tx_vfo: %s(%d)\n", rig_strvfo(rig->state.tx_vfo), rig->state.tx_vfo);
+	rig_debug(RIG_DEBUG_TRACE, "%s: called for vfo: %s(%d)\n", __func__, rig_strvfo(vfo), vfo);
 
   	vfo = rig->state.tx_vfo == RIG_VFO_A ? RIG_VFO_B : RIG_VFO_A;
 
@@ -1623,6 +1619,7 @@ int tmd710_set_vfo(RIG *rig, vfo_t vfo)
 *	This radio has two VFOs, and either one can be the TX/RX.  As such, this function does two things:
 *	- Sets PTT control on the specified VFO.
 *	- Sets the TX_VFO and RX_VFO for use in Set_Freq and Set_Split_Freq
+*	- The value of split is ignored, as the radio is always in "split" mode.
 *
 */
 int tmd710_set_split_vfo (RIG *rig, vfo_t vfo, split_t split, vfo_t txvfo)
@@ -1632,12 +1629,7 @@ int tmd710_set_split_vfo (RIG *rig, vfo_t vfo, split_t split, vfo_t txvfo)
 
     rig_debug(RIG_DEBUG_TRACE, "%s: called vfo: %s\ttxvfo: %s\n", __func__, rig_strvfo(vfo), rig_strvfo(txvfo));
 	
-	rig_debug(RIG_DEBUG_TRACE, "%s: called (as number) vfo: %d\ttxvfo: %d\n", __func__, vfo, txvfo);
-	
-    
 	rig->state.tx_vfo = txvfo;
-
-	rig_debug(RIG_DEBUG_TRACE, "rig->state.tx_vfo: %d\n", rig->state.tx_vfo);
 
 	int txVfoIndex = txvfo == RIG_VFO_A ? 0 : 1;
 

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -482,11 +482,15 @@ static int tmd710_open(RIG *rig) {
 	
 	int retval;
 
+	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
+
 	retval = tmd710_set_vfo( rig, RIG_VFO_B );
 
 	if (retval != RIG_OK) {
-    return retval;
-  }
+    	return retval;
+  	}
+
+	return 0;
 }
 
 static int tmd710_get_vfo_num(RIG *rig, int *vfonum, vfo_t *vfo) {
@@ -998,8 +1002,8 @@ int tmd710_set_split_freq(RIG *rig, vfo_t vfo, freq_t freq) {
 
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 	
-	vfo = vfo == RIG_VFO_A ? RIG_VFO_B : RIG_VFO_A;
-	return tmd710_set_freq(rig, RIG_VFO_B, freq);
+	//vfo = vfo == RIG_VFO_A ? RIG_VFO_B : RIG_VFO_A;
+	return tmd710_set_freq(rig, vfo, freq);
 }
 
 /*
@@ -1010,7 +1014,7 @@ int tmd710_get_split_freq(RIG *rig, vfo_t vfo, freq_t *freq) {
 	 
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 
-	vfo = vfo == RIG_VFO_A ? RIG_VFO_B : RIG_VFO_A;
+	//vfo = vfo == RIG_VFO_A ? RIG_VFO_B : RIG_VFO_A;
 	return tmd710_get_freq(rig, vfo, freq);
 }
 

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -1001,7 +1001,7 @@ int tmd710_do_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
  * tmd710_set_freq
  * Assumes rig!=NULL, freq!=NULL
  */
-int tmd710_set_split_freq(RIG *rig, vfo_t vfo, freq_t freq) {
+int tmd710_set_freq(RIG *rig, vfo_t vfo, freq_t freq) {
 
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 	

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -1033,7 +1033,7 @@ int tmd710_set_split_freq(RIG *rig, vfo_t vfo, freq_t freq) {
 
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 	
-	vfo = rig->state.tx_vfo == RIG_VFO_B ? RIG_VFO_A : RIG_VFO_B;
+	vfo = rig->state.tx_vfo == RIG_VFO_A ? RIG_VFO_A : RIG_VFO_B;
 
 	return tmd710_do_set_freq(rig, vfo, freq);
 }
@@ -1046,7 +1046,7 @@ int tmd710_get_split_freq(RIG *rig, vfo_t vfo, freq_t *freq) {
 	 
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 
-	vfo = rig->state.tx_vfo == RIG_VFO_B ? RIG_VFO_A : RIG_VFO_B;
+	vfo = rig->state.tx_vfo == RIG_VFO_A ? RIG_VFO_A : RIG_VFO_B;
 	
 	return tmd710_do_get_freq(rig, vfo, freq);
 }

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -1629,10 +1629,9 @@ int tmd710_set_split_vfo (RIG *rig, vfo_t vfo, split_t split, vfo_t txvfo)
     
 	rig->state.tx_vfo = txvfo;
 
-	int vfoa = txvfo == RIG_VFO_A ? 1 : 0;
-	int vfob = 1-vfoa;
+	int txVfoIndex = txvfo == RIG_VFO_A ? 0 : 1;
 
-	sprintf(vfobuf, "BC %d,%d", vfoa, vfob );
+	sprintf(vfobuf, "BC %d,%d", txVfoIndex, txVfoIndex );
     retval = kenwood_transaction(rig, vfobuf, NULL, 0);
 	if (retval != RIG_OK)
         return retval;

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -1622,11 +1622,17 @@ int tmd710_set_split_vfo (RIG *rig, vfo_t vfo, split_t split, vfo_t txvfo)
     char vfobuf[16];
     int retval;
 
-    rig_debug(RIG_DEBUG_TRACE, "%s: called %s\n", __func__, rig_strvfo(vfo));
+    rig_debug(RIG_DEBUG_TRACE, "%s: called vfo: %s\ttxvfo: %s\n", __func__, rig_strvfo(vfo), rig_strvfo(txvfo));
+	
+	rig_debug(RIG_DEBUG_TRACE, "%s: called (as number) vfo: %d\ttxvfo: %d\n", __func__, vfo, txvfo);
+	
+    
+	rig->state.tx_vfo = txvfo;
 
-    rig->state.tx_vfo = txvfo;
+	int vfoa = txvfo == RIG_VFO_A ? 1 : 0;
+	int vfob = 1-vfob;
 
-	sprintf(vfobuf, "BC 1,%d", txvfo);
+	sprintf(vfobuf, "BC %d,%d", vfoa, vfob );
     retval = kenwood_transaction(rig, vfobuf, NULL, 0);
 	if (retval != RIG_OK)
         return retval;
@@ -1644,7 +1650,7 @@ int tmd710_get_split_vfo (RIG *rig, vfo_t vfo, split_t *split, vfo_t *txvfo)
 
 	/* Get VFO band */
 
-	retval = kenwood_safe_transaction(rig, "BC", buf, 10, 4);
+	retval = kenwood_safe_transaction(rig, "BC", buf, 10, 6);
 	if (retval != RIG_OK)
 		return retval;
 

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -486,7 +486,7 @@ static int tmd710_open(RIG *rig) {
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 
 	rig->state.tx_vfo = RIG_VFO_A;
-	rig_debug(RIG_DEBUG_TRACE, "rig->state.tx_vfo: %d\n", __func__, rig->state.tx_vfo);
+	rig_debug(RIG_DEBUG_TRACE, "rig->state.tx_vfo: %d\n", __func__, *rig->state.tx_vfo);
 
 
 	return 0;

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -51,6 +51,8 @@
 
 static int tmd710_get_freq(RIG *rig, vfo_t vfo, freq_t *freq);
 static int tmd710_set_freq(RIG *rig, vfo_t vfo, freq_t freq);
+static int tmd710_get_split_freq(RIG *rig, vfo_t vfo, freq_t *freq);
+static int tmd710_set_split_freq(RIG *rig, vfo_t vfo, freq_t freq);
 static int tmd710_set_vfo (RIG *rig, vfo_t vfo);
 static int tmd710_get_vfo(RIG *rig, vfo_t *vfo);
 static int tmd710_set_ts(RIG *rig, vfo_t vfo, shortfreq_t ts);
@@ -981,7 +983,7 @@ int tmd710_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 int tmd710_set_split_freq(RIG *rig, vfo_t vfo, freq_t freq) {
 	 
 	 rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
-	 return tmd710_set_freq(*rig, vfo^1, freq);
+	 return tmd710_set_freq(rig, vfo^1, freq);
 }
 
 /*
@@ -991,7 +993,7 @@ int tmd710_set_split_freq(RIG *rig, vfo_t vfo, freq_t freq) {
 int tmd710_get_split_freq(RIG *rig, vfo_t vfo, freq_t *freq) {
 	 
 	 rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
-	 return tmd710_get_freq(*rig, vfo^1, *freq);
+	 return tmd710_get_freq(rig, vfo^1, freq);
 }
 
 static int tmd710_find_ctcss_index(RIG *rig, tone_t tone, int *ctcss_index) {

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -1005,7 +1005,7 @@ int tmd710_set_freq(RIG *rig, vfo_t vfo, freq_t freq) {
 	
 	rig_debug(RIG_DEBUG_TRACE, "rig->state.tx_vfo: %d\n", rig->state.tx_vfo);
 
-	rig_debug(RIG_DEBUG_TRACE, "tx_vfo: %n(%d)\n", rig_strvfo(rig->state.tx_vfo), rig->state.tx_vfo);
+	rig_debug(RIG_DEBUG_TRACE, "tx_vfo: %s(%d)\n", rig_strvfo(rig->state.tx_vfo), rig->state.tx_vfo);
 
   	vfo = rig->state.tx_vfo == RIG_VFO_A ? RIG_VFO_B : RIG_VFO_A;
 

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -50,6 +50,8 @@
 #include "misc.h"
 
 static int tmd710_open(RIG *rig);
+static int tmd710_do_get_freq(RIG *rig, vfo_t vfo, freq_t *freq);
+static int tmd710_do_set_freq(RIG *rig, vfo_t vfo, freq_t freq);
 static int tmd710_get_freq(RIG *rig, vfo_t vfo, freq_t *freq);
 static int tmd710_set_freq(RIG *rig, vfo_t vfo, freq_t freq);
 static int tmd710_get_split_freq(RIG *rig, vfo_t vfo, freq_t *freq);
@@ -85,7 +87,6 @@ static int tmd710_get_parm(RIG *rig, setting_t parm, value_t *val);
 static int tmd710_set_parm(RIG *rig, setting_t parm, value_t val);
 static int tmd710_get_ext_level(RIG *rig, vfo_t vfo, token_t token, value_t *val);
 static int tmd710_set_ext_level(RIG *rig, vfo_t vfo, token_t token, value_t val);
-
 
 #define TMD710_MODES     (RIG_MODE_FM|RIG_MODE_FMN|RIG_MODE_AM)
 #define TMD710_MODES_FM  (RIG_MODE_FM|RIG_MODE_FMN)
@@ -941,8 +942,9 @@ int tmd710_push_mu(RIG *rig, tmd710_mu *mu_struct)
 /*
  * tmd710_set_freq
  * Assumes rig!=NULL
+ * Common function for getting the main and split frequency.
  */
-int tmd710_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
+int tmd710_do_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
   int retval;
   tmd710_fo fo_struct;
@@ -975,10 +977,11 @@ int tmd710_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 }
 
 /*
- * tmd710_get_freq
+ * tmd710_do_get_freq
  * Assumes rig!=NULL, freq!=NULL
+ * Common function for getting the main and split frequency.
  */
-int tmd710_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
+int tmd710_do_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
   tmd710_fo fo_struct;
   int retval;
@@ -995,15 +998,36 @@ int tmd710_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 }
 
 /*
- * tmd710_get_split_freq
+ * tmd710_set_freq
  * Assumes rig!=NULL, freq!=NULL
  */
 int tmd710_set_split_freq(RIG *rig, vfo_t vfo, freq_t freq) {
 
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 	
-	//vfo = vfo == RIG_VFO_A ? RIG_VFO_B : RIG_VFO_A;
-	return tmd710_set_freq(rig, vfo, freq);
+	return tmd710_set_freq(rig, RIG_VFO_A, freq);
+}
+
+/*
+ * tmd710_get_freq
+ * Assumes rig!=NULL, freq!=NULL
+ */
+int tmd710_get_freq(RIG *rig, vfo_t vfo, freq_t *freq) {
+	 
+	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
+
+	return tmd710_get_freq(rig, RIG_VFO_A, freq);
+}
+
+/*
+ * tmd710_set_split_freq
+ * Assumes rig!=NULL, freq!=NULL
+ */
+int tmd710_set_split_freq(RIG *rig, vfo_t vfo, freq_t freq) {
+
+	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
+	
+	return tmd710_set_freq(rig, RIG_VFO_B, freq);
 }
 
 /*
@@ -1014,8 +1038,7 @@ int tmd710_get_split_freq(RIG *rig, vfo_t vfo, freq_t *freq) {
 	 
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 
-	//vfo = vfo == RIG_VFO_A ? RIG_VFO_B : RIG_VFO_A;
-	return tmd710_get_freq(rig, vfo, freq);
+	return tmd710_get_freq(rig, RIG_VFO_B, freq);
 }
 
 static int tmd710_find_ctcss_index(RIG *rig, tone_t tone, int *ctcss_index) {

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -968,7 +968,7 @@ int tmd710_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
   rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 
-  retval = tmd710_pull_fo(rig, vfo, &fo_struct);
+  retval = tmd710_pull_fo(rig, RIG_VFO_A, &fo_struct);
 
   if (retval == RIG_OK) {
     *freq = fo_struct.freq;
@@ -983,15 +983,8 @@ int tmd710_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
  */
 int tmd710_set_split_freq(RIG *rig, vfo_t vfo, freq_t freq) {
 	 
-	 if( vfo == RIG_VFO_A) {
-		vfo = RIG_VFO_B;
-	}
-	else {
-		vfo = RIG_VFO_A;
-	}
-
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
-	 return tmd710_set_freq(rig, vfo, freq);
+	 return tmd710_set_freq(rig, RIG_VFO_B, freq);
 }
 
 /*
@@ -1000,15 +993,8 @@ int tmd710_set_split_freq(RIG *rig, vfo_t vfo, freq_t freq) {
  */
 int tmd710_get_split_freq(RIG *rig, vfo_t vfo, freq_t *freq) {
 	 
-	if( vfo == RIG_VFO_A) {
-		vfo = RIG_VFO_B;
-	}
-	else {
-		vfo = RIG_VFO_A;
-	}
-
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
-	return tmd710_get_freq(rig, vfo, freq);
+	return tmd710_get_freq(rig, RIG_VFO_B, freq);
 }
 
 static int tmd710_find_ctcss_index(RIG *rig, tone_t tone, int *ctcss_index) {

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -486,7 +486,7 @@ static int tmd710_open(RIG *rig) {
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 
 	rig->state.tx_vfo = RIG_VFO_A;
-	rig_debug(RIG_DEBUG_TRACE, "rig->state.tx_vfo: %d\n", __func__, rig->state.tx_vfo)
+	rig_debug(RIG_DEBUG_TRACE, "rig->state.tx_vfo: %d\n", __func__, rig->state.tx_vfo);
 
 
 	return 0;
@@ -1003,7 +1003,7 @@ int tmd710_set_freq(RIG *rig, vfo_t vfo, freq_t freq) {
 
 	rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 	
-	rig_debug(RIG_DEBUG_TRACE, "rig->state.tx_vfo: %d\n", __func__, rig->state.tx_vfo)
+	rig_debug(RIG_DEBUG_TRACE, "rig->state.tx_vfo: %d\n", __func__, rig->state.tx_vfo);
 
 	rig_debug(RIG_DEBUG_TRACE, "tx_vfo: %n(%d)\n", __func__, rig_strvfo(rig->state.tx_vfo), rig->state.tx_vfo);
 
@@ -1637,7 +1637,7 @@ int tmd710_set_split_vfo (RIG *rig, vfo_t vfo, split_t split, vfo_t txvfo)
     
 	rig->state.tx_vfo = txvfo;
 
-	rig_debug(RIG_DEBUG_TRACE, "rig->state.tx_vfo: %d\n", __func__, rig->state.tx_vfo)
+	rig_debug(RIG_DEBUG_TRACE, "rig->state.tx_vfo: %d\n", __func__, rig->state.tx_vfo);
 
 	int txVfoIndex = txvfo == RIG_VFO_A ? 0 : 1;
 

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -49,6 +49,7 @@
 #include "num_stdio.h"
 #include "misc.h"
 
+static int tmd710_open(RIG *rig);
 static int tmd710_get_freq(RIG *rig, vfo_t vfo, freq_t *freq);
 static int tmd710_set_freq(RIG *rig, vfo_t vfo, freq_t freq);
 static int tmd710_get_split_freq(RIG *rig, vfo_t vfo, freq_t *freq);
@@ -343,7 +344,8 @@ const struct rig_caps tmd710_caps = {
     .priv =  (void *) &tmd710_priv_caps,
 
     .rig_init = kenwood_init,
-    .rig_cleanup = kenwood_cleanup,
+    .rig_open = tmd700_open,
+	.rig_cleanup = kenwood_cleanup,
     .set_freq =  tmd710_set_freq,
     .get_freq =  tmd710_get_freq,
     .set_split_freq =  tmd710_set_split_freq,
@@ -475,6 +477,17 @@ typedef struct {
   int auto_pm_store; // P41 0/1
   int display_partition_bar; // P42 0/1
 } tmd710_mu;
+
+static int tmd710_open(RIG *rig) {
+	
+	int retval;
+
+	retval = tmd710_set_vfo( rig, RIG_VFO_B );
+
+	if (retval != RIG_OK) {
+    return retval;
+  }
+}
 
 static int tmd710_get_vfo_num(RIG *rig, int *vfonum, vfo_t *vfo) {
   char buf[10];

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -1619,7 +1619,7 @@ int tmd710_set_vfo(RIG *rig, vfo_t vfo)
 */
 int tmd710_set_split_vfo (RIG *rig, vfo_t vfo, split_t split, vfo_t txvfo)
 {
-    char vfobuf[16];
+    char vfobuf[16], ackbuf[16];
     int retval;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: called vfo: %s\ttxvfo: %s\n", __func__, rig_strvfo(vfo), rig_strvfo(txvfo));
@@ -1632,7 +1632,7 @@ int tmd710_set_split_vfo (RIG *rig, vfo_t vfo, split_t split, vfo_t txvfo)
 	int txVfoIndex = txvfo == RIG_VFO_A ? 0 : 1;
 
 	sprintf(vfobuf, "BC %d,%d", txVfoIndex, txVfoIndex );
-    retval = kenwood_transaction(rig, vfobuf, NULL, 0);
+    retval = kenwood_transaction(rig, vfobuf, ackbuf, sizeof(ackbuf));
 	if (retval != RIG_OK)
         return retval;
 

--- a/kenwood/tmd710.c
+++ b/kenwood/tmd710.c
@@ -1630,7 +1630,7 @@ int tmd710_set_split_vfo (RIG *rig, vfo_t vfo, split_t split, vfo_t txvfo)
 	rig->state.tx_vfo = txvfo;
 
 	int vfoa = txvfo == RIG_VFO_A ? 1 : 0;
-	int vfob = 1-vfob;
+	int vfob = 1-vfoa;
 
 	sprintf(vfobuf, "BC %d,%d", vfoa, vfob );
     retval = kenwood_transaction(rig, vfobuf, NULL, 0);


### PR DESCRIPTION
Add TM710_(get|set)_split_freq functions.

This allows programs like GPredict to control both sides of the radio by emulating split frequency capability.