### PR TITLE
Remove unused includes

### DIFF
--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -33,7 +33,6 @@
 #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 
 #include <stdio.h>
-#include <stdarg.h>
 #include <string.h>
 #include <inttypes.h>
 #include <time.h>

--- a/rigs/alinco/dx77.c
+++ b/rigs/alinco/dx77.c
@@ -30,7 +30,6 @@
 #include "alinco.h"
 #include <serial.h>
 #include <misc.h>
-#include <cal.h>
 
 /*
  * modes in use by the "2G" command

--- a/rigs/aor/aor.c
+++ b/rigs/aor/aor.c
@@ -22,7 +22,6 @@
 #include <hamlib/config.h>
 
 #include <stdio.h>
-#include <ctype.h>
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/barrett/4050.c
+++ b/rigs/barrett/4050.c
@@ -25,7 +25,6 @@
 #include <hamlib/rig.h>
 #include "serial.h"
 #include "misc.h"
-#include "cal.h"
 #include "token.h"
 #include "register.h"
 

--- a/rigs/barrett/950.c
+++ b/rigs/barrett/950.c
@@ -26,7 +26,6 @@
 #include <hamlib/rig.h>
 #include "serial.h"
 #include "misc.h"
-#include "cal.h"
 #include "token.h"
 #include "register.h"
 

--- a/rigs/barrett/barrett.c
+++ b/rigs/barrett/barrett.c
@@ -27,7 +27,6 @@
 #include <hamlib/rig.h>
 #include "serial.h"
 #include "misc.h"
-#include "cal.h"
 #include "token.h"
 #include "register.h"
 

--- a/rigs/codan/codan.c
+++ b/rigs/codan/codan.c
@@ -27,7 +27,6 @@
 #include <hamlib/rig.h>
 #include "serial.h"
 #include "misc.h"
-#include "cal.h"
 #include "token.h"
 #include "register.h"
 

--- a/rigs/dorji/dra818.c
+++ b/rigs/dorji/dra818.c
@@ -23,7 +23,6 @@
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <stdbool.h>
 
 #include "hamlib/rig.h"
 #include "bandplan.h"

--- a/rigs/dummy/flrig.c
+++ b/rigs/dummy/flrig.c
@@ -28,7 +28,6 @@
 #include <hamlib/rig.h>
 #include <serial.h>
 #include <misc.h>
-#include <cal.h>
 #include <token.h>
 #include <register.h>
 #include <network.h>

--- a/rigs/dummy/netampctl.c
+++ b/rigs/dummy/netampctl.c
@@ -23,7 +23,6 @@
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <errno.h>
 
 #include "hamlib/amplifier.h"
 #include "iofunc.h"

--- a/rigs/dummy/netampctl.c
+++ b/rigs/dummy/netampctl.c
@@ -28,8 +28,6 @@
 #include "iofunc.h"
 #include "misc.h"
 
-#include "amp_dummy.h"
-
 #define CMD_MAX 32
 #define BUF_MAX 64
 

--- a/rigs/dummy/netrigctl.c
+++ b/rigs/dummy/netrigctl.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <errno.h>
 
 #include "hamlib/rig.h"
 #include "network.h"

--- a/rigs/dummy/netrotctl.c
+++ b/rigs/dummy/netrotctl.c
@@ -23,7 +23,6 @@
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <errno.h>
 
 #include "hamlib/rotator.h"
 #include "iofunc.h"

--- a/rigs/dummy/tci1x.c
+++ b/rigs/dummy/tci1x.c
@@ -27,7 +27,6 @@
 #include <hamlib/rig.h>
 #include <serial.h>
 #include <misc.h>
-#include <cal.h>
 #include <token.h>
 #include <register.h>
 #include <network.h>

--- a/rigs/dummy/trxmanager.c
+++ b/rigs/dummy/trxmanager.c
@@ -28,7 +28,6 @@
 #include <hamlib/rig.h>
 #include <serial.h>
 #include <misc.h>
-#include <cal.h>
 #include <token.h>
 #include <register.h>
 #include <network.h>

--- a/rigs/flexradio/dttsp.c
+++ b/rigs/flexradio/dttsp.c
@@ -29,7 +29,6 @@
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
 #include <fcntl.h>   /* File control definitions */
-#include <errno.h>   /* Error number definitions */
 #include <math.h>
 
 #include "hamlib/rig.h"

