### PR TITLE
Phase 2 of moving port structures

### DIFF
--- a/include/hamlib/amplifier.h
+++ b/include/hamlib/amplifier.h
@@ -18,6 +18,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #ifndef _AMPLIFIER_H
 #define _AMPLIFIER_H 1
@@ -444,6 +445,8 @@ rig_ext_lookup HAMLIB_PARAMS((RIG *rig,
 
 extern HAMLIB_EXPORT(setting_t) amp_parse_level(const char *s);
 extern HAMLIB_EXPORT(const char *) amp_strlevel(setting_t);
+
+extern HAMLIB_EXPORT(void *) amp_data_pointer(AMP *amp, rig_ptrx_t idx);
 
 //! @endcond
 

--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -2489,13 +2489,13 @@ typedef hamlib_port_t port_t;
  */
 #else
 /* Define external unique names */
-#define HAMLIB_RIGPORT(r) (hamlib_port_t *)rig_data_pointer(r, RIG_PTRX_RIGPORT)
-#define HAMLIB_PTTPORT(r) (hamlib_port_t *)rig_data_pointer(r, RIG_PTRX_PTTPORT)
-#define HAMLIB_DCDPORT(r) (hamlib_port_t *)rig_data_pointer(r, RIG_PTRX_DCDPORT)
-//#define HAMLIB_CACHE(r) (struct rig_cache *)rig_data_pointer(r, RIG_PTRX_CACHE)
-#define HAMLIB_AMPPORT(a) (hamlib_port_t *)amp_data_pointer(a, RIG_PTRX_AMPPORT)
-#define HAMLIB_ROTPORT(r) (hamlib_port_t *)rot_data_pointer(r, RIG_PTRX_ROTPORT)
-#define HAMLIB_ROTPORT2(r) (hamlib_port_t *)rot_data_pointer(r, RIG_PTRX_ROTPORT2)
+#define HAMLIB_RIGPORT(r) ((hamlib_port_t *)rig_data_pointer(r, RIG_PTRX_RIGPORT))
+#define HAMLIB_PTTPORT(r) ((hamlib_port_t *)rig_data_pointer(r, RIG_PTRX_PTTPORT))
+#define HAMLIB_DCDPORT(r) ((hamlib_port_t *)rig_data_pointer(r, RIG_PTRX_DCDPORT))
+#define HAMLIB_CACHE(r) ((struct rig_cache *)rig_data_pointer(r, RIG_PTRX_CACHE))
+#define HAMLIB_AMPPORT(a) ((hamlib_port_t *)amp_data_pointer(a, RIG_PTRX_AMPPORT))
+#define HAMLIB_ROTPORT(r) ((hamlib_port_t *)rot_data_pointer(r, RIG_PTRX_ROTPORT))
+#define HAMLIB_ROTPORT2(r) ((hamlib_port_t *)rot_data_pointer(r, RIG_PTRX_ROTPORT2))
 #endif
 
 typedef enum {

--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -2479,6 +2479,8 @@ typedef hamlib_port_t port_t;
 #define PTTPORT(r) (&r->state.pttport)
 #define DCDPORT(r) (&r->state.dcdport)
 #define CACHE(r) (&r->state.cache)
+#define AMPPORT(a) (&a->state.ampport)
+#define ROTPORT(r) (&r->state.rotport)
 /* Then when the rigport address is stored as a pointer somewhere else(say,
  *  in the rig structure itself), the definition could be changed to
  *  #define RIGPORT(r) r->somewhereelse
@@ -2486,12 +2488,25 @@ typedef hamlib_port_t port_t;
  */
 #else
 /* Define external unique names */
-/* These will be changed to a function call before release */
-#define HAMLIB_RIGPORT(r) (&r->state.rigport)
-#define HAMLIB_PTTPORT(r) (&r->state.pttport)
-#define HAMLIB_DCDPORT(r) (&r->state.dcdport)
-//#define HAMLIB_CACHE(r) (&r->state.cache)
+#define HAMLIB_RIGPORT(r) (hamlib_port_t *)rig_data_pointer(r, RIG_PTRX_RIGPORT)
+#define HAMLIB_PTTPORT(r) (hamlib_port_t *)rig_data_pointer(r, RIG_PTRX_PTTPORT)
+#define HAMLIB_DCDPORT(r) (hamlib_port_t *)rig_data_pointer(r, RIG_PTRX_DCDPORT)
+//#define HAMLIB_CACHE(r) (struct rig_cache *)rig_data_pointer(r, RIG_PTRX_CACHE)
+#define HAMLIB_AMPPORT(a) (hamlib_port_t *)amp_data_pointer(a, RIG_PTRX_AMPPORT)
+#define HAMLIB_ROTPORT(r) (hamlib_port_t *)rot_data_pointer(r, RIG_PTRX_ROTPORT)
 #endif
+
+typedef enum {
+    RIG_PTRX_NONE=0,
+    RIG_PTRX_RIGPORT,
+    RIG_PTRX_PTTPORT,
+    RIG_PTRX_DCDPORT,
+    RIG_PTRX_CACHE,
+    RIG_PTRX_AMPPORT,
+    RIG_PTRX_ROTPORT,
+// New entries go directly above this line====================
+    RIG_PTRX_MAXIMUM
+} rig_ptrx_t;
 
 #define HAMLIB_ELAPSED_GET 0
 #define HAMLIB_ELAPSED_SET 1
@@ -3829,6 +3844,7 @@ enum GPIO { GPIO1, GPIO2, GPIO3, GPIO4 };
 extern HAMLIB_EXPORT(int) rig_cm108_get_bit(hamlib_port_t *p, enum GPIO gpio, int *bit);
 extern HAMLIB_EXPORT(int) rig_cm108_set_bit(hamlib_port_t *p, enum GPIO gpio, int bit);
 
+extern HAMLIB_EXPORT(void *) rig_data_pointer(RIG *rig, rig_ptrx_t idx);
 
 //! @endcond
 

--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -2481,6 +2481,7 @@ typedef hamlib_port_t port_t;
 #define CACHE(r) (&r->state.cache)
 #define AMPPORT(a) (&a->state.ampport)
 #define ROTPORT(r) (&r->state.rotport)
+#define ROTPORT2(r) (&r->state.rotport2)
 /* Then when the rigport address is stored as a pointer somewhere else(say,
  *  in the rig structure itself), the definition could be changed to
  *  #define RIGPORT(r) r->somewhereelse
@@ -2494,6 +2495,7 @@ typedef hamlib_port_t port_t;
 //#define HAMLIB_CACHE(r) (struct rig_cache *)rig_data_pointer(r, RIG_PTRX_CACHE)
 #define HAMLIB_AMPPORT(a) (hamlib_port_t *)amp_data_pointer(a, RIG_PTRX_AMPPORT)
 #define HAMLIB_ROTPORT(r) (hamlib_port_t *)rot_data_pointer(r, RIG_PTRX_ROTPORT)
+#define HAMLIB_ROTPORT2(r) (hamlib_port_t *)rot_data_pointer(r, RIG_PTRX_ROTPORT2)
 #endif
 
 typedef enum {
@@ -2504,6 +2506,7 @@ typedef enum {
     RIG_PTRX_CACHE,
     RIG_PTRX_AMPPORT,
     RIG_PTRX_ROTPORT,
+    RIG_PTRX_ROTPORT2,
 // New entries go directly above this line====================
     RIG_PTRX_MAXIMUM
 } rig_ptrx_t;

--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -19,7 +19,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
-
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #ifndef _RIG_H
 #define _RIG_H 1
@@ -2463,10 +2463,14 @@ typedef hamlib_port_t_deprecated port_t_deprecated;
 typedef hamlib_port_t port_t;
 #endif
 
-/* Macros to access port structures/pointers
+/* Macros to access data structures/pointers
  * Make it easier to change location in preparation
  *   for moving them out of rig->state.
  * See https://github.com/Hamlib/Hamlib/issues/1445
+ *     https://github.com/Hamlib/Hamlib/issues/1452
+ *     https://github.com/Hamlib/Hamlib/issues/1420
+ *     https://github.com/Hamlib/Hamlib/issues/536
+ *     https://github.com/Hamlib/Hamlib/issues/487
  */
 // Note: Experimental, and subject to change!!
 #if defined(IN_HAMLIB)
@@ -2474,18 +2478,20 @@ typedef hamlib_port_t port_t;
 #define RIGPORT(r) (&r->state.rigport)
 #define PTTPORT(r) (&r->state.pttport)
 #define DCDPORT(r) (&r->state.dcdport)
+#define CACHE(r) (&r->state.cache)
+/* Then when the rigport address is stored as a pointer somewhere else(say,
+ *  in the rig structure itself), the definition could be changed to
+ *  #define RIGPORT(r) r->somewhereelse
+ *  and every reference is updated.
+ */
 #else
 /* Define external unique names */
 /* These will be changed to a function call before release */
 #define HAMLIB_RIGPORT(r) (&r->state.rigport)
 #define HAMLIB_PTTPORT(r) (&r->state.pttport)
 #define HAMLIB_DCDPORT(r) (&r->state.dcdport)
+//#define HAMLIB_CACHE(r) (&r->state.cache)
 #endif
-/* Then when the rigport address is stored as a pointer somewhere else(say,
- *  in the rig structure itself), the definition could be changed to
- *  #define RIGPORT(r) r->somewhereelse
- *  and every reference is updated.
- */
 
 #define HAMLIB_ELAPSED_GET 0
 #define HAMLIB_ELAPSED_SET 1

--- a/include/hamlib/rotator.h
+++ b/include/hamlib/rotator.h
@@ -18,6 +18,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #ifndef _ROTATOR_H
 #define _ROTATOR_H 1
@@ -796,6 +797,8 @@ extern HAMLIB_EXPORT(const char *) rot_strfunc(setting_t);
 extern HAMLIB_EXPORT(const char *) rot_strlevel(setting_t);
 extern HAMLIB_EXPORT(const char *) rot_strparm(setting_t);
 extern HAMLIB_EXPORT(const char *) rot_strstatus(rot_status_t);
+
+extern HAMLIB_EXPORT(void *) rot_data_pointer(ROT *rot, rig_ptrx_t idx);
 
 //! @endcond
 

--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -1576,9 +1576,9 @@ int kenwood_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t txvfo)
     tsplit = RIG_SPLIT_OFF; // default in case rig does not set split status
     retval = rig_get_split_vfo(rig, vfo, &tsplit, &tx_vfo);
 
-    priv->split = rig->state.cache.split = split;
-    rig->state.cache.split_vfo = txvfo;
-    elapsed_ms(&rig->state.cache.time_split, HAMLIB_ELAPSED_SET);
+    priv->split = CACHE(rig)->split = split;
+    CACHE(rig)->split_vfo = txvfo;
+    elapsed_ms(&CACHE(rig)->time_split, HAMLIB_ELAPSED_SET);
 
     // and it should be OK to do a SPLIT_OFF at any time so we won's skip that
     if (retval == RIG_OK && split == RIG_SPLIT_ON && tsplit == RIG_SPLIT_ON)
@@ -1598,7 +1598,7 @@ int kenwood_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t txvfo)
             || rig->caps->rig_model == RIG_MODEL_KX2
             || rig->caps->rig_model == RIG_MODEL_KX3)
     {
-        rig_set_freq(rig, RIG_VFO_B, rig->state.cache.freqMainA);
+        rig_set_freq(rig, RIG_VFO_B, CACHE(rig)->freqMainA);
     }
 
     if (retval != RIG_OK)
@@ -1607,8 +1607,8 @@ int kenwood_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t txvfo)
     }
 
     /* Remember whether split is on, for kenwood_set_vfo */
-    priv->split = rig->state.cache.split = split;
-    elapsed_ms(&rig->state.cache.time_split, HAMLIB_ELAPSED_SET);
+    priv->split = CACHE(rig)->split = split;
+    elapsed_ms(&CACHE(rig)->time_split, HAMLIB_ELAPSED_SET);
 
     RETURNFUNC2(RIG_OK);
 }
@@ -2964,7 +2964,7 @@ static int kenwood_get_power_minmax(RIG *rig, int *power_now, int *power_min,
     }
 
     // Don't do this if PTT is on...don't want to max out power!!
