### PR TITLE
Basic definitions and first steps for making port tables addressed by pointers

### DIFF
--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -2464,6 +2464,21 @@ typedef hamlib_port_t_deprecated port_t_deprecated;
 typedef hamlib_port_t port_t;
 #endif
 
+/* Macros to access port structures/pointers
+ * Make it easier to change location in preparation
+ *   for moving them out of rig->state.
+ * See https://github.com/Hamlib/Hamlib/issues/1445
+ */
+// Note: Experimental, and subject to change!!
+#define RIGPORT(r) (&r->state.rigport)
+#define PTTPORT(r) (&r->state.pttport)
+#define DCDPORT(r) (&r->state.dcdport)
+/* Then when the rigport address is stored as a pointer somewhere else(say,
+ *  in the rig structure itself), the definition could be changed to
+ *  #define RIGPORT(r) r->somewhereelse
+ *  and every reference is updated.
+ */
+
 #define HAMLIB_ELAPSED_GET 0
 #define HAMLIB_ELAPSED_SET 1
 #define HAMLIB_ELAPSED_INVALIDATE 2

--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -2470,9 +2470,18 @@ typedef hamlib_port_t port_t;
  * See https://github.com/Hamlib/Hamlib/issues/1445
  */
 // Note: Experimental, and subject to change!!
+#if defined(IN_HAMLIB)
+/* These are for internal use only */
 #define RIGPORT(r) (&r->state.rigport)
 #define PTTPORT(r) (&r->state.pttport)
 #define DCDPORT(r) (&r->state.dcdport)
+#else
+/* Define external unique names */
+/* These will be changed to a function call before release */
+#define HAMLIB_RIGPORT(r) (&r->state.rigport)
+#define HAMLIB_PTTPORT(r) (&r->state.pttport)
+#define HAMLIB_DCDPORT(r) (&r->state.dcdport)
+#endif
 /* Then when the rigport address is stored as a pointer somewhere else(say,
  *  in the rig structure itself), the definition could be changed to
  *  #define RIGPORT(r) r->somewhereelse

--- a/rigs/kenwood/elecraft.c
+++ b/rigs/kenwood/elecraft.c
@@ -99,7 +99,7 @@ int elecraft_open(RIG *rig)
     struct kenwood_priv_data *priv = rig->state.priv;
     char *model = "Unknown";
     struct rig_state *rs = &rig->state;
-
+    struct hamlib_port *rp = RIGPORT(rig);
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called, rig version=%s\n", __func__,
               rig->caps->version);
@@ -135,7 +135,7 @@ int elecraft_open(RIG *rig)
 
         strcpy(data, "EMPTY");
         // Not going to get carried away with retries and such
-        err = write_block(&rs->rigport, (unsigned char *) cmd, strlen(cmd));
+        err = write_block(rp, (unsigned char *) cmd, strlen(cmd));
 
         if (err != RIG_OK)
         {
@@ -143,7 +143,7 @@ int elecraft_open(RIG *rig)
             return err;
         }
 
-        err = read_string(&rs->rigport, (unsigned char *) buf, sizeof(buf),
+        err = read_string(rp, (unsigned char *) buf, sizeof(buf),
                           ";", 1, 0, 1);
 
         if (err < 0)

--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -245,6 +245,7 @@ int kenwood_transaction(RIG *rig, const char *cmdstr, char *data,
     struct kenwood_priv_data *priv = rig->state.priv;
     struct kenwood_priv_caps *caps = kenwood_caps(rig);
     struct rig_state *rs;
+    struct hamlib_port *rp;   /* Pointer to rigport structure */
 
     if (datasize > 0 && datasize < (cmdstr ? strlen(cmdstr) : 0))
     {
@@ -265,11 +266,12 @@ int kenwood_transaction(RIG *rig, const char *cmdstr, char *data,
     }
 
     rs = &rig->state;
+    rp = RIGPORT(rig);
 
     rs->transaction_active = 1;
 
     /* Emulators don't need any post_write_delay */
-    if (priv->is_emulation) { rs->rigport.post_write_delay = 0; }
+    if (priv->is_emulation) { rp->post_write_delay = 0; }
 
     // if this is an IF cmdstr and not the first time through check cache
     if (cmdstr && strcmp(cmdstr, "IF") == 0 && priv->cache_start.tv_sec != 0)
@@ -328,9 +330,9 @@ transaction_write:
         }
 
         /* flush anything in the read buffer before command is sent */
