### PR TITLE
Fix/cppcheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 *.lo
 *.la
 *.orig
+*.sh.log
+*.sh.trs
 *.swp
 $depbase.Tpo
 Makefile

--- a/cppcheck.sh
+++ b/cppcheck.sh
@@ -21,13 +21,7 @@ SUPPRESS="\
 --suppress=*:extra/gnuradio/ssb.h \
 --suppress=*:extra/gnuradio/wfm.h \
 --suppress=*:extra/gnuradio/wfm.h \
---suppress=*:extra/gnuradio/HrAGC.h \
---suppress=knownConditionTrueFalse:tests/rotctl.c \
---suppress=knownConditionTrueFalse:tests/rigctl.c \
---suppress=knownConditionTrueFalse:tests/ampctl.c \
---suppress=knownConditionTrueFalse:tests/rotctl_parse.c \
---suppress=knownConditionTrueFalse:tests/rigctl_parse.c \
---suppress=knownConditionTrueFalse:tests/ampctl_parse.c"
+--suppress=*:extra/gnuradio/HrAGC.h
 
 #CHECK="\
 #-D RIG_LEVEL_LINEOUT=1 \

--- a/cppcheck.sh
+++ b/cppcheck.sh
@@ -97,7 +97,7 @@ else
                  --inline-suppr \
                  -I src \
                  -I include \
-                 --include=include/config.h \
+                 --include=include/hamlib/config.h \
                  --include=include/hamlib/rig.h \
                  -q \
                  --force \

--- a/cppcheck.sh
+++ b/cppcheck.sh
@@ -93,8 +93,7 @@ if test $# -eq 0 ; then
                  . \
                  >cppcheck.log 2>&1
 else
-        cppcheck --check-config \
-                 --inline-suppr \
+        cppcheck --inline-suppr \
                  -I src \
                  -I include \
                  --include=include/hamlib/config.h \
@@ -105,5 +104,5 @@ else
                  --std=c99 \
                  $SUPPRESS \
                  $CHECK \
-                 $1
+                 "$@"
 fi

--- a/cppcheck.sh
+++ b/cppcheck.sh
@@ -82,8 +82,9 @@ if test $# -eq 0 ; then
         cppcheck --inline-suppr \
                  -I src \
                  -I include \
-                 --include=include/hamlib/config.h \
-                 --include=include/hamlib/rig.h \
+                 -I include/hamlib/ \
+                 -I lib \
+                 -I security \
                  -q \
                  --force \
                  --enable=all \
@@ -96,8 +97,9 @@ else
         cppcheck --inline-suppr \
                  -I src \
                  -I include \
-                 --include=include/hamlib/config.h \
-                 --include=include/hamlib/rig.h \
+                 -I include/hamlib/ \
+                 -I lib \
+                 -I security \
                  -q \
                  --force \
                  --enable=all \

--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -1230,9 +1230,9 @@ void *handle_socket(void *arg)
 
     mutex_rigctld(0);
 #else
-    mutext_rigctld(1);
+    mutex_rigctld(1);
     retcode = rig_open(my_rig);
-    mutext_rigctld(1);
+    mutex_rigctld(1);
 
     if (RIG_OK == retcode && verbose > RIG_DEBUG_ERR)
     {

--- a/tests/rigctltcp.c
+++ b/tests/rigctltcp.c
@@ -1214,9 +1214,9 @@ void *handle_socket(void *arg)
 
     mutex_rigctld(0);
 #else
-    mutext_rigctld(1);
+    mutex_rigctld(1);
     retcode = rig_open(my_rig);
-    mutext_rigctld(1);
+    mutex_rigctld(1);
 
     if (RIG_OK == retcode && verbose > RIG_DEBUG_ERR)
     {

--- a/tests/rigtestlibusb.c
+++ b/tests/rigtestlibusb.c
@@ -27,7 +27,7 @@
 #include <string.h>
 #include "config.h"
 #if defined(HAVE_LIBUSB_H)
-#include "libusb.h"
+#include <libusb.h>
 #elif defined(HAVE_LIBUSB_1_0_LIBUSB_H)
 #include <libusb-1.0/libusb.h>
 #endif


### PR DESCRIPTION
This PR makes it possibile to run cppcheck on a single file or directory; previously, when passing an argument to cppcheck.sh, only the check the configuration would be performed, now this can be done by explicitly passing the `--check-config` argument, eg. with `./cppcheck.sh --check-config FILENAME`

This PR also fixes some warnings issued by cppcheck.