### PR TITLE
Levels 4

### DIFF
--- a/rigs/kenwood/flex6xxx.c
+++ b/rigs/kenwood/flex6xxx.c
@@ -1132,7 +1132,9 @@ const struct rig_caps f6k_caps =
     .has_get_parm =     RIG_PARM_NONE,
     .has_set_parm =     RIG_PARM_NONE,  /* FIXME: parms */
     .level_gran =       {
-        [LVL_KEYSPD] = { .min = { .i = 5 }, .max = { .i = 60 }, .step = { .i = 1 } },
+      [LVL_KEYSPD] = { .min = { .i = 5 }, .max = { .i = 60 }, .step = { .i = 1 } },
+      [LVL_SLOPE_LOW] = { .min = { .i = 10}, .max = { .i = 1000}, .step = { .i = 50} },
+      [LVL_SLOPE_HIGH] = { .min = { .i = 1000}, .max = { .i = 5000}, .step = { .i = 10} },
     },     /* FIXME: granularity */
     .parm_gran =        {},
     //.extlevels =      elecraft_ext_levels,
@@ -1272,6 +1274,7 @@ const struct rig_caps powersdr_caps =
     .has_get_parm =     RIG_PARM_NONE,
     .has_set_parm =     RIG_PARM_NONE,  /* FIXME: parms */
     .level_gran =       {
+#include "level_gran_kenwood.h"
         [LVL_KEYSPD] = { .min = { .i = 5 }, .max = { .i = 60 }, .step = { .i = 1 } },
     },     /* FIXME: granularity */
     .parm_gran =        {},

--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -3151,13 +3151,16 @@ int kenwood_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
     int i, kenwood_val, len, result;
     struct kenwood_priv_data *priv = rig->state.priv;
     struct kenwood_priv_caps *caps = kenwood_caps(rig);
+    gran_t *level_info;
 
     ENTERFUNC;
 
+    /* Check input parameter against level_gran limits */
+    result = check_level_param(rig, level, val, &level_info);
+    if (result != RIG_OK) { RETURNFUNC(result); }
+
     if (RIG_LEVEL_IS_FLOAT(level))
     {
-        if (val.f > 1.0) { RETURNFUNC(-RIG_EINVAL); }
-
         kenwood_val = val.f * 255;
     }
     else
@@ -3239,8 +3242,6 @@ int kenwood_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
             if (retval != RIG_OK) { RETURNFUNC(retval); }
         }
-
-        if (val.f > 1.0 || val.f < 0) { RETURNFUNC(-RIG_EINVAL); }
 
         // is micgain_min ever > 0 ??
         kenwood_val = val.f * (priv->micgain_max - priv->micgain_min) +
@@ -3381,15 +3382,6 @@ int kenwood_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
     case RIG_LEVEL_CWPITCH:
     {
-        gran_t *level_info;
-
-        retval = check_level_param(rig, level, val, &level_info);
-
-        if (retval != RIG_OK)
-        {
-            RETURNFUNC(retval);
-        }
-
         /* Newer rigs have an extra digit of pitch factor */
         int len = (RIG_IS_TS890S || RIG_IS_TS990S) ? 3 : 2;
 
@@ -3401,23 +3393,11 @@ int kenwood_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
     }
 
     case RIG_LEVEL_KEYSPD:
-        if (val.i > 60 || val.i < 5)
-        {
-            RETURNFUNC(-RIG_EINVAL);
-        }
-
         SNPRINTF(levelbuf, sizeof(levelbuf), "KS%03d", val.i);
         break;
 
     case RIG_LEVEL_COMP:
-        if (RIG_IS_TS990S)
-        {
-            kenwood_val = val.f * 255.0f;
-        }
-        else
-        {
-            kenwood_val = val.f * 100.0f;
-        }
+        kenwood_val = (int)((val.f / level_info->step.f) + 0.5f);
 
         SNPRINTF(levelbuf, sizeof(levelbuf), "PL%03d%03d", kenwood_val, kenwood_val);
         break;

--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -3503,6 +3503,7 @@ int kenwood_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     int i, ret, agclevel, len, value;
     struct kenwood_priv_data *priv = rig->state.priv;
     struct kenwood_priv_caps *caps = kenwood_caps(rig);
+    gran_t *level_info;
 
     ENTERFUNC;
 
@@ -3511,6 +3512,8 @@ int kenwood_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         RETURNFUNC(-RIG_EINVAL);
     }
 
+    level_info = &rig->caps->level_gran[rig_setting2idx(level)];
+    
     switch (level)
     {
         int power_now, power_min, power_max;
@@ -3946,8 +3949,7 @@ int kenwood_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         }
 
         sscanf(lvlbuf + 2, "%d", &val->i);
