### PR TITLE
RIG ADAT: Adaptation to firmware 1.40fb and transverter board.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ libs/
 obj/
 .project
 .cproject
+.DS_Store
+._.DS_Store

--- a/rigs/adat/adat.c
+++ b/rigs/adat/adat.c
@@ -5,7 +5,7 @@
 //  adat.c
 //
 //  Created by Frank Goenninger DG1SBG.
-//  Copyright © 2011, 2012 Frank Goenninger.
+//  Copyright © 2011, 2012, 2023 Frank Goenninger.
 //
 //   This library is free software; you can redistribute it and/or
 //   modify it under the terms of the GNU Lesser General Public
@@ -1419,9 +1419,8 @@ int adat_priv_clear_result(RIG *pRig)
         if (pPriv->pcResult != NULL)
         {
             free(pPriv->pcResult);
+            pPriv->pcResult = NULL;
         }
-
-        pPriv->pcResult = NULL;
     }
 
     // Done !
@@ -1545,13 +1544,11 @@ int adat_get_single_cmd_result(RIG *pRig)
                     nRC = -RIG_EINVAL;
                 }
 
+                adat_priv_clear_result(pRig);
+
                 if (nRC == RIG_OK)
                 {
                     adat_priv_set_result(pRig, pcResult);
-                }
-                else
-                {
-                    adat_priv_clear_result(pRig);
                 }
             }
         }
