### PR TITLE
Refactor multicast publisher/server code

### DIFF
--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -2758,7 +2758,13 @@ struct rig_state {
     volatile int morse_data_handler_thread_run;
     void *morse_data_handler_priv_data;
     FIFO_RIG *fifo_morse;
-    int port_multicast;  /*!< May be different so this is initially a copy of rigctl'd port selection */
+    char *multicast_data_addr;  /*!< Multicast data UDP address for publishing rig data and state */
+    int multicast_data_port;  /*!< Multicast data UDP port for publishing rig data and state */
+    char *multicast_cmd_addr;  /*!< Multicast command server UDP address for sending commands to rig */
+    int multicast_cmd_port;  /*!< Multicast command server UDP port for sending commands to rig */
+
+    volatile int multicast_receiver_run;
+    void *multicast_receiver_priv_data;
 };
 
 /**

--- a/src/conf.c
+++ b/src/conf.c
@@ -208,7 +208,7 @@ static const struct confparams frontend_cfg_params[] =
     {
         TOK_MULTICAST_CMD_PORT, "multicast_cmd_port", "Multicast command server UDP port",
         "Multicast data UDP port for sending commands to rig",
-        "4531", RIG_CONF_NUMERIC, { .n = { 0, 1000000, 1 } }
+        "4532", RIG_CONF_NUMERIC, { .n = { 0, 1000000, 1 } }
     },
 
     { RIG_CONF_END, NULL, }

--- a/src/conf.c
+++ b/src/conf.c
@@ -208,7 +208,7 @@ static const struct confparams frontend_cfg_params[] =
     {
         TOK_MULTICAST_CMD_PORT, "multicast_cmd_port", "Multicast command server UDP port",
         "Multicast data UDP port for sending commands to rig",
-        "4532", RIG_CONF_NUMERIC, { .n = { 0, 1000000, 1 } }
+        "4531", RIG_CONF_NUMERIC, { .n = { 0, 1000000, 1 } }
     },
 
     { RIG_CONF_END, NULL, }

--- a/src/conf.c
+++ b/src/conf.c
@@ -92,8 +92,8 @@ static const struct confparams frontend_cfg_params[] =
     },
     {
         TOK_POLL_INTERVAL, "poll_interval", "Rig state poll interval in milliseconds",
-        "Polling interval in milliseconds for transceive emulation, value of 0 disables polling",
-        "0", RIG_CONF_NUMERIC, { .n = { 0, 1000000, 1 } }
+        "Polling interval in milliseconds for transceive emulation, defaults to 1000, value of 0 disables polling",
+        "1000", RIG_CONF_NUMERIC, { .n = { 0, 1000000, 1 } }
     },
     {
         TOK_PTT_TYPE, "ptt_type", "PTT type",
@@ -189,6 +189,26 @@ static const struct confparams frontend_cfg_params[] =
         TOK_OFFSET_VFOB, "offset_vfob", "Offset value in Hz",
         "Add Hz to VFOB/Sub frequency set",
         "0", RIG_CONF_NUMERIC, { .n = {0, 1e12, 1}}
+    },
+    {
+        TOK_MULTICAST_DATA_ADDR, "multicast_data_addr", "Multicast data UDP address",
+        "Multicast data UDP address for publishing rig data and state, value of 0.0.0.0 disables multicast data publishing",
+        "224.0.0.1", RIG_CONF_STRING,
+    },
+    {
+        TOK_MULTICAST_DATA_PORT, "multicast_data_port", "Multicast data UDP port",
+        "Multicast data UDP port for publishing rig data and state",
+        "4532", RIG_CONF_NUMERIC, { .n = { 0, 1000000, 1 } }
+    },
+    {
+        TOK_MULTICAST_CMD_ADDR, "multicast_cmd_addr", "Multicast command server UDP address",
+        "Multicast command UDP address for sending commands to rig, value of 0.0.0.0 disables multicast command server",
+        "224.0.0.2", RIG_CONF_STRING,
+    },
+    {
+        TOK_MULTICAST_CMD_PORT, "multicast_cmd_port", "Multicast command server UDP port",
+        "Multicast data UDP port for sending commands to rig",
+        "4532", RIG_CONF_NUMERIC, { .n = { 0, 1000000, 1 } }
     },
 
     { RIG_CONF_END, NULL, }
@@ -608,7 +628,11 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
         break;
 
     case TOK_POLL_INTERVAL:
-        rs->poll_interval = atof(val);
+        if (1 != sscanf(val, "%ld", &val_i))
+        {
+            return -RIG_EINVAL;
+        }
+        rs->poll_interval = val_i;
         // Make sure cache times out before next poll cycle
         rig_set_cache_timeout_ms(rig, HAMLIB_CACHE_ALL, atol(val));
         break;
@@ -735,7 +759,31 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
         rig_debug(RIG_DEBUG_VERBOSE, "%s: offset_vfob=%ld\n", __func__, val_i);
         break;
 
+    case TOK_MULTICAST_DATA_ADDR:
+        rs->multicast_data_addr = strdup(val);
+        break;
 
+    case TOK_MULTICAST_DATA_PORT:
+        if (1 != sscanf(val, "%ld", &val_i))
+        {
+            return -RIG_EINVAL;
+        }
+
+        rs->multicast_data_port = val_i;
+        break;
+
+    case TOK_MULTICAST_CMD_ADDR:
+        rs->multicast_cmd_addr = strdup(val);
+        break;
+
+    case TOK_MULTICAST_CMD_PORT:
+        if (1 != sscanf(val, "%ld", &val_i))
+        {
+            return -RIG_EINVAL;
+        }
+
+        rs->multicast_cmd_port = val_i;
+        break;
 
     default:
         return -RIG_EINVAL;

--- a/src/event.c
+++ b/src/event.c
@@ -75,12 +75,11 @@ void *rig_poll_routine(void *arg)
     int update_occurred;
 
     vfo_t vfo = RIG_VFO_NONE, vfo_prev = RIG_VFO_NONE;
-    freq_t freq_main = 0, freq_sub = 0, freq_main_prev = 0, freq_sub_prev = 0;
-    rmode_t mode_main = RIG_MODE_NONE, mode_sub = RIG_MODE_NONE,
-            mode_main_prev = RIG_MODE_NONE, mode_sub_prev = RIG_MODE_NONE;
-    pbwidth_t width_main = 0, width_sub = 0, width_main_prev = 0,
-              width_sub_prev = 0;
-    split_t split, split_prev = -1;
+    freq_t freq_main_a = 0, freq_main_b = 0, freq_main_c = 0, freq_sub_a = 0, freq_sub_b = 0, freq_sub_c = 0;
+    rmode_t mode_main_a = 0, mode_main_b = 0, mode_main_c = 0, mode_sub_a = 0, mode_sub_b = 0, mode_sub_c = 0;
+    pbwidth_t width_main_a = 0, width_main_b = 0, width_main_c = 0, width_sub_a = 0, width_sub_b = 0, width_sub_c = 0;
+    ptt_t ptt = RIG_PTT_OFF;
+    split_t split = RIG_SPLIT_OFF;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s(%d): Starting rig poll routine thread\n",
               __FILE__, __LINE__);
@@ -92,6 +91,109 @@ void *rig_poll_routine(void *arg)
 
     while (rs->poll_routine_thread_run)
     {
+        if (rig->state.cache.freqMainA != freq_main_a)
+        {
+            freq_main_a = rig->state.cache.freqMainA;
+            update_occurred = 1;
+        }
+        else if (rig->state.cache.freqMainB != freq_main_b)
+        {
+            freq_main_b = rig->state.cache.freqMainB;
+            update_occurred = 1;
+        }
+        else if (rig->state.cache.freqMainC != freq_main_c)
+        {
+            freq_main_b = rig->state.cache.freqMainC;
+            update_occurred = 1;
+        }
+        else if (rig->state.cache.freqSubA != freq_sub_a)
+        {
+            freq_sub_a = rig->state.cache.freqSubA;
+            update_occurred = 1;
+        }
+        else if (rig->state.cache.freqSubB != freq_sub_b)
+        {
+            freq_sub_b = rig->state.cache.freqSubB;
+            update_occurred = 1;
+        }
+        else if (rig->state.cache.freqSubC != freq_sub_c)
+        {
+            freq_sub_c = rig->state.cache.freqSubC;
+            update_occurred = 1;
+        }
+        else if (rig->state.cache.ptt != ptt)
+        {
+            ptt = rig->state.cache.ptt;
+            update_occurred = 1;
+        }
+        else if (rig->state.cache.split != split)
+        {
+            split = rig->state.cache.split;
+            update_occurred = 1;
+        }
+        else if (rig->state.cache.modeMainA != mode_main_a)
+        {
+            mode_main_a = rig->state.cache.modeMainA;
+            update_occurred = 1;
+        }
+        else if (rig->state.cache.modeMainB != mode_main_b)
+        {
+            mode_main_b = rig->state.cache.modeMainB;
+            update_occurred = 1;
+        }
+        else if (rig->state.cache.modeMainC != mode_main_c)
+        {
+            mode_main_c = rig->state.cache.modeMainC;
+            update_occurred = 1;
+        }
+        else if (rig->state.cache.modeSubA != mode_sub_a)
+        {
+            mode_sub_a = rig->state.cache.modeSubA;
+            update_occurred = 1;
+        }
+        else if (rig->state.cache.modeSubB != mode_sub_b)
+        {
+            mode_sub_b = rig->state.cache.modeSubB;
+            update_occurred = 1;
+        }
+        else if (rig->state.cache.modeSubC != mode_sub_c)
+        {
+            mode_sub_c = rig->state.cache.modeSubC;
+            update_occurred = 1;
+        }
+        else if (rig->state.cache.widthMainA != width_main_a)
+        {
+            width_main_a = rig->state.cache.widthMainA;
+            update_occurred = 1;
+        }
+        else if (rig->state.cache.widthMainB != width_main_b)
+        {
+            width_main_b = rig->state.cache.widthMainB;
+            update_occurred = 1;
+        }
+        else if (rig->state.cache.widthMainC != width_main_c)
+        {
+            width_main_c = rig->state.cache.widthMainC;
+            update_occurred = 1;
+        }
+        else if (rig->state.cache.widthSubA != width_sub_a)
+        {
+            width_sub_a = rig->state.cache.widthSubA;
+            update_occurred = 1;
+        }
+        else if (rig->state.cache.widthSubB != width_sub_b)
+        {
+            width_sub_b = rig->state.cache.widthSubB;
+            update_occurred = 1;
+        }
+        else if (rig->state.cache.widthSubC != width_sub_c)
+        {
+            width_sub_c = rig->state.cache.widthSubC;
+            update_occurred = 1;
+        }
+
+// The original code here actively reads rig state, which can be too intensive and intrusive
+#if 0
         if (rig->caps->get_vfo)
         {
             result = rig_get_vfo(rig, &vfo);
@@ -225,10 +327,12 @@ void *rig_poll_routine(void *arg)
                 split_prev = split;
             }
         }
+#endif
 
         if (update_occurred)
         {
             network_publish_rig_poll_data(rig);
+            update_occurred = 0;
         }
 
         hl_usleep(rs->poll_interval * 1000);

--- a/src/network.c
+++ b/src/network.c
@@ -996,10 +996,10 @@ void *multicast_receiver(void *arg)
     rig_debug(RIG_DEBUG_VERBOSE, "%s(%d): Starting multicast receiver\n", __FILE__,
             __LINE__);
 
-    int optval = 1;
-    if (setsockopt(socket_fd, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval)) < 0)
+    char optval = 1;
+    if (setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) < 0)
     {
-        rig_debug(RIG_DEBUG_ERR, "%s: error enabling UDP port reuse: %s\n", __func__,
+        rig_debug(RIG_DEBUG_ERR, "%s: error enabling UDP address reuse: %s\n", __func__,
                 strerror(errno));
         return NULL;
     }

--- a/src/network.c
+++ b/src/network.c
@@ -1054,7 +1054,7 @@ void *multicast_receiver(void *arg)
         }
 
         // TODO: handle commands from multicast clients
-        rig_debug(RIG_DEBUG_VERBOSE, "%s: received %ld bytes of data: %.*s\n", __func__, result, (int) result, data);
+        rig_debug(RIG_DEBUG_VERBOSE, "%s: received %ld bytes of data: %.*s\n", __func__, (long) result, (int) result, data);
 
         // TODO: if a new snapshot needs to be sent, call network_publish_rig_poll_data() and the publisher routine will send out a snapshot
         // TODO: new logic in publisher needs to be written for other types of responses

--- a/src/network.c
+++ b/src/network.c
@@ -996,6 +996,8 @@ void *multicast_receiver(void *arg)
     rig_debug(RIG_DEBUG_VERBOSE, "%s(%d): Starting multicast receiver\n", __FILE__,
             __LINE__);
 
+// Not working right now
+#if 0
     int optval = 1;
     if (setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) < 0)
     {
@@ -1003,6 +1005,7 @@ void *multicast_receiver(void *arg)
                 strerror(errno));
         return NULL;
     }
+#endif
 
     memset(&dest_addr, 0, sizeof(dest_addr));
     dest_addr.sin_family = AF_INET;

--- a/src/network.c
+++ b/src/network.c
@@ -996,7 +996,7 @@ void *multicast_receiver(void *arg)
     rig_debug(RIG_DEBUG_VERBOSE, "%s(%d): Starting multicast receiver\n", __FILE__,
             __LINE__);
 
-    char optval = 1;
+    int optval = 1;
     if (setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) < 0)
     {
         rig_debug(RIG_DEBUG_ERR, "%s: error enabling UDP address reuse: %s\n", __func__,
@@ -1009,7 +1009,7 @@ void *multicast_receiver(void *arg)
     dest_addr.sin_addr.s_addr = inet_addr(args->multicast_addr);
     dest_addr.sin_port = htons(args->multicast_port);
 
-    if ((bind(socket_fd, (struct sockaddr *) &dest_addr, sizeof(dest_addr))) < 0)
+    if (bind(socket_fd, (struct sockaddr *) &dest_addr, sizeof(dest_addr)) < 0)
     {
         rig_debug(RIG_DEBUG_ERR, "%s: error binding UDP socket to %s:%d: %s\n", __func__,
                 args->multicast_addr, args->multicast_port, strerror(errno));

--- a/src/network.h
+++ b/src/network.h
@@ -36,6 +36,8 @@ int network_publish_rig_transceive_data(RIG *rig);
 int network_publish_rig_spectrum_data(RIG *rig, struct rig_spectrum_line *line);
 HAMLIB_EXPORT(int) network_multicast_publisher_start(RIG *rig, const char *multicast_addr, int multicast_port, enum multicast_item_e items);
 HAMLIB_EXPORT(int) network_multicast_publisher_stop(RIG *rig);
+HAMLIB_EXPORT(int) network_multicast_receiver_start(RIG *rig, const char *multicast_addr, int multicast_port);
+HAMLIB_EXPORT(int) network_multicast_receiver_stop(RIG *rig);
 
 __END_DECLS
 

--- a/src/rig.c
+++ b/src/rig.c
@@ -674,7 +674,7 @@ RIG *HAMLIB_API rig_init(rig_model_t rig_model)
     rs->multicast_data_addr = "224.0.0.1"; // enable multicast data publishing by default
     rs->multicast_data_port = 4532;
     rs->multicast_cmd_addr = "224.0.0.2"; // enable multicast command server by default
-    rs->multicast_cmd_port = 4531;
+    rs->multicast_cmd_port = 4532;
     rs->lo_freq = 0;
     rs->cache.timeout_ms = 500;  // 500ms cache timeout by default
     rs->cache.ptt = 0;

--- a/src/rig.c
+++ b/src/rig.c
@@ -674,7 +674,7 @@ RIG *HAMLIB_API rig_init(rig_model_t rig_model)
     rs->multicast_data_addr = "224.0.0.1"; // enable multicast data publishing by default
     rs->multicast_data_port = 4532;
     rs->multicast_cmd_addr = "224.0.0.2"; // enable multicast command server by default
-    rs->multicast_cmd_port = 4532;
+    rs->multicast_cmd_port = 4531;
     rs->lo_freq = 0;
     rs->cache.timeout_ms = 500;  // 500ms cache timeout by default
     rs->cache.ptt = 0;

--- a/src/token.h
+++ b/src/token.h
@@ -131,6 +131,15 @@
 #define TOK_OFFSET_VFOA  TOKEN_FRONTEND(130)
 /** \brief rig: Add Hz to VFOB/Sub frequency set */
 #define TOK_OFFSET_VFOB  TOKEN_FRONTEND(131)
