### PR TITLE
Fix segfaults with malformed input and wrong command line arguments 

### DIFF
--- a/tests/ampctl_parse.c
+++ b/tests/ampctl_parse.c
@@ -1100,7 +1100,7 @@ int ampctl_parse(AMP *my_amp, FILE *fin, FILE *fout, char *argv[], int argc)
 
                 rp_getline(pmptstr);
 
-                if (!(strcmp(input_line, "")))
+                if (!input_line || !(strcmp(input_line, "")))
                 {
                     fprintf(fout, "? for help, q to quit.\n");
                     fflush(fout);

--- a/tests/ampctl_parse.c
+++ b/tests/ampctl_parse.c
@@ -1161,7 +1161,7 @@ int ampctl_parse(AMP *my_amp, FILE *fin, FILE *fout, char *argv[], int argc)
 
                 rp_getline(pmptstr);
 
-                if (!(strcmp(input_line, "")))
+                if (!input_line || !(strcmp(input_line, "")))
                 {
                     fprintf(fout, "? for help, q to quit.\n");
                     fflush(fout);

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -1478,7 +1478,7 @@ readline_repeat:
 
                 rp_getline(pmptstr);
 
-                if (!(strcmp(input_line, "")))
+                if (!input_line || !(strcmp(input_line, "")))
                 {
                     fprintf(fout, "? for help, q to quit.\n");
                     fflush(fout);

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -1544,7 +1544,7 @@ readline_repeat:
 
                 rp_getline(pmptstr);
 
-                if (!(strcmp(input_line, "")))
+                if (!input_line || !(strcmp(input_line, "")))
                 {
                     fprintf(fout, "? for help, q to quit.\n");
                     fflush(fout);

--- a/tests/rotctl_parse.c
+++ b/tests/rotctl_parse.c
@@ -1160,7 +1160,7 @@ int rotctl_parse(ROT *my_rot, FILE *fin, FILE *fout, char *argv[], int argc,
 
                 rp_getline(pmptstr);
 
-                if (!(strcmp(input_line, "")))
+                if (!input_line || !(strcmp(input_line, "")))
                 {
                     fprintf(fout, "? for help, q to quit.\n");
                     fflush(fout);

--- a/tests/rotctl_parse.c
+++ b/tests/rotctl_parse.c
@@ -1221,7 +1221,7 @@ int rotctl_parse(ROT *my_rot, FILE *fin, FILE *fout, char *argv[], int argc,
 
                 rp_getline(pmptstr);
 
-                if (!(strcmp(input_line, "")))
+                if (!input_line || !(strcmp(input_line, "")))
                 {
                     fprintf(fout, "? for help, q to quit.\n");
                     fflush(fout);


### PR DESCRIPTION
This PR avoid a segfault when the user is sending a malformed command through a redirected stdin and the `-` argument is not given.
This PR fixes getting an unexpected NULL pointer, but probably the program shouldn't read from stdin when the `-` argument is not given and should not get to execute those lines.

The first commit fixes commands without a mandatory argument, such as:
```
echo L | tests/ampctl
```
and the same with `rigctl` and `rotctl`.

The second commit fixes commands with a wrong argument, such as::
```
echo L x | tests/ampctl
```
and the same with `rigctl` and `rotctl`.
