### PR TITLE
Fix QRP Labs QCX Morse Sending

### DIFF
--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -5196,6 +5196,7 @@ int kenwood_send_morse(RIG *rig, vfo_t vfo, const char *msg)
         case RIG_MODEL_K3S:
         case RIG_MODEL_KX2:
         case RIG_MODEL_KX3:
+        case RIG_MODEL_QRPLABS:
             SNPRINTF(morsebuf, sizeof(morsebuf), "KY %s", m2);
             break;
 


### PR DESCRIPTION
Before this fix, hamlib used the TS480 protocol for sending morse
which adds a lot of spaces on the end.

The QCX actually uses the Elecraft morse sending protocol so switch it
over to using that.

Tested with QCX Mini firmware v1.09a