-        val->i = (val->i * rig->caps->level_gran[LVL_CWPITCH].step.i)
-                 + rig->caps->level_gran[LVL_CWPITCH].min.i;
+        val->i = (val->i * level_info->step.i) + level_info->min.i;
         break;
 
     case RIG_LEVEL_KEYSPD:
@@ -3973,14 +3975,7 @@ int kenwood_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 
         sscanf(lvlbuf + 2, "%3d", &raw_value);
 
-        if (RIG_IS_TS990S)
-        {
-            val->f = (float) raw_value / 255.0f;
-        }
-        else
-        {
-            val->f = (float) raw_value / 100.0f;
-        }
+        val->f = (float) raw_value * level_info->step.f;
 
         break;
     }

--- a/rigs/kenwood/pihpsdr.c
+++ b/rigs/kenwood/pihpsdr.c
@@ -246,6 +246,14 @@ const struct rig_caps pihpsdr_caps =
         RIG_FLT_END,
     },
 
+    .level_gran =
+    {
+#include "level_gran_kenwood.h"
+        [LVL_VOXDELAY] = { .min = { .i = 0 }, .max = { .i = 30 }, .step = { .i = 1 } },
+        [LVL_KEYSPD] = {.min = {.i = 5}, .max = {.i = 50}, .step = {.i = 1}},
+        [LVL_CWPITCH] = {.min = {.i = 400}, .max = {.i = 1000}, .step = {.i = 50}},
+        [LVL_BKIN_DLYMS] = {.min = {.i = 0}, .max = {.i = 1000}, .step = {.i = 50}},
+    },
     .str_cal = PIHPSDR_STR_CAL,
 
     .priv = (void *)& ts2000_priv_caps,

--- a/rigs/kenwood/ts480.c
+++ b/rigs/kenwood/ts480.c
@@ -1924,6 +1924,7 @@ const struct rig_caps sdruno_caps =
     },
     .vfo_ops = TS480_VFO_OPS,
     .level_gran = {
+#include "level_gran_kenwood.h"
         [LVL_RAWSTR] = { .min = { .i = 0 }, .max = { .i = 255 } },
         [LVL_VOXDELAY] = { .min = { .i = 0 }, .max = { .i = 30 }, .step = { .i = 1 } },
         [LVL_KEYSPD] = {.min = {.i = 10}, .max = {.i = 60}, .step = {.i = 1}},

--- a/rigs/kenwood/ts480.c
+++ b/rigs/kenwood/ts480.c
@@ -1752,6 +1752,17 @@ const struct rig_caps pt8000a_caps =
         {RIG_MODE_FM, kHz(6.0)},
         RIG_FLT_END,
     },
+    .level_gran =
+    {
+#include "level_gran_kenwood.h"
+        [LVL_RAWSTR] = { .min = { .i = 0 }, .max = { .i = 255 } },
+        [LVL_VOXDELAY] = { .min = { .i = 0 }, .max = { .i = 30 }, .step = { .i = 1 } },
+        [LVL_KEYSPD] = {.min = {.i = 10}, .max = {.i = 60}, .step = {.i = 1}},
+        [LVL_CWPITCH] = {.min = {.i = 400}, .max = {.i = 1000}, .step = {.i = 50}},
+        [LVL_BKIN_DLYMS] = {.min = {.i = 0}, .max = {.i = 1000}, .step = {.i = 50}},
+        [LVL_SLOPE_LOW] = {.min = {.i = 0}, .max = {.i = 2400}, .step = {.i = 10}},
+        [LVL_SLOPE_HIGH] = {.min = {.i = 0}, .max = {.i = 5000}, .step = {.i = 10}},
+    },
     .priv = (void *)& ts480_priv_caps,
     .rig_init = kenwood_init,
     .rig_open = kenwood_open,

--- a/rigs/kenwood/ts990s.c
+++ b/rigs/kenwood/ts990s.c
@@ -150,6 +150,7 @@ const struct rig_caps ts990s_caps =
 #include "level_gran_kenwood.h"
         [LVL_ATT]     = { .min = { .i = 0 }, .max = { .i = 18 }, .step = { .i = 6 } },
         [LVL_CWPITCH] = { .min = { .i = 300 }, .max = { .i = 1100 }, .step = { .i = 10 } },
+        [LVL_COMP]    = { .min = { .f = 0.0 }, .max = { .f = 1.0 }, .step = { .f = 1.0f/255.0f } },
     },
     .parm_gran =  {},
     .vfo_ops =  TS990S_VFO_OP,


### PR DESCRIPTION
Use level_gran[] data for all kenwood_[set|get]_level ops.

Use the table data for limits and granularity.  

Part of issue #1144 
