### PR TITLE
Fix/unused includes

### DIFF
--- a/amplifiers/elecraft/kpa1500.c
+++ b/amplifiers/elecraft/kpa1500.c
@@ -25,8 +25,6 @@
 #include <hamlib/config.h>
 
 #include <stdio.h>
-#include <stdlib.h>      /* Standard library definitions */
-#include <string.h>      /* String function definitions */
 
 #include "register.h"
 

--- a/amplifiers/gemini/dx1200.c
+++ b/amplifiers/gemini/dx1200.c
@@ -25,8 +25,6 @@
 #include <hamlib/config.h>
 
 #include <stdio.h>
-#include <stdlib.h>      /* Standard library definitions */
-#include <string.h>      /* String function definitions */
 
 #include "register.h"
 

--- a/rigs/adat/adat.c
+++ b/rigs/adat/adat.c
@@ -33,7 +33,6 @@
 #include <unistd.h>
 #include <math.h>
 #include <ctype.h>
-#include <time.h>
 
 // ---------------------------------------------------------------------------
 //    HAMLIB INCLUDES

--- a/rigs/adat/adat.c
+++ b/rigs/adat/adat.c
@@ -31,7 +31,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <math.h>
 #include <ctype.h>
 
 // ---------------------------------------------------------------------------

--- a/rigs/alinco/alinco.c
+++ b/rigs/alinco/alinco.c
@@ -20,12 +20,6 @@
  */
 
 #include <hamlib/config.h>
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
-
 #include <hamlib/rig.h>
 #include <register.h>
 

--- a/rigs/alinco/alinco.c
+++ b/rigs/alinco/alinco.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 
 #include <hamlib/rig.h>
 #include <register.h>

--- a/rigs/alinco/dx77.c
+++ b/rigs/alinco/dx77.c
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include <hamlib/rig.h>
 #include "idx_builtin.h"

--- a/rigs/alinco/dx77.c
+++ b/rigs/alinco/dx77.c
@@ -25,8 +25,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
-
 
 #include <hamlib/rig.h>
 #include "idx_builtin.h"

--- a/rigs/alinco/dxsr8.c
+++ b/rigs/alinco/dxsr8.c
@@ -23,7 +23,6 @@
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include <hamlib/rig.h>
 #include <serial.h>

--- a/rigs/aor/aor.c
+++ b/rigs/aor/aor.c
@@ -22,9 +22,6 @@
 #include <hamlib/config.h>
 
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 #include <ctype.h>
 
 #include "hamlib/rig.h"

--- a/rigs/aor/aor.c
+++ b/rigs/aor/aor.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 #include <ctype.h>
 
 #include "hamlib/rig.h"

--- a/rigs/aor/ar3030.c
+++ b/rigs/aor/ar3030.c
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/aor/ar7030.c
+++ b/rigs/aor/ar7030.c
@@ -28,7 +28,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <math.h>
 
 #include <hamlib/rig.h>
 #include "aor.h"

--- a/rigs/aor/ar7030.c
+++ b/rigs/aor/ar7030.c
@@ -27,7 +27,6 @@
 #include <hamlib/config.h>
 
 #include <stdio.h>
-#include <string.h>
 
 #include <hamlib/rig.h>
 #include "aor.h"

--- a/rigs/aor/ar7030p.c
+++ b/rigs/aor/ar7030p.c
@@ -28,7 +28,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <math.h>
 #include <assert.h>
 #include <stdlib.h>
 

--- a/rigs/barrett/4050.c
+++ b/rigs/barrett/4050.c
@@ -21,9 +21,6 @@
 #include <hamlib/config.h>
 
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
 
 #include <hamlib/rig.h>
 #include "serial.h"

--- a/rigs/barrett/4050.c
+++ b/rigs/barrett/4050.c
@@ -24,7 +24,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <math.h>
 
 #include <hamlib/rig.h>
 #include "serial.h"

--- a/rigs/barrett/950.c
+++ b/rigs/barrett/950.c
@@ -21,9 +21,7 @@
 #include <hamlib/config.h>
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #include <hamlib/rig.h>
 #include "serial.h"

--- a/rigs/barrett/950.c
+++ b/rigs/barrett/950.c
@@ -24,7 +24,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <math.h>
 
 #include <hamlib/rig.h>
 #include "serial.h"

--- a/rigs/barrett/barrett.c
+++ b/rigs/barrett/barrett.c
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #include <hamlib/rig.h>
 #include "serial.h"

--- a/rigs/barrett/barrett.c
+++ b/rigs/barrett/barrett.c
@@ -24,7 +24,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <math.h>
 
 #include <hamlib/rig.h>
 #include "serial.h"

--- a/rigs/barrett/barrett.h
+++ b/rigs/barrett/barrett.h
@@ -24,10 +24,6 @@
 
 #include "hamlib/rig.h"
 
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
-
 #define BACKEND_VER "20220113"
 
 #define EOM "\x0d"

--- a/rigs/codan/codan.c
+++ b/rigs/codan/codan.c
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #include <hamlib/rig.h>
 #include "serial.h"

--- a/rigs/codan/codan.c
+++ b/rigs/codan/codan.c
@@ -24,7 +24,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <math.h>
 
 #include <hamlib/rig.h>
 #include "serial.h"

--- a/rigs/codan/codan.h
+++ b/rigs/codan/codan.h
@@ -24,10 +24,6 @@
 
 #include "hamlib/rig.h"
 
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
-
 #define BACKEND_VER "20211228"
 
 #define EOM "\x0d"

--- a/rigs/dorji/dorji.c
+++ b/rigs/dorji/dorji.c
@@ -21,10 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
-#include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
-
 #include "hamlib/rig.h"
 #include "register.h"
 

--- a/rigs/dorji/dra818.c
+++ b/rigs/dorji/dra818.c
@@ -21,10 +21,8 @@
 
 #include <hamlib/config.h>
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 #include <stdbool.h>
 
 #include "hamlib/rig.h"

--- a/rigs/drake/drake.c
+++ b/rigs/drake/drake.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/dummy/amp_dummy.c
+++ b/rigs/dummy/amp_dummy.c
@@ -24,7 +24,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 
 #include "hamlib/amplifier.h"
 #include "serial.h"

--- a/rigs/dummy/amp_dummy.c
+++ b/rigs/dummy/amp_dummy.c
@@ -22,8 +22,6 @@
 #include <hamlib/config.h>
 
 #include <stdlib.h>
-#include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/amplifier.h"
 #include "serial.h"

--- a/rigs/dummy/amp_dummy.c
+++ b/rigs/dummy/amp_dummy.c
@@ -25,8 +25,6 @@
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
 #include <math.h>
-#include <sys/time.h>
-#include <time.h>
 
 #include "hamlib/amplifier.h"
 #include "serial.h"

--- a/rigs/dummy/dummy.c
+++ b/rigs/dummy/dummy.c
@@ -30,8 +30,6 @@
 // cppcheck-suppress *
 #include <unistd.h>  /* UNIX standard function definitions */
 // cppcheck-suppress *
-#include <math.h>
-// cppcheck-suppress *
 #include <time.h>
 
 #include "hamlib/rig.h"

--- a/rigs/dummy/dummy_common.c
+++ b/rigs/dummy/dummy_common.c
@@ -23,8 +23,6 @@
 
 // cppcheck-suppress *
 #include <stdlib.h>
-// cppcheck-suppress *
-#include <string.h>  /* String function definitions */
 
 #include "hamlib/rig.h"
 