-    if (rs->cache.ptt == RIG_PTT_ON)
+    if (CACHE(rig)->ptt == RIG_PTT_ON)
     {
         rig_debug(RIG_DEBUG_TRACE, "%s: ptt on so not checking min/max power levels\n",
                   __func__);

--- a/src/amplifier.c
+++ b/src/amplifier.c
@@ -20,6 +20,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 /**
  * \addtogroup amplifier
@@ -185,6 +186,7 @@ AMP *HAMLIB_API amp_init(amp_model_t amp_model)
     AMP *amp;
     const struct amp_caps *caps;
     struct amp_state *rs;
+    hamlib_port_t *ap;
 
     amp_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
@@ -224,37 +226,41 @@ AMP *HAMLIB_API amp_init(amp_model_t amp_model)
      */
     rs = &amp->state;
 
-    rs->comm_state = 0;
-    rs->ampport.type.rig = caps->port_type; /* default from caps */
+    //TODO allocate and link new ampport
+    // For now, use the embedded one
+    ap = AMPPORT(amp);
 
-    rs->ampport.write_delay = caps->write_delay;
-    rs->ampport.post_write_delay = caps->post_write_delay;
-    rs->ampport.timeout = caps->timeout;
-    rs->ampport.retry = caps->retry;
+    rs->comm_state = 0;
+    ap->type.rig = caps->port_type; /* default from caps */
+
+    ap->write_delay = caps->write_delay;
+    ap->post_write_delay = caps->post_write_delay;
+    ap->timeout = caps->timeout;
+    ap->retry = caps->retry;
     rs->has_get_level = caps->has_get_level;
 
     switch (caps->port_type)
     {
     case RIG_PORT_SERIAL:
         // Don't think we need a default port here
-        //strncpy(rs->ampport.pathname, DEFAULT_SERIAL_PORT, HAMLIB_FILPATHLEN - 1);
-        rs->ampport.parm.serial.rate = caps->serial_rate_max;   /* fastest ! */
-        rs->ampport.parm.serial.data_bits = caps->serial_data_bits;
-        rs->ampport.parm.serial.stop_bits = caps->serial_stop_bits;
-        rs->ampport.parm.serial.parity = caps->serial_parity;
-        rs->ampport.parm.serial.handshake = caps->serial_handshake;
+        //strncpy(ap->pathname, DEFAULT_SERIAL_PORT, HAMLIB_FILPATHLEN - 1);
+        ap->parm.serial.rate = caps->serial_rate_max;   /* fastest ! */
+        ap->parm.serial.data_bits = caps->serial_data_bits;
+        ap->parm.serial.stop_bits = caps->serial_stop_bits;
+        ap->parm.serial.parity = caps->serial_parity;
+        ap->parm.serial.handshake = caps->serial_handshake;
         break;
 
     case RIG_PORT_NETWORK:
     case RIG_PORT_UDP_NETWORK:
-        strncpy(rs->ampport.pathname, "127.0.0.1:4531", HAMLIB_FILPATHLEN - 1);
+        strncpy(ap->pathname, "127.0.0.1:4531", HAMLIB_FILPATHLEN - 1);
         break;
 
     default:
-        strncpy(rs->ampport.pathname, "", HAMLIB_FILPATHLEN - 1);
+        strncpy(ap->pathname, "", HAMLIB_FILPATHLEN - 1);
     }
 
-    rs->ampport.fd = -1;
+    ap->fd = -1;
 
     /*
      * let the backend a chance to setup his private data
@@ -279,7 +285,7 @@ AMP *HAMLIB_API amp_init(amp_model_t amp_model)
     // Now we have to copy our new rig state hamlib_port structure to the deprecated one
     // Clients built on older 4.X versions will use the old structure
     // Clients built on newer 4.5 versions will use the new structure
-    memcpy(&amp->state.ampport_deprecated, &amp->state.ampport,
+    memcpy(&amp->state.ampport_deprecated, ap,
            sizeof(amp->state.ampport_deprecated));
 
     return amp;
@@ -306,6 +312,7 @@ int HAMLIB_API amp_open(AMP *amp)
 {
     const struct amp_caps *caps;
     struct amp_state *rs;
+    hamlib_port_t *ap = AMPPORT(amp);
     int status;
     int net1, net2, net3, net4, port;
 
@@ -324,21 +331,21 @@ int HAMLIB_API amp_open(AMP *amp)
         return -RIG_EINVAL;
     }
 
-    rs->ampport.fd = -1;
+    ap->fd = -1;
 
     // determine if we have a network address
-    if (sscanf(rs->ampport.pathname, "%d.%d.%d.%d:%d", &net1, &net2, &net3, &net4,
+    if (sscanf(ap->pathname, "%d.%d.%d.%d:%d", &net1, &net2, &net3, &net4,
                &port) == 5)
     {
         rig_debug(RIG_DEBUG_TRACE, "%s: using network address %s\n", __func__,
-                  rs->ampport.pathname);
-        rs->ampport.type.rig = RIG_PORT_NETWORK;
+                  ap->pathname);
+        ap->type.rig = RIG_PORT_NETWORK;
     }
 
-    switch (rs->ampport.type.rig)
+    switch (ap->type.rig)
     {
     case RIG_PORT_SERIAL:
-        status = serial_open(&rs->ampport);
+        status = serial_open(ap);
 
         if (status != 0)
         {
@@ -348,7 +355,7 @@ int HAMLIB_API amp_open(AMP *amp)
         break;
 
     case RIG_PORT_PARALLEL:
-        status = par_open(&rs->ampport);
+        status = par_open(ap);
 
         if (status < 0)
         {
@@ -358,18 +365,18 @@ int HAMLIB_API amp_open(AMP *amp)
         break;
 
     case RIG_PORT_DEVICE:
-        status = open(rs->ampport.pathname, O_RDWR, 0);
+        status = open(ap->pathname, O_RDWR, 0);
 
         if (status < 0)
         {
             return -RIG_EIO;
         }
 
-        rs->ampport.fd = status;
+        ap->fd = status;
         break;
 
     case RIG_PORT_USB:
-        status = usb_port_open(&rs->ampport);
+        status = usb_port_open(ap);
 
         if (status < 0)
         {
@@ -385,7 +392,7 @@ int HAMLIB_API amp_open(AMP *amp)
     case RIG_PORT_NETWORK:
     case RIG_PORT_UDP_NETWORK:
         /* FIXME: default port */
-        status = network_open(&rs->ampport, 4531);
+        status = network_open(ap, 4531);
 
         if (status < 0)
         {
@@ -412,31 +419,31 @@ int HAMLIB_API amp_open(AMP *amp)
 
         if (status != RIG_OK)
         {
-            memcpy(&amp->state.ampport_deprecated, &amp->state.ampport,
+	    memcpy(&amp->state.ampport_deprecated, ap,
                    sizeof(amp->state.ampport_deprecated));
             return status;
         }
     }
 
-    if (rs->ampport.parm.serial.dtr_state == RIG_SIGNAL_ON)
+    if (ap->parm.serial.dtr_state == RIG_SIGNAL_ON)
     {
-        ser_set_dtr(&rs->ampport, 1);
+        ser_set_dtr(ap, 1);
     }
     else
     {
-        ser_set_dtr(&rs->ampport, 0);
+        ser_set_dtr(ap, 0);
     }
 
-    if (rs->ampport.parm.serial.rts_state == RIG_SIGNAL_ON)
+    if (ap->parm.serial.rts_state == RIG_SIGNAL_ON)
     {
-        ser_set_rts(&rs->ampport, 1);
+        ser_set_rts(ap, 1);
     }
     else
     {
-        ser_set_rts(&rs->ampport, 0);
+        ser_set_rts(ap, 0);
     }
 
-    memcpy(&amp->state.ampport_deprecated, &amp->state.ampport,
+    memcpy(&amp->state.ampport_deprecated, ap,
            sizeof(amp->state.ampport_deprecated));
 
     return RIG_OK;
@@ -464,6 +471,7 @@ int HAMLIB_API amp_close(AMP *amp)
 {
     const struct amp_caps *caps;
     struct amp_state *rs;
+    hamlib_port_t *ap = AMPPORT(amp);
 
     amp_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
@@ -499,32 +507,32 @@ int HAMLIB_API amp_close(AMP *amp)
     }
 
 
-    if (rs->ampport.fd != -1)
+    if (ap->fd != -1)
     {
-        switch (rs->ampport.type.rig)
+        switch (ap->type.rig)
         {
         case RIG_PORT_SERIAL:
-            ser_close(&rs->ampport);
+            ser_close(ap);
             break;
 
         case RIG_PORT_PARALLEL:
-            par_close(&rs->ampport);
+            par_close(ap);
             break;
 
         case RIG_PORT_USB:
-            usb_port_close(&rs->ampport);
+            usb_port_close(ap);
             break;
 
         case RIG_PORT_NETWORK:
         case RIG_PORT_UDP_NETWORK:
-            network_close(&rs->ampport);
+            network_close(ap);
             break;
 
         default:
-            close(rs->ampport.fd);
+            close(ap->fd);
         }
 
-        rs->ampport.fd = -1;
+        ap->fd = -1;
     }
 
     remove_opened_amp(amp);
@@ -949,5 +957,21 @@ int HAMLIB_API amp_get_powerstat(AMP *amp, powerstat_t *status)
     return amp->caps->get_powerstat(amp, status);
 }
 
-
+/**
+ * \brief Get the address of amplifier data structure(s)
+ *
+ * \sa rig_data_pointer
+ *
+ */
+void * HAMLIB_API amp_data_pointer(AMP *amp, rig_ptrx_t idx)
+{
+  switch(idx)
+    {
+    case RIG_PTRX_AMPPORT:
+      return AMPPORT(amp);
+    default:
+      amp_debug(RIG_DEBUG_ERR, "%s: Invalid data index=%d\n", __func__, idx);
+      return NULL;
+    }
+}
 /*! @} */

--- a/src/conf.c
+++ b/src/conf.c
@@ -573,7 +573,7 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
         }
 
         // JTDX and WSJTX currently use state.pttport to check for PTT_NONE
-        rig->state.pttport.type.ptt = pttp->type.ptt;
+//        rig->state.pttport.type.ptt = pttp->type.ptt;
         rs->pttport_deprecated.type.ptt = pttp->type.ptt;
 
         break;

--- a/src/conf.c
+++ b/src/conf.c
@@ -239,6 +239,9 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
 {
     struct rig_caps *caps;
     struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
+    hamlib_port_t *pttp = PTTPORT(rig);
+    hamlib_port_t *dcdp = DCDPORT(rig);
     long val_i;
 
     caps = rig->caps;
@@ -247,7 +250,7 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
     switch (token)
     {
     case TOK_PATHNAME:
-        strncpy(rs->rigport.pathname, val, HAMLIB_FILPATHLEN - 1);
+        strncpy(rp->pathname, val, HAMLIB_FILPATHLEN - 1);
         strncpy(rs->rigport_deprecated.pathname, val, HAMLIB_FILPATHLEN - 1);
         break;
 
@@ -257,7 +260,7 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
             return -RIG_EINVAL;//value format error
         }
 
-        rs->rigport.write_delay = val_i;
+        rp->write_delay = val_i;
         rs->rigport_deprecated.write_delay = val_i;
         break;
 
@@ -267,7 +270,7 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
             return -RIG_EINVAL;//value format error
         }
 
-        rs->rigport.post_write_delay = val_i;
+        rp->post_write_delay = val_i;
         rs->rigport_deprecated.post_write_delay = val_i;
         break;
 
@@ -286,7 +289,7 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
             return -RIG_EINVAL;//value format error
         }
 
-        rs->rigport.timeout = val_i;
+        rp->timeout = val_i;
         rs->rigport_deprecated.timeout = val_i;
         break;
 
@@ -296,12 +299,12 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
             return -RIG_EINVAL;//value format error
         }
 
-        rs->rigport.retry = val_i;
+        rp->retry = val_i;
         rs->rigport_deprecated.retry = val_i;
         break;
 
     case TOK_SERIAL_SPEED:
-        if (rs->rigport.type.rig != RIG_PORT_SERIAL)
+        if (rp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
@@ -311,12 +314,12 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
             return -RIG_EINVAL;//value format error
         }
 
-        rs->rigport.parm.serial.rate = val_i;
+        rp->parm.serial.rate = val_i;
         rs->rigport_deprecated.parm.serial.rate = val_i;
         break;
 
     case TOK_DATA_BITS:
-        if (rs->rigport.type.rig != RIG_PORT_SERIAL)
+        if (rp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
@@ -326,12 +329,12 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
             return -RIG_EINVAL;//value format error
         }
 
-        rs->rigport.parm.serial.data_bits = val_i;
+        rp->parm.serial.data_bits = val_i;
         rs->rigport_deprecated.parm.serial.data_bits = val_i;
         break;
 
     case TOK_STOP_BITS:
-        if (rs->rigport.type.rig != RIG_PORT_SERIAL)
+        if (rp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
@@ -341,39 +344,39 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
             return -RIG_EINVAL;//value format error
         }
 
-        rs->rigport.parm.serial.stop_bits = val_i;
+        rp->parm.serial.stop_bits = val_i;
         rs->rigport_deprecated.parm.serial.stop_bits = val_i;
         break;
 
     case TOK_PARITY:
