### PR TITLE
fix build instructions in INSTALL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -15,6 +15,8 @@ main directory and do the following:
 
   1. Configure the source code by typing:
 
+        $ ./bootstrap
+        $ autoconf
         $ ./configure
 
      If configure does not exist you can create it with ./bootstrap


### PR DESCRIPTION
./bootstrap and autoconf are missing. the is broken as-is and now fixed.