-        rig_flush(&rs->rigport);
+        rig_flush(rp);
 
-        retval = write_block(&rs->rigport, (unsigned char *) cmd, len);
+        retval = write_block(rp, (unsigned char *) cmd, len);
 
         free(cmd);
 
@@ -382,7 +384,7 @@ transaction_write:
         /* no reply expected so we need to write a command that always
            gives a reply so we can read any error replies from the actual
            command being sent without blocking */
-        if (RIG_OK != (retval = write_block(&rs->rigport,
+        if (RIG_OK != (retval = write_block(rp,
                                             (unsigned char *) priv->verify_cmd, strlen(priv->verify_cmd))))
         {
             goto transaction_quit;
@@ -396,7 +398,7 @@ transaction_read:
     // eventually we should be able to get rid of this but requires testing all Kenwood rigs
     len = min(datasize ? datasize + 1 : strlen(priv->verify_cmd) + 48,
               KENWOOD_MAX_BUF_LEN);
-    retval = read_string(&rs->rigport, (unsigned char *) buffer, len,
+    retval = read_string(rp, (unsigned char *) buffer, len,
                          cmdtrm_str, strlen(cmdtrm_str), 0, 1);
     rig_debug(RIG_DEBUG_TRACE, "%s: read_string len=%d '%s'\n", __func__,
               (int)strlen(buffer), buffer);
@@ -404,12 +406,12 @@ transaction_read:
     if (retval < 0)
     {
         rig_debug(RIG_DEBUG_WARN,
-                  "%s: read_string retval < 0, retval = %d, retry_read=%d, rs->rigport.retry=%d\n",
+                  "%s: read_string retval < 0, retval = %d, retry_read=%d, rp->retry=%d\n",
                   __func__,
-                  retval, retry_read, rs->rigport.retry);
+                  retval, retry_read, rp->retry);
 
         // only retry if we expect a response from the command
-        if (retry_read++ < rs->rigport.retry)
+        if (retry_read++ < rp->retry)
         {
             goto transaction_write;
             // we use to not re-do the write
@@ -439,7 +441,7 @@ transaction_read:
         rig_debug(RIG_DEBUG_ERR, "%s: Command is not correctly terminated '%s'\n",
                   __func__, buffer);
 
-        if (retry_read++ < rs->rigport.retry)
+        if (retry_read++ < rp->retry)
         {
             goto transaction_write;
         }
@@ -471,7 +473,7 @@ transaction_read:
                 rig_debug(RIG_DEBUG_VERBOSE, "%s: Overflow for '%s'\n", __func__, cmdstr);
             }
 
-            if (retry_read++ < rs->rigport.retry)
+            if (retry_read++ < rp->retry)
             {
                 goto transaction_write;
             }
@@ -488,7 +490,7 @@ transaction_read:
                           cmdstr);
             }
 
-            if (retry_read++ < rs->rigport.retry)
+            if (retry_read++ < rp->retry)
             {
                 goto transaction_write;
             }
@@ -531,10 +533,10 @@ transaction_read:
                 }
             }
 
-            if (retry_read++ < rs->rigport.retry)
+            if (retry_read++ < rp->retry)
             {
                 rig_debug(RIG_DEBUG_ERR, "%s: Retrying shortly %d of %d\n", __func__,
-                          retry_read, rs->rigport.retry);
+                          retry_read, rp->retry);
                 hl_usleep(rig->caps->timeout * 1000);
                 goto transaction_write;
             }
