### PR TITLE
Fix unterminated comment

### DIFF
--- a/rigs/mds/serialnum.c
+++ b/rigs/mds/serialnum.c
@@ -16,7 +16,7 @@
     12 - Radio Inhibit (Sleep).
     13 - Reserved
     14 - PTT +5V
-
+*/
 
 void serial_num(char *s)
 {


### PR DESCRIPTION
Fixes a cppcheck error:
rigs/mds/serialnum.c:106:1: error: Unmatched '}'. Configuration: ''. [syntaxError]