--- a/rigs/dummy/flrig.c
+++ b/rigs/dummy/flrig.c
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>             /* String function definitions */
-#include <unistd.h>             /* UNIX standard function definitions */
 
 #include <hamlib/rig.h>
 #include <serial.h>

--- a/rigs/dummy/flrig.c
+++ b/rigs/dummy/flrig.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <string.h>             /* String function definitions */
 #include <unistd.h>             /* UNIX standard function definitions */
-#include <math.h>
 
 #include <hamlib/rig.h>
 #include <serial.h>

--- a/rigs/dummy/flrig.h
+++ b/rigs/dummy/flrig.h
@@ -24,10 +24,6 @@
 
 #include "hamlib/rig.h"
 
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
-
 #define EOM "\r"
 #define TRUE 1
 #define FALSE 0

--- a/rigs/dummy/netampctl.c
+++ b/rigs/dummy/netampctl.c
@@ -24,7 +24,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 #include <errno.h>
 
 #include "hamlib/amplifier.h"

--- a/rigs/dummy/netampctl.c
+++ b/rigs/dummy/netampctl.c
@@ -23,7 +23,6 @@
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 #include <errno.h>
 
 #include "hamlib/amplifier.h"

--- a/rigs/dummy/netrigctl.c
+++ b/rigs/dummy/netrigctl.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 #include <errno.h>
 
 #include "hamlib/rig.h"

--- a/rigs/dummy/netrigctl.c
+++ b/rigs/dummy/netrigctl.c
@@ -26,7 +26,6 @@
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
 #include <math.h>
-#include <time.h>
 #include <errno.h>
 
 #include "hamlib/rig.h"

--- a/rigs/dummy/netrotctl.c
+++ b/rigs/dummy/netrotctl.c
@@ -23,7 +23,6 @@
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 #include <errno.h>
 
 #include "hamlib/rotator.h"

--- a/rigs/dummy/netrotctl.c
+++ b/rigs/dummy/netrotctl.c
@@ -24,7 +24,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 #include <errno.h>
 
 #include "hamlib/rotator.h"

--- a/rigs/dummy/tci1x.c
+++ b/rigs/dummy/tci1x.c
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>             /* String function definitions */
-#include <unistd.h>             /* UNIX standard function definitions */
 
 #include <hamlib/rig.h>
 #include <serial.h>

--- a/rigs/dummy/tci1x.c
+++ b/rigs/dummy/tci1x.c
@@ -24,7 +24,6 @@
 #include <stdlib.h>
 #include <string.h>             /* String function definitions */
 #include <unistd.h>             /* UNIX standard function definitions */
-#include <math.h>
 
 #include <hamlib/rig.h>
 #include <serial.h>

--- a/rigs/dummy/trxmanager.c
+++ b/rigs/dummy/trxmanager.c
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>             /* String function definitions */
-#include <unistd.h>             /* UNIX standard function definitions */
 
 #include <hamlib/rig.h>
 #include <serial.h>

--- a/rigs/dummy/trxmanager.c
+++ b/rigs/dummy/trxmanager.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <string.h>             /* String function definitions */
 #include <unistd.h>             /* UNIX standard function definitions */
-#include <math.h>
 
 #include <hamlib/rig.h>
 #include <serial.h>

--- a/rigs/dummy/trxmanager.h
+++ b/rigs/dummy/trxmanager.h
@@ -26,10 +26,6 @@
 
 #include "hamlib/rig.h"
 
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
-
 #define BACKEND_VER "20210613"
 
 #define EOM "\r"

--- a/rigs/elad/fdm_duo.c
+++ b/rigs/elad/fdm_duo.c
@@ -22,7 +22,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 #include <stdio.h>
 
 #include <hamlib/rig.h>

--- a/rigs/flexradio/flexradio.c
+++ b/rigs/flexradio/flexradio.c
@@ -24,7 +24,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 
 #include "hamlib/rig.h"
 #include "flexradio.h"

--- a/rigs/flexradio/flexradio.c
+++ b/rigs/flexradio/flexradio.c
@@ -21,10 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
-#include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
-
 #include "hamlib/rig.h"
 #include "flexradio.h"
 #include "register.h"

--- a/rigs/flexradio/sdr1k.c
+++ b/rigs/flexradio/sdr1k.c
@@ -22,8 +22,6 @@
 #include <hamlib/config.h>
 
 #include <stdlib.h>
-#include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 #include <math.h>
 
 #include "hamlib/rig.h"

--- a/rigs/gomspace/gs100.c
+++ b/rigs/gomspace/gs100.c
@@ -29,7 +29,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <assert.h>
 
 #include "hamlib/rig.h"

--- a/rigs/gomspace/gs100.c
+++ b/rigs/gomspace/gs100.c
@@ -31,7 +31,6 @@
 #include <string.h>
 #include <unistd.h>
 #include <math.h>
-#include <time.h>
 #include <assert.h>
 
 #include "hamlib/rig.h"

--- a/rigs/gomspace/gs100.c
+++ b/rigs/gomspace/gs100.c
@@ -30,7 +30,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <math.h>
 #include <assert.h>
 
 #include "hamlib/rig.h"

--- a/rigs/icmarine/icm710.c
+++ b/rigs/icmarine/icm710.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <math.h>
 
 #include <hamlib/rig.h>
 #include <serial.h>

--- a/rigs/icmarine/icm710.c
+++ b/rigs/icmarine/icm710.c
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #include <hamlib/rig.h>
 #include <serial.h>

--- a/rigs/icmarine/icm710.h
+++ b/rigs/icmarine/icm710.h
@@ -26,10 +26,6 @@
 #include "cal.h"
 #include "tones.h"
 
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
-
 struct icm710_priv_caps {
     unsigned char default_remote_id;  /* the remote default equipment's ID */
 };

--- a/rigs/icmarine/icmarine.c
+++ b/rigs/icmarine/icmarine.c
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include <hamlib/rig.h>
 #include <serial.h>

--- a/rigs/icmarine/icmarine.c
+++ b/rigs/icmarine/icmarine.c
@@ -24,7 +24,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 
 #include <hamlib/rig.h>
 #include <serial.h>

