### PR TITLE
Kenwood levels

### DIFF
--- a/rigs/kenwood/k3.c
+++ b/rigs/kenwood/k3.c
@@ -217,6 +217,7 @@ const struct rig_caps k3_caps =
     .level_gran = {
         // cppcheck-suppress *
         [LVL_KEYSPD] = { .min = { .i = 8 }, .max = { .i = 50 }, .step = { .i = 1 } },
+        [LVL_ATT] = { .min = { .i = 0 }, .max = { .i = 10 }, .step = { .i = 10 } },
     },
     .parm_gran =        {},
     .extlevels =        k3_ext_levels,
@@ -369,6 +370,7 @@ const struct rig_caps k3s_caps =
     .has_set_parm =     RIG_PARM_NONE,  /* FIXME: parms */
     .level_gran = {
         [LVL_KEYSPD] = { .min = { .i = 8 }, .max = { .i = 50 }, .step = { .i = 1 } },
+        [LVL_ATT] = { .min = { .i = 0 }, .max = { .i = 15 }, .step = { .i = 5 } },
     },
     .parm_gran =        {},
     .extlevels =        k3_ext_levels,
@@ -521,6 +523,7 @@ const struct rig_caps k4_caps =
     .has_set_parm =     RIG_PARM_NONE,  /* FIXME: parms */
     .level_gran = {
         [LVL_KEYSPD] = { .min = { .i = 8 }, .max = { .i = 50 }, .step = { .i = 1 } },
+        [LVL_ATT] = { .min = { .i = 0 }, .max = { .i = 15 }, .step = { .i = 5 } },
     },
     .parm_gran =        {},
     .extlevels =        k3_ext_levels,
@@ -672,6 +675,7 @@ const struct rig_caps kx3_caps =
     .has_set_parm =     RIG_PARM_NONE,  /* FIXME: parms */
     .level_gran = {
         [LVL_KEYSPD] = { .min = { .i = 8 }, .max = { .i = 50 }, .step = { .i = 1 } },
+        [LVL_ATT] = { .min = { .i = 0 }, .max = { .i = 10 }, .step = { .i = 10 } },
     },
     .parm_gran =        {},
     .extlevels =        kx3_ext_levels,
@@ -823,6 +827,7 @@ const struct rig_caps kx2_caps =
     .has_set_parm =     RIG_PARM_NONE,  /* FIXME: parms */
     .level_gran = {
         [LVL_KEYSPD] = { .min = { .i = 8 }, .max = { .i = 50 }, .step = { .i = 1 } },
+        [LVL_ATT] = { .min = { .i = 0 }, .max = { .i = 10 }, .step = { .i = 10 } },
     },
     .parm_gran =        {},
     .extlevels =        kx3_ext_levels,

--- a/rigs/kenwood/level_gran_kenwood.h
+++ b/rigs/kenwood/level_gran_kenwood.h
@@ -5,7 +5,7 @@
         [LVL_RAWSTR]        = { .min = { .i = 0 },     .max = { .i = 255 } },
         /* levels with dB units */
         [LVL_PREAMP]        = { .min = { .i = 10 },    .max = { .i = 20 },   .step = { .i = 10 } },
-        [LVL_ATT]           = { .min = { .i = 12 },    .max = { .i = 12 },   .step = { .i = 0 } },
+        [LVL_ATT]           = { .min = { .i = 0 },     .max = { .i = 12 },   .step = { .i = 0 } },
         [LVL_STRENGTH]      = { .min = { .i = 0 },     .max = { .i = 60 },   .step = { .i = 0 } },
         [LVL_NB]            = { .min = { .f = 0 },     .max = { .f = 10 },    .step = { .f = 1 } },
         /* levels with WPM units */

--- a/rigs/kenwood/ts590.c
+++ b/rigs/kenwood/ts590.c
@@ -412,6 +412,10 @@ const struct rig_caps ts590sg_caps =
     .has_get_level = TS590_LEVEL_ALL,
     .set_level = kenwood_set_level,
     .get_level = kenwood_get_level,
+    .level_gran =
+    {
+#include "level_gran_kenwood.h"
+    },
     .has_get_func = TS590_FUNC_ALL,
     .has_set_func = TS590_FUNC_ALL,
     .set_func = kenwood_set_func,

