### PR TITLE
Fix FIFO pop() sign issue and clean up morse data handler code

### DIFF
--- a/src/fifo.c
+++ b/src/fifo.c
@@ -35,7 +35,7 @@ int push(FIFO_RIG *fifo, const char *msg)
     return RIG_OK;
 }
 
-char pop(FIFO_RIG *fifo)
+int pop(FIFO_RIG *fifo)
 {
     if (fifo->tail == fifo->head) { return -1; }
 

--- a/src/fifo.h
+++ b/src/fifo.h
@@ -1,4 +1,4 @@
 void initFIFO(FIFO_RIG *fifo);
 void resetFIFO(FIFO_RIG *fifo);
 int push(FIFO_RIG *fifo, const char *msg);
-char pop(FIFO_RIG *fifo);
+int pop(FIFO_RIG *fifo);


### PR DESCRIPTION
The morse data handler was not detecting the negative (-1) result of pop() due to issues with signedness. Changing pop() return value to int fixed the issue (tested on Raspberry Pi). This may affect/fix #1334 