### PR TITLE
Fix sending morse with QRPLabs QCX rigs

### DIFF
--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -4937,9 +4937,11 @@ int kenwood_send_morse(RIG *rig, vfo_t vfo, const char *msg)
             /*
              * If answer is "KY0;", there is space in buffer and we can proceed.
              * If answer is "KY1;", we have to wait a while
+             * If answer is "KY2;", there is space in buffer and we aren't sending so we can proceed.
              * If answer is something else, return with error to prevent infinite loops
              */
             if (!strncmp(m2, "KY0", 3)) { break; }
+            if (!strncmp(m2, "KY2", 3)) { break; }
 
             if (!strncmp(m2, "KY1", 3)) { hl_usleep(500000); }
             else { RETURNFUNC(-RIG_EINVAL); }


### PR DESCRIPTION
The QCX series emulates the Kenwood TS480. However for the sending
morse command it seems to be more in line with the Elecraft K series
rigs.

Before this change, the QCX mini would reply to the KY command with
KY2 which was not understood. The QCX mini defines the KY responses to
be:

- KY0; if message sending is in progress and the transmit text buffer is not more than 75% full
- KY1; if message sending is in progress and the transmit text buffer is more than 75% full
- KY2; if no message is being sent, therefore the transmit text buffer is emtpy

This seems to be an extension of the original Kenwood protocol but it
is exactly as implemented by Elecraft in their K series rigs.

This patch treats the KY2 response the same as the KY0 response
meaning - OK to transmit.
