### PR TITLE
Fix issues with async I/O

### DIFF
--- a/rigs/icom/frame.c
+++ b/rigs/icom/frame.c
@@ -530,6 +530,12 @@ static int read_icom_frame_generic(hamlib_port_t *p,
     while ((read < rxbuffer_len) && (rxbuffer[read - 1] != FI)
             && (rxbuffer[read - 1] != COL));
 
+    // Check that we have a valid frame preamble (which might be just a single preable character)
+    if (rxbuffer[0] != PR)
+    {
+        return -RIG_EPROTO;
+    }
+
     return (read);
 }
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -2147,6 +2147,12 @@ int HAMLIB_API parse_hoststr(char *hoststr, int hoststr_len, char host[256],
 //#define RIG_FLUSH_REMOVE
 int HAMLIB_API rig_flush(hamlib_port_t *port)
 {
+    // Data should never be flushed when using async I/O
+    if (port->asyncio)
+    {
+        return RIG_OK;
+    }
+
 #ifndef RIG_FLUSH_REMOVE
     rig_debug(RIG_DEBUG_TRACE, "%s: called for %s device\n", __func__,
               port->type.rig == RIG_PORT_SERIAL ? "serial" : "network");


### PR DESCRIPTION
* Disable rig port flushing when async I/O is enabled. Flushing when async I/O is enabled caused issues with Icom rig pushing waterfall data.
* Improve validation of Icom frames, as each frame must start with the preamble byte.
