### PR TITLE
Fix include not found by cppcheck.sh

### DIFF
--- a/cppcheck.sh
+++ b/cppcheck.sh
@@ -82,7 +82,7 @@ if test $# -eq 0 ; then
         cppcheck --inline-suppr \
                  -I src \
                  -I include \
-                 --include=include/config.h \
+                 --include=include/hamlib/config.h \
                  --include=include/hamlib/rig.h \
                  -q \
                  --force \


### PR DESCRIPTION
Fixes:
nofile:0:0: error: Can not open include file 'include/config.h' that is explicitly included. [preprocessorErrorDirective]