--- a/rigs/icmarine/icmarine.h
+++ b/rigs/icmarine/icmarine.h
@@ -26,10 +26,6 @@
 #include "cal.h"
 #include "tones.h"
 
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
-
 #define BACKEND_VER "20181007"
 
 struct icmarine_priv_caps {

--- a/rigs/icom/delta2.c
+++ b/rigs/icom/delta2.c
@@ -33,7 +33,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 
 #include <hamlib/rig.h>
 #include "icom.h"

--- a/rigs/icom/ic2730.c
+++ b/rigs/icom/ic2730.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 
 #include "hamlib/rig.h"
 #include "idx_builtin.h"

--- a/rigs/icom/ic7200.c
+++ b/rigs/icom/ic7200.c
@@ -27,7 +27,6 @@
 #include <hamlib/config.h>
 
 #include <stdlib.h>
-#include <string.h>  /* String function definitions */
 
 #include <hamlib/rig.h>
 #include "token.h"

--- a/rigs/icom/ic7300.c
+++ b/rigs/icom/ic7300.c
@@ -22,7 +22,6 @@
 
 #include <hamlib/config.h>
 
-#include <string.h>
 #include <stdlib.h>
 
 #include <hamlib/rig.h>

--- a/rigs/icom/ic7410.c
+++ b/rigs/icom/ic7410.c
@@ -22,7 +22,6 @@
 #include <hamlib/config.h>
 
 #include <stdlib.h>
-#include <string.h>  /* String function definitions */
 
 #include <hamlib/rig.h>
 #include "token.h"

--- a/rigs/icom/ic7600.c
+++ b/rigs/icom/ic7600.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <string.h>
 #include <stdlib.h>
 
 #include <hamlib/rig.h>

--- a/rigs/icom/ic7610.c
+++ b/rigs/icom/ic7610.c
@@ -22,7 +22,6 @@
 
 #include <hamlib/config.h>
 
-#include <string.h>
 #include <stdlib.h>
 
 #include <hamlib/rig.h>

--- a/rigs/icom/ic7700.c
+++ b/rigs/icom/ic7700.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <string.h>
 #include <stdlib.h>
 
 #include <hamlib/rig.h>

--- a/rigs/icom/ic78.c
+++ b/rigs/icom/ic78.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 
 #include "hamlib/rig.h"
 #include "icom.h"

--- a/rigs/icom/ic7800.c
+++ b/rigs/icom/ic7800.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <string.h>  /* String function definitions */
 #include <stdlib.h>
 
 #include <hamlib/rig.h>

--- a/rigs/icom/ic9100.c
+++ b/rigs/icom/ic9100.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 
 #include <hamlib/rig.h>
 #include "icom.h"

--- a/rigs/icom/icr30.c
+++ b/rigs/icom/icr30.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 
 #include "hamlib/rig.h"
 #include "token.h"

--- a/rigs/icom/icr6.c
+++ b/rigs/icom/icr6.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 
 #include "hamlib/rig.h"
 #include "icom.h"

--- a/rigs/icom/icr9500.c
+++ b/rigs/icom/icr9500.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 
 #include <hamlib/rig.h>
 #include "serial.h"

--- a/rigs/icom/id1.c
+++ b/rigs/icom/id1.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 
 #include "hamlib/rig.h"
 #include "idx_builtin.h"

--- a/rigs/icom/id31.c
+++ b/rigs/icom/id31.c
@@ -22,7 +22,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 
 #include "hamlib/rig.h"
 #include "idx_builtin.h"

--- a/rigs/icom/id4100.c
+++ b/rigs/icom/id4100.c
@@ -22,7 +22,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 
 #include "hamlib/rig.h"
 #include "idx_builtin.h"

--- a/rigs/icom/id51.c
+++ b/rigs/icom/id51.c
@@ -22,7 +22,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 
 #include "hamlib/rig.h"
 #include "token.h"

--- a/rigs/icom/id5100.c
+++ b/rigs/icom/id5100.c
@@ -22,7 +22,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 
 #include "hamlib/rig.h"
 #include "idx_builtin.h"

--- a/rigs/icom/optoscan.c
+++ b/rigs/icom/optoscan.c
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/icom/optoscan.c
+++ b/rigs/icom/optoscan.c
@@ -24,7 +24,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/icom/xiegu.c
+++ b/rigs/icom/xiegu.c
@@ -32,7 +32,6 @@
 #include <hamlib/config.h>
 
 #include <stdlib.h>
-#include <string.h>  /* String function definitions */
 
 #include <hamlib/rig.h>
 #include "token.h"

--- a/rigs/jrc/jrc.c
+++ b/rigs/jrc/jrc.c
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 #include <math.h>
 
 #include "hamlib/rig.h"

--- a/rigs/kachina/kachina.c
+++ b/rigs/kachina/kachina.c
@@ -21,9 +21,7 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/kachina/kachina.c
+++ b/rigs/kachina/kachina.c
@@ -24,7 +24,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/kenwood/flex.c
+++ b/rigs/kenwood/flex.c
@@ -25,7 +25,6 @@
  */
 
 #include <string.h>
-#include <stdlib.h>
 
 #include "flex.h"
 #include "kenwood.h"

--- a/rigs/kenwood/ic10.c
+++ b/rigs/kenwood/ic10.c
@@ -27,7 +27,6 @@
 #include <stdio.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 #include <ctype.h>   /* character class tests */
 
 #include "hamlib/rig.h"

--- a/rigs/kenwood/ic10.c
+++ b/rigs/kenwood/ic10.c
@@ -26,7 +26,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 #include <ctype.h>   /* character class tests */
 
 #include "hamlib/rig.h"

--- a/rigs/kenwood/th.c
+++ b/rigs/kenwood/th.c
@@ -26,7 +26,6 @@
 #include <stdio.h>
 #include <math.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "kenwood.h"

--- a/rigs/kenwood/thd72.c
+++ b/rigs/kenwood/thd72.c
@@ -22,7 +22,6 @@
 #include <hamlib/config.h>
 
 #include <stdlib.h>
-#include <unistd.h>
 #include <math.h>
 
 #include "hamlib/rig.h"

--- a/rigs/kenwood/thd74.c
+++ b/rigs/kenwood/thd74.c
@@ -22,7 +22,6 @@
 #include <hamlib/config.h>
 
 #include <stdlib.h>
-#include <unistd.h>
 #include <math.h>
 
 #include "hamlib/rig.h"

--- a/rigs/kenwood/thf6a.c
+++ b/rigs/kenwood/thf6a.c
@@ -28,7 +28,6 @@
 #include <hamlib/config.h>
 
 #include <stdlib.h>
-#include <string.h>
 
 #include <hamlib/rig.h>
 #include "tones.h"

--- a/rigs/kenwood/thf7.c
+++ b/rigs/kenwood/thf7.c
@@ -22,7 +22,6 @@
 #include <hamlib/config.h>
 
 #include <stdlib.h>
-#include <string.h>
 
 #include <hamlib/rig.h>
 #include "tones.h"

--- a/rigs/kenwood/thg71.c
+++ b/rigs/kenwood/thg71.c
@@ -24,7 +24,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include <hamlib/rig.h>
 #include "kenwood.h"

--- a/rigs/kenwood/tmd700.c
+++ b/rigs/kenwood/tmd700.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 
 #include "hamlib/rig.h"
 #include "kenwood.h"

--- a/rigs/kenwood/tmd700.c
+++ b/rigs/kenwood/tmd700.c
@@ -22,7 +22,6 @@
 #include <hamlib/config.h>
 
 #include <stdlib.h>
-#include <math.h>
 
 #include "hamlib/rig.h"
 #include "kenwood.h"

--- a/rigs/kenwood/tmv7.c
+++ b/rigs/kenwood/tmv7.c
@@ -21,10 +21,8 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include <hamlib/rig.h>
 #include "kenwood.h"

--- a/rigs/kenwood/transfox.c
+++ b/rigs/kenwood/transfox.c
@@ -24,7 +24,6 @@
 #include <hamlib/config.h>
 
 #include <stdlib.h>
-#include <string.h>
 
 #include <hamlib/rig.h>
 #include "kenwood.h"

--- a/rigs/kenwood/trc80.c
+++ b/rigs/kenwood/trc80.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 
 #include "hamlib/rig.h"
 #include "bandplan.h"

--- a/rigs/kenwood/ts140.c
+++ b/rigs/kenwood/ts140.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 #include <stdio.h>
 
 #include "hamlib/rig.h"

--- a/rigs/kenwood/ts480.c
+++ b/rigs/kenwood/ts480.c
@@ -24,7 +24,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
 
 #include <hamlib/rig.h>
 #include "cal.h"

--- a/rigs/kenwood/ts590.c
+++ b/rigs/kenwood/ts590.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 #include <stdio.h>
 
 #include "hamlib/rig.h"

--- a/rigs/kenwood/ts680.c
+++ b/rigs/kenwood/ts680.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 #include <stdio.h>
 
 #include "hamlib/rig.h"

--- a/rigs/kenwood/ts690.c
+++ b/rigs/kenwood/ts690.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 
 #include <hamlib/rig.h>
 #include "bandplan.h"

--- a/rigs/kenwood/ts790.c
+++ b/rigs/kenwood/ts790.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 
 #include <hamlib/rig.h>
 #include "kenwood.h"

--- a/rigs/kenwood/ts850.c
+++ b/rigs/kenwood/ts850.c
@@ -23,7 +23,6 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <string.h>
 #include <math.h>
 
 #include <hamlib/rig.h>

--- a/rigs/kenwood/ts930.c
+++ b/rigs/kenwood/ts930.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 
 #include <hamlib/rig.h>
 #include <bandplan.h>

--- a/rigs/kenwood/ts940.c
+++ b/rigs/kenwood/ts940.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 
 #include <hamlib/rig.h>
 #include "bandplan.h"

--- a/rigs/kenwood/ts990s.c
+++ b/rigs/kenwood/ts990s.c
@@ -23,7 +23,6 @@
 #include <hamlib/config.h>
 
 #include <stdlib.h>
-#include <string.h>
 
 #include <hamlib/rig.h>
 #include "kenwood.h"

--- a/rigs/kit/dwt.c
+++ b/rigs/kit/dwt.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 #include <stdio.h>
 #include "hamlib/rig.h"
 

--- a/rigs/kit/funcube.c
+++ b/rigs/kit/funcube.c
@@ -31,7 +31,6 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
 #include "hamlib/rig.h"
 #include "token.h"
 #include "misc.h"

--- a/rigs/kit/hiqsdr.c
+++ b/rigs/kit/hiqsdr.c
@@ -22,7 +22,6 @@
 #include <stdlib.h>
 #include <stdio.h>   /* Standard input/output definitions */
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 #include <fcntl.h>   /* File control definitions */
 #include <errno.h>   /* Error number definitions */
 

--- a/rigs/kit/hiqsdr.c
+++ b/rigs/kit/hiqsdr.c
@@ -25,7 +25,6 @@
 #include <unistd.h>  /* UNIX standard function definitions */
 #include <fcntl.h>   /* File control definitions */
 #include <errno.h>   /* Error number definitions */
-#include <math.h>
 
 #include "hamlib/rig.h"
 #include "iofunc.h"

--- a/rigs/kit/kit.c
+++ b/rigs/kit/kit.c
@@ -21,10 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
-#include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
-
 #include "hamlib/rig.h"
 #include "register.h"
 

--- a/rigs/kit/miniVNA.c
+++ b/rigs/kit/miniVNA.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/kit/miniVNA.c
+++ b/rigs/kit/miniVNA.c
@@ -21,10 +21,7 @@
 
 #include <hamlib/config.h>
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/kit/pcrotor.c
+++ b/rigs/kit/pcrotor.c
@@ -22,8 +22,6 @@
 #include <hamlib/config.h>
 
 #include <stdlib.h>
-#include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rotator.h"
 #include "parallel.h"

--- a/rigs/kit/rs_hfiq.c
+++ b/rigs/kit/rs_hfiq.c
@@ -29,7 +29,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/lowe/lowe.c
+++ b/rigs/lowe/lowe.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/lowe/lowe.c
+++ b/rigs/lowe/lowe.c
@@ -22,7 +22,6 @@
 #include <hamlib/config.h>
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
 

--- a/rigs/pcr/pcr.c
+++ b/rigs/pcr/pcr.c
@@ -34,7 +34,6 @@
 #include <stdlib.h>
 #include <string.h>     /* String function definitions */
 #include <unistd.h>     /* UNIX standard function definitions */
-#include <math.h>
 #include <errno.h>
 #include <ctype.h>
 

--- a/rigs/pcr/pcr.c
+++ b/rigs/pcr/pcr.c
@@ -33,7 +33,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>     /* String function definitions */
-#include <unistd.h>     /* UNIX standard function definitions */
 #include <errno.h>
 #include <ctype.h>
 

--- a/rigs/prm80/prm80.c
+++ b/rigs/prm80/prm80.c
@@ -26,7 +26,6 @@
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
 #include <ctype.h>
-#include <math.h>
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/prm80/prm80.c
+++ b/rigs/prm80/prm80.c
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 #include <ctype.h>
 
 #include "hamlib/rig.h"

--- a/rigs/prm80/prm8060.c
+++ b/rigs/prm80/prm8060.c
@@ -21,9 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
-#include <string.h>
-
 #include "hamlib/rig.h"
 #include "idx_builtin.h"
 #include "prm80.h"

--- a/rigs/racal/ra3702.c
+++ b/rigs/racal/ra3702.c
@@ -20,7 +20,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 
 #include <hamlib/rig.h>
 #include "idx_builtin.h"

--- a/rigs/racal/ra37xx.c
+++ b/rigs/racal/ra37xx.c
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/racal/ra37xx.c
+++ b/rigs/racal/ra37xx.c
@@ -24,7 +24,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/racal/ra6790.c
+++ b/rigs/racal/ra6790.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 
 #include <hamlib/rig.h>
 #include "idx_builtin.h"

--- a/rigs/racal/racal.c
+++ b/rigs/racal/racal.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/racal/racal.c
+++ b/rigs/racal/racal.c
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/rft/rft.c
+++ b/rigs/rft/rft.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/rft/rft.c
+++ b/rigs/rft/rft.c
@@ -21,10 +21,7 @@
 
 #include <hamlib/config.h>
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/rs/gp2000.c
+++ b/rigs/rs/gp2000.c
@@ -31,7 +31,6 @@
 #include <stdlib.h>
 #include <string.h>     /* String function definitions */
 #include <unistd.h>     /* UNIX standard function definitions */
-#include <math.h>
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/rs/gp2000.c
+++ b/rigs/rs/gp2000.c
@@ -30,7 +30,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>     /* String function definitions */
-#include <unistd.h>     /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/rs/rs.c
+++ b/rigs/rs/rs.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/rs/rs.c
+++ b/rigs/rs/rs.c
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/skanti/skanti.c
+++ b/rigs/skanti/skanti.c
@@ -22,9 +22,7 @@
 #include <hamlib/config.h>
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include <hamlib/rig.h>
 #include <serial.h>

--- a/rigs/skanti/skanti.c
+++ b/rigs/skanti/skanti.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 
 #include <hamlib/rig.h>
 #include <serial.h>

--- a/rigs/skanti/trp8000.c
+++ b/rigs/skanti/trp8000.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 
 #include <hamlib/rig.h>
 #include "idx_builtin.h"

--- a/rigs/tapr/tapr.c
+++ b/rigs/tapr/tapr.c
@@ -21,10 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
-#include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
-
 #include "hamlib/rig.h"
 #include "register.h"
 #include "serial.h"

--- a/rigs/tentec/orion.c
+++ b/rigs/tentec/orion.c
@@ -71,7 +71,6 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 #include <math.h>
 
 #include <hamlib/rig.h>

--- a/rigs/tentec/orion.c
+++ b/rigs/tentec/orion.c
@@ -72,8 +72,6 @@
 #include <ctype.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <time.h>
-#include <sys/time.h>
 #include <math.h>
 
 #include <hamlib/rig.h>

--- a/rigs/tentec/tentec.c
+++ b/rigs/tentec/tentec.c
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 #include <math.h>
 
 #include "hamlib/rig.h"

--- a/rigs/tentec/tentec2.c
+++ b/rigs/tentec/tentec2.c
@@ -57,7 +57,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/tentec/tentec2.c
+++ b/rigs/tentec/tentec2.c
@@ -54,9 +54,7 @@
 #include <hamlib/config.h>
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/tentec/tt550.c
+++ b/rigs/tentec/tt550.c
@@ -28,7 +28,6 @@
 #include <unistd.h>     /* UNIX standard function definitions */
 #include <fcntl.h>      /* File control definitions */
 #include <errno.h>      /* Error number definitions */
-#include <math.h>
 
 #include <hamlib/rig.h>
 #include "serial.h"

--- a/rigs/tuner/tuner.c
+++ b/rigs/tuner/tuner.c
@@ -21,7 +21,6 @@
 
 #include "tuner.h"  /* config.h */
 
-#include <stdlib.h>
 
 #include "hamlib/rig.h"
 #include "register.h"

--- a/rigs/tuner/v4l.c
+++ b/rigs/tuner/v4l.c
@@ -18,10 +18,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
-
-#include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 #include <math.h>
 #include <errno.h>
 
@@ -36,7 +33,6 @@
 
 #ifdef V4L_IOCTL
 
-#include <stdlib.h>
 #include "idx_builtin.h"
 
 

--- a/rigs/tuner/v4l2.c
+++ b/rigs/tuner/v4l2.c
@@ -18,10 +18,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
-
-#include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 #include <math.h>
 #include <errno.h>
 
@@ -36,7 +33,6 @@
 
 #ifdef V4L_IOCTL
 
-#include <stdlib.h>
 #include "idx_builtin.h"
 
 

--- a/rigs/uniden/uniden.c
+++ b/rigs/uniden/uniden.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/uniden/uniden.c
+++ b/rigs/uniden/uniden.c
@@ -22,7 +22,6 @@
 #include <hamlib/config.h>
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
 

--- a/rigs/uniden/uniden_digital.c
+++ b/rigs/uniden/uniden_digital.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/uniden/uniden_digital.c
+++ b/rigs/uniden/uniden_digital.c
@@ -22,9 +22,7 @@
 #include <hamlib/config.h>
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/winradio/g303.c
+++ b/rigs/winradio/g303.c
@@ -19,7 +19,6 @@
  *
  */
 
-#include <stdlib.h>
 
 #include <hamlib/rig.h>
 #include "winradio.h"

--- a/rigs/winradio/g305.c
+++ b/rigs/winradio/g305.c
@@ -19,7 +19,6 @@
  *
  */
 
-#include <stdlib.h>
 
 #include <hamlib/rig.h>
 #include "winradio.h"

--- a/rigs/winradio/g313-posix.c
+++ b/rigs/winradio/g313-posix.c
@@ -22,7 +22,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 

--- a/rigs/winradio/winradio.c
+++ b/rigs/winradio/winradio.c
@@ -22,7 +22,6 @@
 
 #include "winradio.h"   /* config.h */
 
-#include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>

--- a/rigs/winradio/winradio.c
+++ b/rigs/winradio/winradio.c
@@ -27,7 +27,6 @@
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif
-#include <math.h>
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/wj/wj.c
+++ b/rigs/wj/wj.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/wj/wj.c
+++ b/rigs/wj/wj.c
@@ -23,8 +23,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/wj/wj8888.c
+++ b/rigs/wj/wj8888.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 
 #include <hamlib/rig.h>
 #include "idx_builtin.h"

--- a/rigs/yaesu/frg100.c
+++ b/rigs/yaesu/frg100.c
@@ -26,7 +26,6 @@
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/yaesu/frg8800.c
+++ b/rigs/yaesu/frg8800.c
@@ -24,10 +24,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
-#include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
-
 #include "hamlib/rig.h"
 #include "serial.h"
 #include "misc.h"

--- a/rigs/yaesu/frg9600.c
+++ b/rigs/yaesu/frg9600.c
@@ -24,10 +24,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
-#include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
-
 #include "hamlib/rig.h"
 #include "serial.h"
 #include "misc.h"

--- a/rigs/yaesu/ft100.c
+++ b/rigs/yaesu/ft100.c
@@ -29,7 +29,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>     /* String function definitions */
-#include <unistd.h>     /* UNIX standard function definitions */
 #include <math.h>
 
 #include "hamlib/rig.h"

--- a/rigs/yaesu/ft1000d.c
+++ b/rigs/yaesu/ft1000d.c
@@ -32,7 +32,6 @@
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "bandplan.h"

--- a/rigs/yaesu/ft1000mp.c
+++ b/rigs/yaesu/ft1000mp.c
@@ -35,7 +35,6 @@
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 #include <math.h>
 
 #include "hamlib/rig.h"

--- a/rigs/yaesu/ft600.c
+++ b/rigs/yaesu/ft600.c
@@ -29,7 +29,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/yaesu/ft600.c
+++ b/rigs/yaesu/ft600.c
@@ -30,7 +30,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <math.h>
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/yaesu/ft736.c
+++ b/rigs/yaesu/ft736.c
@@ -25,8 +25,6 @@
 #include <hamlib/config.h>
 
 #include <stdlib.h>
-#include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/yaesu/ft747.c
+++ b/rigs/yaesu/ft747.c
@@ -37,7 +37,6 @@
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/yaesu/ft757gx.c
+++ b/rigs/yaesu/ft757gx.c
@@ -39,7 +39,6 @@
 
 #include <stdlib.h>
 #include <string.h>     /* String function definitions */
-#include <unistd.h>     /* UNIX standard function definitions */
 
 #include <hamlib/rig.h>
 #include "serial.h"

--- a/rigs/yaesu/ft767gx.c
+++ b/rigs/yaesu/ft767gx.c
@@ -38,7 +38,6 @@
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/yaesu/ft817.c
+++ b/rigs/yaesu/ft817.c
@@ -48,7 +48,6 @@
 
 #include <stdlib.h>
 #include <string.h>     /* String function definitions */
-#include <unistd.h>     /* UNIX standard function definitions */
 #include <stdbool.h>
 
 #ifdef HAVE_SYS_TIME_H

--- a/rigs/yaesu/ft840.c
+++ b/rigs/yaesu/ft840.c
@@ -29,7 +29,6 @@
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "bandplan.h"

--- a/rigs/yaesu/ft847.c
+++ b/rigs/yaesu/ft847.c
@@ -48,7 +48,6 @@
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/yaesu/ft857.c
+++ b/rigs/yaesu/ft857.c
@@ -52,7 +52,6 @@
 
 #include <hamlib/config.h>
 
-#include <math.h>
 #include <stdlib.h>
 #include <string.h>     /* String function definitions */
 #include <unistd.h>     /* UNIX standard function definitions */

--- a/rigs/yaesu/ft857.c
+++ b/rigs/yaesu/ft857.c
@@ -54,7 +54,6 @@
 
 #include <stdlib.h>
 #include <string.h>     /* String function definitions */
-#include <unistd.h>     /* UNIX standard function definitions */
 
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>

--- a/rigs/yaesu/ft890.c
+++ b/rigs/yaesu/ft890.c
@@ -29,7 +29,6 @@
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "bandplan.h"

--- a/rigs/yaesu/ft897.c
+++ b/rigs/yaesu/ft897.c
@@ -60,7 +60,6 @@
 
 #include <stdlib.h>
 #include <string.h>     /* String function definitions */
-#include <unistd.h>     /* UNIX standard function definitions */
 
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>

--- a/rigs/yaesu/ft900.c
+++ b/rigs/yaesu/ft900.c
@@ -29,7 +29,6 @@
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "bandplan.h"

--- a/rigs/yaesu/ft920.c
+++ b/rigs/yaesu/ft920.c
@@ -32,7 +32,6 @@
 
 #include <stdlib.h>
 #include <string.h> /* String function definitions */
-#include <unistd.h> /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "bandplan.h"

--- a/rigs/yaesu/ft980.c
+++ b/rigs/yaesu/ft980.c
@@ -88,7 +88,6 @@
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 #include <sys/time.h> /* for timeofday call */
 
 #include "hamlib/rig.h"

--- a/rigs/yaesu/ft990.c
+++ b/rigs/yaesu/ft990.c
@@ -36,7 +36,6 @@
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "bandplan.h"

--- a/rigs/yaesu/ft990v12.c
+++ b/rigs/yaesu/ft990v12.c
@@ -42,7 +42,6 @@
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "bandplan.h"

--- a/rigs/yaesu/vr5000.c
+++ b/rigs/yaesu/vr5000.c
@@ -58,10 +58,6 @@
 
 // cppcheck-suppress *
 #include <stdlib.h>
-// cppcheck-suppress *
-#include <string.h>  /* String function definitions */
-// cppcheck-suppress *
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/yaesu/vx1700.c
+++ b/rigs/yaesu/vx1700.c
@@ -33,7 +33,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
 
 #include "idx_builtin.h"
 #include "hamlib/rig.h"

--- a/rigs/yaesu/yaesu.c
+++ b/rigs/yaesu/yaesu.c
@@ -25,8 +25,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
-#include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rig.h"

--- a/rotators/amsat/if100.c
+++ b/rotators/amsat/if100.c
@@ -21,9 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
-#include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 #include <math.h>
 
 #ifdef HAVE_SYS_IOCTL_H

--- a/rotators/ars/ars.c
+++ b/rotators/ars/ars.c
@@ -24,7 +24,6 @@
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif

--- a/rotators/celestron/celestron.c
+++ b/rotators/celestron/celestron.c
@@ -24,7 +24,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <math.h>
 #include <ctype.h>
 
 #include "hamlib/rotator.h"

--- a/rotators/celestron/celestron.c
+++ b/rotators/celestron/celestron.c
@@ -21,9 +21,7 @@
 #include <hamlib/config.h>
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <ctype.h>
 
 #include "hamlib/rotator.h"

--- a/rotators/cnctrk/cnctrk.c
+++ b/rotators/cnctrk/cnctrk.c
@@ -21,7 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <math.h>
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */

--- a/rotators/cnctrk/cnctrk.c
+++ b/rotators/cnctrk/cnctrk.c
@@ -22,8 +22,6 @@
 #include <hamlib/config.h>
 
 #include <stdlib.h>
-#include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>

--- a/rotators/easycomm/easycomm.c
+++ b/rotators/easycomm/easycomm.c
@@ -27,7 +27,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 
 #include "hamlib/rotator.h"
 #include "serial.h"

--- a/rotators/easycomm/easycomm.c
+++ b/rotators/easycomm/easycomm.c
@@ -24,9 +24,7 @@
 #include <hamlib/config.h>
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rotator.h"
 #include "serial.h"

--- a/rotators/ether6/ether6.c
+++ b/rotators/ether6/ether6.c
@@ -24,7 +24,6 @@
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include <hamlib/rotator.h>
 #include "serial.h"

--- a/rotators/ether6/ether6.c
+++ b/rotators/ether6/ether6.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 
 #include <hamlib/rotator.h>
 #include "serial.h"

--- a/rotators/ether6/ether6.c
+++ b/rotators/ether6/ether6.c
@@ -26,8 +26,6 @@
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
 #include <math.h>
-#include <sys/time.h>
-#include <time.h>
 
 #include <hamlib/rotator.h>
 #include "serial.h"

--- a/rotators/fodtrack/fodtrack.c
+++ b/rotators/fodtrack/fodtrack.c
@@ -22,8 +22,6 @@
 #include <hamlib/config.h>
 
 #include <stdlib.h>
-#include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif

--- a/rotators/grbltrk/grbltrk.c
+++ b/rotators/grbltrk/grbltrk.c
@@ -23,7 +23,6 @@
 #include "config.h"
 #endif
 
-#include <math.h>
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */

--- a/rotators/gs232a/gs232.c
+++ b/rotators/gs232a/gs232.c
@@ -22,9 +22,7 @@
 #include <hamlib/config.h>
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 #include <math.h>
 
 #include "hamlib/rotator.h"

--- a/rotators/gs232a/gs232a.c
+++ b/rotators/gs232a/gs232a.c
@@ -24,11 +24,9 @@
 // cppcheck-suppress *
 #include <stdio.h>
 // cppcheck-suppress *
-#include <stdlib.h>
 // cppcheck-suppress *
 #include <string.h>  /* String function definitions */
 // cppcheck-suppress *
-#include <unistd.h>  /* UNIX standard function definitions */
 // cppcheck-suppress *
 #include <math.h>
 

--- a/rotators/heathkit/hd1780.c
+++ b/rotators/heathkit/hd1780.c
@@ -31,7 +31,6 @@
 #include <stdio.h>
 #include <stdlib.h>             /* Standard library definitions */
 #include <string.h>             /* String function definitions */
-#include <unistd.h>             /* UNIX standard function definitions */
 
 #include "hamlib/rotator.h"
 #include "serial.h"

--- a/rotators/ioptron/rot_ioptron.c
+++ b/rotators/ioptron/rot_ioptron.c
@@ -24,7 +24,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <math.h>
 #include <ctype.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/rotators/ioptron/rot_ioptron.c
+++ b/rotators/ioptron/rot_ioptron.c
@@ -21,9 +21,7 @@
 #include <hamlib/config.h>
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <ctype.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/rotators/m2/rc2800.c
+++ b/rotators/m2/rc2800.c
@@ -24,7 +24,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <math.h>
 #include <ctype.h>
 
 #include "hamlib/rotator.h"

--- a/rotators/m2/rc2800.c
+++ b/rotators/m2/rc2800.c
@@ -21,9 +21,7 @@
 #include <hamlib/config.h>
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <ctype.h>
 
 #include "hamlib/rotator.h"

--- a/rotators/meade/meade.c
+++ b/rotators/meade/meade.c
@@ -26,7 +26,6 @@
 #include <unistd.h>  /* UNIX standard function definitions */
 #include <math.h>
 #include <sys/time.h>
-#include <time.h>
 
 #include <hamlib/rotator.h>
 #include <num_stdio.h>

--- a/rotators/meade/meade.c
+++ b/rotators/meade/meade.c
@@ -23,7 +23,6 @@
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 #include <math.h>
 #include <sys/time.h>
 

--- a/rotators/radant/radant.c
+++ b/rotators/radant/radant.c
@@ -27,7 +27,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <math.h>
 
 #include "hamlib/rotator.h"
 #include "serial.h"

--- a/rotators/radant/radant.c
+++ b/rotators/radant/radant.c
@@ -24,9 +24,7 @@
 #include <hamlib/config.h>
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include "hamlib/rotator.h"
 #include "serial.h"

--- a/rotators/rotorez/rotorez.c
+++ b/rotators/rotorez/rotorez.c
@@ -35,7 +35,6 @@
 #include <stdio.h>
 #include <stdlib.h>          /* Standard library definitions */
 #include <string.h>          /* String function definitions */
-#include <unistd.h>          /* UNIX standard function definitions */
 #include <ctype.h>            /* for isdigit function */
 
 #include "hamlib/rotator.h"

--- a/rotators/sartek/sartek.c
+++ b/rotators/sartek/sartek.c
@@ -23,9 +23,7 @@
 #include <hamlib/config.h>
 
 #include <stdio.h>
-#include <stdlib.h>             /* Standard library definitions */
 #include <string.h>             /* String function definitions */
-#include <unistd.h>             /* UNIX standard function definitions */
 
 #include "hamlib/rotator.h"
 #include "serial.h"

--- a/rotators/satel/satel.c
+++ b/rotators/satel/satel.c
@@ -23,10 +23,8 @@
 #include <strings.h>
 #include <hamlib/config.h>
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <ctype.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/rotators/satel/satel.c
+++ b/rotators/satel/satel.c
@@ -27,7 +27,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <math.h>
 #include <ctype.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/rotators/spid/spid.c
+++ b/rotators/spid/spid.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <math.h>
 
 #include "hamlib/rotator.h"
 #include "serial.h"

--- a/rotators/spid/spid.c
+++ b/rotators/spid/spid.c
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #include "hamlib/rotator.h"
 #include "serial.h"

--- a/rotators/ts7400/ts7400.c
+++ b/rotators/ts7400/ts7400.c
@@ -22,8 +22,6 @@
 #include <hamlib/config.h>
 
 #include <stdlib.h>
-#include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 #include <math.h>
 #include <sys/time.h>
 

--- a/rotators/ts7400/ts7400.c
+++ b/rotators/ts7400/ts7400.c
@@ -26,7 +26,6 @@
 #include <unistd.h>  /* UNIX standard function definitions */
 #include <math.h>
 #include <sys/time.h>
-#include <time.h>
 
 #include <hamlib/rotator.h>
 #include "serial.h"

--- a/security/md5.h
+++ b/security/md5.h
@@ -26,7 +26,6 @@
  */
 
 #include <stdlib.h>
-#include <string.h>
 #include "hamlib/rig.h"
 
 typedef unsigned long MD5_u32plus;

--- a/src/amp_conf.c
+++ b/src/amp_conf.c
@@ -35,7 +35,6 @@
 #include <stdarg.h>
 #include <stdio.h>   /* Standard input/output definitions */
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include <hamlib/amplifier.h>
 

--- a/src/amp_reg.c
+++ b/src/amp_reg.c
@@ -32,7 +32,6 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <stdio.h>
 #include <sys/types.h>
 

--- a/src/amp_settings.c
+++ b/src/amp_settings.c
@@ -41,8 +41,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdio.h>
-
 #include <hamlib/rig.h>
 #include <hamlib/amplifier.h>
 

--- a/src/cm108.c
+++ b/src/cm108.c
@@ -34,14 +34,11 @@
  */
 #include <hamlib/config.h>
 
-#include <stdlib.h>
-#include <stdio.h>   /* Standard input/output definitions */
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
 #include <fcntl.h>   /* File control definitions */
 #include <errno.h>   /* Error number definitions */
 #include <sys/types.h>
-#include <unistd.h>
 
 #ifdef HAVE_SYS_IOCTL_H
 #  include <sys/ioctl.h>

--- a/src/cm108.c
+++ b/src/cm108.c
@@ -40,7 +40,6 @@
 #include <unistd.h>  /* UNIX standard function definitions */
 #include <fcntl.h>   /* File control definitions */
 #include <errno.h>   /* Error number definitions */
-#include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -36,7 +36,6 @@
 #include <stdarg.h>
 #include <stdio.h>   /* Standard input/output definitions */
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include <hamlib/rig.h>
 #include "token.h"

--- a/src/debug.c
+++ b/src/debug.c
@@ -32,15 +32,12 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 #include <stdarg.h>
 #include <stdio.h>  /* Standard input/output definitions */
 #include <string.h> /* String function definitions */
-#include <unistd.h> /* UNIX standard function definitions */
 #include <fcntl.h>  /* File control definitions */
 #include <errno.h>  /* Error number definitions */
 #include <sys/types.h>
-#include <unistd.h>
 
 #ifdef ANDROID
 #  include <android/log.h>

--- a/src/debug.c
+++ b/src/debug.c
@@ -41,7 +41,6 @@
 #include <errno.h>  /* Error number definitions */
 #include <sys/types.h>
 #include <unistd.h>
-#include <time.h>
 
 #ifdef ANDROID
 #  include <android/log.h>

--- a/src/ext.c
+++ b/src/ext.c
@@ -36,11 +36,9 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 #include <stdarg.h>
 #include <stdio.h>   /* Standard input/output definitions */
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include <hamlib/rig.h>
 

--- a/src/extamp.c
+++ b/src/extamp.c
@@ -42,11 +42,9 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 #include <stdarg.h>
 #include <stdio.h>   /* Standard input/output definitions */
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include <hamlib/amplifier.h>
 

--- a/src/iofunc.c
+++ b/src/iofunc.c
@@ -33,7 +33,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 #include <stdio.h>   /* Standard input/output definitions */
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
@@ -41,7 +40,6 @@
 #include <errno.h>   /* Error number definitions */
 #include <sys/time.h>
 #include <sys/types.h>
-#include <unistd.h>
 
 #include <hamlib/rig.h>
 #include "iofunc.h"

--- a/src/locator.c
+++ b/src/locator.c
@@ -78,7 +78,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>

--- a/src/mem.c
+++ b/src/mem.c
@@ -36,7 +36,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/microham.c
+++ b/src/microham.c
@@ -29,7 +29,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
 #include <unistd.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/misc.c
+++ b/src/misc.c
@@ -34,7 +34,6 @@
 #include <stdarg.h>
 #include <stdio.h>   /* Standard input/output definitions */
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 #include <fcntl.h>   /* File control definitions */
 #include <errno.h>   /* Error number definitions */
 

--- a/src/network.c
+++ b/src/network.c
@@ -40,7 +40,6 @@
 #include <unistd.h>  /* UNIX standard function definitions */
 #include <fcntl.h>   /* File control definitions */
 #include <errno.h>   /* Error number definitions */
-#include <sys/time.h>
 #include <sys/types.h>
 #include <signal.h>
 #include <pthread.h>

--- a/src/parallel.c
+++ b/src/parallel.c
@@ -30,14 +30,11 @@
  */
 #include <hamlib/config.h>
 
-#include <stdlib.h>
-#include <stdio.h>   /* Standard input/output definitions */
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
 #include <fcntl.h>   /* File control definitions */
 #include <errno.h>   /* Error number definitions */
 #include <sys/types.h>
-#include <unistd.h>
 
 #ifdef HAVE_SYS_IOCTL_H
 #  include <sys/ioctl.h>

--- a/src/parallel.c
+++ b/src/parallel.c
@@ -36,7 +36,6 @@
 #include <unistd.h>  /* UNIX standard function definitions */
 #include <fcntl.h>   /* File control definitions */
 #include <errno.h>   /* Error number definitions */
-#include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
 

--- a/src/register.c
+++ b/src/register.c
@@ -31,7 +31,6 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <stdio.h>
 #include <sys/types.h>
 

--- a/src/rot_conf.c
+++ b/src/rot_conf.c
@@ -36,7 +36,6 @@
 #include <stdarg.h>
 #include <stdio.h>   /* Standard input/output definitions */
 #include <string.h>  /* String function definitions */
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #include <hamlib/rotator.h>
 

--- a/src/rot_reg.c
+++ b/src/rot_reg.c
@@ -32,7 +32,6 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <stdio.h>
 #include <sys/types.h>
 

--- a/src/rot_settings.c
+++ b/src/rot_settings.c
@@ -37,9 +37,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/serial.c
+++ b/src/serial.c
@@ -40,7 +40,6 @@
 #include <unistd.h>  /* UNIX standard function definitions */
 #include <fcntl.h>   /* File control definitions */
 #include <errno.h>   /* Error number definitions */
-#include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <ctype.h>

--- a/src/serial.c
+++ b/src/serial.c
@@ -41,7 +41,6 @@
 #include <fcntl.h>   /* File control definitions */
 #include <errno.h>   /* Error number definitions */
 #include <sys/types.h>
-#include <unistd.h>
 #include <ctype.h>
 
 #ifdef HAVE_SYS_IOCTL_H

--- a/src/sleep.c
+++ b/src/sleep.c
@@ -37,7 +37,6 @@
  */
 #include <unistd.h>
 #include <errno.h>
-#include <time.h>
 #include <pthread.h>
 #include "config.h"
 #include "sleep.h"

--- a/src/usb_port.c
+++ b/src/usb_port.c
@@ -36,9 +36,7 @@
 
 
 #include <stdlib.h>
-#include <stdio.h>   /* Standard input/output definitions */
 #include <string.h>  /* String function definitions */
-#include <unistd.h>
 #include <errno.h>
 #include <sys/types.h>
 

--- a/tests/ampctl.c
+++ b/tests/ampctl.c
@@ -29,7 +29,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <ctype.h>
 #include <errno.h>
 #include <getopt.h>

--- a/tests/ampctl.c
+++ b/tests/ampctl.c
@@ -24,8 +24,6 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  */
-#include <hamlibdatetime.h>
-
 #include <hamlib/config.h>
 
 #include <stdio.h>

--- a/tests/dumpcaps.c
+++ b/tests/dumpcaps.c
@@ -23,7 +23,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <stdlib.h>
 
 #include <hamlib/rig.h>
 #include "misc.h"

--- a/tests/dumpcaps_amp.c
+++ b/tests/dumpcaps_amp.c
@@ -22,8 +22,6 @@
 #include <hamlib/config.h>
 
 #include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
 
 #include <hamlib/rig.h>
 #include "misc.h"

--- a/tests/dumpcaps_rot.c
+++ b/tests/dumpcaps_rot.c
@@ -23,7 +23,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <stdlib.h>
 
 #include <hamlib/rig.h>
 #include "misc.h"

--- a/tests/memcsv.c
+++ b/tests/memcsv.c
@@ -26,7 +26,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <ctype.h>
 #include <errno.h>
 

--- a/tests/memload.c
+++ b/tests/memload.c
@@ -21,11 +21,6 @@
 
 #include <hamlib/config.h>
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <unistd.h>
-
 #include <hamlib/rig.h>
 #include "misc.h"
 

--- a/tests/memsave.c
+++ b/tests/memsave.c
@@ -20,10 +20,6 @@
  */
 #include <hamlib/config.h>
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <unistd.h>
 #include <ctype.h>
 
 #include <hamlib/rig.h>

--- a/tests/rigctl.c
+++ b/tests/rigctl.c
@@ -23,8 +23,6 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  */
-#include <hamlibdatetime.h>
-
 #include <hamlib/config.h>
 
 #include <stdio.h>

--- a/tests/rigctl.c
+++ b/tests/rigctl.c
@@ -27,8 +27,8 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <ctype.h>
 #include <errno.h>
 #include <getopt.h>

--- a/tests/rigctlcom.c
+++ b/tests/rigctlcom.c
@@ -42,7 +42,6 @@
 // cppcheck-suppress *
 #include <string.h>
 // cppcheck-suppress *
-#include <unistd.h>
 // cppcheck-suppress *
 #include <ctype.h>
 // cppcheck-suppress *

--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -69,7 +69,6 @@
 #endif
 
 #include <hamlib/rig.h>
-#include <hamlibdatetime.h>
 #include "misc.h"
 #include "iofunc.h"
 #include "serial.h"

--- a/tests/rigmem.c
+++ b/tests/rigmem.c
@@ -27,7 +27,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <ctype.h>
 #include <errno.h>
 

--- a/tests/rigsmtr.c
+++ b/tests/rigsmtr.c
@@ -1,3 +1,4 @@
+
 /*
  * rigsmtr.c - (C) Stephane Fillod 2007
  *
@@ -25,7 +26,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <ctype.h>
 #include <errno.h>
 #include <math.h>

--- a/tests/rigswr.c
+++ b/tests/rigswr.c
@@ -25,7 +25,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <ctype.h>
 #include <errno.h>
 

--- a/tests/rotctl.c
+++ b/tests/rotctl.c
@@ -23,8 +23,6 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  */
-#include <hamlibdatetime.h>
-
 #include <hamlib/config.h>
 
 #include <stdio.h>

--- a/tests/rotctl.c
+++ b/tests/rotctl.c
@@ -28,7 +28,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <ctype.h>
 #include <errno.h>
 #include <getopt.h>


### PR DESCRIPTION
This PR deletes some includes that the tool `iwyu` says that are unused.
It seems safe to remove them because make doesn't show new warnings and `make check` still succeeds:
```
PASS: testcpp.sh
============================================================================
Testsuite summary for Hamlib 4.5~git
============================================================================
# TOTAL: 1
# PASS:  1
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
[...]
PASS: testrig.sh
PASS: testfreq.sh
PASS: testbcd.sh
PASS: testloc.sh
PASS: testrigcaps.sh
PASS: testcache.sh
PASS: testcookie.sh
PASS: testgrid.sh
============================================================================
Testsuite summary for Hamlib 4.5~git
============================================================================
# TOTAL: 8
# PASS:  8
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```

There are more includes that could be deleted or moved from a *.h to the corresponding *.c, but these other changes are better done in a future PR:
```
- #include <arpa/inet.h>
- #include <cal.h>
- #include <config.h>
- #include <ctype.h>
- #include <errno.h>
- #include <fcntl.h>
- #include <getopt.h>
- #include <hamlib/amplifier.h>
- #include <hamlib/config.h>
- #include <hamlib/rig.h>
- #include <hamlib/rotator.h>
- #include <iofunc.h>
- #include <limits.h>
- #include <linux/types.h>
- #include <misc.h>
- #include <netinet/in.h>
- #include <network.h>
- #include <pthread.h>
- #include <register.h>
- #include <serial.h>
- #include <signal.h>
- #include <stdarg.h>
- #include <stdbool.h>
- #include <stdint.h>
- #include <stdlib.h>
- #include <sys/ioctl.h>
- #include <sys/param.h>
- #include <sys/socket.h>
- #include <sys/stat.h>
- #include <sys/time.h>
- #include <sys/types.h>
- #include <token.h>
- #include <tones.h>
- #include <unistd.h>
```