--- a/rigs/flexradio/dttsp.c
+++ b/rigs/flexradio/dttsp.c
@@ -28,7 +28,6 @@
 #include <stdio.h>   /* Standard input/output definitions */
 #include <string.h>  /* String function definitions */
 #include <unistd.h>  /* UNIX standard function definitions */
-#include <fcntl.h>   /* File control definitions */
 #include <math.h>
 
 #include "hamlib/rig.h"

--- a/rigs/gomspace/gs100.c
+++ b/rigs/gomspace/gs100.c
@@ -34,7 +34,6 @@
 #include "hamlib/rig.h"
 #include "serial.h"
 #include "parallel.h"
-#include "gpio.h"
 #include "misc.h"
 #include "tones.h"
 #include "idx_builtin.h"

--- a/rigs/gomspace/gs100.c
+++ b/rigs/gomspace/gs100.c
@@ -34,7 +34,6 @@
 #include "hamlib/rig.h"
 #include "serial.h"
 #include "parallel.h"
-#include "cm108.h"
 #include "gpio.h"
 #include "misc.h"
 #include "tones.h"

--- a/rigs/icmarine/icm710.c
+++ b/rigs/icmarine/icm710.c
@@ -28,7 +28,6 @@
 #include <hamlib/rig.h>
 #include <serial.h>
 #include <misc.h>
-#include <cal.h>
 #include <token.h>
 #include <register.h>
 

--- a/rigs/icmarine/icm710.h
+++ b/rigs/icmarine/icm710.h
@@ -23,7 +23,6 @@
 #define _ICM710_H 1
 
 #include "hamlib/rig.h"
