### PR TITLE
Fix segfault on rigctl exit

### DIFF
--- a/src/rig.c
+++ b/src/rig.c
@@ -8112,6 +8112,7 @@ void *morse_data_handler(void *arg)
     }
 
     free(rig->state.fifo_morse);
+    rig->state.fifo_morse = NULL;
     pthread_exit(NULL);
     return NULL;
 }


### PR DESCRIPTION
If rigctl does a recovery close/open cycle, a freed buffer gets reused. This can cause segfault or worse.