### PR TITLE
Fix 'get_powerstat' command provided by rigctld regarding extended response protocol

### DIFF
--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -4796,7 +4796,7 @@ declare_proto_rig(get_powerstat)
         fprintf(fout, "%s: ", cmd->arg1);
     }
 
-    fprintf(fout, "%d\n", stat);
+    fprintf(fout, "%d%c", stat, resp_sep);
     rig_powerstat = stat; // update our global so others can see powerstat
 
     RETURNFUNC2(status);


### PR DESCRIPTION
The `get_powerstat` command provided by rigctld currently responds to a `;\get_powerstat` with a multi-line response.
According to the extended response protocol, if the request starts with a punctuation character, the entire response shall be on one line.

Before:
```
> ;\get_powerstat
< get_powerstat:;Power Status: 1
< RPRT 0
```

After:
```
> ;\get_powerstat
< get_powerstat:;Power Status: 1;RPRT 0

> +\get_powerstat
< get_powerstat:
< Power Status: 1
< RPRT 0

> \get_powerstat
< 1
```