-        if (rs->rigport.type.rig != RIG_PORT_SERIAL)
+        if (rp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
         if (!strcmp(val, "None"))
         {
-            rs->rigport.parm.serial.parity = RIG_PARITY_NONE;
+            rp->parm.serial.parity = RIG_PARITY_NONE;
             rs->rigport_deprecated.parm.serial.parity = RIG_PARITY_SPACE;
         }
         else if (!strcmp(val, "Odd"))
         {
-            rs->rigport.parm.serial.parity = RIG_PARITY_ODD;
+            rp->parm.serial.parity = RIG_PARITY_ODD;
             rs->rigport_deprecated.parm.serial.parity = RIG_PARITY_SPACE;
         }
         else if (!strcmp(val, "Even"))
         {
-            rs->rigport.parm.serial.parity = RIG_PARITY_EVEN;
+            rp->parm.serial.parity = RIG_PARITY_EVEN;
             rs->rigport_deprecated.parm.serial.parity = RIG_PARITY_SPACE;
         }
         else if (!strcmp(val, "Mark"))
         {
-            rs->rigport.parm.serial.parity = RIG_PARITY_MARK;
+            rp->parm.serial.parity = RIG_PARITY_MARK;
             rs->rigport_deprecated.parm.serial.parity = RIG_PARITY_SPACE;
         }
         else if (!strcmp(val, "Space"))
         {
-            rs->rigport.parm.serial.parity = RIG_PARITY_SPACE;
+            rp->parm.serial.parity = RIG_PARITY_SPACE;
             rs->rigport_deprecated.parm.serial.parity = RIG_PARITY_SPACE;
         }
         else
@@ -384,7 +387,7 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
         break;
 
     case TOK_HANDSHAKE:
-        if (rs->rigport.type.rig != RIG_PORT_SERIAL)
+        if (rp->type.rig != RIG_PORT_SERIAL)
         {
             rig_debug(RIG_DEBUG_ERR,
                       "%s: setting handshake is invalid for non-serial port rig type\n",
@@ -394,17 +397,17 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
 
         if (!strcmp(val, "None"))
         {
-            rs->rigport.parm.serial.handshake = RIG_HANDSHAKE_NONE;
+            rp->parm.serial.handshake = RIG_HANDSHAKE_NONE;
             rs->rigport_deprecated.parm.serial.handshake = RIG_HANDSHAKE_HARDWARE;
         }
         else if (!strcmp(val, "XONXOFF"))
         {
-            rs->rigport.parm.serial.handshake = RIG_HANDSHAKE_XONXOFF;
+            rp->parm.serial.handshake = RIG_HANDSHAKE_XONXOFF;
             rs->rigport_deprecated.parm.serial.handshake = RIG_HANDSHAKE_HARDWARE;
         }
         else if (!strcmp(val, "Hardware"))
         {
-            rs->rigport.parm.serial.handshake = RIG_HANDSHAKE_HARDWARE;
+            rp->parm.serial.handshake = RIG_HANDSHAKE_HARDWARE;
             rs->rigport_deprecated.parm.serial.handshake = RIG_HANDSHAKE_HARDWARE;
         }
         else
@@ -415,24 +418,24 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
         break;
 
     case TOK_RTS_STATE:
-        if (rs->rigport.type.rig != RIG_PORT_SERIAL)
+        if (rp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
         if (!strcmp(val, "Unset"))
         {
-            rs->rigport.parm.serial.rts_state = RIG_SIGNAL_UNSET;
+            rp->parm.serial.rts_state = RIG_SIGNAL_UNSET;
             rs->rigport_deprecated.parm.serial.rts_state = RIG_SIGNAL_UNSET;
         }
         else if (!strcmp(val, "ON"))
         {
-            rs->rigport.parm.serial.rts_state = RIG_SIGNAL_ON;
+            rp->parm.serial.rts_state = RIG_SIGNAL_ON;
             rs->rigport_deprecated.parm.serial.rts_state = RIG_SIGNAL_ON;
         }
         else if (!strcmp(val, "OFF"))
         {
-            rs->rigport.parm.serial.rts_state = RIG_SIGNAL_OFF;
+            rp->parm.serial.rts_state = RIG_SIGNAL_OFF;
             rs->rigport_deprecated.parm.serial.rts_state = RIG_SIGNAL_OFF;
         }
         else
@@ -443,24 +446,24 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
         break;
 
     case TOK_DTR_STATE:
-        if (rs->rigport.type.rig != RIG_PORT_SERIAL)
+        if (rp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
         if (!strcmp(val, "Unset"))
         {
-            rs->rigport.parm.serial.dtr_state = RIG_SIGNAL_UNSET;
+            rp->parm.serial.dtr_state = RIG_SIGNAL_UNSET;
             rs->rigport_deprecated.parm.serial.dtr_state = RIG_SIGNAL_UNSET;
         }
         else if (!strcmp(val, "ON"))
         {
-            rs->rigport.parm.serial.dtr_state = RIG_SIGNAL_ON;
+            rp->parm.serial.dtr_state = RIG_SIGNAL_ON;
             rs->rigport_deprecated.parm.serial.dtr_state = RIG_SIGNAL_ON;
         }
         else if (!strcmp(val, "OFF"))
         {
-            rs->rigport.parm.serial.dtr_state = RIG_SIGNAL_OFF;
+            rp->parm.serial.dtr_state = RIG_SIGNAL_OFF;
             rs->rigport_deprecated.parm.serial.dtr_state = RIG_SIGNAL_OFF;
         }
         else
@@ -522,46 +525,46 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
     case TOK_PTT_TYPE:
         if (!strcmp(val, "RIG"))
         {
-            rs->pttport.type.ptt = RIG_PTT_RIG;
+            pttp->type.ptt = RIG_PTT_RIG;
             caps->ptt_type = RIG_PTT_RIG;
         }
         else if (!strcmp(val, "RIGMICDATA"))
         {
-            rs->pttport.type.ptt = RIG_PTT_RIG_MICDATA;
+            pttp->type.ptt = RIG_PTT_RIG_MICDATA;
             caps->ptt_type = RIG_PTT_RIG_MICDATA;
         }
         else if (!strcmp(val, "DTR"))
         {
-            rs->pttport.type.ptt = RIG_PTT_SERIAL_DTR;
+            pttp->type.ptt = RIG_PTT_SERIAL_DTR;
             caps->ptt_type = RIG_PTT_SERIAL_DTR;
         }
         else if (!strcmp(val, "RTS"))
         {
-            rs->pttport.type.ptt = RIG_PTT_SERIAL_RTS;
+            pttp->type.ptt = RIG_PTT_SERIAL_RTS;
             caps->ptt_type = RIG_PTT_SERIAL_RTS;
         }
         else if (!strcmp(val, "Parallel"))
         {
-            rs->pttport.type.ptt = RIG_PTT_PARALLEL;
+            pttp->type.ptt = RIG_PTT_PARALLEL;
             caps->ptt_type = RIG_PTT_PARALLEL;
         }
         else if (!strcmp(val, "CM108"))
         {
-            rs->pttport.type.ptt = RIG_PTT_CM108;
+            pttp->type.ptt = RIG_PTT_CM108;
             caps->ptt_type = RIG_PTT_CM108;
         }
         else if (!strcmp(val, "GPIO"))
         {
-            rs->pttport.type.ptt = RIG_PTT_GPIO;
+            pttp->type.ptt = RIG_PTT_GPIO;
         }
         else if (!strcmp(val, "GPION"))
         {
-            rs->pttport.type.ptt = RIG_PTT_GPION;
+            pttp->type.ptt = RIG_PTT_GPION;
             caps->ptt_type = RIG_PTT_GPION;
         }
         else if (!strcmp(val, "None"))
         {
-            rs->pttport.type.ptt = RIG_PTT_NONE;
+            pttp->type.ptt = RIG_PTT_NONE;
             caps->ptt_type = RIG_PTT_NONE;
         }
         else
@@ -570,13 +573,13 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
         }
 
         // JTDX and WSJTX currently use state.pttport to check for PTT_NONE
-        rig->state.pttport.type.ptt = rs->pttport.type.ptt;
-        rs->pttport_deprecated.type.ptt = rs->pttport.type.ptt;
+        rig->state.pttport.type.ptt = pttp->type.ptt;
+        rs->pttport_deprecated.type.ptt = pttp->type.ptt;
 
         break;
 
     case TOK_PTT_PATHNAME:
-        strncpy(rs->pttport.pathname, val, HAMLIB_FILPATHLEN - 1);
+        strncpy(pttp->pathname, val, HAMLIB_FILPATHLEN - 1);
         strncpy(rs->pttport_deprecated.pathname, val, HAMLIB_FILPATHLEN - 1);
         break;
 
@@ -586,55 +589,55 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
             return -RIG_EINVAL;//value format error
         }
 
-        rs->pttport.parm.cm108.ptt_bitnum = val_i;
-        rs->rigport.parm.cm108.ptt_bitnum = val_i;
+        pttp->parm.cm108.ptt_bitnum = val_i;
+        rp->parm.cm108.ptt_bitnum = val_i;
         rs->pttport_deprecated.parm.cm108.ptt_bitnum = val_i;
         break;
 
     case TOK_DCD_TYPE:
         if (!strcmp(val, "RIG"))
         {
-            rs->dcdport.type.dcd = RIG_DCD_RIG;
+            dcdp->type.dcd = RIG_DCD_RIG;
             rs->dcdport_deprecated.type.dcd = RIG_DCD_RIG;
         }
         else if (!strcmp(val, "DSR"))
         {
-            rs->dcdport.type.dcd = RIG_DCD_SERIAL_DSR;
+            dcdp->type.dcd = RIG_DCD_SERIAL_DSR;
             rs->dcdport_deprecated.type.dcd = RIG_DCD_SERIAL_DSR;
         }
         else if (!strcmp(val, "CTS"))
         {
-            rs->dcdport.type.dcd = RIG_DCD_SERIAL_CTS;
+            dcdp->type.dcd = RIG_DCD_SERIAL_CTS;
             rs->dcdport_deprecated.type.dcd = RIG_DCD_SERIAL_CTS;
         }
         else if (!strcmp(val, "CD"))
         {
-            rs->dcdport.type.dcd = RIG_DCD_SERIAL_CAR;
+            dcdp->type.dcd = RIG_DCD_SERIAL_CAR;
             rs->dcdport_deprecated.type.dcd = RIG_DCD_SERIAL_CAR;
         }
         else if (!strcmp(val, "Parallel"))
         {
-            rs->dcdport.type.dcd = RIG_DCD_PARALLEL;
+            dcdp->type.dcd = RIG_DCD_PARALLEL;
             rs->dcdport_deprecated.type.dcd = RIG_DCD_PARALLEL;
         }
         else if (!strcmp(val, "CM108"))
         {
-            rs->dcdport.type.dcd = RIG_DCD_CM108;
+            dcdp->type.dcd = RIG_DCD_CM108;
             rs->dcdport_deprecated.type.dcd = RIG_DCD_CM108;
         }
         else if (!strcmp(val, "GPIO"))
         {
-            rs->dcdport.type.dcd = RIG_DCD_GPIO;
+            dcdp->type.dcd = RIG_DCD_GPIO;
             rs->dcdport_deprecated.type.dcd = RIG_DCD_GPIO;
         }
         else if (!strcmp(val, "GPION"))
         {
-            rs->dcdport.type.dcd = RIG_DCD_GPION;
+            dcdp->type.dcd = RIG_DCD_GPION;
             rs->dcdport_deprecated.type.dcd = RIG_DCD_GPION;
         }
         else if (!strcmp(val, "None"))
         {
-            rs->dcdport.type.dcd = RIG_DCD_NONE;
+            dcdp->type.dcd = RIG_DCD_NONE;
             rs->dcdport_deprecated.type.dcd = RIG_DCD_NONE;
         }
         else
@@ -645,7 +648,7 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
         break;
 
     case TOK_DCD_PATHNAME:
-        strncpy(rs->dcdport.pathname, val, HAMLIB_FILPATHLEN - 1);
+        strncpy(dcdp->pathname, val, HAMLIB_FILPATHLEN - 1);
         strncpy(rs->dcdport_deprecated.pathname, val, HAMLIB_FILPATHLEN - 1);
         break;
 
@@ -728,7 +731,7 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
             return -RIG_EINVAL; //value format error
         }
 
-        rs->rigport.flushx = val_i ? 1 : 0;
+        rp->flushx = val_i ? 1 : 0;
         break;
 
     case TOK_TWIDDLE_TIMEOUT:
@@ -768,7 +771,7 @@ static int frontend_set_conf(RIG *rig, token_t token, const char *val)
             return -RIG_EINVAL;
         }
 
-        rs->rigport.timeout_retry = val_i;
+        rp->timeout_retry = val_i;
         break;
 
     case TOK_OFFSET_VFOA:
@@ -833,21 +836,24 @@ static int frontend_get_conf2(RIG *rig, token_t token, char *val, int val_len)
 {
     struct rig_state *rs;
     const char *s = "";
+    hamlib_port_t *rp = RIGPORT(rig);
+    hamlib_port_t *pttp = PTTPORT(rig);
+    hamlib_port_t *dcdp = DCDPORT(rig);
 
     rs = &rig->state;
 
     switch (token)
     {
     case TOK_PATHNAME:
-        SNPRINTF(val, val_len, "%s", rs->rigport.pathname);
+        SNPRINTF(val, val_len, "%s", rp->pathname);
         break;
 
     case TOK_WRITE_DELAY:
-        SNPRINTF(val, val_len, "%d", rs->rigport.write_delay);
+        SNPRINTF(val, val_len, "%d", rp->write_delay);
         break;
 
     case TOK_POST_WRITE_DELAY:
-        SNPRINTF(val, val_len, "%d", rs->rigport.post_write_delay);
+        SNPRINTF(val, val_len, "%d", rp->post_write_delay);
         break;
 
     case TOK_POST_PTT_DELAY:
@@ -855,11 +861,11 @@ static int frontend_get_conf2(RIG *rig, token_t token, char *val, int val_len)
         break;
 
     case TOK_TIMEOUT:
-        SNPRINTF(val, val_len, "%d", rs->rigport.timeout);
+        SNPRINTF(val, val_len, "%d", rp->timeout);
         break;
 
     case TOK_RETRY:
-        SNPRINTF(val, val_len, "%d", rs->rigport.retry);
+        SNPRINTF(val, val_len, "%d", rp->retry);
         break;
 
 #if 0 // needs to be replace?
@@ -871,39 +877,39 @@ static int frontend_get_conf2(RIG *rig, token_t token, char *val, int val_len)
 #endif
 
     case TOK_SERIAL_SPEED:
-        if (rs->rigport.type.rig != RIG_PORT_SERIAL)
+        if (rp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
-        SNPRINTF(val, val_len, "%d", rs->rigport.parm.serial.rate);
+        SNPRINTF(val, val_len, "%d", rp->parm.serial.rate);
         break;
 
     case TOK_DATA_BITS:
-        if (rs->rigport.type.rig != RIG_PORT_SERIAL)
+        if (rp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
-        SNPRINTF(val, val_len, "%d", rs->rigport.parm.serial.data_bits);
+        SNPRINTF(val, val_len, "%d", rp->parm.serial.data_bits);
         break;
 
     case TOK_STOP_BITS:
-        if (rs->rigport.type.rig != RIG_PORT_SERIAL)
+        if (rp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
-        SNPRINTF(val, val_len, "%d", rs->rigport.parm.serial.stop_bits);
+        SNPRINTF(val, val_len, "%d", rp->parm.serial.stop_bits);
         break;
 
     case TOK_PARITY:
-        if (rs->rigport.type.rig != RIG_PORT_SERIAL)
+        if (rp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
-        switch (rs->rigport.parm.serial.parity)
+        switch (rp->parm.serial.parity)
         {
         case RIG_PARITY_NONE:
             s = "None";
@@ -933,7 +939,7 @@ static int frontend_get_conf2(RIG *rig, token_t token, char *val, int val_len)
         break;
 
     case TOK_HANDSHAKE:
-        if (rs->rigport.type.rig != RIG_PORT_SERIAL)
+        if (rp->type.rig != RIG_PORT_SERIAL)
         {
             rig_debug(RIG_DEBUG_ERR,
                       "%s: getting handshake is invalid for non-serial port rig type\n",
@@ -941,7 +947,7 @@ static int frontend_get_conf2(RIG *rig, token_t token, char *val, int val_len)
             return -RIG_EINVAL;
         }
 
-        switch (rs->rigport.parm.serial.handshake)
+        switch (rp->parm.serial.handshake)
         {
         case RIG_HANDSHAKE_NONE:
             s = "None";
@@ -963,12 +969,12 @@ static int frontend_get_conf2(RIG *rig, token_t token, char *val, int val_len)
         break;
 
     case TOK_RTS_STATE:
-        if (rs->rigport.type.rig != RIG_PORT_SERIAL)
+        if (rp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
-        switch (rs->rigport.parm.serial.rts_state)
+        switch (rp->parm.serial.rts_state)
         {
         case RIG_SIGNAL_UNSET:
             s = "Unset";
@@ -990,12 +996,12 @@ static int frontend_get_conf2(RIG *rig, token_t token, char *val, int val_len)
         break;
 
     case TOK_DTR_STATE:
-        if (rs->rigport.type.rig != RIG_PORT_SERIAL)
+        if (rp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
-        switch (rs->rigport.parm.serial.dtr_state)
+        switch (rp->parm.serial.dtr_state)
         {
         case RIG_SIGNAL_UNSET:
             s = "Unset";
@@ -1029,7 +1035,7 @@ static int frontend_get_conf2(RIG *rig, token_t token, char *val, int val_len)
         break;
 
     case TOK_PTT_TYPE:
-        switch (rs->pttport.type.ptt)
+        switch (pttp->type.ptt)
         {
         case RIG_PTT_RIG:
             s = "RIG";
@@ -1075,15 +1081,15 @@ static int frontend_get_conf2(RIG *rig, token_t token, char *val, int val_len)
         break;
 
     case TOK_PTT_PATHNAME:
-        strcpy(val, rs->pttport.pathname);
+        strcpy(val, pttp->pathname);
         break;
 
     case TOK_PTT_BITNUM:
-        SNPRINTF(val, val_len, "%d", rs->pttport.parm.cm108.ptt_bitnum);
+        SNPRINTF(val, val_len, "%d", pttp->parm.cm108.ptt_bitnum);
         break;
 
     case TOK_DCD_TYPE:
-        switch (rs->dcdport.type.dcd)
+        switch (dcdp->type.dcd)
         {
         case RIG_DCD_RIG:
             s = "RIG";
@@ -1129,7 +1135,7 @@ static int frontend_get_conf2(RIG *rig, token_t token, char *val, int val_len)
         break;
 
     case TOK_DCD_PATHNAME:
-        strcpy(val, rs->dcdport.pathname);
+        strcpy(val, dcdp->pathname);
         break;
 
     case TOK_LO_FREQ:
@@ -1157,7 +1163,7 @@ static int frontend_get_conf2(RIG *rig, token_t token, char *val, int val_len)
         break;
 
     case TOK_FLUSHX:
-        SNPRINTF(val, val_len, "%d", rs->rigport.flushx);
+        SNPRINTF(val, val_len, "%d", rp->flushx);
         break;
 
     case TOK_DISABLE_YAESU_BANDSELECT:
@@ -1177,7 +1183,7 @@ static int frontend_get_conf2(RIG *rig, token_t token, char *val, int val_len)
         break;
 
     case TOK_TIMEOUT_RETRY:
-        SNPRINTF(val, val_len, "%d", rs->rigport.timeout_retry);
+        SNPRINTF(val, val_len, "%d", rp->timeout_retry);
         break;
 
     case TOK_MULTICAST_DATA_ADDR:
@@ -1200,7 +1206,7 @@ static int frontend_get_conf2(RIG *rig, token_t token, char *val, int val_len)
         return -RIG_EINVAL;
     }
 
-    memcpy(&rs->rigport_deprecated, &rs->rigport, sizeof(hamlib_port_t_deprecated));
+    memcpy(&rs->rigport_deprecated, rp, sizeof(hamlib_port_t_deprecated));
 
     return RIG_OK;
 }
@@ -1371,7 +1377,6 @@ token_t HAMLIB_API rig_token_lookup(RIG *rig, const char *name)
  */
 int HAMLIB_API rig_set_conf(RIG *rig, token_t token, const char *val)
 {
-    struct rig_state *rs = &rig->state;
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
     if (!rig || !rig->caps)
@@ -1380,7 +1385,7 @@ int HAMLIB_API rig_set_conf(RIG *rig, token_t token, const char *val)
     }
 
     // Some parameters can be ignored
-    if (token == TOK_HANDSHAKE && (rs->rigport.type.rig != RIG_PORT_SERIAL))
+    if (token == TOK_HANDSHAKE && (RIGPORT(rig)->type.rig != RIG_PORT_SERIAL))
     {
         rig_debug(RIG_DEBUG_WARN,
                   "%s: handshake is not valid for non-serial port rig\n", __func__);

--- a/src/multicast.c
+++ b/src/multicast.c
@@ -297,7 +297,7 @@ static int multicast_send_json(RIG *rig)
 //    sprintf(msg,"%s:f=%.1f", date_strget(msg, (int)sizeof(msg), 0), f);
     msg[0] = 0;
     snprintf(buf, sizeof(buf), "%s:%s", rig->caps->model_name,
-             rig->state.rigport.pathname);
+             RIGPORT(rig)->pathname);
     strcat(msg, "{\n");
     json_add_string(msg, "ID", buf, 1);
     json_add_time(msg, 1);
@@ -339,7 +339,7 @@ void *multicast_thread_rx(void *vrig)
     while (rig->state.multicast->runflag)
     {
 #if 0
-        ret = read_string(&rig->state.rigport, (unsigned char *) buf, sizeof(buf), "\n",
+        ret = read_string(RIGPORT(rig), (unsigned char *) buf, sizeof(buf), "\n",
                           1,
                           0, 1);
 #endif
@@ -652,8 +652,8 @@ int main(int argc, const char *argv[])
         return 1;
     }
 
-    strncpy(rig->state.rigport.pathname, "/dev/ttyUSB0", HAMLIB_FILPATHLEN - 1);
-    rig->state.rigport.parm.serial.rate = 38400;
+    strncpy(RIGPORT(rig)->pathname, "/dev/ttyUSB0", HAMLIB_FILPATHLEN - 1);
+    RIGPORT(rig)->parm.serial.rate = 38400;
     rig_open(rig);
     multicast_init(rig, "224.0.0.1", 4532);
     pthread_join(rig->state.multicast->threadid, NULL);

--- a/src/rig.c
+++ b/src/rig.c
@@ -20,6 +20,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 /**
  * \addtogroup rig
@@ -8614,3 +8615,36 @@ int morse_data_handler_set_keyspd(RIG *rig, int keyspd)
     return RIG_OK;
 }
 #endif
+
+/*
+ * \brief Get the address of a Hamlib data structure
+ * \param rig Pointer to main data anchor
+ * \param idx enum for which pointer requested
+ *
+ * Get the address of a structure without relying on changeable
+ *   internal data organization.
+ *
+ * \retval The address of the enumed structure
+ *
+ * Note: This is meant for use by the HAMLIB_???PORT macros mostly. Only
+ *  compatiblity with them is supported.
+ *
+ * \sa amp_data_pointer, rot_data_pointer
+ */
+HAMLIB_EXPORT(void *) rig_data_pointer(RIG *rig, rig_ptrx_t idx)
+{
+  switch(idx)
+    {
+    case RIG_PTRX_RIGPORT:
+      return RIGPORT(rig);
+    case RIG_PTRX_PTTPORT:
+      return PTTPORT(rig);
+    case RIG_PTRX_DCDPORT:
+      return DCDPORT(rig);
+    case RIG_PTRX_CACHE:
+      return CACHE(rig);
+    default:
+      rig_debug(RIG_DEBUG_ERR, "%s: Invalid data index=%d\n", __func__, idx);
+      return NULL;
+    }
+}

--- a/src/rig.c
+++ b/src/rig.c
@@ -518,6 +518,7 @@ RIG *HAMLIB_API rig_init(rig_model_t rig_model)
     RIG *rig;
     const struct rig_caps *caps;
     struct rig_state *rs;
+    hamlib_port_t *rp, *pttp, *dcdp;
     int i;
 
     rig_check_rig_caps();
@@ -582,11 +583,17 @@ RIG *HAMLIB_API rig_init(rig_model_t rig_model)
     pthread_mutex_init(&rs->mutex_set_transaction, NULL);
 #endif
 
+    //TODO Allocate and link ports
+    // For now, use the embedded ones
+    rp = RIGPORT(rig);
+    pttp = PTTPORT(rig);
+    dcdp = DCDPORT(rig);
+    
     rs->rig_model = caps->rig_model;
     rs->priv = NULL;
     rs->async_data_enabled = 0;
-    rs->rigport.fd = -1;
-    rs->pttport.fd = -1;
+    rp->fd = -1;
+    pttp->fd = -1;
     rs->comm_state = 0;
     rig->state.depth = 1;
 #if 0 // extra debug if needed
@@ -594,9 +601,9 @@ RIG *HAMLIB_API rig_init(rig_model_t rig_model)
               __LINE__, &rs->comm_state,
               rs->comm_state);
 #endif
-    rs->rigport.type.rig = caps->port_type; /* default from caps */
+    rp->type.rig = caps->port_type; /* default from caps */
 #if defined(HAVE_PTHREAD)
-    rs->rigport.asyncio = 0;
+    rp->asyncio = 0;
 #endif
     rig->state.comm_status = RIG_COMM_STATUS_CONNECTING;
 
@@ -605,73 +612,73 @@ RIG *HAMLIB_API rig_init(rig_model_t rig_model)
     switch (caps->port_type)
     {
     case RIG_PORT_SERIAL:
-        strncpy(rs->rigport.pathname, DEFAULT_SERIAL_PORT, HAMLIB_FILPATHLEN - 1);
-        rs->rigport.parm.serial.rate = caps->serial_rate_max;   /* fastest ! */
-        rs->rigport.parm.serial.data_bits = caps->serial_data_bits;
-        rs->rigport.parm.serial.stop_bits = caps->serial_stop_bits;
-        rs->rigport.parm.serial.parity = caps->serial_parity;
-        rs->rigport.parm.serial.handshake = caps->serial_handshake;
+        strncpy(rp->pathname, DEFAULT_SERIAL_PORT, HAMLIB_FILPATHLEN - 1);
+        rp->parm.serial.rate = caps->serial_rate_max;   /* fastest ! */
+        rp->parm.serial.data_bits = caps->serial_data_bits;
+        rp->parm.serial.stop_bits = caps->serial_stop_bits;
+        rp->parm.serial.parity = caps->serial_parity;
+        rp->parm.serial.handshake = caps->serial_handshake;
         break;
 
     case RIG_PORT_PARALLEL:
-        strncpy(rs->rigport.pathname, DEFAULT_PARALLEL_PORT, HAMLIB_FILPATHLEN - 1);
+        strncpy(rp->pathname, DEFAULT_PARALLEL_PORT, HAMLIB_FILPATHLEN - 1);
         break;
 
     /* Adding support for CM108 GPIO.  This is compatible with CM108 series
      * USB audio chips from CMedia and SSS1623 series USB audio chips from 3S
      */
     case RIG_PORT_CM108:
-        strncpy(rs->rigport.pathname, DEFAULT_CM108_PORT, HAMLIB_FILPATHLEN);
+        strncpy(rp->pathname, DEFAULT_CM108_PORT, HAMLIB_FILPATHLEN);
 
-        if (rs->rigport.parm.cm108.ptt_bitnum == 0)
+        if (rp->parm.cm108.ptt_bitnum == 0)
         {
-            rs->rigport.parm.cm108.ptt_bitnum = DEFAULT_CM108_PTT_BITNUM;
-            rs->pttport.parm.cm108.ptt_bitnum = DEFAULT_CM108_PTT_BITNUM;
+            rp->parm.cm108.ptt_bitnum = DEFAULT_CM108_PTT_BITNUM;
+            pttp->parm.cm108.ptt_bitnum = DEFAULT_CM108_PTT_BITNUM;
         }
 
         break;
 
     case RIG_PORT_GPIO:
-        strncpy(rs->rigport.pathname, DEFAULT_GPIO_PORT, HAMLIB_FILPATHLEN);
+        strncpy(rp->pathname, DEFAULT_GPIO_PORT, HAMLIB_FILPATHLEN);
         break;
 
     case RIG_PORT_NETWORK:
     case RIG_PORT_UDP_NETWORK:
-        strncpy(rs->rigport.pathname, "127.0.0.1:4532", HAMLIB_FILPATHLEN - 1);
+        strncpy(rp->pathname, "127.0.0.1:4532", HAMLIB_FILPATHLEN - 1);
         break;
 
     default:
-        strncpy(rs->rigport.pathname, "", HAMLIB_FILPATHLEN - 1);
+        strncpy(rp->pathname, "", HAMLIB_FILPATHLEN - 1);
     }
 
-    rs->rigport.write_delay = caps->write_delay;
-    rs->rigport.post_write_delay = caps->post_write_delay;
+    rp->write_delay = caps->write_delay;
+    rp->post_write_delay = caps->post_write_delay;
 
     // since we do two timeouts now we can cut the timeout in half for serial
     if (caps->port_type == RIG_PORT_SERIAL && caps->timeout_retry >= 0)
     {
-        rs->rigport.timeout = caps->timeout / 2;
+        rp->timeout = caps->timeout / 2;
     }
 
-    rs->rigport.retry = caps->retry;
+    rp->retry = caps->retry;
 
     if (caps->timeout_retry < 0)
     {
         // Rigs may disable read timeout retries
-        rs->rigport.timeout_retry = 0;
+        rp->timeout_retry = 0;
     }
     else if (caps->timeout_retry == 0)
     {
         // Default to 1 retry for read timeouts
-        rs->rigport.timeout_retry = 1;
+        rp->timeout_retry = 1;
     }
     else
     {
-        rs->rigport.timeout_retry = caps->timeout_retry;
+        rp->timeout_retry = caps->timeout_retry;
     }
 
-    rs->pttport.type.ptt = caps->ptt_type;
-    rs->dcdport.type.dcd = caps->dcd_type;
+    pttp->type.ptt = caps->ptt_type;
+    dcdp->type.dcd = caps->dcd_type;
 
     rs->vfo_comp = 0.0; /* override it with preferences */
     rs->current_vfo = RIG_VFO_CURR; /* we don't know yet! */
@@ -837,7 +844,7 @@ RIG *HAMLIB_API rig_init(rig_model_t rig_model)
     rs->max_ifshift = caps->max_ifshift;
     rs->announces = caps->announces;
 
-    rs->rigport.fd = rs->pttport.fd = rs->dcdport.fd = -1;
+    rp->fd = pttp->fd = dcdp->fd = -1;
     // some rigs (like SDR) behave differnt when checking for power on
     // So we assume power is on until one of the backends KNOWS it is off
     rs->powerstat = RIG_POWER_ON; // default to power on until proven otherwise
@@ -889,6 +896,9 @@ int HAMLIB_API rig_open(RIG *rig)
 {
     struct rig_caps *caps;
     struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
+    hamlib_port_t *pttp = PTTPORT(rig);
+    hamlib_port_t *dcdp = DCDPORT(rig);
     int status = RIG_OK;
     value_t parm_value;
     //unsigned int net1, net2, net3, net4, net5, net6, net7, net8, port;
@@ -904,10 +914,10 @@ int HAMLIB_API rig_open(RIG *rig)
 
     caps = rig->caps;
     rs = &rig->state;
-    rs->rigport.rig = rig;
+    rp->rig = rig;
     rs->rigport_deprecated.rig = rig;
 
-    if (strcmp(rs->rigport.pathname, "USB") == 0)
+    if (strcmp(rp->pathname, "USB") == 0)
     {
         rig_debug(RIG_DEBUG_ERR, "%s: 'USB' is not a valid COM port name\n", __func__);
         errno = 2;
@@ -917,27 +927,27 @@ int HAMLIB_API rig_open(RIG *rig)
     // rigctl/rigctld may have deprecated values -- backwards compatibility
     if (rs->rigport_deprecated.pathname[0] != 0)
     {
-        strcpy(rs->rigport.pathname, rs->rigport_deprecated.pathname);
+        strcpy(rp->pathname, rs->rigport_deprecated.pathname);
     }
 
     if (rs->pttport_deprecated.type.ptt != RIG_PTT_NONE)
     {
-        rs->pttport.type.ptt = rs->pttport_deprecated.type.ptt;
+        pttp->type.ptt = rs->pttport_deprecated.type.ptt;
     }
 
     if (rs->dcdport_deprecated.type.dcd != RIG_DCD_NONE)
     {
-        rs->dcdport.type.dcd = rs->dcdport_deprecated.type.dcd;
+        dcdp->type.dcd = rs->dcdport_deprecated.type.dcd;
     }
 
     if (rs->pttport_deprecated.pathname[0] != 0)
     {
-        strcpy(rs->pttport.pathname, rs->pttport_deprecated.pathname);
+        strcpy(pttp->pathname, rs->pttport_deprecated.pathname);
     }
 
     if (rs->dcdport_deprecated.pathname[0] != 0)
     {
-        strcpy(rs->dcdport.pathname, rs->dcdport_deprecated.pathname);
+        strcpy(dcdp->pathname, rs->dcdport_deprecated.pathname);
     }
 
     rig_settings_load_all(NULL); // load default .hamlib_settings
@@ -987,12 +997,12 @@ int HAMLIB_API rig_open(RIG *rig)
               "%s: async_data_enable=%d, async_data_supported=%d\n", __func__,
               rs->async_data_enabled, caps->async_data_supported);
     rs->async_data_enabled = rs->async_data_enabled && caps->async_data_supported;
-    rs->rigport.asyncio = rs->async_data_enabled;
+    rp->asyncio = rs->async_data_enabled;
 
-    if (strlen(rs->rigport.pathname) > 0)
+    if (strlen(rp->pathname) > 0)
     {
         char hoststr[256], portstr[6];
-        status = parse_hoststr(rs->rigport.pathname, sizeof(rs->rigport.pathname),
+        status = parse_hoststr(rp->pathname, sizeof(rp->pathname),
                                hoststr, portstr);
 
         if (status == RIG_OK) { is_network = 1; }
@@ -1001,16 +1011,16 @@ int HAMLIB_API rig_open(RIG *rig)
 #if 0
     // determine if we have a network address
     //
-    is_network |= sscanf(rs->rigport.pathname, "%u.%u.%u.%u:%u", &net1, &net2,
+    is_network |= sscanf(rp->pathname, "%u.%u.%u.%u:%u", &net1, &net2,
                          &net3, &net4, &port) == 5;
-    is_network |= sscanf(rs->rigport.pathname, ":%u", &port) == 1;
-    is_network |= sscanf(rs->rigport.pathname, "%u::%u:%u:%u:%u:%u", &net1, &net2,
+    is_network |= sscanf(rp->pathname, ":%u", &port) == 1;
+    is_network |= sscanf(rp->pathname, "%u::%u:%u:%u:%u:%u", &net1, &net2,
                          &net3, &net4, &net5, &port) == 6;
-    is_network |= sscanf(rs->rigport.pathname, "%u:%u:%u:%u:%u:%u:%u:%u:%u", &net1,
+    is_network |= sscanf(rp->pathname, "%u:%u:%u:%u:%u:%u:%u:%u:%u", &net1,
                          &net2, &net3, &net4, &net5, &net6, &net7, &net8, &port) == 9;
 
     // if we haven't met one of the condition above then we must have a hostname
-    if (!is_network && (token = strtok_r(rs->rigport.pathname, ":", &strtokp)))
+    if (!is_network && (token = strtok_r(rp->pathname, ":", &strtokp)))
     {
         rig_debug(RIG_DEBUG_TRACE, "%s: token1=%s\n", __func__, token);
         token = strtok_r(strtokp, ":", &strtokp);
@@ -1028,8 +1038,8 @@ int HAMLIB_API rig_open(RIG *rig)
     if (is_network)
     {
         rig_debug(RIG_DEBUG_TRACE, "%s: using network address %s\n", __func__,
-                  rs->rigport.pathname);
-        rs->rigport.type.rig = RIG_PORT_NETWORK;
+                  rp->pathname);
+        rp->type.rig = RIG_PORT_NETWORK;
 
         if (RIG_BACKEND_NUM(rig->caps->rig_model) == RIG_ICOM)
         {
@@ -1039,7 +1049,7 @@ int HAMLIB_API rig_open(RIG *rig)
             {
                 rig_debug(RIG_DEBUG_TRACE, "%s(%d): Icom rig UDP network enabled\n", __FILE__,
                           __LINE__);
-                rs->rigport.type.rig = RIG_PORT_UDP_NETWORK;
+                rp->type.rig = RIG_PORT_UDP_NETWORK;
             }
 
 #endif
@@ -1051,55 +1061,55 @@ int HAMLIB_API rig_open(RIG *rig)
         rig_debug(RIG_DEBUG_VERBOSE, "%s(%d): %p rs->comm_state==1?=%d\n", __func__,
                   __LINE__, &rs->comm_state,
                   rs->comm_state);
-        port_close(&rs->rigport, rs->rigport.type.rig);
+        port_close(rp, rp->type.rig);
         rs->comm_state = 0;
         RETURNFUNC2(-RIG_EINVAL);
     }
 
     rs->comm_status = RIG_COMM_STATUS_CONNECTING;
 
-    rs->rigport.fd = -1;
+    rp->fd = -1;
 
-    if (rs->rigport.type.rig == RIG_PORT_SERIAL)
+    if (rp->type.rig == RIG_PORT_SERIAL)
     {
-        if (rs->rigport.parm.serial.rts_state != RIG_SIGNAL_UNSET
-                && rs->rigport.parm.serial.handshake == RIG_HANDSHAKE_HARDWARE)
+        if (rp->parm.serial.rts_state != RIG_SIGNAL_UNSET
+                && rp->parm.serial.handshake == RIG_HANDSHAKE_HARDWARE)
         {
             rig_debug(RIG_DEBUG_ERR,
                       "%s: cannot set RTS with hardware handshake \"%s\"\n",
                       __func__,
-                      rs->rigport.pathname);
+                      rp->pathname);
             RETURNFUNC2(-RIG_ECONF);
         }
 
-        if ('\0' == rs->pttport.pathname[0]
-                || !strcmp(rs->pttport.pathname, rs->rigport.pathname))
+        if ('\0' == pttp->pathname[0]
+                || !strcmp(pttp->pathname, rp->pathname))
         {
             /* check for control line conflicts */
-            if (rs->rigport.parm.serial.rts_state != RIG_SIGNAL_UNSET
-                    && rs->pttport.type.ptt == RIG_PTT_SERIAL_RTS)
+            if (rp->parm.serial.rts_state != RIG_SIGNAL_UNSET
+                    && pttp->type.ptt == RIG_PTT_SERIAL_RTS)
             {
                 rig_debug(RIG_DEBUG_ERR,
                           "%s: cannot set RTS with PTT by RTS \"%s\"\n",
                           __func__,
-                          rs->rigport.pathname);
+                          rp->pathname);
                 RETURNFUNC2(-RIG_ECONF);
             }
 
-            if (rs->rigport.parm.serial.dtr_state != RIG_SIGNAL_UNSET
-                    && rs->pttport.type.ptt == RIG_PTT_SERIAL_DTR)
+            if (rp->parm.serial.dtr_state != RIG_SIGNAL_UNSET
+                    && pttp->type.ptt == RIG_PTT_SERIAL_DTR)
             {
                 rig_debug(RIG_DEBUG_ERR,
                           "%s: cannot set DTR with PTT by DTR \"%s\"\n",
                           __func__,
-                          rs->rigport.pathname);
+                          rp->pathname);
                 RETURNFUNC2(-RIG_ECONF);
             }
         }
     }
 
-    rs->rigport.timeout = caps->timeout;
-    status = port_open(&rs->rigport);
+    rp->timeout = caps->timeout;
+    status = port_open(rp);
 
     if (status < 0)
     {
@@ -1110,7 +1120,7 @@ int HAMLIB_API rig_open(RIG *rig)
         RETURNFUNC2(status);
     }
 
-    switch (rs->pttport.type.ptt)
+    switch (pttp->type.ptt)
     {
     case RIG_PTT_NONE:
     case RIG_PTT_RIG:
@@ -1119,124 +1129,123 @@ int HAMLIB_API rig_open(RIG *rig)
 
     case RIG_PTT_SERIAL_RTS:
     case RIG_PTT_SERIAL_DTR:
-        if (rs->pttport.pathname[0] == '\0'
-                && rs->rigport.type.rig == RIG_PORT_SERIAL)
+        if (pttp->pathname[0] == '\0'
+                && rp->type.rig == RIG_PORT_SERIAL)
         {
-            strcpy(rs->pttport.pathname, rs->rigport.pathname);
+            strcpy(pttp->pathname, rp->pathname);
         }
 
-        if (!strcmp(rs->pttport.pathname, rs->rigport.pathname))
+        if (!strcmp(pttp->pathname, rp->pathname))
         {
-            rs->pttport.fd = rs->rigport.fd;
+            pttp->fd = rp->fd;
 
             /* Needed on Linux because the serial port driver sets RTS/DTR
                on open - only need to address the PTT line as we offer
                config parameters to control the other (dtr_state &
                rts_state) */
-            if (rs->pttport.type.ptt == RIG_PTT_SERIAL_DTR)
+            if (pttp->type.ptt == RIG_PTT_SERIAL_DTR)
             {
-                status = ser_set_dtr(&rs->pttport, 0);
+                status = ser_set_dtr(pttp, 0);
             }
 
-            if (rs->pttport.type.ptt == RIG_PTT_SERIAL_RTS)
+            if (pttp->type.ptt == RIG_PTT_SERIAL_RTS)
             {
-                status = ser_set_rts(&rs->pttport, 0);
+                status = ser_set_rts(pttp, 0);
             }
         }
         else
         {
-            rs->pttport.fd = ser_open(&rs->pttport);
+            pttp->fd = ser_open(pttp);
 
-            if (rs->pttport.fd < 0)
+            if (pttp->fd < 0)
             {
                 rig_debug(RIG_DEBUG_ERR,
                           "%s: cannot open PTT device \"%s\"\n",
                           __func__,
-                          rs->pttport.pathname);
+                          pttp->pathname);
                 status = -RIG_EIO;
             }
 
             if (RIG_OK == status
-                    && (rs->pttport.type.ptt == RIG_PTT_SERIAL_DTR
-                        || rs->pttport.type.ptt == RIG_PTT_SERIAL_RTS))
+                    && (pttp->type.ptt == RIG_PTT_SERIAL_DTR
+                        || pttp->type.ptt == RIG_PTT_SERIAL_RTS))
             {
                 /* Needed on Linux because the serial port driver sets
                    RTS/DTR high on open - set both low since we offer no
                    control of the non-PTT line and low is better than
                    high */
-                status = ser_set_dtr(&rs->pttport, 0);
+                status = ser_set_dtr(pttp, 0);
 
                 if (RIG_OK == status)
                 {
-                    status = ser_set_rts(&rs->pttport, 0);
+                    status = ser_set_rts(pttp, 0);
                 }
             }
 
-            ser_close(&rs->pttport);
+            ser_close(pttp);
         }
 
         break;
 
     case RIG_PTT_PARALLEL:
-        rs->pttport.fd = par_open(&rs->pttport);
+        pttp->fd = par_open(pttp);
 
-        if (rs->pttport.fd < 0)
+        if (pttp->fd < 0)
         {
             rig_debug(RIG_DEBUG_ERR,
                       "%s: cannot open PTT device \"%s\"\n",
                       __func__,
-                      rs->pttport.pathname);
+                      pttp->pathname);
             status = -RIG_EIO;
         }
         else
         {
-            par_ptt_set(&rs->pttport, RIG_PTT_OFF);
+            par_ptt_set(pttp, RIG_PTT_OFF);
         }
 
         break;
 
     case RIG_PTT_CM108:
-        rs->pttport.fd = cm108_open(&rs->pttport);
+        pttp->fd = cm108_open(pttp);
 
-        strncpy(rs->rigport.pathname, DEFAULT_CM108_PORT, HAMLIB_FILPATHLEN);
+        strncpy(rp->pathname, DEFAULT_CM108_PORT, HAMLIB_FILPATHLEN);
 
-        if (rs->rigport.parm.cm108.ptt_bitnum == 0)
+        if (rp->parm.cm108.ptt_bitnum == 0)
         {
-            rs->rigport.parm.cm108.ptt_bitnum = DEFAULT_CM108_PTT_BITNUM;
-            rs->pttport.parm.cm108.ptt_bitnum = DEFAULT_CM108_PTT_BITNUM;
+            rp->parm.cm108.ptt_bitnum = DEFAULT_CM108_PTT_BITNUM;
+            pttp->parm.cm108.ptt_bitnum = DEFAULT_CM108_PTT_BITNUM;
         }
 
-        if (rs->pttport.fd < 0)
+        if (pttp->fd < 0)
         {
             rig_debug(RIG_DEBUG_ERR,
                       "%s: cannot open PTT device \"%s\"\n",
                       __func__,
-                      rs->pttport.pathname);
+                      pttp->pathname);
             status = -RIG_EIO;
         }
         else
         {
-            cm108_ptt_set(&rs->pttport, RIG_PTT_OFF);
+            cm108_ptt_set(pttp, RIG_PTT_OFF);
         }
 
         break;
 
     case RIG_PTT_GPIO:
     case RIG_PTT_GPION:
-        rs->pttport.fd = gpio_open(&rs->pttport, 1,
-                                   RIG_PTT_GPION == rs->pttport.type.ptt ? 0 : 1);
+        pttp->fd = gpio_open(pttp, 1, RIG_PTT_GPION == pttp->type.ptt ? 0 : 1);
 
-        if (rs->pttport.fd < 0)
+        if (pttp->fd < 0)
         {
             rig_debug(RIG_DEBUG_ERR,
                       "%s: cannot open PTT device \"GPIO%s\"\n",
                       __func__,
-                      rs->pttport.pathname);
+                      pttp->pathname);
             status = -RIG_EIO;
         }
         else
         {
-            gpio_ptt_set(&rs->pttport, RIG_PTT_OFF);
+            gpio_ptt_set(pttp, RIG_PTT_OFF);
         }
 
         break;
@@ -1245,11 +1254,11 @@ int HAMLIB_API rig_open(RIG *rig)
         rig_debug(RIG_DEBUG_ERR,
                   "%s: unsupported PTT type %d\n",
                   __func__,
-                  rs->pttport.type.ptt);
+                  pttp->type.ptt);
         status = -RIG_ECONF;
     }
 
-    switch (rs->dcdport.type.dcd)
+    switch (dcdp->type.dcd)
     {
     case RIG_DCD_NONE:
     case RIG_DCD_RIG:
@@ -1258,41 +1267,41 @@ int HAMLIB_API rig_open(RIG *rig)
     case RIG_DCD_SERIAL_DSR:
     case RIG_DCD_SERIAL_CTS:
     case RIG_DCD_SERIAL_CAR:
-        if (rs->dcdport.pathname[0] == '\0'
-                && rs->rigport.type.rig == RIG_PORT_SERIAL)
+        if (dcdp->pathname[0] == '\0'
+                && rp->type.rig == RIG_PORT_SERIAL)
         {
-            strcpy(rs->dcdport.pathname, rs->rigport.pathname);
+            strcpy(dcdp->pathname, rp->pathname);
         }
 
-        if (strcmp(rs->dcdport.pathname, rs->rigport.pathname) == 0)
+        if (strcmp(dcdp->pathname, rp->pathname) == 0)
         {
-            rs->dcdport.fd = rs->rigport.fd;
+            dcdp->fd = rp->fd;
         }
         else
         {
-            rs->dcdport.fd = ser_open(&rs->dcdport);
+            dcdp->fd = ser_open(dcdp);
         }
 
-        if (rs->dcdport.fd < 0)
+        if (dcdp->fd < 0)
         {
             rig_debug(RIG_DEBUG_ERR,
                       "%s: cannot open DCD device \"%s\"\n",
                       __func__,
-                      rs->dcdport.pathname);
+                      dcdp->pathname);
             status = -RIG_EIO;
         }
 
         break;
 
     case RIG_DCD_PARALLEL:
-        rs->dcdport.fd = par_open(&rs->dcdport);
+        dcdp->fd = par_open(dcdp);
 
-        if (rs->dcdport.fd < 0)
+        if (dcdp->fd < 0)
         {
             rig_debug(RIG_DEBUG_ERR,
                       "%s: cannot open DCD device \"%s\"\n",
                       __func__,
-                      rs->dcdport.pathname);
+                      dcdp->pathname);
             status = -RIG_EIO;
         }
 
@@ -1300,15 +1309,15 @@ int HAMLIB_API rig_open(RIG *rig)
 
     case RIG_DCD_GPIO:
     case RIG_DCD_GPION:
-        rs->dcdport.fd = gpio_open(&rs->dcdport, 0,
-                                   RIG_DCD_GPION == rs->dcdport.type.dcd ? 0 : 1);
+        dcdp->fd = gpio_open(dcdp, 0,
+                                   RIG_DCD_GPION == dcdp->type.dcd ? 0 : 1);
 
-        if (rs->dcdport.fd < 0)
+        if (dcdp->fd < 0)
         {
             rig_debug(RIG_DEBUG_ERR,
                       "%s: cannot open DCD device \"GPIO%s\"\n",
                       __func__,
-                      rs->dcdport.pathname);
+                      dcdp->pathname);
             status = -RIG_EIO;
         }
 
@@ -1318,13 +1327,13 @@ int HAMLIB_API rig_open(RIG *rig)
         rig_debug(RIG_DEBUG_ERR,
                   "%s: unsupported DCD type %d\n",
                   __func__,
-                  rs->dcdport.type.dcd);
+                  dcdp->type.dcd);
         status = -RIG_ECONF;
     }
 
     if (status < 0)
     {
-        port_close(&rs->rigport, rs->rigport.type.rig);
+        port_close(rp, rp->type.rig);
         rig->state.comm_status = RIG_COMM_STATUS_ERROR;
         RETURNFUNC2(status);
     }
@@ -1337,7 +1346,7 @@ int HAMLIB_API rig_open(RIG *rig)
 
         if (status < 0)
         {
-            port_close(&rs->rigport, rs->rigport.type.rig);
+            port_close(rp, rp->type.rig);
             rig->state.comm_status = RIG_COMM_STATUS_ERROR;
             RETURNFUNC2(status);
         }
@@ -1357,8 +1366,8 @@ int HAMLIB_API rig_open(RIG *rig)
      * Maybe the backend has something to initialize
      * In case of failure, just close down and report error code.
      */
-    int retry_save = rs->rigport.retry;
-    rs->rigport.retry = 0;
+    int retry_save = rp->retry;
+    rp->retry = 0;
 
     if (caps->rig_open != NULL)
     {
@@ -1404,8 +1413,8 @@ int HAMLIB_API rig_open(RIG *rig)
             }
 
 #endif
-            port_close(&rs->rigport, rs->rigport.type.rig);
-            memcpy(&rs->rigport_deprecated, &rs->rigport, sizeof(hamlib_port_t_deprecated));
+            port_close(rp, rp->type.rig);
+            memcpy(&rs->rigport_deprecated, rp, sizeof(hamlib_port_t_deprecated));
             rs->comm_state = 0;
             rig->state.comm_status = RIG_COMM_STATUS_ERROR;
             RETURNFUNC2(status);
@@ -1466,7 +1475,7 @@ int HAMLIB_API rig_open(RIG *rig)
     {
         rig_debug(RIG_DEBUG_ERR, "%s: cw_data_handler_start failed: %s\n", __func__,
                   rigerror(status));
-        port_close(&rs->rigport, rs->rigport.type.rig);
+        port_close(rp, rp->type.rig);
         RETURNFUNC2(status);
     }
 
@@ -1535,12 +1544,12 @@ int HAMLIB_API rig_open(RIG *rig)
         }
     }
 
-    rs->rigport.retry = retry_save;
+    rp->retry = retry_save;
 
-    memcpy(&rs->rigport_deprecated, &rs->rigport, sizeof(hamlib_port_t_deprecated));
-    memcpy(&rs->pttport_deprecated, &rs->pttport, sizeof(hamlib_port_t_deprecated));
-    memcpy(&rs->dcdport_deprecated, &rs->dcdport, sizeof(hamlib_port_t_deprecated));
-    rig_flush_force(&rs->rigport, 1);
+    memcpy(&rs->rigport_deprecated, rp, sizeof(hamlib_port_t_deprecated));
+    memcpy(&rs->pttport_deprecated, pttp, sizeof(hamlib_port_t_deprecated));
+    memcpy(&rs->dcdport_deprecated, dcdp, sizeof(hamlib_port_t_deprecated));
+    rig_flush_force(rp, 1);
 
 #if defined(HAVE_PTHREAD)
     enum multicast_item_e items = RIG_MULTICAST_POLL | RIG_MULTICAST_TRANSCEIVE
@@ -1602,6 +1611,9 @@ int HAMLIB_API rig_open(RIG *rig)
 int HAMLIB_API rig_close(RIG *rig)
 {
     const struct rig_caps *caps;
+    hamlib_port_t *rp = RIGPORT(rig);
+    hamlib_port_t *pttp = PTTPORT(rig);
+    hamlib_port_t *dcdp = DCDPORT(rig);
     struct rig_state *rs;
 
     if (!rig || !rig->caps)
@@ -1652,7 +1664,7 @@ int HAMLIB_API rig_close(RIG *rig)
      * FIXME: what happens if PTT and rig ports are the same?
      *          (eg. ptt_type = RIG_PTT_SERIAL)
      */
-    switch (rs->pttport.type.ptt)
+    switch (pttp->type.ptt)
     {
     case RIG_PTT_NONE:
     case RIG_PTT_RIG:
@@ -1662,14 +1674,14 @@ int HAMLIB_API rig_close(RIG *rig)
     case RIG_PTT_SERIAL_RTS:
 
         // If port is already closed, do nothing
-        if (rs->pttport.fd > -1)
+        if (pttp->fd > -1)
         {
-            ser_set_rts(&rs->pttport, 0);
+            ser_set_rts(pttp, 0);
 
-            if (rs->pttport.fd != rs->rigport.fd)
+            if (pttp->fd != rp->fd)
             {
-                port_close(&rs->pttport, RIG_PORT_SERIAL);
-                memcpy(&rs->rigport_deprecated, &rs->rigport, sizeof(hamlib_port_t_deprecated));
+                port_close(pttp, RIG_PORT_SERIAL);
+                memcpy(&rs->rigport_deprecated, rp, sizeof(hamlib_port_t_deprecated));
             }
         }
 
@@ -1678,43 +1690,43 @@ int HAMLIB_API rig_close(RIG *rig)
     case RIG_PTT_SERIAL_DTR:
 
         // If port is already closed, do nothing
-        if (rs->pttport.fd > -1)
+        if (pttp->fd > -1)
         {
-            ser_set_dtr(&rs->pttport, 0);
+            ser_set_dtr(pttp, 0);
 
-            if (rs->pttport.fd != rs->rigport.fd)
+            if (pttp->fd != rp->fd)
             {
-                port_close(&rs->pttport, RIG_PORT_SERIAL);
-                memcpy(&rs->rigport_deprecated, &rs->rigport, sizeof(hamlib_port_t_deprecated));
+                port_close(pttp, RIG_PORT_SERIAL);
+                memcpy(&rs->rigport_deprecated, rp, sizeof(hamlib_port_t_deprecated));
             }
         }
 
         break;
 
     case RIG_PTT_PARALLEL:
-        par_ptt_set(&rs->pttport, RIG_PTT_OFF);
-        par_close(&rs->pttport);
+        par_ptt_set(pttp, RIG_PTT_OFF);
+        par_close(pttp);
         break;
 
     case RIG_PTT_CM108:
-        cm108_ptt_set(&rs->pttport, RIG_PTT_OFF);
-        cm108_close(&rs->pttport);
+        cm108_ptt_set(pttp, RIG_PTT_OFF);
+        cm108_close(pttp);
         break;
 
     case RIG_PTT_GPIO:
     case RIG_PTT_GPION:
-        gpio_ptt_set(&rs->pttport, RIG_PTT_OFF);
-        gpio_close(&rs->pttport);
+        gpio_ptt_set(pttp, RIG_PTT_OFF);
+        gpio_close(pttp);
         break;
 
     default:
         rig_debug(RIG_DEBUG_ERR,
                   "%s: unsupported PTT type %d\n",
                   __func__,
-                  rs->pttport.type.ptt);
+                  pttp->type.ptt);
     }
 
-    switch (rs->dcdport.type.dcd)
+    switch (dcdp->type.dcd)
     {
     case RIG_DCD_NONE:
     case RIG_DCD_RIG:
@@ -1723,33 +1735,33 @@ int HAMLIB_API rig_close(RIG *rig)
     case RIG_DCD_SERIAL_DSR:
     case RIG_DCD_SERIAL_CTS:
     case RIG_DCD_SERIAL_CAR:
-        if (rs->dcdport.fd != rs->rigport.fd)
+        if (dcdp->fd != rp->fd)
         {
-            port_close(&rs->dcdport, RIG_PORT_SERIAL);
-            memcpy(&rs->rigport_deprecated, &rs->rigport, sizeof(hamlib_port_t_deprecated));
+            port_close(dcdp, RIG_PORT_SERIAL);
+            memcpy(&rs->rigport_deprecated, rp, sizeof(hamlib_port_t_deprecated));
         }
 
         break;
 
     case RIG_DCD_PARALLEL:
-        par_close(&rs->dcdport);
+        par_close(dcdp);
         break;
 
     case RIG_DCD_GPIO:
     case RIG_DCD_GPION:
-        gpio_close(&rs->dcdport);
+        gpio_close(dcdp);
         break;
 
     default:
         rig_debug(RIG_DEBUG_ERR,
                   "%s: unsupported DCD type %d\n",
                   __func__,
-                  rs->dcdport.type.dcd);
+                  dcdp->type.dcd);
     }
 
-    rs->dcdport.fd = rs->pttport.fd = -1;
+    dcdp->fd = pttp->fd = -1;
 
-    port_close(&rs->rigport, rs->rigport.type.rig);
+    port_close(rp, rp->type.rig);
 
     // zero split so it will allow it to be set again on open for rigctld
     rig->state.cache.split = 0;
@@ -1797,6 +1809,8 @@ int HAMLIB_API rig_cleanup(RIG *rig)
     {
         rig->caps->rig_cleanup(rig);
     }
+
+    //TODO Release and null any allocated port structures
 
     free(rig);
 
@@ -3373,6 +3387,8 @@ int HAMLIB_API rig_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 {
     const struct rig_caps *caps;
     struct rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
+    hamlib_port_t *pttp = PTTPORT(rig);
     int retcode = RIG_OK;
 
     if (CHECK_RIG_ARG(rig))
@@ -3388,7 +3404,7 @@ int HAMLIB_API rig_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 
     LOCK(1);
 
-    switch (rig->state.pttport.type.ptt)
+    switch (pttp->type.ptt)
     {
     case RIG_PTT_RIG:
         if (ptt == RIG_PTT_ON_MIC || ptt == RIG_PTT_ON_DATA)
@@ -3536,19 +3552,19 @@ int HAMLIB_API rig_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
            port when PTT is reset and seize the port when PTT is set,
            this allows limited sharing of the PTT port between
            applications so long as there is no contention */
-        if (strcmp(rs->pttport.pathname, rs->rigport.pathname)
-                && rs->pttport.fd < 0
+        if (strcmp(pttp->pathname, rp->pathname)
+                && pttp->fd < 0
                 && RIG_PTT_OFF != ptt)
         {
 
-            rs->pttport.fd = ser_open(&rs->pttport);
+            pttp->fd = ser_open(pttp);
 
-            if (rs->pttport.fd < 0)
+            if (pttp->fd < 0)
             {
                 rig_debug(RIG_DEBUG_ERR,
                           "%s: cannot open PTT device \"%s\"\n",
                           __func__,
-                          rs->pttport.pathname);
+                          pttp->pathname);
                 ELAPSED2;
                 RETURNFUNC(-RIG_EIO);
             }
@@ -3556,7 +3572,7 @@ int HAMLIB_API rig_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
             /* Needed on Linux because the serial port driver sets RTS/DTR
                high on open - set both since we offer no control of
                the non-PTT line and low is better than high */
-            retcode = ser_set_rts(&rs->pttport, 0);
+            retcode = ser_set_rts(pttp, 0);
 
             if (RIG_OK != retcode)
             {
@@ -3565,16 +3581,16 @@ int HAMLIB_API rig_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
             }
         }
 
-        retcode = ser_set_dtr(&rig->state.pttport, ptt != RIG_PTT_OFF);
+        retcode = ser_set_dtr(pttp, ptt != RIG_PTT_OFF);
 
         rig_debug(RIG_DEBUG_TRACE, "%s:  rigport=%s, pttport=%s, ptt_share=%d\n",
-                  __func__, rs->pttport.pathname, rs->rigport.pathname, rs->ptt_share);
+                  __func__, rp->pathname, pttp->pathname, rs->ptt_share);
 
-        if (strcmp(rs->pttport.pathname, rs->rigport.pathname)
+        if (strcmp(pttp->pathname, rp->pathname)
                 && ptt == RIG_PTT_OFF && rs->ptt_share != 0)
         {
             /* free the port */
-            ser_close(&rs->pttport);
+            ser_close(pttp);
         }
 
         break;
@@ -3585,20 +3601,20 @@ int HAMLIB_API rig_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
            port when PTT is reset and seize the port when PTT is set,
            this allows limited sharing of the PTT port between
            applications so long as there is no contention */
-        if (strcmp(rs->pttport.pathname, rs->rigport.pathname)
-                && rs->pttport.fd < 0
+        if (strcmp(pttp->pathname, rp->pathname)
+                && pttp->fd < 0
                 && RIG_PTT_OFF != ptt)
         {
             rig_debug(RIG_DEBUG_TRACE, "%s: PTT RTS debug#1\n", __func__);
 
-            rs->pttport.fd = ser_open(&rs->pttport);
+            pttp->fd = ser_open(pttp);
 
-            if (rs->pttport.fd < 0)
+            if (pttp->fd < 0)
             {
                 rig_debug(RIG_DEBUG_ERR,
                           "%s: cannot open PTT device \"%s\"\n",
                           __func__,
-                          rs->pttport.pathname);
+                          pttp->pathname);
                 ELAPSED2;
                 RETURNFUNC(-RIG_EIO);
             }
@@ -3606,7 +3622,7 @@ int HAMLIB_API rig_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
             /* Needed on Linux because the serial port driver sets RTS/DTR
                high on open - set both since we offer no control of the
                non-PTT line and low is better than high */
-            retcode = ser_set_dtr(&rs->pttport, 0);
+            retcode = ser_set_dtr(pttp, 0);
 
             if (RIG_OK != retcode)
             {
@@ -3616,31 +3632,31 @@ int HAMLIB_API rig_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
             }
         }
 
-        retcode = ser_set_rts(&rig->state.pttport, ptt != RIG_PTT_OFF);
+        retcode = ser_set_rts(pttp, ptt != RIG_PTT_OFF);
 
         rig_debug(RIG_DEBUG_TRACE, "%s:  rigport=%s, pttport=%s, ptt_share=%d\n",
-                  __func__, rs->pttport.pathname, rs->rigport.pathname, rs->ptt_share);
+                  __func__, rp->pathname, pttp->pathname, rs->ptt_share);
 
-        if (strcmp(rs->pttport.pathname, rs->rigport.pathname)
+        if (strcmp(pttp->pathname, rp->pathname)
                 && ptt == RIG_PTT_OFF && rs->ptt_share != 0)
         {
             /* free the port */
-            ser_close(&rs->pttport);
+            ser_close(pttp);
         }
 
         break;
 
     case RIG_PTT_PARALLEL:
-        retcode = par_ptt_set(&rig->state.pttport, ptt);
+        retcode = par_ptt_set(pttp, ptt);
         break;
 
     case RIG_PTT_CM108:
-        retcode = cm108_ptt_set(&rig->state.pttport, ptt);
+        retcode = cm108_ptt_set(pttp, ptt);
         break;
 
     case RIG_PTT_GPIO:
     case RIG_PTT_GPION:
-        retcode = gpio_ptt_set(&rig->state.pttport, ptt);
+        retcode = gpio_ptt_set(pttp, ptt);
         break;
 
     case RIG_PTT_NONE:
@@ -3649,7 +3665,7 @@ int HAMLIB_API rig_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 
     default:
         rig_debug(RIG_DEBUG_WARN, "%s: unknown PTT type=%d\n", __func__,
-                  rig->state.pttport.type.ptt);
+                  pttp->type.ptt);
         ELAPSED2;
         RETURNFUNC(-RIG_EINVAL);
     }
@@ -3669,7 +3685,7 @@ int HAMLIB_API rig_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 
     if (retcode != RIG_OK) { rig_debug(RIG_DEBUG_ERR, "%s: return code=%d\n", __func__, retcode); }
 
-    memcpy(&rig->state.pttport_deprecated, &rig->state.pttport,
+    memcpy(&rig->state.pttport_deprecated, pttp,
            sizeof(rig->state.pttport_deprecated));
 
     if (rig->state.post_ptt_delay > 0) { hl_usleep(rig->state.post_ptt_delay * 1000); }
@@ -3698,6 +3714,8 @@ int HAMLIB_API rig_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
 {
     const struct rig_caps *caps;
     struct rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
+    hamlib_port_t *pttp = PTTPORT(rig);
     int retcode = RIG_OK;
     int status;
     vfo_t curr_vfo;
@@ -3739,7 +3757,7 @@ int HAMLIB_API rig_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
 
     LOCK(1);
 
-    switch (rig->state.pttport.type.ptt)
+    switch (pttp->type.ptt)
     {
     case RIG_PTT_RIG:
     case RIG_PTT_RIG_MICDATA:
@@ -3843,15 +3861,15 @@ int HAMLIB_API rig_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
 
 #endif
 
-        if (strcmp(rs->pttport.pathname, rs->rigport.pathname)
-                && rs->pttport.fd < 0)
+        if (strcmp(pttp->pathname, rp->pathname)
+                && pttp->fd < 0)
         {
             /* port is closed so assume PTT off */
             *ptt = RIG_PTT_OFF;
         }
         else
         {
-            retcode = ser_get_rts(&rig->state.pttport, &status);
+            retcode = ser_get_rts(pttp, &status);
             *ptt = status ? RIG_PTT_ON : RIG_PTT_OFF;
         }
 
@@ -3881,15 +3899,15 @@ int HAMLIB_API rig_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
 
 #endif
 
-        if (strcmp(rs->pttport.pathname, rs->rigport.pathname)
-                && rs->pttport.fd < 0)
+        if (strcmp(pttp->pathname, rp->pathname)
+                && pttp->fd < 0)
         {
             /* port is closed so assume PTT off */
             *ptt = RIG_PTT_OFF;
         }
         else
         {
-            retcode = ser_get_dtr(&rig->state.pttport, &status);
+            retcode = ser_get_dtr(pttp, &status);
             *ptt = status ? RIG_PTT_ON : RIG_PTT_OFF;
         }
 
@@ -3916,7 +3934,7 @@ int HAMLIB_API rig_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
             RETURNFUNC(retcode);
         }
 
-        retcode = par_ptt_get(&rig->state.pttport, ptt);
+        retcode = par_ptt_get(pttp, ptt);
 
         if (retcode == RIG_OK)
         {
@@ -3945,7 +3963,7 @@ int HAMLIB_API rig_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
             RETURNFUNC(retcode);
         }
 
-        retcode = cm108_ptt_get(&rig->state.pttport, ptt);
+        retcode = cm108_ptt_get(pttp, ptt);
 
         if (retcode == RIG_OK)
         {
@@ -3976,7 +3994,7 @@ int HAMLIB_API rig_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
         }
 
         elapsed_ms(&rig->state.cache.time_ptt, HAMLIB_ELAPSED_SET);
-        retcode = gpio_ptt_get(&rig->state.pttport, ptt);
+        retcode = gpio_ptt_get(pttp, ptt);
         ELAPSED2;
         LOCK(0);
         RETURNFUNC(retcode);
@@ -4015,6 +4033,7 @@ int HAMLIB_API rig_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
 int HAMLIB_API rig_get_dcd(RIG *rig, vfo_t vfo, dcd_t *dcd)
 {
     const struct rig_caps *caps;
+    hamlib_port_t *dcdp = DCDPORT(rig);
     int retcode, rc2, status;
     vfo_t curr_vfo;
 
@@ -4035,7 +4054,7 @@ int HAMLIB_API rig_get_dcd(RIG *rig, vfo_t vfo, dcd_t *dcd)
 
     caps = rig->caps;
 
-    switch (rig->state.dcdport.type.dcd)
+    switch (dcdp->type.dcd)
     {
     case RIG_DCD_RIG:
         if (caps->get_dcd == NULL)
@@ -4086,24 +4105,24 @@ int HAMLIB_API rig_get_dcd(RIG *rig, vfo_t vfo, dcd_t *dcd)
         break;
 
     case RIG_DCD_SERIAL_CTS:
-        retcode = ser_get_cts(&rig->state.dcdport, &status);
-        memcpy(&rig->state.dcdport_deprecated, &rig->state.dcdport,
+        retcode = ser_get_cts(dcdp, &status);
+        memcpy(&rig->state.dcdport_deprecated, dcdp,
                sizeof(rig->state.dcdport_deprecated));
         *dcd = status ? RIG_DCD_ON : RIG_DCD_OFF;
         ELAPSED2;
         RETURNFUNC(retcode);
 
     case RIG_DCD_SERIAL_DSR:
-        retcode = ser_get_dsr(&rig->state.dcdport, &status);
-        memcpy(&rig->state.dcdport_deprecated, &rig->state.dcdport,
+        retcode = ser_get_dsr(dcdp, &status);
+        memcpy(&rig->state.dcdport_deprecated, dcdp,
                sizeof(rig->state.dcdport_deprecated));
         *dcd = status ? RIG_DCD_ON : RIG_DCD_OFF;
         ELAPSED2;
         RETURNFUNC(retcode);
 
     case RIG_DCD_SERIAL_CAR:
-        retcode = ser_get_car(&rig->state.dcdport, &status);
-        memcpy(&rig->state.dcdport_deprecated, &rig->state.dcdport,
+        retcode = ser_get_car(dcdp, &status);
+        memcpy(&rig->state.dcdport_deprecated, dcdp,
                sizeof(rig->state.dcdport_deprecated));
         *dcd = status ? RIG_DCD_ON : RIG_DCD_OFF;
         ELAPSED2;
@@ -4111,16 +4130,16 @@ int HAMLIB_API rig_get_dcd(RIG *rig, vfo_t vfo, dcd_t *dcd)
 
 
     case RIG_DCD_PARALLEL:
-        retcode = par_dcd_get(&rig->state.dcdport, dcd);
-        memcpy(&rig->state.dcdport_deprecated, &rig->state.dcdport,
+        retcode = par_dcd_get(dcdp, dcd);
+        memcpy(&rig->state.dcdport_deprecated, dcdp,
                sizeof(rig->state.dcdport_deprecated));
         ELAPSED2;
         RETURNFUNC(retcode);
 
     case RIG_DCD_GPIO:
     case RIG_DCD_GPION:
-        retcode = gpio_dcd_get(&rig->state.dcdport, dcd);
-        memcpy(&rig->state.dcdport_deprecated, &rig->state.dcdport,
+        retcode = gpio_dcd_get(dcdp, dcd);
+        memcpy(&rig->state.dcdport_deprecated, dcdp,
                sizeof(rig->state.dcdport_deprecated));
         ELAPSED2;
         RETURNFUNC(retcode);
@@ -6499,7 +6518,7 @@ int HAMLIB_API rig_set_powerstat(RIG *rig, powerstat_t status)
     }
 
     // if anything is queued up flush it
-    rig_flush_force(&rig->state.rigport, 1);
+    rig_flush_force(RIGPORT(rig), 1);
     ELAPSED2;
     RETURNFUNC(retcode);
 }
@@ -8241,7 +8260,7 @@ void *async_data_handler(void *arg)
                 if (rs->transaction_active)
                 {
                     unsigned char data = (unsigned char) result;
-                    write_block_sync_error(&rs->rigport, &data, 1);
+                    write_block_sync_error(RIGPORT(rig), &data, 1);
                 }
 
                 // TODO: error handling -> store errors in rig state -> to be exposed in async snapshot packets
@@ -8275,7 +8294,7 @@ void *async_data_handler(void *arg)
         }
         else
         {
-            result = write_block_sync(&rs->rigport, frame, frame_length);
+            result = write_block_sync(RIGPORT(rig), frame, frame_length);
 
             if (result < 0)
             {
@@ -8459,12 +8478,12 @@ extern int read_icom_frame(hamlib_port_t *p, const unsigned char rxbuffer[],
 HAMLIB_EXPORT(int) rig_send_raw(RIG *rig, const unsigned char *send,
                                 int send_len, unsigned char *reply, int reply_len, unsigned char *term)
 {
-    struct rig_state *rs = &rig->state;
     int nbytes;
     int retval;
+    hamlib_port_t *rp = RIGPORT(rig);
     int simulate = rig->caps->rig_model == RIG_MODEL_DUMMY ||
                    rig->caps->rig_model == RIG_MODEL_NONE ||
-                   rs->rigport.rig == RIG_PORT_NONE;
+                   rp->rig == RIG_PORT_NONE;
     ENTERFUNC;
 
     ELAPSED1;
@@ -8481,7 +8500,7 @@ HAMLIB_EXPORT(int) rig_send_raw(RIG *rig, const unsigned char *send,
     }
     else
     {
-        retval = write_block(&rs->rigport, send, send_len);
+        retval = write_block(rp, send, send_len);
 
         if (retval < 0)
         {
@@ -8506,25 +8525,25 @@ HAMLIB_EXPORT(int) rig_send_raw(RIG *rig, const unsigned char *send,
             if (term == NULL)
             {
                 rig_debug(RIG_DEBUG_VERBOSE, "%s: reading binary frame\n", __func__);
-                retval = read_string(&rs->rigport, buf, reply_len, NULL, 0, 0, 1);
+                retval = read_string(rp, buf, reply_len, NULL, 0, 0, 1);
             }
             else if (*term == 0xfd) // then we want an Icom frame
             {
                 rig_debug(RIG_DEBUG_VERBOSE, "%s: reading icom frame\n", __func__);
-                retval = read_icom_frame(&rs->rigport, buf, sizeof(buf));
+                retval = read_icom_frame(rp, buf, sizeof(buf));
             }
             else // we'll assume the provided terminator works
             {
                 rig_debug(RIG_DEBUG_VERBOSE, "%s: reading frame terminated by 0x%x\n", __func__,
                           *term);
-                retval = read_string(&rs->rigport, buf, sizeof(buf), (const char *)term,
+                retval = read_string(rp, buf, sizeof(buf), (const char *)term,
                                      1, 0, 1);
             }
 
             if (retval < RIG_OK)
             {
                 rig_debug(RIG_DEBUG_ERR, "%s: read_string, result=%d\n", __func__, retval);
-                rig_flush_force(&rs->rigport, 1);
+                rig_flush_force(rp, 1);
                 set_transaction_inactive(rig);
                 RETURNFUNC(retval);
             }
@@ -8535,7 +8554,7 @@ HAMLIB_EXPORT(int) rig_send_raw(RIG *rig, const unsigned char *send,
             {
                 rig_debug(RIG_DEBUG_ERR, "%s: reply_len(%d) less than reply from rig(%d)\n",
                           __func__, reply_len, nbytes);
-                rig_flush_force(&rs->rigport, 1);
+                rig_flush_force(rp, 1);
                 set_transaction_inactive(rig);
                 return -RIG_EINVAL;
             }
@@ -8545,12 +8564,12 @@ HAMLIB_EXPORT(int) rig_send_raw(RIG *rig, const unsigned char *send,
     }
     else
     {
-        rig_flush_force(&rs->rigport, 1);
+        rig_flush_force(rp, 1);
         set_transaction_inactive(rig);
         RETURNFUNC(retval);
     }
 
-    rig_flush_force(&rs->rigport, 1);
+    rig_flush_force(rp, 1);
     set_transaction_inactive(rig);
 
     ELAPSED2;

--- a/src/rotator.c
+++ b/src/rotator.c
@@ -19,6 +19,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 /**
  * \addtogroup rotator
@@ -219,6 +220,7 @@ ROT *HAMLIB_API rot_init(rot_model_t rot_model)
     ROT *rot;
     const struct rot_caps *caps;
     struct rot_state *rs;
+    hamlib_port_t *rotp, *rotp2;
 
     rot_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
@@ -258,41 +260,46 @@ ROT *HAMLIB_API rot_init(rot_model_t rot_model)
      */
     rs = &rot->state;
 
+    //TODO Allocate new rotport[2]
+    // For now, use the embedded ones
+    rotp = ROTPORT(rot);
+    rotp2 = ROTPORT2(rot);
+    
     rs->comm_state = 0;
-    rs->rotport.type.rig = caps->port_type; /* default from caps */
+    rotp->type.rig = caps->port_type; /* default from caps */
 
-    rs->rotport.write_delay = caps->write_delay;
-    rs->rotport.post_write_delay = caps->post_write_delay;
-    rs->rotport.timeout = caps->timeout;
-    rs->rotport.retry = caps->retry;
+    rotp->write_delay = caps->write_delay;
+    rotp->post_write_delay = caps->post_write_delay;
+    rotp->timeout = caps->timeout;
+    rotp->retry = caps->retry;
 
     switch (caps->port_type)
     {
     case RIG_PORT_SERIAL:
-        strncpy(rs->rotport.pathname, DEFAULT_SERIAL_PORT, HAMLIB_FILPATHLEN - 1);
-        rs->rotport.parm.serial.rate = rs->rotport2.parm.serial.rate =
+        strncpy(rotp->pathname, DEFAULT_SERIAL_PORT, HAMLIB_FILPATHLEN - 1);
+        rotp->parm.serial.rate = rotp2->parm.serial.rate =
                                            caps->serial_rate_max;   /* fastest ! */
-        rs->rotport.parm.serial.data_bits = rs->rotport2.parm.serial.data_bits =
+        rotp->parm.serial.data_bits = rotp2->parm.serial.data_bits =
                                                 caps->serial_data_bits;
-        rs->rotport.parm.serial.stop_bits = rs->rotport2.parm.serial.stop_bits =
+        rotp->parm.serial.stop_bits = rotp2->parm.serial.stop_bits =
                                                 caps->serial_stop_bits;
-        rs->rotport.parm.serial.parity = rs->rotport2.parm.serial.parity =
+        rotp->parm.serial.parity = rotp2->parm.serial.parity =
                                              caps->serial_parity;
-        rs->rotport.parm.serial.handshake = rs->rotport2.parm.serial.handshake =
+        rotp->parm.serial.handshake = rotp2->parm.serial.handshake =
                                                 caps->serial_handshake;
         break;
 
     case RIG_PORT_PARALLEL:
-        strncpy(rs->rotport.pathname, DEFAULT_PARALLEL_PORT, HAMLIB_FILPATHLEN - 1);
+        strncpy(rotp->pathname, DEFAULT_PARALLEL_PORT, HAMLIB_FILPATHLEN - 1);
         break;
 
     case RIG_PORT_NETWORK:
     case RIG_PORT_UDP_NETWORK:
-        strncpy(rs->rotport.pathname, "127.0.0.1:4533", HAMLIB_FILPATHLEN - 1);
+        strncpy(rotp->pathname, "127.0.0.1:4533", HAMLIB_FILPATHLEN - 1);
         break;
 
     default:
-        strncpy(rs->rotport.pathname, "", HAMLIB_FILPATHLEN - 1);
+        strncpy(rotp->pathname, "", HAMLIB_FILPATHLEN - 1);
     }
 
     rs->min_el = caps->min_el;
@@ -301,7 +308,7 @@ ROT *HAMLIB_API rot_init(rot_model_t rot_model)
     rs->max_az = caps->max_az;
     rs->current_speed = 50; // Set default speed to 50%
 
-    rs->rotport.fd = -1;
+    rotp->fd = -1;
 
     rs->has_get_func = caps->has_get_func;
     rs->has_set_func = caps->has_set_func;
@@ -338,7 +345,7 @@ ROT *HAMLIB_API rot_init(rot_model_t rot_model)
     // Now we have to copy our new rig state hamlib_port structure to the deprecated one
     // Clients built on older 4.X versions will use the old structure
     // Clients built on newer 4.5 versions will use the new structure
-    memcpy(&rot->state.rotport_deprecated, &rot->state.rotport,
+    memcpy(&rot->state.rotport_deprecated, rotp,
            sizeof(rot->state.rotport_deprecated));
 
     return rot;
@@ -366,6 +373,8 @@ int HAMLIB_API rot_open(ROT *rot)
 {
     const struct rot_caps *caps;
     struct rot_state *rs;
+    hamlib_port_t *rotp = ROTPORT(rot);
+    hamlib_port_t *rotp2 = ROTPORT2(rot);
     int status;
     int net1, net2, net3, net4, port;
 
@@ -384,30 +393,30 @@ int HAMLIB_API rot_open(ROT *rot)
         return -RIG_EINVAL;
     }
 
-    rs->rotport.fd = -1;
-    rs->rotport2.fd = -1;
+    rotp->fd = -1;
+    rotp2->fd = -1;
 
     // determine if we have a network address
-    if (sscanf(rs->rotport.pathname, "%d.%d.%d.%d:%d", &net1, &net2, &net3, &net4,
+    if (sscanf(rotp->pathname, "%d.%d.%d.%d:%d", &net1, &net2, &net3, &net4,
                &port) == 5)
     {
         rig_debug(RIG_DEBUG_TRACE, "%s: using network address %s\n", __func__,
-                  rs->rotport.pathname);
-        rs->rotport.type.rig = RIG_PORT_NETWORK;
+                  rotp->pathname);
+        rotp->type.rig = RIG_PORT_NETWORK;
     }
 
-    if (sscanf(rs->rotport2.pathname, "%d.%d.%d.%d:%d", &net1, &net2, &net3, &net4,
+    if (sscanf(rotp2->pathname, "%d.%d.%d.%d:%d", &net1, &net2, &net3, &net4,
                &port) == 5)
     {
         rig_debug(RIG_DEBUG_TRACE, "%s: using network address %s\n", __func__,
-                  rs->rotport2.pathname);
-        rs->rotport2.type.rig = RIG_PORT_NETWORK;
+                  rotp2->pathname);
+        rotp2->type.rig = RIG_PORT_NETWORK;
     }
 
-    switch (rs->rotport.type.rig)
+    switch (rotp->type.rig)
     {
     case RIG_PORT_SERIAL:
-        status = serial_open(&rs->rotport);
+        status = serial_open(rotp);
 
         if (status != 0)
         {
@@ -416,9 +425,9 @@ int HAMLIB_API rot_open(ROT *rot)
 
         // RT21 has 2nd serial port elevation
         // so if a 2nd pathname is provided we'll open it
-        if (rot->caps->rot_model == ROT_MODEL_RT21 && rs->rotport2.pathname[0] != 0)
+        if (rot->caps->rot_model == ROT_MODEL_RT21 && rotp2->pathname[0] != 0)
         {
-            status = serial_open(&rs->rotport2);
+            status = serial_open(rotp2);
 
             if (status != 0)
             {
@@ -429,7 +438,7 @@ int HAMLIB_API rot_open(ROT *rot)
         break;
 
     case RIG_PORT_PARALLEL:
-        status = par_open(&rs->rotport);
+        status = par_open(rotp);
 
         if (status < 0)
         {
@@ -439,27 +448,27 @@ int HAMLIB_API rot_open(ROT *rot)
         break;
 
     case RIG_PORT_DEVICE:
-        status = open(rs->rotport.pathname, O_RDWR, 0);
+        status = open(rotp->pathname, O_RDWR, 0);
 
         if (status < 0)
         {
             return -RIG_EIO;
         }
 
-        rs->rotport.fd = status;
+        rotp->fd = status;
 
         // RT21 has 2nd serial port elevation
         // so if a 2nd pathname is provided we'll open it
-        if (rot->caps->rot_model == ROT_MODEL_RT21 && rs->rotport2.pathname[0] != 0)
+        if (rot->caps->rot_model == ROT_MODEL_RT21 && rotp2->pathname[0] != 0)
         {
-            status = open(rs->rotport2.pathname, O_RDWR, 0);
+            status = open(rotp2->pathname, O_RDWR, 0);
 
             if (status < 0)
             {
                 return -RIG_EIO;
             }
 
-            rs->rotport2.fd = status;
+            rotp2->fd = status;
         }
 
         break;
@@ -467,7 +476,7 @@ int HAMLIB_API rot_open(ROT *rot)
 #if defined(HAVE_LIB_USB_H) || defined(HAMB_LIBUSB_1_0_LIBUSB_H)
 
     case RIG_PORT_USB:
-        status = usb_port_open(&rs->rotport);
+        status = usb_port_open(rotp);
 
         if (status < 0)
         {
@@ -484,7 +493,7 @@ int HAMLIB_API rot_open(ROT *rot)
     case RIG_PORT_NETWORK:
     case RIG_PORT_UDP_NETWORK:
         /* FIXME: default port */
-        status = network_open(&rs->rotport, 4533);
+        status = network_open(rotp, 4533);
 
         if (status < 0)
         {
@@ -511,31 +520,31 @@ int HAMLIB_API rot_open(ROT *rot)
 
         if (status != RIG_OK)
         {
-            memcpy(&rot->state.rotport_deprecated, &rot->state.rotport,
+            memcpy(&rot->state.rotport_deprecated, rotp,
                    sizeof(rot->state.rotport_deprecated));
             return status;
         }
     }
 
-    if (rs->rotport.parm.serial.dtr_state == RIG_SIGNAL_ON)
+    if (rotp->parm.serial.dtr_state == RIG_SIGNAL_ON)
     {
-        ser_set_dtr(&rs->rotport, 1);
+        ser_set_dtr(rotp, 1);
     }
     else
     {
-        ser_set_dtr(&rs->rotport, 0);
+        ser_set_dtr(rotp, 0);
     }
 
-    if (rs->rotport.parm.serial.rts_state == RIG_SIGNAL_ON)
+    if (rotp->parm.serial.rts_state == RIG_SIGNAL_ON)
     {
-        ser_set_rts(&rs->rotport, 1);
+        ser_set_rts(rotp, 1);
     }
     else
     {
-        ser_set_rts(&rs->rotport, 0);
+        ser_set_rts(rotp, 0);
     }
 
-    memcpy(&rot->state.rotport_deprecated, &rot->state.rotport,
+    memcpy(&rot->state.rotport_deprecated, rotp,
            sizeof(rot->state.rotport_deprecated));
 
     return RIG_OK;
@@ -561,6 +570,7 @@ int HAMLIB_API rot_close(ROT *rot)
 {
     const struct rot_caps *caps;
     struct rot_state *rs;
+    hamlib_port_t *rotp = ROTPORT(rot);
 
     rot_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
@@ -587,42 +597,42 @@ int HAMLIB_API rot_close(ROT *rot)
     }
 
 
-    if (rs->rotport.fd != -1)
+    if (rotp->fd != -1)
     {
-        switch (rs->rotport.type.rig)
+        switch (rotp->type.rig)
         {
         case RIG_PORT_SERIAL:
-            ser_close(&rs->rotport);
+            ser_close(rotp);
             break;
 
         case RIG_PORT_PARALLEL:
-            par_close(&rs->rotport);
+            par_close(rotp);
             break;
 
 #if defined(HAVE_LIB_USB_H) || defined(HAMB_LIBUSB_1_0_LIBUSB_H)
 
         case RIG_PORT_USB:
-            usb_port_close(&rs->rotport);
+            usb_port_close(rotp);
             break;
 #endif
 
         case RIG_PORT_NETWORK:
         case RIG_PORT_UDP_NETWORK:
-            network_close(&rs->rotport);
+            network_close(rotp);
             break;
 
         default:
-            close(rs->rotport.fd);
+            close(rotp->fd);
         }
 
-        rs->rotport.fd = -1;
+        rotp->fd = -1;
     }
 
     remove_opened_rot(rot);
 
     rs->comm_state = 0;
 
-    memcpy(&rot->state.rotport_deprecated, &rot->state.rotport,
+    memcpy(&rot->state.rotport_deprecated, rotp,
            sizeof(rot->state.rotport_deprecated));
 
     return RIG_OK;
@@ -670,6 +680,8 @@ int HAMLIB_API rot_cleanup(ROT *rot)
         rot->caps->rot_cleanup(rot);
     }
 
+    //TODO Release any allocated port structures
+    
     free(rot);
 
     return RIG_OK;
@@ -1031,4 +1043,23 @@ int HAMLIB_API rot_get_status(ROT *rot, rot_status_t *status)
     return rot->caps->get_status(rot, status);
 }
 
+/**
+ * \brief Get the address of rotator data structure(s)
+ *
+ * \sa rig_data_pointer
+ *
+ */
+void * HAMLIB_API rot_data_pointer(ROT *rot, rig_ptrx_t idx)
+{
+  switch(idx)
+    {
+    case RIG_PTRX_ROTPORT:
+      return ROTPORT(rot);
+    case RIG_PTRX_ROTPORT2:
+      return ROTPORT2(rot);
+    default:
+      rot_debug(RIG_DEBUG_ERR, "%s: Invalid data index=%d\n", __func__, idx);
+      return NULL;
+    }
+}
 /*! @} */

--- a/src/serial.c
+++ b/src/serial.c
@@ -1051,7 +1051,7 @@ int HAMLIB_API ser_set_rts(hamlib_port_t *p, int state)
 
 /**
  * \brief Get RTS bit
- * \param p supposed to be &rig->state.rigport
+ * \param p supposed to be RIGPORT(rig)
  * \param state non-NULL
  */
 int HAMLIB_API ser_get_rts(hamlib_port_t *p, int *state)
@@ -1134,7 +1134,7 @@ int HAMLIB_API ser_set_dtr(hamlib_port_t *p, int state)
 
 /**
  * \brief Get DTR bit
- * \param p supposed to be &rig->state.rigport
+ * \param p supposed to be RIGPORT(rig)
  * \param state non-NULL
  */
 int HAMLIB_API ser_get_dtr(hamlib_port_t *p, int *state)
@@ -1186,7 +1186,7 @@ int HAMLIB_API ser_set_brk(const hamlib_port_t *p, int state)
 
 /**
  * \brief Get Carrier (CI?) bit
- * \param p supposed to be &rig->state.rigport
+ * \param p supposed to be RIGPORT(rig)
  * \param state non-NULL
  */
 int HAMLIB_API ser_get_car(hamlib_port_t *p, int *state)
@@ -1209,7 +1209,7 @@ int HAMLIB_API ser_get_car(hamlib_port_t *p, int *state)
 
 /**
  * \brief Get Clear to Send (CTS) bit
- * \param p supposed to be &rig->state.rigport
+ * \param p supposed to be RIGPORT(rig)
  * \param state non-NULL
  */
 int HAMLIB_API ser_get_cts(hamlib_port_t *p, int *state)
@@ -1232,7 +1232,7 @@ int HAMLIB_API ser_get_cts(hamlib_port_t *p, int *state)
 
 /**
  * \brief Get Data Set Ready (DSR) bit
- * \param p supposed to be &rig->state.rigport
+ * \param p supposed to be RIGPORT(rig)
  * \param state non-NULL
  */
 int HAMLIB_API ser_get_dsr(hamlib_port_t *p, int *state)

--- a/src/snapshot_data.c
+++ b/src/snapshot_data.c
@@ -22,7 +22,7 @@ static int snapshot_serialize_rig(cJSON *rig_node, RIG *rig)
 
     cJSON *id_node = cJSON_CreateObject();
     cJSON_AddStringToObject(id_node, "model", rig->caps->model_name);
-    cJSON_AddStringToObject(id_node, "endpoint", rig->state.rigport.pathname);
+    cJSON_AddStringToObject(id_node, "endpoint", RIGPORT(rig)->pathname);
     cJSON_AddStringToObject(id_node, "process", snapshot_data_pid);
     cJSON_AddStringToObject(id_node, "deviceId", rig->state.device_id);
     cJSON_AddItemToObject(rig_node, "id", id_node);

--- a/tests/example.c
+++ b/tests/example.c
@@ -43,9 +43,9 @@ int main()
     /* Instantiate a rig */
     my_rig = rig_init(MODEL); // your rig model.
 
-    strncpy(my_rig->state.rigport.pathname, PATH, HAMLIB_FILPATHLEN - 1);
+    rig_set_conf(my_rig, rig_token_lookup(my_rig, "rig_pathname"), PATH);
 
-    my_rig->state.rigport.parm.serial.rate = BAUD; // your baud rate
+    HAMLIB_RIGPORT(my_rig)->parm.serial.rate = BAUD; // your baud rate
 
     /* Open my rig */
     retcode = rig_open(my_rig);
@@ -131,7 +131,7 @@ int main()
     if (range)
     {
         char vfolist[256];
-        rig_sprintf_vfo(vfolist, sizeof(vfo_list), my_rig->state.vfo_list);
+        rig_sprintf_vfo(vfolist, sizeof(vfolist), my_rig->state.vfo_list);
         printf("Range start=%"PRIfreq", end=%"PRIfreq", low_power=%d, high_power=%d, vfos=%s\n",
                range->startf, range->endf, range->low_power, range->high_power, vfolist);
     }


### PR DESCRIPTION
Add functions (and macro definitions to call them) for users to retrieve port addresses for rigs, amps, and rotators.
Functions easily expandable for other structures.
Port internal routines in src/ to use them.
 
Still about 1200 references to go.