+/** \brief rig: Multicast data UDP address for publishing rig data and state, default 224.0.0.1, value of 0.0.0.0 disables multicast data publishing */
+#define TOK_MULTICAST_DATA_ADDR  TOKEN_FRONTEND(132)
+/** \brief rig: Multicast data UDP port, default 4532 */
+#define TOK_MULTICAST_DATA_PORT  TOKEN_FRONTEND(133)
+/** \brief rig: Multicast command server UDP address for sending commands to rig, default 224.0.0.2, value of 0.0.0.0 disables multicast command server */
+#define TOK_MULTICAST_CMD_ADDR  TOKEN_FRONTEND(134)
+/** \brief rig: Multicast command server UDP port, default 4532 */
+#define TOK_MULTICAST_CMD_PORT  TOKEN_FRONTEND(135)
+
 /*
  * rotator specific tokens
  * (strictly, should be documented as rotator_internal)

--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -105,8 +105,6 @@ static struct option long_options[] =
     {"twiddle_rit",     1, 0, 'w'},
     {"uplink",          1, 0, 'x'},
     {"debug-time-stamps", 0, 0, 'Z'},
-    {"multicast-addr",  1, 0, 'M'},
-    {"multicast-port",  1, 0, 'n'},
     {"password",        1, 0, 'A'},
     {"rigctld-idle",    0, 0, 'R'},
     {"bind-all",        0, 0, 'b'},
@@ -145,8 +143,6 @@ static int volatile ctrl_c;
 
 const char *portno = "4532";
 const char *src_addr = NULL; /* INADDR_ANY */
