### PR TITLE
added RIG_MTYPE_VOICE and RIG_MTYPE_MORSE to chan_type_t and IC 7300,…

### DIFF
--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -1643,7 +1643,9 @@ typedef enum {
     RIG_MTYPE_MEMOPAD,      /*!< Memory pad */
     RIG_MTYPE_SAT,          /*!< Satellite */
     RIG_MTYPE_BAND,         /*!< VFO/Band channel */
-    RIG_MTYPE_PRIO          /*!< Priority channel */
+    RIG_MTYPE_PRIO,         /*!< Priority channel */
+	RIG_MTYPE_VOICE,		/*!< Stored Voice Message */
+	RIG_MTYPE_MORSE			/*!< Morse Message */
 } chan_type_t;
 
 

--- a/rigs/icom/ic7300.c
+++ b/rigs/icom/ic7300.c
@@ -758,6 +758,8 @@ const struct rig_caps ic7300_caps =
 
     .chan_list =  {
         {   1,  99, RIG_MTYPE_MEM  },
+		{	1,	8,	RIG_MTYPE_VOICE },
+		{	1,	8,	RIG_MTYPE_MORSE }
         RIG_CHAN_END,
     },
 
@@ -1001,6 +1003,8 @@ struct rig_caps ic9700_caps =
 
     .chan_list =  {
         {   1,  99, RIG_MTYPE_MEM  },
+		{	1,	8,	RIG_MTYPE_VOICE },
+		{	1,	8,	RIG_MTYPE_MORSE }
         RIG_CHAN_END,
     },
 
@@ -1323,6 +1327,8 @@ const struct rig_caps ic705_caps =
 
     .chan_list =  {
         {   1,  99, RIG_MTYPE_MEM  },
+		{	1,	8,	RIG_MTYPE_VOICE },
+		{	1,	8,	RIG_MTYPE_MORSE }
         RIG_CHAN_END,
     },
 
@@ -1597,6 +1603,8 @@ const struct rig_caps ic905_caps =
 
     .chan_list =  {
         {   1,  99, RIG_MTYPE_MEM  },
+		{	1,	8,	RIG_MTYPE_VOICE },
+		{	1,	8,	RIG_MTYPE_MORSE }
         RIG_CHAN_END,
     },
 

--- a/rigs/icom/ic7300.c
+++ b/rigs/icom/ic7300.c
@@ -759,7 +759,7 @@ const struct rig_caps ic7300_caps =
     .chan_list =  {
         {   1,  99, RIG_MTYPE_MEM  },
 		{	1,	8,	RIG_MTYPE_VOICE },
-		{	1,	8,	RIG_MTYPE_MORSE }
+		{	1,	8,	RIG_MTYPE_MORSE },
         RIG_CHAN_END,
     },
 
@@ -1004,7 +1004,7 @@ struct rig_caps ic9700_caps =
     .chan_list =  {
         {   1,  99, RIG_MTYPE_MEM  },
 		{	1,	8,	RIG_MTYPE_VOICE },
-		{	1,	8,	RIG_MTYPE_MORSE }
+		{	1,	8,	RIG_MTYPE_MORSE },
         RIG_CHAN_END,
     },
 
@@ -1328,7 +1328,7 @@ const struct rig_caps ic705_caps =
     .chan_list =  {
         {   1,  99, RIG_MTYPE_MEM  },
 		{	1,	8,	RIG_MTYPE_VOICE },
-		{	1,	8,	RIG_MTYPE_MORSE }
+		{	1,	8,	RIG_MTYPE_MORSE },
         RIG_CHAN_END,
     },
 
@@ -1604,7 +1604,7 @@ const struct rig_caps ic905_caps =
     .chan_list =  {
         {   1,  99, RIG_MTYPE_MEM  },
 		{	1,	8,	RIG_MTYPE_VOICE },
-		{	1,	8,	RIG_MTYPE_MORSE }
+		{	1,	8,	RIG_MTYPE_MORSE },
         RIG_CHAN_END,
     },
 


### PR DESCRIPTION
Add RIG_MTYPE_VOICE and RIG_MTYPE_MORSE as memory types. Added these types to chan_list for IC7300, IC9700 and IC705 for now.