### PR TITLE
Fix warning message for twiddle_rit

### DIFF
--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -599,7 +599,7 @@ int main(int argc, char *argv[])
 
             twiddle_rit = atoi(optarg);
             fprintf(stderr,
-                    "twiddle_timeout is deprecated...use e.g. --set-conf=twiddle_timeout=5\n");
+                    "twiddle_rit is deprecated...use e.g. --set-conf=twiddle_rit=1\n");
             break;
 
 

--- a/tests/rigctltcp.c
+++ b/tests/rigctltcp.c
@@ -586,7 +586,7 @@ int main(int argc, char *argv[])
 
             twiddle_rit = atoi(optarg);
             fprintf(stderr,
-                    "twiddle_timeout is deprecated...use e.g. --set-conf=twiddle_timeout=5\n");
+                    "twiddle_rit is deprecated...use e.g. --set-conf=twiddle_rit=1\n");
             break;
 
 


### PR DESCRIPTION
It was referencing a different option.