### PR TITLE
Fix man page of rigctld

### DIFF
--- a/doc/man1/rigctld.1
+++ b/doc/man1/rigctld.1
@@ -396,11 +396,11 @@ option as it generates no output on its own.
 Sets password on rigctld which requires hamlib to use rig_set_password and rigctl to use \\password to access rigctld.  A 32-char shared secret will be displayed to be used on the client side.
 .
 .TP
-.BR \-R ", " \-\-rigctld_idle
+.BR \-R ", " \-\-rigctld\-idle
 Will make rigctld close the rig when no clients are connected.  Normally remains connected to speed up connects.
 .
 .TP
-.BR \-b ", " \-\-bind_all
+.BR \-b ", " \-\-bind\-all
 Will make rigctld try to bind to first network device available.
 .
 .TP


### PR DESCRIPTION
The options rigctld-idle and bind-all where written with an underscore.