-#include "cal.h"
 #include "tones.h"
 
 struct icm710_priv_caps {

--- a/rigs/icmarine/icmarine.c
+++ b/rigs/icmarine/icmarine.c
@@ -27,7 +27,6 @@
 #include <hamlib/rig.h>
 #include <serial.h>
 #include <misc.h>
-#include <cal.h>
 #include <token.h>
 #include <register.h>
 

--- a/rigs/icmarine/icmarine.h
+++ b/rigs/icmarine/icmarine.h
@@ -23,7 +23,6 @@
 #define _ICMARINE_H 1
 
 #include "hamlib/rig.h"
-#include "cal.h"
 #include "tones.h"
 
 #define BACKEND_VER "20181007"

--- a/rigs/icom/delta2.c
+++ b/rigs/icom/delta2.c
@@ -37,7 +37,6 @@
 #include <hamlib/rig.h>
 #include "icom.h"
 #include "icom_defs.h"
-#include "frame.h"
 #include "misc.h"
 
 #define DELTAII_VFO_ALL (RIG_VFO_A|RIG_VFO_B|RIG_VFO_MEM)

--- a/rigs/icom/ic7410.c
+++ b/rigs/icom/ic7410.c
@@ -29,7 +29,6 @@
 
 #include "icom.h"
 #include "icom_defs.h"
-#include "frame.h"
 #include "misc.h"
 #include "bandplan.h"
 

--- a/rigs/icom/ic9100.c
+++ b/rigs/icom/ic9100.c
@@ -25,7 +25,6 @@
 #include <hamlib/rig.h>
 #include "icom.h"
 #include "icom_defs.h"
-#include "frame.h"
 #include "idx_builtin.h"
 #include "bandplan.h"
 

--- a/rigs/icom/icr7000.c
+++ b/rigs/icom/icr7000.c
@@ -30,7 +30,6 @@
 
 #include "icom.h"
 #include "icom_defs.h"
-#include "frame.h"
 
 
 #define ICR7000_MODES (RIG_MODE_AM|RIG_MODE_SSB|RIG_MODE_FM|RIG_MODE_WFM)

--- a/rigs/icom/icr9000.c
+++ b/rigs/icom/icr9000.c
@@ -30,7 +30,6 @@
 
 #include "icom.h"
 #include "icom_defs.h"
-#include "frame.h"
 
 
 #define ICR9000_MODES (RIG_MODE_AM|RIG_MODE_SSB|RIG_MODE_FM|RIG_MODE_RTTY|RIG_MODE_CW|RIG_MODE_WFM)

--- a/rigs/icom/icr9500.c
+++ b/rigs/icom/icr9500.c
@@ -29,7 +29,6 @@
 
 #include "icom.h"
 #include "icom_defs.h"
-#include "frame.h"
 
 
 #define ICR9500_MODES (RIG_MODE_AM|RIG_MODE_AMS|\

--- a/rigs/icom/id51.c
+++ b/rigs/icom/id51.c
@@ -28,7 +28,6 @@
 #include "icom.h"
 #include "idx_builtin.h"
 #include "icom_defs.h"
-#include "frame.h"
 
 /*
  * Specs and protocol details comes from the chapter 17 of ID-51A_E_PLUS2_CD_0.pdf

--- a/rigs/icom/optoscan.c
+++ b/rigs/icom/optoscan.c
@@ -27,7 +27,6 @@
 #include "hamlib/rig.h"
 #include "serial.h"
 #include "misc.h"
-#include "cal.h"
 #include "token.h"
 
 #include "icom.h"

--- a/rigs/icom/optoscan.h
+++ b/rigs/icom/optoscan.h
@@ -23,7 +23,6 @@
 #define _OPTOSCAN_H 1
 
 #include <hamlib/rig.h>
-#include <cal.h>
 #include <tones.h>
 
 #define TOK_TAPECNTL  TOKEN_BACKEND(1)

--- a/rigs/kachina/kachina.c
+++ b/rigs/kachina/kachina.c
@@ -26,7 +26,6 @@
 #include "hamlib/rig.h"
 #include "serial.h"
 #include "misc.h"
-#include "cal.h"
 #include "register.h"
 
 #include "kachina.h"

--- a/rigs/kenwood/flex6xxx.c
+++ b/rigs/kenwood/flex6xxx.c
@@ -33,7 +33,6 @@
 #include "bandplan.h"
 #include "flex.h"
 #include "token.h"
-#include "cal.h"
 
 #define F6K_MODES (RIG_MODE_CW|RIG_MODE_SSB|RIG_MODE_AM|RIG_MODE_FM|RIG_MODE_PKTLSB|RIG_MODE_PKTUSB)
 

--- a/rigs/kit/hiqsdr.c
+++ b/rigs/kit/hiqsdr.c
@@ -22,7 +22,6 @@
 #include <stdlib.h>
 #include <stdio.h>   /* Standard input/output definitions */
 #include <string.h>  /* String function definitions */
-#include <fcntl.h>   /* File control definitions */
 
 #include "hamlib/rig.h"
 #include "iofunc.h"

--- a/rigs/kit/hiqsdr.c
+++ b/rigs/kit/hiqsdr.c
@@ -23,7 +23,6 @@
 #include <stdio.h>   /* Standard input/output definitions */
 #include <string.h>  /* String function definitions */
 #include <fcntl.h>   /* File control definitions */
-#include <errno.h>   /* Error number definitions */
 
 #include "hamlib/rig.h"
 #include "iofunc.h"

--- a/rigs/mds/mds.c
+++ b/rigs/mds/mds.c
@@ -27,7 +27,6 @@
 #include <hamlib/rig.h>
 #include "serial.h"
 #include "misc.h"
-#include "cal.h"
 #include "token.h"
 #include "register.h"
 

--- a/rigs/pcr/pcr.c
+++ b/rigs/pcr/pcr.c
@@ -34,7 +34,6 @@
 #include <stdlib.h>
 #include <string.h>     /* String function definitions */
 #include <errno.h>
-#include <ctype.h>
 
 #include "hamlib/rig.h"
 #include "serial.h"

--- a/rigs/prm80/prm80.c
+++ b/rigs/prm80/prm80.c
@@ -28,7 +28,6 @@
 
 #include "hamlib/rig.h"
 #include "serial.h"
-#include "cal.h"
 #include "register.h"
 #include "idx_builtin.h"
 

--- a/rigs/racal/ra37xx.c
+++ b/rigs/racal/ra37xx.c
@@ -27,7 +27,6 @@
 #include "hamlib/rig.h"
 #include "serial.h"
 #include "misc.h"
-#include "cal.h"
 #include "register.h"
 #include "token.h"
 

--- a/rigs/racal/racal.c
+++ b/rigs/racal/racal.c
@@ -28,7 +28,6 @@
 #include "hamlib/rig.h"
 #include "serial.h"
 #include "misc.h"
-#include "cal.h"
 #include "register.h"
 #include "token.h"
 

--- a/rigs/rs/ek89x.c
+++ b/rigs/rs/ek89x.c
@@ -29,7 +29,6 @@
 #include <hamlib/config.h>
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>     /* String function definitions */
 
 #include "hamlib/rig.h"

--- a/rigs/skanti/skanti.c
+++ b/rigs/skanti/skanti.c
@@ -27,7 +27,6 @@
 #include <hamlib/rig.h>
 #include <serial.h>
 #include <misc.h>
-#include <cal.h>
 #include <register.h>
 
 #include "skanti.h"

--- a/rigs/tentec/orion.c
+++ b/rigs/tentec/orion.c
@@ -79,7 +79,6 @@
 #include "misc.h"
 #include "idx_builtin.h"
 #include "orion.h"
-#include <cal.h>
 
 #ifdef TT565_TIME
 /**

--- a/rigs/tentec/tentec.c
+++ b/rigs/tentec/tentec.c
@@ -29,7 +29,6 @@
 #include "hamlib/rig.h"
 #include "serial.h"
 #include "misc.h"
-#include "cal.h"
 #include "register.h"
 
 #include "tentec.h"

--- a/rigs/tentec/tentec2.c
+++ b/rigs/tentec/tentec2.c
@@ -59,7 +59,6 @@
 #include "hamlib/rig.h"
 #include "serial.h"
 #include "misc.h"
-#include "cal.h"
 #include "register.h"
 
 #include "tentec.h"

--- a/rigs/tentec/tt550.c
+++ b/rigs/tentec/tt550.c
@@ -30,7 +30,6 @@
 #include <hamlib/rig.h>
 #include "serial.h"
 #include "misc.h"
-#include "cal.h"
 
 #include "tt550.h"
 

--- a/rigs/tentec/tt550.c
+++ b/rigs/tentec/tt550.c
@@ -26,7 +26,6 @@
 #include <stdio.h>      /* Standard input/output definitions */
 #include <string.h>     /* String function definitions */
 #include <unistd.h>     /* UNIX standard function definitions */
-#include <fcntl.h>      /* File control definitions */
 
 #include <hamlib/rig.h>
 #include "serial.h"

--- a/rigs/tentec/tt550.c
+++ b/rigs/tentec/tt550.c
@@ -27,7 +27,6 @@
 #include <string.h>     /* String function definitions */
 #include <unistd.h>     /* UNIX standard function definitions */
 #include <fcntl.h>      /* File control definitions */
-#include <errno.h>      /* Error number definitions */
 
 #include <hamlib/rig.h>
 #include "serial.h"

--- a/rigs/tentec/tt550.h
+++ b/rigs/tentec/tt550.h
@@ -23,7 +23,6 @@
 #define _TT550_H 1
 
 #include <hamlib/rig.h>
-#include <cal.h>
 
 
 #define EOM "\015"		/* CR */

--- a/rigs/uniden/uniden.h
+++ b/rigs/uniden/uniden.h
@@ -23,7 +23,6 @@
 #define _UNIDEN_H 1
 
 #include <hamlib/rig.h>
-#include <cal.h>
 
 #define BACKEND_VER	"20200621"
 

--- a/rigs/wj/wj.c
+++ b/rigs/wj/wj.c
@@ -27,7 +27,6 @@
 #include "hamlib/rig.h"
 #include "serial.h"
 #include "misc.h"
-#include "cal.h"
 #include "register.h"
 #include "token.h"
 

--- a/rigs/yaesu/ft1000mp.c
+++ b/rigs/yaesu/ft1000mp.c
@@ -41,7 +41,6 @@
 #include "bandplan.h"
 #include "serial.h"
 #include "misc.h"
-#include "cal.h"
 #include "yaesu.h"
 #include "ft1000mp.h"
 

--- a/security/password.c
+++ b/security/password.c
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
 #include "hamlib/rig.h"
 #include "password.h"
 #include "md5.h"

--- a/src/debug.c
+++ b/src/debug.c
@@ -36,7 +36,6 @@
 #include <stdio.h>  /* Standard input/output definitions */
 #include <string.h> /* String function definitions */
 #include <fcntl.h>  /* File control definitions */
-#include <errno.h>  /* Error number definitions */
 #include <sys/types.h>
 
 #ifdef ANDROID

--- a/src/debug.c
+++ b/src/debug.c
@@ -35,7 +35,6 @@
 #include <stdarg.h>
 #include <stdio.h>  /* Standard input/output definitions */
 #include <string.h> /* String function definitions */
-#include <fcntl.h>  /* File control definitions */
 #include <sys/types.h>
 
 #ifdef ANDROID

--- a/src/iofunc.c
+++ b/src/iofunc.c
@@ -50,7 +50,6 @@
 #include "usb_port.h"
 #include "network.h"
 #include "cm108.h"
-#include "gpio.h"
 #include "asyncpipe.h"
 
 #if defined(WIN32) && defined(HAVE_WINDOWS_H)

--- a/src/mem.c
+++ b/src/mem.c
@@ -39,7 +39,6 @@
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <fcntl.h>
 
 #include <hamlib/rig.h>
 

--- a/src/microham.c
+++ b/src/microham.c
@@ -36,10 +36,6 @@
 #include <time.h>
 #include <limits.h>
 
-#ifdef HAVE_ERRNO_H
-#  include <errno.h>
-#endif
-
 #ifdef HAVE_SYS_SELECT_H
 #  include <sys/select.h>
 #endif

--- a/src/misc.c
+++ b/src/misc.c
@@ -34,7 +34,6 @@
 #include <stdarg.h>
 #include <stdio.h>   /* Standard input/output definitions */
 #include <string.h>  /* String function definitions */
-#include <fcntl.h>   /* File control definitions */
 
 #ifdef HAVE_SYS_TYPES_H
 #  include <sys/types.h>

--- a/src/misc.c
+++ b/src/misc.c
@@ -35,7 +35,6 @@
 #include <stdio.h>   /* Standard input/output definitions */
 #include <string.h>  /* String function definitions */
 #include <fcntl.h>   /* File control definitions */
-#include <errno.h>   /* Error number definitions */
 
 #ifdef HAVE_SYS_TYPES_H
 #  include <sys/types.h>

--- a/src/register.c
+++ b/src/register.c
@@ -28,7 +28,6 @@
 
 #include <hamlib/config.h>
 
-#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/src/rig.c
+++ b/src/rig.c
@@ -58,7 +58,6 @@
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <fcntl.h>
 #include <errno.h>
 #ifdef HAVE_PTHREAD
 #include <pthread.h>

--- a/src/rig.c
+++ b/src/rig.c
@@ -67,7 +67,6 @@
 #include <hamlib/rig.h>
 #include "serial.h"
 #include "parallel.h"
-#include "usb_port.h"
 #include "network.h"
 #include "event.h"
 #include "cm108.h"

--- a/src/rot_settings.c
+++ b/src/rot_settings.c
@@ -43,7 +43,6 @@
 
 #include <hamlib/rig.h>
 #include <hamlib/rotator.h>
-#include "cal.h"
 
 
 #ifndef DOC_HIDDEN

--- a/src/rot_settings.c
+++ b/src/rot_settings.c
@@ -40,7 +40,6 @@
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <fcntl.h>
 
 #include <hamlib/rig.h>
 #include <hamlib/rotator.h>

--- a/src/usb_port.c
+++ b/src/usb_port.c
@@ -37,7 +37,6 @@
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
-#include <errno.h>
 #include <sys/types.h>
 
 #include <hamlib/rig.h>

--- a/tests/memcsv.c
+++ b/tests/memcsv.c
@@ -27,7 +27,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
-#include <errno.h>
 
 #include <getopt.h>
 

--- a/tests/memcsv.c
+++ b/tests/memcsv.c
@@ -28,8 +28,6 @@
 #include <string.h>
 #include <ctype.h>
 
-#include <getopt.h>
-
 #include <hamlib/rig.h>
 #include "misc.h"
 #include "sprintflst.h"

--- a/tests/rigmem.c
+++ b/tests/rigmem.c
@@ -28,7 +28,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
-#include <errno.h>
 
 #include <getopt.h>
 

--- a/tests/rigsmtr.c
+++ b/tests/rigsmtr.c
@@ -26,7 +26,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
-#include <errno.h>
 #include <math.h>
 
 #include <getopt.h>

--- a/tests/rigswr.c
+++ b/tests/rigswr.c
@@ -26,7 +26,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
-#include <errno.h>
 
 #include <getopt.h>
 


### PR DESCRIPTION
This PR removes some unused includes and shouldn't result in different binaries, however the file src/.libs/libhamlib.so.4.0.6 is different after these changes, even after deleting the section of the Makefile that updates src/hamlibdatetime.h

I checked that it compiles and it doesn't add warnings.

Found with [iwyu](https://include-what-you-use.org/).