### PR TITLE
Restore shared library ABI compatibility with previous hamlibs

### DIFF
--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -2388,7 +2388,7 @@ typedef struct hamlib_port {
     int fd_sync_error_read;     /*!< file descriptor for reading synchronous data error codes */
 #endif
     short timeout_retry;    /*!< number of retries to make in case of read timeout errors, some serial interfaces may require this, 0 to disable */
-    int post_ptt_delay;         /*!< delay after PTT to allow for relays and such */
+// DO NOT ADD ANYTHING HERE UNTIL 5.0!!
 } hamlib_port_t;
 
  
@@ -2787,6 +2787,8 @@ struct rig_state {
     rig_comm_status_t comm_status; /*!< Detailed rig control status */
     char device_id[HAMLIB_RIGNAMSIZ];
     int dual_watch; /*!< Boolean DUAL_WATCH status */
+    int post_ptt_delay;         /*!< delay after PTT to allow for relays and such */
+// New rig_state items go before this line ============================================
 };
 
 /**
@@ -2799,7 +2801,7 @@ struct rig_state {
  * It is NOT fine to touch this struct AT ALL!!!
  */
 struct rig_state_deprecated {
-    /********* ENSURE YOU DO NOT EVERY MODIFY THIS STRUCTURE *********/
+    /********* ENSURE YOU DO NOT EVER MODIFY THIS STRUCTURE *********/
     /********* It will remain forever to provide DLL backwards compatiblity ******/
     /*
      * overridable fields

--- a/src/conf.c
+++ b/src/conf.c
@@ -268,7 +268,15 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
         }
 
         rs->rigport.post_write_delay = val_i;
-        rs->rigport_deprecated.timeout = val_i;
+        rs->rigport_deprecated.post_write_delay = val_i;
+        break;
+
+    case TOK_POST_PTT_DELAY:
+        if (1 != sscanf(val, "%ld", &val_i))
+        {
+	  return -RIG_EINVAL;
+        }
+        rs->post_ptt_delay = val_i;
         break;
 
     case TOK_TIMEOUT:
@@ -841,7 +849,7 @@ static int frontend_get_conf2(RIG *rig, token_t token, char *val, int val_len)
         break;
 
     case TOK_POST_PTT_DELAY:
-        SNPRINTF(val, val_len, "%d", rs->rigport.post_ptt_delay);
+        SNPRINTF(val, val_len, "%d", rs->post_ptt_delay);
         break;
 
     case TOK_TIMEOUT:

--- a/src/rig.c
+++ b/src/rig.c
@@ -3562,7 +3562,7 @@ int HAMLIB_API rig_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 
     memcpy(&rig->state.pttport_deprecated, &rig->state.pttport,
            sizeof(rig->state.pttport_deprecated));
-    if (rig->state.rigport.post_ptt_delay > 0) hl_usleep(rig->state.rigport.post_ptt_delay*1000);
+    if (rig->state.post_ptt_delay > 0) hl_usleep(rig->state.post_ptt_delay*1000);
     ELAPSED2;
 
     RETURNFUNC(retcode);


### PR DESCRIPTION
No need for post_ptt_delay to be in hamlib_port - move it to misc
  rig_state data.
Update references to post_ptt_delay
Fix a couple of typos
Add code to actually set post_ptt_delay

Fixes issue #1412