@@ -564,10 +566,10 @@ transaction_read:
             rig_debug(RIG_DEBUG_ERR, "%s: wrong reply %c%c for command %c%c\n",
                       __func__, buffer[0], buffer[1], cmdstr[0], cmdstr[1]);
 
-            rig_debug(RIG_DEBUG_ERR, "%s: retry_read=%d, rs->rigport.retry=%d\n", __func__,
-                      retry_read, rs->rigport.retry);
+            rig_debug(RIG_DEBUG_ERR, "%s: retry_read=%d, rp->retry=%d\n", __func__,
+                      retry_read, rp->retry);
 
-            if (retry_read++ < rs->rigport.retry)
+            if (retry_read++ < rp->retry)
             {
                 if (strlen(buffer) == 0)
                 {
@@ -640,7 +642,7 @@ transaction_read:
                       __func__, buffer[0], buffer[1]
                       , priv->verify_cmd[0], priv->verify_cmd[1]);
 
-            if (retry_read++ < rs->rigport.retry)
+            if (retry_read++ < rp->retry)
             {
                 goto transaction_write;
             }
@@ -740,7 +742,7 @@ int kenwood_safe_transaction(RIG *rig, const char *cmd, char *buf,
             hl_usleep(50 * 1000); // let's do a short wait
         }
     }
-    while (err != RIG_OK && ++retry < rig->state.rigport.retry);
+    while (err != RIG_OK && ++retry < RIGPORT(rig)->retry);
 
     RETURNFUNC2(err);
 }
@@ -869,12 +871,12 @@ int kenwood_open(RIG *rig)
     int err, i;
     char *idptr;
     char id[KENWOOD_MAX_BUF_LEN];
-    int retry_save = rig->state.rigport.retry;
+    int retry_save = RIGPORT(rig)->retry;
 
     ENTERFUNC;
 
     id[0] = 0;
-    rig->state.rigport.retry = 0;
+    RIGPORT(rig)->retry = 0;
 
     priv->question_mark_response_means_rejected = 0;
 
@@ -946,7 +948,7 @@ int kenwood_open(RIG *rig)
         {
             rig_debug(RIG_DEBUG_ERR, "%s: cannot get f/w version, defaulting to 1.0\n",
                       __func__);
-            rig->state.rigport.retry = retry_save;
+            RIGPORT(rig)->retry = retry_save;
             priv->fw_rev_uint = 100;
         }
         else
@@ -964,7 +966,7 @@ int kenwood_open(RIG *rig)
             else
             {
                 rig_debug(RIG_DEBUG_ERR, "%s: cannot get f/w version\n", __func__);
-                rig->state.rigport.retry = retry_save;
+                RIGPORT(rig)->retry = retry_save;
                 RETURNFUNC(-RIG_EPROTO);
             }
         }
@@ -983,7 +985,7 @@ int kenwood_open(RIG *rig)
         if (RIG_OK != err)
         {
             rig_debug(RIG_DEBUG_ERR, "%s: no response from rig\n", __func__);
-            rig->state.rigport.retry = retry_save;
+            RIGPORT(rig)->retry = retry_save;
             RETURNFUNC(err);
         }
 
@@ -1000,7 +1002,7 @@ int kenwood_open(RIG *rig)
         if (err != RIG_OK)
         {
             rig_debug(RIG_DEBUG_ERR, "%s: cannot get identification\n", __func__);
-            rig->state.rigport.retry = retry_save;
+            RIGPORT(rig)->retry = retry_save;
             RETURNFUNC(err);
         }
     }
@@ -1087,7 +1089,7 @@ int kenwood_open(RIG *rig)
                           rig_strvfo(priv->tx_vfo));
             }
 
-            rig->state.rigport.retry = retry_save;
+            RIGPORT(rig)->retry = retry_save;
 
             RETURNFUNC(RIG_OK);
         }
@@ -1108,7 +1110,7 @@ int kenwood_open(RIG *rig)
 
     // we're making this non fatal
     // mismatched IDs can still be tested
