### PR TITLE
Fix initializer-overrides warnings by clang

### DIFF
--- a/rigs/alinco/dx77.c
+++ b/rigs/alinco/dx77.c
@@ -214,7 +214,6 @@ const struct rig_caps dx77_caps =
         RIG_FRNG_END,
     },
     .tx_range_list1 = {RIG_FRNG_END,},
-    .tx_range_list2 = {RIG_FRNG_END,},
 
     .rx_range_list2 =
     {

--- a/rigs/yaesu/ft991.c
+++ b/rigs/yaesu/ft991.c
@@ -353,7 +353,6 @@ const struct rig_caps ft991_caps =
     .send_voice_mem =     newcat_send_voice_mem,
     .set_clock =          newcat_set_clock,
     .get_clock =          newcat_get_clock,
-    .scan =               newcat_scan,
     .hamlib_check_rig_caps = HAMLIB_CHECK_RIG_CAPS
 };
 


### PR DESCRIPTION
Fixes:
```
dx77.c:225:5: warning: initializer overrides prior initialization of this subobject [-Winitializer-overrides]
    {
    ^
dx77.c:217:23: note: previous initialization is here
    .tx_range_list2 = {RIG_FRNG_END,},
                      ^~~~~~~~~~~~~~~

ft991.c:356:27: warning: initializer overrides prior initialization of this subobject [-Winitializer-overrides]
    .scan =               newcat_scan,
                          ^~~~~~~~~~~
ft991.c:352:27: note: previous initialization is here
    .scan =               newcat_scan,
                          ^~~~~~~~~~~
```