### PR TITLE
Improve read timeout retry logic

### DIFF
--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -2084,6 +2084,7 @@ struct rig_caps {
     int (*password)(RIG *rig, const char *key1); /*< Send encrypted password if rigctld is secured with -A/--password */
     int (*set_lock_mode)(RIG *rig, int mode);
     int (*get_lock_mode)(RIG *rig, int *mode);
+    short timeout_retry;    /*!< number of retries to make in case of read timeout errors, some serial interfaces may require this, 0 to use default value, -1 to disable */
 };
 //! @endcond
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -72,7 +72,7 @@ static const struct confparams frontend_cfg_params[] =
     {
         TOK_TIMEOUT_RETRY, "timeout_retry", "Number of retries for read timeouts",
         "Set the number of retries for data read timeouts that may occur especially with some serial interfaces",
-        "0", RIG_CONF_NUMERIC, { .n = { 0, 100, 1 } }
+        "1", RIG_CONF_NUMERIC, { .n = { 0, 100, 1 } }
     },
     {
         TOK_RANGE_SELECTED, "Selected range list", "Range list#",

--- a/src/rig.c
+++ b/src/rig.c
@@ -623,12 +623,28 @@ RIG *HAMLIB_API rig_init(rig_model_t rig_model)
     rs->rigport.post_write_delay = caps->post_write_delay;
 
     // since we do two timeouts now we can cut the timeout in half for serial
-    if (caps->port_type == RIG_PORT_SERIAL)
+    if (caps->port_type == RIG_PORT_SERIAL && caps->timeout_retry >= 0)
     {
         rs->rigport.timeout = caps->timeout / 2;
     }
 
     rs->rigport.retry = caps->retry;
+
+    if (caps->timeout_retry < 0)
+    {
+        // Rigs may disable read timeout retries
+        rs->rigport.timeout_retry = 0;
+    }
+    else if (caps->timeout_retry == 0)
+    {
+        // Default to 1 retry for read timeouts
+        rs->rigport.timeout_retry = 1;
+    }
+    else
+    {
+        rs->rigport.timeout_retry = caps->timeout_retry;
+    }
+
     rs->pttport.type.ptt = caps->ptt_type;
     rs->dcdport.type.dcd = caps->dcd_type;
 

--- a/src/serial.c
+++ b/src/serial.c
@@ -727,6 +727,7 @@ int HAMLIB_API serial_flush(hamlib_port_t *p)
 {
     int len;
     int timeout_save;
+    short timeout_retry_save;
     unsigned char buf[4096];
 
     if (p->fd == uh_ptt_fd || p->fd == uh_radio_fd || p->flushx)
@@ -757,7 +758,9 @@ int HAMLIB_API serial_flush(hamlib_port_t *p)
     }
 
     timeout_save = p->timeout;
+    timeout_retry_save = p->timeout_retry;
     p->timeout = 1;
+    p->timeout_retry = 0;
 
     do
     {
@@ -794,10 +797,13 @@ int HAMLIB_API serial_flush(hamlib_port_t *p)
     while (len > 0);
 
     p->timeout = timeout_save;
+    p->timeout_retry = timeout_retry_save;
+
     rig_debug(RIG_DEBUG_VERBOSE, "tcflush%s\n", "");
-    tcflush(p->fd,
-            TCIFLUSH); // we also do this flush https://github.com/Hamlib/Hamlib/issues/1241
-    return (RIG_OK);
+    // we also do this flush https://github.com/Hamlib/Hamlib/issues/1241
+    tcflush(p->fd,TCIFLUSH);
+
+    return RIG_OK;
 }
 
 


### PR DESCRIPTION
* Set default `timeout_retry` value to 1
* Allow per-rig override of the setting
* Disable `timeout_retry` during serial flush to avoid slowing down flushes