-    rig->state.rigport.retry = retry_save;
+    RIGPORT(rig)->retry = retry_save;
 
     RETURNFUNC(RIG_OK);
 }
@@ -2866,15 +2868,15 @@ static int kenwood_get_micgain_minmax(RIG *rig, int *micgain_now,
     // we batch these commands together for speed
     char *cmd = "MG;MG000;MG;MG255;MG;MG000;";
     int n;
-    struct rig_state *rs = &rig->state;
+    struct hamlib_port *rp = RIGPORT(rig);
 
     ENTERFUNC;
 
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, strlen(cmd));
+    retval = write_block(rp, (unsigned char *) cmd, strlen(cmd));
 
     if (retval != RIG_OK) { RETURNFUNC(retval); }
 
-    retval = read_string(&rs->rigport, (unsigned char *) levelbuf, sizeof(levelbuf),
+    retval = read_string(rp, (unsigned char *) levelbuf, sizeof(levelbuf),
                          NULL, 0, 1, 1);
 
     rig_debug(RIG_DEBUG_TRACE, "%s: retval=%d\n", __func__, retval);
@@ -2928,6 +2930,7 @@ static int kenwood_get_power_minmax(RIG *rig, int *power_now, int *power_min,
     char *cmd;
     int n;
     struct rig_state *rs = &rig->state;
+    struct hamlib_port *rp = RIGPORT(rig);
 
     ENTERFUNC;
 
@@ -2940,16 +2943,16 @@ static int kenwood_get_power_minmax(RIG *rig, int *power_now, int *power_min,
     // TS890S can't take power levels outside 5-100 and 5-25
     // So all we'll do is read power_now
     case RIG_MODEL_TS890S:
-        rig->state.power_min = *power_min = 5;
-        rig->state.power_max = *power_max = 100;
+        rs->power_min = *power_min = 5;
+        rs->power_max = *power_max = 100;
 
-        if (rig->state.current_mode == RIG_MODE_AM) { *power_max = 50; }
+        if (rs->current_mode == RIG_MODE_AM) { *power_max = 50; }
 
-        if (rig->state.current_freq >= 70)
+        if (rs->current_freq >= 70)
         {
-            rig->state.power_max = 50;
+            rs->power_max = 50;
 
-            if (rig->state.current_mode == RIG_MODE_AM) { *power_max = 13; }
+            if (rs->current_mode == RIG_MODE_AM) { *power_max = 13; }
         }
 
 
@@ -2961,18 +2964,18 @@ static int kenwood_get_power_minmax(RIG *rig, int *power_now, int *power_min,
     }
 
     // Don't do this if PTT is on...don't want to max out power!!
-    if (rig->state.cache.ptt == RIG_PTT_ON)
+    if (rs->cache.ptt == RIG_PTT_ON)
     {
         rig_debug(RIG_DEBUG_TRACE, "%s: ptt on so not checking min/max power levels\n",
                   __func__);
         // return the last values we got
-        *power_now = rig->state.power_now;
-        *power_min = rig->state.power_min;
-        *power_max = rig->state.power_max;
+        *power_now = rs->power_now;
+        *power_min = rs->power_min;
+        *power_max = rs->power_max;
         RETURNFUNC(RIG_OK);
     }
 
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, strlen(cmd));
+    retval = write_block(rp, (unsigned char *) cmd, strlen(cmd));
 
     if (retval != RIG_OK) { RETURNFUNC(retval); }
 
@@ -2985,7 +2988,7 @@ static int kenwood_get_power_minmax(RIG *rig, int *power_now, int *power_min,
         expected_length = 18;
     }
 
-    retval = read_string(&rs->rigport, (unsigned char *) levelbuf,
+    retval = read_string(rp, (unsigned char *) levelbuf,
                          expected_length + 1,
                          NULL, 0, 0, 1);
 
@@ -3033,9 +3036,9 @@ static int kenwood_get_power_minmax(RIG *rig, int *power_now, int *power_min,
     rig_debug(RIG_DEBUG_TRACE, "%s: returning now=%d, min=%d, max=%d\n", __func__,
               *power_now, *power_min, *power_max);
 
-    rig->state.power_now = *power_now;
-    rig->state.power_min = *power_min;
-    rig->state.power_max = *power_max;
+    rs->power_now = *power_now;
+    rs->power_min = *power_min;
+    rs->power_max = *power_max;
     RETURNFUNC(RIG_OK);
 }
 
@@ -3780,8 +3783,8 @@ int kenwood_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         // This could be done by rig but easy enough to make it automagic
         if (priv->ag_format < 0)
         {
-            int retry_save = rig->state.rigport.retry;
-            rig->state.rigport.retry = 0;  // speed up this check so no retries
+            int retry_save = RIGPORT(rig)->retry;
+            RIGPORT(rig)->retry = 0;  // speed up this check so no retries
             rig_debug(RIG_DEBUG_TRACE, "%s: AF format check determination...\n", __func__);
             // Determine AG format
             // =-1 == Undetermine
@@ -3819,7 +3822,7 @@ int kenwood_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
                 }
             }
 
-            rig->state.rigport.retry = retry_save;
+            RIGPORT(rig)->retry = retry_save;
         }
 
         rig_debug(RIG_DEBUG_TRACE, "%s: ag_format=%d\n", __func__, priv->ag_format);
@@ -5089,7 +5092,7 @@ int kenwood_get_trn(RIG *rig, int *trn)
 int kenwood_set_powerstat(RIG *rig, powerstat_t status)
 {
     int retval;
-    struct rig_state *state = &rig->state;
+    struct hamlib_port *rp = RIGPORT(rig);
     struct kenwood_priv_data *priv = rig->state.priv;
 
     if ((priv->is_k3 || priv->is_k3s) && status == RIG_POWER_ON)
@@ -5100,7 +5103,7 @@ int kenwood_set_powerstat(RIG *rig, powerstat_t status)
     }
 
     int i = 0;
-    int retry_save = rig->state.rigport.retry;
+    int retry_save = rp->retry;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called status=%d\n", __func__, status);
 
@@ -5108,11 +5111,11 @@ int kenwood_set_powerstat(RIG *rig, powerstat_t status)
     {
         // When powering on a Kenwood rig needs dummy bytes to wake it up,
         // then wait at least 200ms and within 2 seconds issue the power-on command again
-        write_block(&state->rigport, (unsigned char *) "PS1;", 4);
+        write_block(rp, (unsigned char *) "PS1;", 4);
         hl_usleep(500000);
     }
 
-    rig->state.rigport.retry = 0;
+    rp->retry = 0;
 
     retval = kenwood_transaction(rig,
                                  (status == RIG_POWER_ON) ? "PS1;" : "PS0;",
@@ -5128,7 +5131,7 @@ int kenwood_set_powerstat(RIG *rig, powerstat_t status)
 
             if (retval == RIG_OK)
             {
-                rig->state.rigport.retry = retry_save;
+                rp->retry = retry_save;
                 RETURNFUNC2(retval);
             }
 
@@ -5136,7 +5139,7 @@ int kenwood_set_powerstat(RIG *rig, powerstat_t status)
         }
     }
 
