### PR TITLE
Remove dead code

### DIFF
--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -309,7 +309,7 @@ int main(int argc, char *argv[])
             exit(0);
 
         case 'V':
-            printf("rigctl %s\n", hamlib_version2);
+            printf("rigctld %s\n", hamlib_version2);
             exit(0);
 
         case 'R':

--- a/tests/rigctltcp.c
+++ b/tests/rigctltcp.c
@@ -312,7 +312,7 @@ int main(int argc, char *argv[])
             exit(0);
 
         case 'V':
-            printf("rigctl %s\n", hamlib_version2);
+            printf("rigctltcp %s\n", hamlib_version2);
             exit(0);
 
         case 'R':
@@ -656,7 +656,7 @@ int main(int argc, char *argv[])
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s\n", rigstartup);
 
-    rig_debug(RIG_DEBUG_VERBOSE, "rigctld %s\n", hamlib_version2);
+    rig_debug(RIG_DEBUG_VERBOSE, "rigctltcp %s\n", hamlib_version2);
     rig_debug(RIG_DEBUG_VERBOSE, "%s",
               "Report bugs to <hamlib-developer@lists.sourceforge.net>\n\n");
     rig_debug(RIG_DEBUG_VERBOSE, "Max# of rigctld client services=%d\n",
@@ -1513,7 +1513,7 @@ handle_exit:
 
 void usage(void)
 {
-    printf("Usage: rigctld [OPTION]...\n"
+    printf("Usage: rigctltcp [OPTION]...\n"
            "Daemon serving COMMANDs to a connected radio transceiver or receiver.\n\n");
 
 


### PR DESCRIPTION
This PR removes code that can never execute because `getopt()/getopt_long()` find a missing argument only at the end of the command line; in that case a `'?'` is returned and an error message is printed by default (to stderr), otherwise the next argument is returned as `optarg`, even if it starts with a `'-'`.

I'm marking this PR as draft even if I think that it is good to be merged because I haven't tested all the programs that I'm changing and because ideally Hamlib could print a specific error message when a numeric argument is not given, for example if I forget the model number, the next argument `-L` is converted to zero by `my_model = atoi(optarg);`:
```
$ tests/rigctl -m -L
Unknown rig num 0, or initialization error.
Please check with --list option.
```

Specific error messages can be seen for example with `ls`:
```
$ /usr/bin/ls -w
/usr/bin/ls: option requires an argument -- 'w'
Try '/usr/bin/ls --help' for more information.
$ LANG=C /usr/bin/ls -w -w
/usr/bin/ls: invalid line width: '-w'
$ LANG=C /usr/bin/ls -ww
/usr/bin/ls: invalid line width: 'w'
```
