### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Note: if ./configure does not exist run ./bootstrap first
         ./configure
         make
         sudo make install
+        ln -s /usr/local/lib/libhamlib.so.4.0.0 /usr/lib/libhamlib.so.4
 
 For debugging use this configure
         ./configure CFLAGS=-g -O0 -fPIC --no-create --no-recursio


### PR DESCRIPTION
libhamlib needs a link from /usr/lib, it seems like /usr/local/lib is not a default place in Unbutu 20.04 to look for libraries ...