-    rig->state.rigport.retry = retry_save;
+    rp->retry = retry_save;
 
     if (i == 9)
     {
@@ -5156,7 +5159,7 @@ int kenwood_get_powerstat(RIG *rig, powerstat_t *status)
 {
     char pwrbuf[6];
     int result;
-    struct rig_state *state = &rig->state;
+    struct hamlib_port *rp = RIGPORT(rig);
     struct kenwood_priv_data *priv = rig->state.priv;
 
     ENTERFUNC;
@@ -5182,19 +5185,19 @@ int kenwood_get_powerstat(RIG *rig, powerstat_t *status)
     short timeout_retry_save;
     int timeout_save;
 
-    retry_save = state->rigport.retry;
-    timeout_retry_save = state->rigport.timeout_retry;
-    timeout_save = state->rigport.timeout;
+    retry_save = rp->retry;
+    timeout_retry_save = rp->timeout_retry;
+    timeout_save = rp->timeout;
 
-    state->rigport.retry = 0;
-    state->rigport.timeout_retry = 0;
-    state->rigport.timeout = 500;
+    rp->retry = 0;
+    rp->timeout_retry = 0;
+    rp->timeout = 500;
 
     result = kenwood_safe_transaction(rig, "PS", pwrbuf, 6, 3);
 
-    state->rigport.retry = retry_save;
-    state->rigport.timeout_retry = timeout_retry_save;
-    state->rigport.timeout = timeout_save;
+    rp->retry = retry_save;
+    rp->timeout_retry = timeout_retry_save;
+    rp->timeout = timeout_save;
 
     // Rig may respond here already
     if (result == RIG_OK)
@@ -5221,7 +5224,7 @@ int kenwood_get_powerstat(RIG *rig, powerstat_t *status)
     // after waiting for at least 200ms and within 2 seconds after dummy data
     hl_usleep(500000);
     // Discard any unsolicited data
-    rig_flush(&rig->state.rigport);
+    rig_flush(rp);
 
     result = kenwood_safe_transaction(rig, "PS", pwrbuf, 6, 3);
 

--- a/rigs/kenwood/thd72.c
+++ b/rigs/kenwood/thd72.c
@@ -1456,7 +1456,7 @@ static int thd72_get_channel(RIG *rig, vfo_t vfo, channel_t *chan,
 
 static int thd72_get_block(RIG *rig, int block_num, char *block)
 {
-    hamlib_port_t *rp = &rig->state.rigport;
+    hamlib_port_t *rp = RIGPORT(rig);
     char cmd[CMD_SZ] = "R\0\0\0\0";
     char resp[CMD_SZ];
     int ret;
@@ -1518,7 +1518,7 @@ static int thd72_get_block(RIG *rig, int block_num, char *block)
 int thd72_get_chan_all_cb(RIG *rig, chan_cb_t chan_cb, rig_ptr_t arg)
 {
     int i, j, ret;
-    hamlib_port_t *rp = &rig->state.rigport;
+    hamlib_port_t *rp = RIGPORT(rig);
     channel_t *chan;
     chan_t *chan_list = rig->state.chan_list;
     int chan_next = chan_list[0].start;

--- a/rigs/kenwood/thd74.c
+++ b/rigs/kenwood/thd74.c
@@ -1448,7 +1448,7 @@ int thd74_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
 
 static int thd74_get_block(RIG *rig, int block_num, char *block)
 {
-    hamlib_port_t *rp = &rig->state.rigport;
+    hamlib_port_t *rp = RIGPORT(rig);
     char cmd[CMD_SZ] = "R\0\0\0\0";
     char resp[CMD_SZ];
     int ret;
@@ -1510,7 +1510,7 @@ static int thd74_get_block(RIG *rig, int block_num, char *block)
 int thd74_get_chan_all_cb(RIG *rig, chan_cb_t chan_cb, rig_ptr_t arg)
 {
     int i, j, ret;
-    hamlib_port_t *rp = &rig->state.rigport;
+    hamlib_port_t *rp = RIGPORT(rig);
     channel_t *chan;
     chan_t *chan_list = rig->state.chan_list;
     int chan_next = chan_list[0].start;

--- a/rigs/kenwood/ts2000.c
+++ b/rigs/kenwood/ts2000.c
@@ -519,7 +519,7 @@ static int ts2000_read_meter(RIG *rig, int expected_meter, int *value)
 {
     int retval;
     char cmdbuf[8];
-    struct rig_state *rs = &rig->state;
+    struct hamlib_port *rp = RIGPORT(rig);
     char ackbuf[32];
     int expected_len = 8;
     int read_meter;
@@ -529,7 +529,7 @@ static int ts2000_read_meter(RIG *rig, int expected_meter, int *value)
 
     SNPRINTF(cmdbuf, sizeof(cmdbuf), "RM;");
 
-    retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+    retval = write_block(rp, (unsigned char *) cmdbuf, strlen(cmdbuf));
 
     rig_debug(RIG_DEBUG_TRACE, "%s: write_block retval=%d\n", __func__, retval);
 
@@ -540,7 +540,7 @@ static int ts2000_read_meter(RIG *rig, int expected_meter, int *value)
 
     // TS-2000 returns values for a single meter at the same time, for example: RM10000;
 
-    retval = read_string(&rs->rigport, (unsigned char *) ackbuf, expected_len + 1,
+    retval = read_string(rp, (unsigned char *) ackbuf, expected_len + 1,
                          NULL, 0, 0, 1);
 
     rig_debug(RIG_DEBUG_TRACE, "%s: read_string retval=%d\n", __func__, retval);

--- a/rigs/kenwood/ts450s.c
+++ b/rigs/kenwood/ts450s.c
@@ -85,9 +85,9 @@ int ts450_open(RIG *rig)
         return err;
     }
 
-    maxtries = rig->state.rigport.retry;
+    maxtries = RIGPORT(rig)->retry;
     /* no retry for this command that may be missing */
-    rig->state.rigport.retry = 0;
+    RIGPORT(rig)->retry = 0;
 
     err = kenwood_simple_transaction(rig, "TO", 3);
 
@@ -98,7 +98,7 @@ int ts450_open(RIG *rig)
         rig->state.has_get_func &= ~RIG_FUNC_TONE;
     }
 
-    rig->state.rigport.retry = maxtries;
+    RIGPORT(rig)->retry = maxtries;
 
     return RIG_OK;
 }

--- a/rigs/kenwood/ts480.c
+++ b/rigs/kenwood/ts480.c
@@ -429,13 +429,13 @@ static int ts480_read_meters(RIG *rig, int *swr, int *comp, int *alc)
 {
     int retval;
     char *cmd = "RM;";
-    struct rig_state *rs = &rig->state;
+    struct hamlib_port *rp = RIGPORT(rig);
     char ackbuf[32];
     int expected_len = 24;
 
     ENTERFUNC;
 
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, strlen(cmd));
+    retval = write_block(rp, (unsigned char *) cmd, strlen(cmd));
 
     rig_debug(RIG_DEBUG_TRACE, "%s: write_block retval=%d\n", __func__, retval);
 
@@ -446,7 +446,7 @@ static int ts480_read_meters(RIG *rig, int *swr, int *comp, int *alc)
 
     // TS-480 returns values for all meters at the same time, for example: RM10000;RM20000;RM30000;
 
-    retval = read_string(&rs->rigport, (unsigned char *) ackbuf, expected_len + 1,
+    retval = read_string(rp, (unsigned char *) ackbuf, expected_len + 1,
                          NULL, 0, 0, 1);
 
     rig_debug(RIG_DEBUG_TRACE, "%s: read_string retval=%d\n", __func__, retval);

--- a/rigs/kenwood/ts590.c
+++ b/rigs/kenwood/ts590.c
@@ -596,13 +596,13 @@ static int ts590_read_meters(RIG *rig, int *swr, int *comp, int *alc)
 {
     int retval;
     char *cmd = "RM;";
-    struct rig_state *rs = &rig->state;
+    struct hamlib_port *rp = RIGPORT(rig);
     char ackbuf[32];
     int expected_len = 24;
 
     ENTERFUNC;
 
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, strlen(cmd));
+    retval = write_block(rp, (unsigned char *) cmd, strlen(cmd));
 
     rig_debug(RIG_DEBUG_TRACE, "%s: write_block retval=%d\n", __func__, retval);
 
@@ -613,7 +613,7 @@ static int ts590_read_meters(RIG *rig, int *swr, int *comp, int *alc)
 
     // TS-590 returns values for all meters at the same time, for example: RM10000;RM20000;RM30000;
 
-    retval = read_string(&rs->rigport, (unsigned char *) ackbuf, expected_len + 1,
+    retval = read_string(rp, (unsigned char *) ackbuf, expected_len + 1,
                          NULL, 0, 0, 1);
 
     rig_debug(RIG_DEBUG_TRACE, "%s: read_string retval=%d\n", __func__, retval);

--- a/rigs/kenwood/xg3.c
+++ b/rigs/kenwood/xg3.c
@@ -198,7 +198,7 @@ int xg3_init(RIG *rig)
     }
 
     rig->state.priv = (void *)priv;
-    rig->state.rigport.type.rig = RIG_PORT_SERIAL;
+    RIGPORT(rig)->type.rig = RIG_PORT_SERIAL;
 // Tried set_trn to turn transceiver on/off but turning it on isn't enabled in hamlib for some reason
 // So we use PTT instead
 //  rig->state.transceive = RIG_TRN_RIG; // this allows xg3_set_trn to be called
@@ -280,7 +280,7 @@ int xg3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     char cmdbuf[32], replybuf[32];
     int retval;
     size_t replysize = sizeof(replybuf);
-    struct rig_state *rs = &rig->state;
+    struct hamlib_port *rp = RIGPORT(rig);
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
@@ -288,7 +288,7 @@ int xg3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     {
     case RIG_LEVEL_RFPOWER:
         SNPRINTF(cmdbuf, sizeof(cmdbuf), "L;");
-        retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+        retval = write_block(rp, (unsigned char *) cmdbuf, strlen(cmdbuf));
 
         if (retval != RIG_OK)
         {
@@ -297,7 +297,7 @@ int xg3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
             return retval;
         }
 
-        retval = read_string(&rs->rigport, (unsigned char *) replybuf, replysize,
+        retval = read_string(rp, (unsigned char *) replybuf, replysize,
                              ";", 1, 0, 1);
 
         if (retval < 0)
@@ -424,7 +424,7 @@ int xg3_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
  */
 int xg3_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
-    struct rig_state *rs;
+    struct hamlib_port *rp;
     char freqbuf[50];
     int freqsize = sizeof(freqbuf);
     char cmdbuf[16];
@@ -441,7 +441,7 @@ int xg3_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
     tvfo = (vfo == RIG_VFO_CURR ||
             vfo == RIG_VFO_VFO) ? rig->state.current_vfo : vfo;
-    rs = &rig->state;
+    rp = RIGPORT(rig);
 
     switch (tvfo)
     {
@@ -467,7 +467,7 @@ int xg3_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
         SNPRINTF(cmdbuf, sizeof(cmdbuf), "F;");
     }
 
-    retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+    retval = write_block(rp, (unsigned char *) cmdbuf, strlen(cmdbuf));
 
     if (retval != RIG_OK)
     {
@@ -475,7 +475,7 @@ int xg3_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
         return retval;
     }
 
-    retval = read_string(&rs->rigport, (unsigned char *) freqbuf, freqsize,
+    retval = read_string(rp, (unsigned char *) freqbuf, freqsize,
                          ";", 1, 0, 1);
 
     if (retval < 0)
@@ -574,7 +574,7 @@ int xg3_get_mem(RIG *rig, vfo_t vfo, int *ch)
     char cmdbuf[32];
     char reply[32];
     int retval;
-    struct rig_state *rs = &rig->state;
+    struct hamlib_port *rp = RIGPORT(rig);
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
@@ -586,7 +586,7 @@ int xg3_get_mem(RIG *rig, vfo_t vfo, int *ch)
         return retval;
     }
 
-    retval = read_string(&rs->rigport, (unsigned char *) reply, sizeof(reply),
+    retval = read_string(rp, (unsigned char *) reply, sizeof(reply),
                          ";", 1, 0, 1);
 
     if (retval < 0)


### PR DESCRIPTION
Proposed implementation for pointerizing addresses of port structures.

Define macros that return pointers to the current tables.  After converting all references to use the macros instead of hard coding, the macro definitions can be changed as needed to address dynamically created and expandable structures.

Phase 1 of issue #1445 

