### PR TITLE
Fix minor typo in man page for rigctld

### DIFF
--- a/doc/man1/rigctld.1
+++ b/doc/man1/rigctld.1
@@ -436,7 +436,7 @@ Since most of the
 .B Hamlib
 operations have a
 .BR set " and a " get
-method, a single pper case letter will be used for
+method, a single upper case letter will be used for
 .B set
 methods whereas the corresponding single lower case letter refers to the
 .B get


### PR DESCRIPTION
Added missing u character in command section of man page for rigctld.