### PR TITLE
Fix handling of EPOWER error code and reduce unnecessary commands in Yaesu newcat backend

### DIFF
--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -176,7 +176,8 @@ enum rig_errcode_e {
  */
 #define RIG_IS_SOFT_ERRCODE(errcode) (errcode == RIG_EINVAL || errcode == RIG_ENIMPL || errcode == RIG_ERJCTED \
     || errcode == RIG_ETRUNC || errcode == RIG_ENAVAIL || errcode == RIG_ENTARGET \
-    || errcode == RIG_EVFO || errcode == RIG_EDOM || errcode == RIG_ESECURITY)
+    || errcode == RIG_EVFO || errcode == RIG_EDOM || errcode == RIG_EDEPRECATED \
+    || errcode == RIG_ESECURITY || errcode == RIG_EPOWER)
 
 /**
  * \brief Token in the netrigctl protocol for returning error code

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -481,6 +481,26 @@ int newcat_init(RIG *rig)
     priv->current_mem = NC_MEM_CHANNEL_NONE;
     priv->fast_set_commands = FALSE;
 
+    /*
+     * Determine the type of rig from the model number.  Note it is
+     * possible for several model variants to exist; i.e., all the
+     * FT-9000 variants.
+     */
+
+    is_ft450 = newcat_is_rig(rig, RIG_MODEL_FT450);
+    is_ft891 = newcat_is_rig(rig, RIG_MODEL_FT891);
+    is_ft950 = newcat_is_rig(rig, RIG_MODEL_FT950);
+    is_ft991 = newcat_is_rig(rig, RIG_MODEL_FT991);
+    is_ft2000 = newcat_is_rig(rig, RIG_MODEL_FT2000);
+    is_ftdx9000 = newcat_is_rig(rig, RIG_MODEL_FT9000);
+    is_ftdx5000 = newcat_is_rig(rig, RIG_MODEL_FTDX5000);
+    is_ftdx1200 = newcat_is_rig(rig, RIG_MODEL_FTDX1200);
+    is_ftdx3000 = newcat_is_rig(rig, RIG_MODEL_FTDX3000);
+    is_ftdx3000dm = FALSE; // Detected dynamically
+    is_ftdx101d = newcat_is_rig(rig, RIG_MODEL_FTDX101D);
+    is_ftdx101mp = newcat_is_rig(rig, RIG_MODEL_FTDX101MP);
+    is_ftdx10 = newcat_is_rig(rig, RIG_MODEL_FTDX10);
+
     RETURNFUNC(RIG_OK);
 }
 
@@ -7327,26 +7347,6 @@ ncboolean newcat_valid_command(RIG *rig, char const *const command)
         RETURNFUNC2(FALSE);
     }
 
-    /*
-     * Determine the type of rig from the model number.  Note it is
-     * possible for several model variants to exist; i.e., all the
-     * FT-9000 variants.
-     */
-
-    is_ft450 = newcat_is_rig(rig, RIG_MODEL_FT450);
-    is_ft891 = newcat_is_rig(rig, RIG_MODEL_FT891);
-    is_ft950 = newcat_is_rig(rig, RIG_MODEL_FT950);
-    is_ft991 = newcat_is_rig(rig, RIG_MODEL_FT991);
-    is_ft2000 = newcat_is_rig(rig, RIG_MODEL_FT2000);
-    is_ftdx9000 = newcat_is_rig(rig, RIG_MODEL_FT9000);
-    is_ftdx5000 = newcat_is_rig(rig, RIG_MODEL_FTDX5000);
-    is_ftdx1200 = newcat_is_rig(rig, RIG_MODEL_FTDX1200);
-    is_ftdx3000 = newcat_is_rig(rig, RIG_MODEL_FTDX3000);
-    is_ftdx3000dm = newcat_get_rigid(rig) == 462;
-    is_ftdx101d = newcat_is_rig(rig, RIG_MODEL_FTDX101D);
-    is_ftdx101mp = newcat_is_rig(rig, RIG_MODEL_FTDX101MP);
-    is_ftdx10 = newcat_is_rig(rig, RIG_MODEL_FTDX10);
-
     if (!is_ft450 && !is_ft950 && !is_ft891 && !is_ft991 && !is_ft2000
             && !is_ftdx5000 && !is_ftdx9000 && !is_ftdx1200 && !is_ftdx3000 && !is_ftdx101d
             && !is_ftdx101mp && !is_ftdx10)
@@ -10082,6 +10082,8 @@ int newcat_get_rigid(RIG *rig)
         {
             s += 2;     /* ID0310, jump past ID */
             priv->rig_id = atoi(s);
+
+            is_ftdx3000dm = priv->rig_id == NC_RIGID_FTDX3000DM;
         }
 
         rig_debug(RIG_DEBUG_TRACE, "rig_id = %d, idstr = %s\n", priv->rig_id,

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -1745,9 +1745,8 @@ readline_repeat:
                 && cmd_entry->cmd != 0xf0 // chk_vfo
                 && cmd_entry->cmd != 0x87) // set_powerstat
         {
-            //rig_debug(RIG_DEBUG_WARN, "%s: %s - only \\set_powerstat can be run \n", __func__, rigerror(-RIG_EPOWER));
             rig_debug(RIG_DEBUG_WARN,
-                      "%s: only \\set_powerstat can be run when rig powered off\n", __func__);
+                      "%s: command %s not allowed when rig is powered off\n", __func__, cmd_entry->name);
             retcode = -RIG_EPOWER;
         }
         else

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -1737,10 +1737,11 @@ readline_repeat:
             if (retcode == RIG_OK) { rig_powerstat = stat; }
         }
 
-        // only command allows when powered off is 0x87=set_powerstat
-        if (retcode == RIG_OK && (rig_powerstat == RIG_POWER_OFF
-                                  || rig_powerstat == RIG_POWER_STANDBY)
-                && cmd_entry->cmd != 0x01 // dump_caps
+        // Allow only certain commands when the rig is powered off
+        if (retcode == RIG_OK && (rig_powerstat == RIG_POWER_OFF || rig_powerstat == RIG_POWER_STANDBY)
+                && cmd_entry->cmd != '1' // dump_caps
+                && cmd_entry->cmd != '3' // dump_conf
+                && cmd_entry->cmd != 0x8f // dump_state
                 && cmd_entry->cmd != 0xf0 // chk_vfo
                 && cmd_entry->cmd != 0x87) // set_powerstat
         {


### PR DESCRIPTION
* Fix handling of the new EPOWER error code: do not re-open rig and fix/extend allowed commands when rig is powered off.
* Fix Yaesu newcat backend to not try to call rig ID command during command validation.

Tested on FTDX101 and FT-991A.
