### PR TITLE
Man1

### DIFF
--- a/doc/man1/rigctl.1
+++ b/doc/man1/rigctl.1
@@ -734,6 +734,11 @@ Stop sending the current morse code.
 Wait for morse to finish -- only works on full break-in
 .
 .TP
+.BR 0x94 ", " send_voice_mem " \(aq" \fIMsgnum\fP \(aq
+Have rig transmit internal message
+.RI \(aq Msgnum \(aq
+.
+.TP
 .BR 0x8b ", " get_dcd
 Get
 .RI \(aq DCD \(aq

--- a/doc/man1/rigctl.1
+++ b/doc/man1/rigctl.1
@@ -876,9 +876,9 @@ Level is a token: \(oqPREAMP\(cq, \(oqATT\(cq, \(oqVOXDELAY\(cq, \(oqAF\(cq,
 \(oqBAL\(cq, \(oqMETER\(cq, \(oqVOXGAIN\(cq, \(oqANTIVOX\(cq,
 \(oqSLOPE_LOW\(cq, \(oqSLOPE_HIGH\(cq, \(oqBKIN_DLYMS\(cq, \(oqRAWSTR\(cq, \(oqSWR\(cq,
 \(oqALC\(cq, \(oqSTRENGTH\(cq, \(oqRFPOWER_METER\(cq, \(oqCOMPMETER\(cq, \(oqVD_METER\(cq, \(oqID_METER\(cq,
-\(oqNOTCHF_RAW\(cq, \(oqMONITOR_GAIN\(cq, \(oqNQ\(cq, \(oqRFPOWER_METER_WATTS\cq, \(oqSPECTRUM_MODE\(cq,
-\(oqSPECTRUM_SPAN\(cq, \(oqSPECTRUM_EDGE_LOW\(cq, \(oqSPECTRUM_EDGE_HIGH\(cq, \(oqSPECTRUM_SPEED\cq,
-\(oqSPECTRUM_REF\(cq, (oqSPECTRUM_AVG\(cq, \(oqSPECTRUM_ATT\cq, \(oqTEMP_METER\cq, \(oqBAND_SELECT\(cq,
+\(oqNOTCHF_RAW\(cq, \(oqMONITOR_GAIN\(cq, \(oqNQ\(cq, \(oqRFPOWER_METER_WATTS\(cq, \(oqSPECTRUM_MODE\(cq,
+\(oqSPECTRUM_SPAN\(cq, \(oqSPECTRUM_EDGE_LOW\(cq, \(oqSPECTRUM_EDGE_HIGH\(cq, \(oqSPECTRUM_SPEED\(cq,
+\(oqSPECTRUM_REF\(cq, \(oqSPECTRUM_AVG\(cq, \(oqSPECTRUM_ATT\(cq, \(oqTEMP_METER\(cq, \(oqBAND_SELECT\(cq,
 \(oqUSB_AF\(cq.
 .IP
 The Level Value can be a float or an integer value.  For the AGC token the

--- a/doc/man1/rigctld.1
+++ b/doc/man1/rigctld.1
@@ -868,9 +868,9 @@ evel is a token: \(oqPREAMP\(cq, \(oqATT\(cq, \(oqVOXDELAY\(cq, \(oqAF\(cq,
 \(oqBAL\(cq, \(oqMETER\(cq, \(oqVOXGAIN\(cq, \(oqANTIVOX\(cq,
 \(oqSLOPE_LOW\(cq, \(oqSLOPE_HIGH\(cq, \(oqBKIN_DLYMS\(cq, \(oqRAWSTR\(cq, \(oqSWR\(cq,
 \(oqALC\(cq, \(oqSTRENGTH\(cq, \(oqRFPOWER_METER\(cq, \(oqCOMPMETER\(cq, \(oqVD_METER\(cq, \(oqID_METER\(cq,
-\(oqNOTCHF_RAW\(cq, \(oqMONITOR_GAIN\(cq, \(oqNQ\(cq, \(oqRFPOWER_METER_WATTS\cq, \(oqSPECTRUM_MODE\(cq,
-\(oqSPECTRUM_SPAN\(cq, \(oqSPECTRUM_EDGE_LOW\(cq, \(oqSPECTRUM_EDGE_HIGH\(cq, \(oqSPECTRUM_SPEED\cq,
-\(oqSPECTRUM_REF\(cq, (oqSPECTRUM_AVG\(cq, \(oqSPECTRUM_ATT\cq, \(oqTEMP_METER\cq, \(oqBAND_SELECT\(cq,
+\(oqNOTCHF_RAW\(cq, \(oqMONITOR_GAIN\(cq, \(oqNQ\(cq, \(oqRFPOWER_METER_WATTS\(cq, \(oqSPECTRUM_MODE\(cq,
+\(oqSPECTRUM_SPAN\(cq, \(oqSPECTRUM_EDGE_LOW\(cq, \(oqSPECTRUM_EDGE_HIGH\(cq, \(oqSPECTRUM_SPEED\(cq,
+\(oqSPECTRUM_REF\(cq, \(oqSPECTRUM_AVG\(cq, \(oqSPECTRUM_ATT\(cq, \(oqTEMP_METER\(cq, \(oqBAND_SELECT\(cq,
 \(oqUSB_AF\(cq.
 .IP
 The Level Value can be a float or an integer value.  For the AGC token the

--- a/doc/man1/rigctld.1
+++ b/doc/man1/rigctld.1
@@ -726,6 +726,19 @@ Send
 symbols.
 .
 .TP
+.BR 0xbb ", " stop_morse "
+Stop sending the current morse code.
+.
+.TP
+.BR 0xbc ", " wait_morse "
+Wait for morse to finish -- only works on full break-in
+.
+.TP
+.BR 0x94 ", " send_voice_mem " \(aq" \fIMsgnum\fP \(aq
+Have rig transmit internal message
+.RI \(aq Msgnum \(aq
+.
+.TP
 .BR 0x8b ", " get_dcd
 Get
 .RI \(aq DCD \(aq

--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -246,7 +246,7 @@ int kenwood_transaction(RIG *rig, const char *cmdstr, char *data,
     struct kenwood_priv_caps *caps = kenwood_caps(rig);
     struct rig_state *rs;
 
-    if (datasize > 0 && datasize < strlen(cmdstr)) {
+    if (datasize > 0 && datasize < (cmdstr ? strlen(cmdstr) : 0)) {
     rig_debug(RIG_DEBUG_WARN, "%s called cmd=%s datasize=%d, datasize < cmd length?\n", __func__,
               cmdstr ? cmdstr : "(NULL)",
               (int)datasize);


### PR DESCRIPTION
Small fixes for master

Typos and missing commands in man pages
Avoid NULL in debug statement