--- a/rigs/kenwood/ts850.c
+++ b/rigs/kenwood/ts850.c
@@ -128,6 +128,7 @@ const struct rig_caps ts850_caps =
     .level_gran =
     {
 #include "level_gran_kenwood.h"
+      [LVL_CWPITCH] = { .min = { .i = 400 }, .max = { .i = 1000 }, .step = { .i = 50 } },
     },
     .parm_gran =  {},
     .extparms = ts850_ext_parms,

--- a/rigs/kenwood/ts850.c
+++ b/rigs/kenwood/ts850.c
@@ -494,19 +494,6 @@ int ts850_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         val->f = (float)atoi(&lvlbuf[3]) / 30.0;
         break;
 
-    case RIG_LEVEL_CWPITCH:
-        retval = kenwood_transaction(rig, "PT", lvlbuf, sizeof(lvlbuf));
-
-        if (retval != RIG_OK)
-        {
-            return retval;
-        }
-
-        val->i = atoi(&lvlbuf[2]);
-        val->i = (val->i - 8) * 50 + 800;
-        break;
-
-
     default:
         return kenwood_get_level(rig, vfo, level, val);
     }

--- a/rigs/kenwood/ts890s.c
+++ b/rigs/kenwood/ts890s.c
@@ -602,6 +602,9 @@ const struct rig_caps ts890s_caps =
     .level_gran =
     {
 #include "level_gran_kenwood.h"
+        [LVL_ATT]     = { .min = { .i = 0 }, .max = { .i = 18 }, .step = { .i = 6 } },
+        [LVL_CWPITCH] = { .min = { .i = 300 }, .max = { .i = 1100 }, .step = { .i = 5 } },
+        [LVL_SQL] = { .min = { .f = 0 }, .max = { .f = 1.0f }, .step = { .f = 1.0/255.0 } },
     },
     .has_get_func = TS890_FUNC_ALL,
     .has_set_func = TS890_FUNC_ALL,

--- a/rigs/kenwood/ts890s.c
+++ b/rigs/kenwood/ts890s.c
@@ -98,19 +98,6 @@ int kenwood_ts890_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
         SNPRINTF(levelbuf, sizeof(levelbuf), "GC%d", kenwood_val);
         break;
 
-    case RIG_LEVEL_CWPITCH:
-
-        // TODO: Merge this and formatting difference into kenwood.c
-        if (val.i < 300 || val.i > 1100)
-        {
-            return -RIG_EINVAL;
-        }
-
-        /* 300 - 1100 Hz -> 000 - 160 */
-        kenwood_val = (val.i - 298) / 5; /* Round to nearest 5Hz */
-        SNPRINTF(levelbuf, sizeof(levelbuf), "PT%03d", kenwood_val);
-        break;
-
     default:
         return kenwood_set_level(rig, vfo, level, val);
     }

--- a/rigs/kenwood/ts990s.c
+++ b/rigs/kenwood/ts990s.c
@@ -148,6 +148,8 @@ const struct rig_caps ts990s_caps =
     .level_gran =
     {
 #include "level_gran_kenwood.h"
+      [LVL_ATT]     = { .min = { .i = 0 }, .max = { .i = 18 }, .step = { .i = 6 } },
+      [LVL_CWPITCH] = { .min = { .i = 300 }, .max = { .i = 1100 }, .step = { .i = 10 } },
     },
     .parm_gran =  {},
     .vfo_ops =  TS990S_VFO_OP,

--- a/rigs/kenwood/ts990s.c
+++ b/rigs/kenwood/ts990s.c
@@ -540,18 +540,6 @@ int ts990s_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     }
     break;
 
-    case RIG_LEVEL_CWPITCH:
-        retval = kenwood_safe_transaction(rig, "PT", lvlbuf, sizeof(lvlbuf), 5);
-
-        if (retval != RIG_OK)
-        {
-            return retval;
-        }
-
-        sscanf(lvlbuf + 2, "%d", &lvl);
-        val->i = 300 + lvl * 10;
-        break;
-
     case RIG_LEVEL_RFPOWER:
         retval = kenwood_safe_transaction(rig, "PC", lvlbuf, sizeof(lvlbuf), 5);
 

--- a/rigs/kenwood/tx500.c
+++ b/rigs/kenwood/tx500.c
@@ -150,7 +150,9 @@ const struct rig_caps tx500_caps =
     .has_set_level =  RIG_LEVEL_SET(TX500_LEVEL_ALL),
     .has_get_parm =  RIG_PARM_NONE,
     .has_set_parm =  RIG_PARM_NONE,    /* FIXME: parms */
