### PR TITLE
990 meter

### DIFF
--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -3471,6 +3471,54 @@ int get_kenwood_level(RIG *rig, const char *cmd, float *fval, int *ival)
     RETURNFUNC(RIG_OK);
 }
 
+/* Helper to get and parse meter values using RM
+ * Note that we turn readings on, but nothing off.
+ * 'pips' is the number of LED bars lit in the digital meter, max=70
+ */
+int get_kenwood_meter_reading(RIG *rig, char meter, int *pips)
+{
+    char reading[9];   /* 8 char + '\0' */
+    int retval;
+    char target[] = "RMx1"; /* Turn on reading this meter */
+
+    target[2] = meter;
+    retval = kenwood_transaction(rig, target, NULL, 0);
+
+    if (retval != RIG_OK)
+    {
+        return retval;
+    }
+
+    /* Read the first value */
+    retval = kenwood_transaction(rig, "RM", reading, sizeof(reading));
+
+    if (retval != RIG_OK)
+    {
+        return retval;
+    }
+
+    /* Find the one we want */
+    while (strncmp(reading, target, 3) != 0)
+    {
+        /* That wasn't it, get the next one */
+        retval = kenwood_transaction(rig, NULL, reading, sizeof(reading));
+
+        if (retval != RIG_OK)
+        {
+            return retval;
+        }
+
+        if (reading[0] != target[0] || reading[1] != target[1])
+        {
+            /* Somebody else's data, bail */
+            return -RIG_EPROTO;
+        }
+    }
+
+    sscanf(reading + 3, "%4d", pips);
+    return RIG_OK;
+
+}
 
 /*
  * kenwood_get_level

--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -1100,15 +1100,6 @@ int kenwood_open(RIG *rig)
     // mismatched IDs can still be tested
     rig->state.rigport.retry = retry_save;
 
-
-    // TS-990S needs to ensure all RM meters are turned off as first one with read on gets read
-    // Any RM commands need to be ON/READ/OFF to allow other apps or threads to read meters
-
-    if (RIG_IS_TS990S)
-    {
-        kenwood_transaction(rig, "RM10;RM20;RM30;RM40;RM50;RM60;", NULL, 0);
-    }
-
     RETURNFUNC(RIG_OK);
 }
 

--- a/rigs/kenwood/kenwood.h
+++ b/rigs/kenwood/kenwood.h
@@ -264,6 +264,7 @@ int kenwood_get_trn(RIG *rig, int *trn);
 /* only use if returned string has length 6, e.g. 'SQ011;' */
 int get_kenwood_level(RIG *rig, const char *cmd, float *fval, int *ival);
 int get_kenwood_func(RIG *rig, const char *cmd, int *status);
+int get_kenwood_meter_reading(RIG *rig, char meter, int *pips);
 
 extern const struct rig_caps ts950s_caps;
 extern const struct rig_caps ts950sdx_caps;

--- a/rigs/kenwood/ts890s.c
+++ b/rigs/kenwood/ts890s.c
@@ -106,56 +106,6 @@ int kenwood_ts890_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
     return kenwood_transaction(rig, levelbuf, NULL, 0);
 }
 
-/* Helper to get and parse meter values using RM
- * Note that we turn readings on, but nothing off.
- * 'pips' is the number of LED bars lit in the digital meter, max=70
- */
-static
-int ts890_get_meter_reading(RIG *rig, char meter, int *pips)
-{
-    char reading[9];   /* 8 char + '\0' */
-    int retval;
-    char target[] = "RMx1"; /* Turn on reading this meter */
-
-    target[2] = meter;
-    retval = kenwood_transaction(rig, target, NULL, 0);
-
-    if (retval != RIG_OK)
-    {
-        return retval;
-    }
-
-    /* Read the first value */
-    retval = kenwood_transaction(rig, "RM", reading, sizeof(reading));
-
-    if (retval != RIG_OK)
-    {
-        return retval;
-    }
-
-    /* Find the one we want */
-    while (strncmp(reading, target, 3) != 0)
-    {
-        /* That wasn't it, get the next one */
-        retval = kenwood_transaction(rig, NULL, reading, sizeof(reading));
-
-        if (retval != RIG_OK)
-        {
-            return retval;
-        }
-
-        if (reading[0] != target[0] || reading[1] != target[1])
-        {
-            /* Somebody else's data, bail */
-            return -RIG_EPROTO;
-        }
-    }
-
-    sscanf(reading + 3, "%4d", pips);
-    return RIG_OK;
-
-}
-
 int kenwood_ts890_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
     char ackbuf[50];
@@ -253,7 +203,7 @@ int kenwood_ts890_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         return RIG_OK;
 
     case RIG_LEVEL_ALC:
-        retval = ts890_get_meter_reading(rig, '1', &levelint);
+        retval = get_kenwood_meter_reading(rig, '1', &levelint);
 
         if (retval != RIG_OK)
         {
@@ -264,7 +214,7 @@ int kenwood_ts890_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         return RIG_OK;
 
     case RIG_LEVEL_SWR:
-        retval = ts890_get_meter_reading(rig, '2', &levelint);
+        retval = get_kenwood_meter_reading(rig, '2', &levelint);
 
         if (retval != RIG_OK)
         {
@@ -287,7 +237,7 @@ int kenwood_ts890_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         return RIG_OK;
 
     case RIG_LEVEL_COMP_METER:
-        retval = ts890_get_meter_reading(rig, '3', &levelint);
+        retval = get_kenwood_meter_reading(rig, '3', &levelint);
 
         if (retval != RIG_OK)
         {
@@ -301,7 +251,7 @@ int kenwood_ts890_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         return RIG_OK;
 
     case RIG_LEVEL_ID_METER:
-        retval = ts890_get_meter_reading(rig, '4', &levelint);
+        retval = get_kenwood_meter_reading(rig, '4', &levelint);
 
         if (retval != RIG_OK)
         {
@@ -312,7 +262,7 @@ int kenwood_ts890_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         return RIG_OK;
 
     case RIG_LEVEL_VD_METER:
-        retval = ts890_get_meter_reading(rig, '5', &levelint);
+        retval = get_kenwood_meter_reading(rig, '5', &levelint);
 
         if (retval != RIG_OK)
         {
@@ -324,7 +274,7 @@ int kenwood_ts890_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 
     case RIG_LEVEL_TEMP_METER:
 #if 0
-        retval = ts890_get_meter_reading(rig, '6', &levelint);
+        retval = get_kenwood_meter_reading(rig, '6', &levelint);
 
         if (retval != RIG_OK)
         {

--- a/rigs/kenwood/ts990s.c
+++ b/rigs/kenwood/ts990s.c
@@ -647,16 +647,12 @@ int ts990s_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         break;
 
     case RIG_LEVEL_SWR:
-        // we need to turn on read, read it, and turn it off again
-        // first RM meter with read on is the that gets read with RM;
-        retval = kenwood_safe_transaction(rig, "RM21;RM;RM20", lvlbuf, sizeof(lvlbuf), 8);
-
+        retval = get_kenwood_meter_reading(rig, '2', &lvl);
         if (retval != RIG_OK)
         {
             return retval;
         }
 
-        sscanf(lvlbuf, "RM2%d", &lvl);
         val->f = rig_raw2val_float(lvl, &rig->caps->swr_cal);
         val->f = round(val->f*10)/10.0;  // 1 decimal place precision 
         break;


### PR DESCRIPTION
Use general meter reader for TS-990 SWR reading.

Should also allow for ALC/COMP/IC/VD/TEMP get_level implementations.