@@ -2630,28 +2627,9 @@ adat_priv_data_ptr adat_new_priv_data(RIG *pRig)
     {
         // Init Priv Data
 
-        pPriv = pRig->state.priv = (adat_priv_data_ptr) calloc(sizeof(adat_priv_data_t),
-                                   1);
+        pPriv = pRig->state.priv = (adat_priv_data_ptr) calloc(1,sizeof(adat_priv_data_t));
 
-        if (pRig->state.priv != NULL)
-        {
-            char acBuf[ ADAT_BUFSZ + 1 ];
-            memset(acBuf, 0, ADAT_BUFSZ + 1);
-
-            // FIXME: pointless code at init time
-#if 0
-            nRC = adat_get_conf(pRig, TOKEN_ADAT_PRODUCT_NAME, acBuf);
-
-            if (nRC == 0)
-            {
-                pPriv->pcProductName = strdup(acBuf);
-
-                pRig->state.priv = (void *) pPriv;
-            }
-
-#endif
-        }
-        else
+        if (pRig->state.priv == NULL)
         {
             nRC = -RIG_ENOMEM;
         }

--- a/rigs/adat/adat.h
+++ b/rigs/adat/adat.h
@@ -5,7 +5,7 @@
 //  adat.h
 //
 //  Created by Frank Goenninger DG1SBG.
-//  Copyright © 2011, 2012 Frank Goenninger.
+//  Copyright © 2011, 2012, 2023 Frank Goenninger.
 //
 //   This library is free software; you can redistribute it and/or
 //   modify it under the terms of the GNU Lesser General Public
@@ -42,10 +42,10 @@
 //    GLOBAL DEFINITIONS
 // ---------------------------------------------------------------------------
 
-#define BACKEND_VER "20191206"
+#define BACKEND_VER "20230927"
 
-#define ADAT_BUFSZ                 256
-#define ADAT_RESPSZ                256
+#define ADAT_BUFSZ                 255
+#define ADAT_RESPSZ                255
 
 #define ADAT_CR                    "\x0d"
 #define ADAT_EOL                   "\x0a"
@@ -100,7 +100,7 @@
 
 // ADAT MODE DEFINITIONS
 
-#define ADAT_MODE_LENGTH           5
+#define ADAT_MODE_LENGTH           15
 #define ADAT_NR_MODES              8
 
 // Each mode is defined by three values:

--- a/rigs/adat/adt_200a.c
+++ b/rigs/adat/adt_200a.c
@@ -5,7 +5,7 @@
 //  adt_200a.c
 //
 //  Created by Frank Goenninger DG1SBG.
-//  Copyright © 2011, 2012 Frank Goenninger.
+//  Copyright © 2011, 2012, 2023 Frank Goenninger.
 //
 //   This library is free software; you can redistribute it and/or
 //   modify it under the terms of the GNU Lesser General Public
@@ -100,12 +100,18 @@ const struct rig_caps adt_200a_caps =
     .rx_range_list1 =
     {
         { kHz(10), MHz(30), ADT_200A_MODES, -1, -1, ADT_200A_VFO },
+        { MHz(50), MHz(50.5), ADT_200A_MODES, -1, -1, ADT_200A_VFO },
+        { MHz(70), MHz(70.7), ADT_200A_MODES, -1, -1, ADT_200A_VFO },
+        { MHz(146), MHz(148), ADT_200A_MODES, -1, -1, ADT_200A_VFO },
         RIG_FRNG_END,
     },
 
     .tx_range_list1 =
     {
         { kHz(10), MHz(30), ADT_200A_MODES, mW(100), W(50), ADT_200A_VFO },
+        { MHz(50), MHz(50.5), ADT_200A_MODES, mW(10), W(1), ADT_200A_FRA },
+        { MHz(70), MHz(70.7), ADT_200A_MODES, mW(10), W(1), ADT_200A_FRA },
+        { MHz(146), MHz(148), ADT_200A_MODES, mW(10), mW(100), ADT_200A_FRA },
         RIG_FRNG_END,
     },
 
@@ -163,8 +169,10 @@ const struct rig_caps adt_200a_caps =
         { RIG_MODE_FM, Hz(8000) },
         { RIG_MODE_FM, Hz(9000) },
         { RIG_MODE_FM, Hz(10000) },
-        { RIG_MODE_FM, Hz(11000) },
         { RIG_MODE_FM, Hz(12000) },
+        { RIG_MODE_FM, Hz(15000) },
+        { RIG_MODE_FM, Hz(20000) },
+        { RIG_MODE_FM, Hz(25000) },
         RIG_FLT_END,
     },
     .str_cal = ADT_200A_STR_CAL,

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -10537,6 +10537,7 @@ int newcat_get_vfo_mode(RIG *rig, vfo_t vfo, rmode_t *vfo_mode)
     {
     case 27: offset = 21; priv->width_frequency = 8; break;
 
+    case 41: // FT-991 V2-01 seems to randomly give 13 extra bytes
     case 28: offset = 22; priv->width_frequency = 9; break;
 
     default:

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -2924,6 +2924,7 @@ int newcat_get_rit(RIG *rig, vfo_t vfo, shortfreq_t *rit)
     {
     case 27: offset = 13; break;
 
+    case 41: // FT-991 V2-01 seems to randomly give 13 extra bytes
     case 28: offset = 14; break;
 
     default: offset = 0;
@@ -3040,6 +3041,7 @@ int newcat_get_xit(RIG *rig, vfo_t vfo, shortfreq_t *xit)
     {
     case 27: offset = 13; break;
 
+    case 41: // FT-991 V2-01 seems to randomly give 13 extra bytes
     case 28: offset = 14; break;
 
     default: offset = 0;

--- a/rigs/yaesu/newcat.h
+++ b/rigs/yaesu/newcat.h
@@ -50,7 +50,7 @@
 typedef char ncboolean;
 
 /* shared function version */
-#define NEWCAT_VER "20230914"
+#define NEWCAT_VER "20230927"
 
 /* Hopefully large enough for future use, 128 chars plus '\0' */
 #define NEWCAT_DATA_LEN                 129


### PR DESCRIPTION
This is a pull request containing:
1. Some small code cleanups to prevent infrequent crashs in function adat_priv_set_result()
2. Adaptation to new firmware version 1.40fb and the new 6m/4m/2m transverter board 
    * A change in available filter bandwidths in FM mode
    * A change in VFO 1 capabilities: VFO 1 can now be switched to 6m, 4m, and 2m bands

Vy 73 de Frank DG1SBG