-    .level_gran =  {},                 /* FIXME: granularity */
+    .level_gran =  {
+#include "level_gran_kenwood.h"
+    },                 /* FIXME: granularity */
     .parm_gran =  {},
     .vfo_ops =  TX500_VFO_OP,
     .scan_ops =  TX500_SCAN_OP,

--- a/src/misc.c
+++ b/src/misc.c
@@ -960,6 +960,45 @@ static const struct
     { AMP_LEVEL_NONE, "" },
 };
 
+/*
+ * \brief check input to set_level
+ * \param rig Pointer to rig data
+ * \param level RIG_LEVEL_* trying to set
+ * \param val Raw input from the caller
+ * \param gran If not NULL, set to location of level_gran data
+ *
+ * \return RIG_OK if value is in range for this level, -RIG_EINVAL if not
+ */
+int check_level_param(RIG *rig, setting_t level, value_t val, gran_t **gran)
+{
+    gran_t *this_gran;
+
+    this_gran = &rig->caps->level_gran[rig_setting2idx(level)];
+    if (gran)
+        {
+	    *gran = this_gran;
+	}
+    /* If min==max==0, all values are OK here but may be checked later */
+    if (this_gran->min.i == 0 && this_gran->max.i == 0)
+        {
+	    return RIG_OK;
+        }
+    if (RIG_LEVEL_IS_FLOAT(level))
+        {
+	  if (val.f < this_gran->min.f || val.f > this_gran->max.f)
+	    {
+	      return -RIG_EINVAL;
+	    }
+	}
+    else
+        {
+	  if (val.i < this_gran->min.i || val.i > this_gran->max.i)
+	    {
+	      return -RIG_EINVAL;
+	    }
+	}
+    return RIG_OK;
+}
 
 /**
  * \brief Convert alpha string to enum RIG_LEVEL_...

--- a/src/misc.c
+++ b/src/misc.c
@@ -978,13 +978,13 @@ int check_level_param(RIG *rig, setting_t level, value_t val, gran_t **gran)
         {
 	    *gran = this_gran;
 	}
-    /* If min==max==0, all values are OK here but may be checked later */
-    if (this_gran->min.i == 0 && this_gran->max.i == 0)
-        {
-	    return RIG_OK;
-        }
     if (RIG_LEVEL_IS_FLOAT(level))
         {
+	  /* If min==max==0, all values are OK here but may be checked later */
+	  if (this_gran->min.f == 0.0f && this_gran->max.f == 0.0f)
+	    {
+	      return RIG_OK;
+	    }
 	  if (val.f < this_gran->min.f || val.f > this_gran->max.f)
 	    {
 	      return -RIG_EINVAL;
@@ -992,6 +992,11 @@ int check_level_param(RIG *rig, setting_t level, value_t val, gran_t **gran)
 	}
     else
         {
+	  /* If min==max==0, all values are OK here but may be checked later */
+	  if (this_gran->min.i == 0 && this_gran->max.i == 0)
+	    {
+	      return RIG_OK;
+	    }
 	  if (val.i < this_gran->min.i || val.i > this_gran->max.i)
 	    {
 	      return -RIG_EINVAL;

--- a/src/misc.h
+++ b/src/misc.h
@@ -209,6 +209,8 @@ extern HAMLIB_EXPORT(int) rig_settings_save(char *setting, void *value, settings
 extern HAMLIB_EXPORT(int) rig_settings_load(char *setting, void *value, settings_value_t valuet);
 extern HAMLIB_EXPORT(int) rig_settings_load_all(char *settings_file);
 
+extern int check_level_param(RIG *rig, setting_t level, value_t val, gran_t **gran);
+
 __END_DECLS
 
 #endif /* _MISC_H */


### PR DESCRIPTION
Phase 1 of issue #1144 - Levels Range Implementation.

This is a first step toward using the level data for all rig-specific limit checking.  Since there are many discrepancies between the code and the level data, I've tried to allow the rollout to be done piecemeal.

This pull adds the checking routine, some updates to the level data for Kenwood rigs, and enables the usage of that data for RIG_LVL_CWPITCH in rigs/kenwood/kenwood.c

It's obviously not something for 4.5.x, but I'd like to get it into the 4.6 trunk so others can wring it out.

Thanks & 73
N3GB