-const char *multicast_addr = "0.0.0.0";
-int multicast_port = 4532;
 extern char rigctld_password[65];
 char resp_sep = '\n';
 extern int lock_mode;
@@ -618,33 +614,6 @@ int main(int argc, char *argv[])
             rig_set_debug_time_stamp(1);
             break;
 
-        case 'M':
-            if (!optarg)
-            {
-                usage();    /* wrong arg count */
-                exit(1);
-            }
-
-            multicast_addr = optarg;
-            break;
-
-        case 'n':
-            if (!optarg)
-            {
-                usage();    /* wrong arg count */
-                exit(1);
-            }
-
-            multicast_port = atoi(optarg);
-
-            if (multicast_port == 0)
-            {
-                fprintf(stderr, "Invalid multicast port: %s\n", optarg);
-                exit(1);
-            }
-
-            break;
-
         default:
             usage();    /* unknown option? */
             exit(1);
@@ -866,18 +835,6 @@ int main(int argc, char *argv[])
     }
 
     saved_result = result;
-
-    enum multicast_item_e items = RIG_MULTICAST_POLL | RIG_MULTICAST_TRANSCEIVE |
-                                  RIG_MULTICAST_SPECTRUM;
-    retcode = network_multicast_publisher_start(my_rig, multicast_addr,
-              multicast_port, items);
-
-    if (retcode != RIG_OK)
-    {
-        rig_debug(RIG_DEBUG_ERR, "%s: network_multicast_server failed: %s\n", __FILE__,
-                  rigerror(retcode));
-        // we will consider this non-fatal for now
-    }
 
     do
     {
@@ -1147,8 +1104,6 @@ int main(int argc, char *argv[])
 #else
     rig_close(my_rig); /* close port */
 #endif
-
-    network_multicast_publisher_stop(my_rig);
 
     rig_cleanup(my_rig); /* if you care about memory */
 
@@ -1464,8 +1419,6 @@ void usage(void)
         "  -w, --twiddle_rit             suppress VFOB getfreq so RIT can be twiddled\n"
         "  -x, --uplink                  set uplink get_freq ignore, 1=Sub, 2=Main\n"
         "  -Z, --debug-time-stamps       enable time stamps for debug messages\n"
-        "  -M, --multicast-addr=addr     set multicast UDP address, default 0.0.0.0 (off), recommend 224.0.1.1\n"
-        "  -n, --multicast-port=port     set multicast UDP port, default 4532\n"
         "  -A, --password                set password for rigctld access\n"
         "  -R, --rigctld-idle            make rigctld close the rig when no clients are connected\n"
         "  -h, --help                    display this help and exit\n"


### PR DESCRIPTION
@mdblack98 NOTE: This is a draft PR until I get to test the code properly on Windows too. It seems also the UDP server has some bug on Linux, but didn't spot it yet :)

This PR addresses the following:

* Create a separate "receiver" server routine for multicast command handling (move it out of the publisher, they're not related) -> See the TODOs in the `multicast_receiver()` function for the actual implementation
* Move the rig cache change detection to the rig poll routine (see event.c now!) and enable it by default -> publishing of rig state changes via UDP seems to work
* Remove conflicting mutlicast publisher initialization from rigctld daemon
* Add rig set-conf address/port parameters for both multicast data publisher and the command server
