### PR TITLE
CTCSS/TONE functions for TS-890S

### DIFF
--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -4623,11 +4623,11 @@ int kenwood_set_ctcss_sql(RIG *rig, vfo_t vfo, tone_t tone)
             RETURNFUNC(-RIG_EINVAL);
         }
 
-        SNPRINTF(buf, sizeof(buf), "CN%c%02d", c, i - kenwood_caps(rig)->tone_table_base);
+        SNPRINTF(buf, sizeof(buf), "CN%c%02d", c, i + kenwood_caps(rig)->tone_table_base);
     }
     else
     {
-        SNPRINTF(buf, sizeof(buf), "CN%02d", i - kenwood_caps(rig)->tone_table_base);
+        SNPRINTF(buf, sizeof(buf), "CN%02d", i + kenwood_caps(rig)->tone_table_base);
     }
 
     RETURNFUNC(kenwood_transaction(rig, buf, NULL, 0));

--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -4422,7 +4422,7 @@ int kenwood_set_ctcss_tone(RIG *rig, vfo_t vfo, tone_t tone)
     }
 
     /* TODO: replace menu no 57 by a define */
-    SNPRINTF(tonebuf, sizeof(tonebuf), "EX%03d%04d", 57, i + 1);
+    SNPRINTF(tonebuf, sizeof(tonebuf), "EX%03d%04d", 57, i + kenwood_caps(rig)->tone_table_base);
 
     RETURNFUNC(kenwood_transaction(rig, tonebuf, NULL, 0));
 }
@@ -4473,11 +4473,11 @@ int kenwood_set_ctcss_tone_tn(RIG *rig, vfo_t vfo, tone_t tone)
             RETURNFUNC(-RIG_EINVAL);
         }
 
-        SNPRINTF(buf, sizeof(buf), "TN%c%02d", c, i + 1);
+        SNPRINTF(buf, sizeof(buf), "TN%c%02d", c, i + kenwood_caps(rig)->tone_table_base);
     }
     else
     {
-        SNPRINTF(buf, sizeof(buf), "TN%02d", i + 1);
+        SNPRINTF(buf, sizeof(buf), "TN%02d", i + kenwood_caps(rig)->tone_table_base);
     }
 
     RETURNFUNC(kenwood_transaction(rig, buf, NULL, 0));
@@ -4554,7 +4554,7 @@ int kenwood_get_ctcss_tone(RIG *rig, vfo_t vfo, tone_t *tone)
     tonebuf[2] = '\0';
     tone_idx = atoi(tonebuf);
 
-    if (tone_idx == 0)
+    if (tone_idx < kenwood_caps(rig)->tone_table_base)
     {
         rig_debug(RIG_DEBUG_ERR, "%s: CTCSS tone is zero (%s)\n",
                   __func__, tonebuf);
@@ -4572,7 +4572,7 @@ int kenwood_get_ctcss_tone(RIG *rig, vfo_t vfo, tone_t *tone)
         }
     }
 
-    *tone = caps->ctcss_list[tone_idx - 1];
+    *tone = caps->ctcss_list[tone_idx] - kenwood_caps(rig)->tone_table_base;
 
     RETURNFUNC(RIG_OK);
 }
@@ -4623,11 +4623,11 @@ int kenwood_set_ctcss_sql(RIG *rig, vfo_t vfo, tone_t tone)
             RETURNFUNC(-RIG_EINVAL);
         }
 
-        SNPRINTF(buf, sizeof(buf), "CN%c%02d", c, i + 1);
+        SNPRINTF(buf, sizeof(buf), "CN%c%02d", c, i - kenwood_caps(rig)->tone_table_base);
     }
     else
     {
-        SNPRINTF(buf, sizeof(buf), "CN%02d", i + 1);
+        SNPRINTF(buf, sizeof(buf), "CN%02d", i - kenwood_caps(rig)->tone_table_base);
     }
 
     RETURNFUNC(kenwood_transaction(rig, buf, NULL, 0));
@@ -4692,7 +4692,7 @@ int kenwood_get_ctcss_sql(RIG *rig, vfo_t vfo, tone_t *tone)
 
     tone_idx = atoi(tonebuf + offs);
 
-    if (tone_idx == 0)
+    if (tone_idx < kenwood_caps(rig)->tone_table_base)
     {
         rig_debug(RIG_DEBUG_ERR, "%s: CTCSS is zero (%s)\n",
                   __func__, tonebuf);
@@ -4710,7 +4710,7 @@ int kenwood_get_ctcss_sql(RIG *rig, vfo_t vfo, tone_t *tone)
         }
     }
 
-    *tone = caps->ctcss_list[tone_idx - 1];
+    *tone = caps->ctcss_list[tone_idx] - kenwood_caps(rig)->tone_table_base;
 
     RETURNFUNC(RIG_OK);
 }

--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -181,6 +181,18 @@ tone_t kenwood42_ctcss_list[] =
     0,
 };
 
+/*
+ * 51 CTCSS sub-audible tones
+ */
+tone_t kenwood51_ctcss_list[] =
+{
+   670 ,  693,  719,  744,  770,  797,  825,  854,  885,  915, /*  0- 9 */
+   948 ,  974, 1000, 1035, 1072, 1109, 1148, 1188, 1230, 1273, /* 10-19 */
+   1318, 1365, 1413, 1462, 1514, 1567, 1598, 1622, 1655, 1679, /* 20-29 */
+   1713, 1738, 1773, 1799, 1835, 1862, 1899, 1928, 1966, 1995, /* 30-39 */
+   2035, 2065, 2107, 2181, 2257, 2291, 2336, 2418, 2503, 2541, /* 40-49 */
+   17500, 0 /* 50-99 */
+};
 
 /* Token definitions for .cfgparams in rig_caps
  *
@@ -4492,7 +4504,14 @@ int kenwood_get_ctcss_tone(RIG *rig, vfo_t vfo, tone_t *tone)
 
     caps = rig->caps;
 
-    if (RIG_IS_TS990S)
+    if (RIG_IS_TS890S)
+      {
+	char buf[5];
+	
+	retval = kenwood_safe_transaction(rig, "TN", buf, sizeof(buf), 4);
+	memcpy(tonebuf, buf + 2, 2);
+      }
+    else if (RIG_IS_TS990S)
     {
         char cmd[4];
         char buf[6];

--- a/rigs/kenwood/kenwood.h
+++ b/rigs/kenwood/kenwood.h
@@ -191,6 +191,7 @@ extern rmode_t kenwood_mode_table[KENWOOD_MODE_TABLE_MAX];
 
 extern tone_t kenwood38_ctcss_list[];
 extern tone_t kenwood42_ctcss_list[];
+extern tone_t kenwood51_ctcss_list[];
 
 int kenwood_transaction(RIG *rig, const char *cmdstr, char *data, size_t datasize);
 int kenwood_safe_transaction(RIG *rig, const char *cmd, char *buf,

--- a/rigs/kenwood/kenwood.h
+++ b/rigs/kenwood/kenwood.h
@@ -137,6 +137,7 @@ struct kenwood_priv_caps
     struct kenwood_slope_filter *slope_filter_high; /* Last entry should have value == -1 and frequency_hz == -1 */
     struct kenwood_slope_filter *slope_filter_low; /* Last entry should have value == -1 and frequency_hz == -1 */
     double swr;
+    int tone_table_base; /* Offset of first value in rigs tone tables, default=0 */
 };
 
 struct kenwood_priv_data

--- a/rigs/kenwood/pihpsdr.c
+++ b/rigs/kenwood/pihpsdr.c
@@ -68,6 +68,7 @@ static int pihspdr_set_channel(RIG *rig, vfo_t vfo, const channel_t *chan);
 static struct kenwood_priv_caps  ts2000_priv_caps  =
 {
     .cmdtrm =  EOM_KEN,
+    .tone_table_base = 1,
 };
 
 /* memory capabilities */

--- a/rigs/kenwood/r5000.c
+++ b/rigs/kenwood/r5000.c
@@ -46,6 +46,7 @@ static struct kenwood_priv_caps  r5000_priv_caps  =
 {
     .cmdtrm =  EOM_KEN,
     .if_len =  32,
+    .tone_table_base = 1,
 };
 
 /*

--- a/rigs/kenwood/ts2000.c
+++ b/rigs/kenwood/ts2000.c
@@ -18,6 +18,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -232,6 +233,7 @@ static struct kenwood_priv_caps  ts2000_priv_caps  =
     .filter_width = ts2000_filter_width,
     .slope_filter_high = ts2000_slope_filter_high,
     .slope_filter_low = ts2000_slope_filter_low,
+    .tone_table_base = 1,
 };
 
 /* memory capabilities */

--- a/rigs/kenwood/ts440.c
+++ b/rigs/kenwood/ts440.c
@@ -43,6 +43,7 @@ static struct kenwood_priv_caps  ts440_priv_caps  =
 {
     .cmdtrm =  EOM_KEN,
     .if_len =  37,
+    .tone_table_base = 1,
 };
 
 /*

--- a/rigs/kenwood/ts50s.c
+++ b/rigs/kenwood/ts50s.c
@@ -39,6 +39,7 @@
 static struct kenwood_priv_caps  ts50_priv_caps  =
 {
     .cmdtrm =  EOM_KEN,
+    .tone_table_base = 1,
 };
 
 /*

--- a/rigs/kenwood/ts570.c
+++ b/rigs/kenwood/ts570.c
@@ -18,6 +18,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -43,6 +44,7 @@
 static struct kenwood_priv_caps ts570_priv_caps  =
 {
     .cmdtrm =  EOM_KEN,
+    .tone_table_base = 1,
 };
 
 static int ts570_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)

--- a/rigs/kenwood/ts590.c
+++ b/rigs/kenwood/ts590.c
@@ -1683,6 +1683,7 @@ static struct kenwood_priv_caps ts590_priv_caps =
     .filter_width = ts590_filter_width,
     .slope_filter_high = ts590_slope_filter_high,
     .slope_filter_low = ts590_slope_filter_low,
+    .tone_table_base = 0,
 };
 
 /**

--- a/rigs/kenwood/ts711.c
+++ b/rigs/kenwood/ts711.c
@@ -52,6 +52,7 @@
 static struct kenwood_priv_caps  ts711_priv_caps  =
 {
     .cmdtrm =  EOM_KEN,
+    .tone_table_base = 1,
 };
 
 /*

--- a/rigs/kenwood/ts790.c
+++ b/rigs/kenwood/ts790.c
@@ -53,6 +53,7 @@
 static struct kenwood_priv_caps  ts790_priv_caps  =
 {
     .cmdtrm =  EOM_KEN,
+    .tone_table_base = 1,
 };
 
 /*

--- a/rigs/kenwood/ts811.c
+++ b/rigs/kenwood/ts811.c
@@ -38,6 +38,7 @@
 static struct kenwood_priv_caps  ts811_priv_caps  =
 {
     .cmdtrm =  EOM_KEN,
+    .tone_table_base = 1,
 };
 
 /*

--- a/rigs/kenwood/ts850.c
+++ b/rigs/kenwood/ts850.c
@@ -62,6 +62,7 @@
 static struct kenwood_priv_caps  ts850_priv_caps  =
 {
     .cmdtrm =  EOM_KEN,
+    .tone_table_base = 1,
 };
 
 /* forward definitions */

--- a/rigs/kenwood/ts870s.c
+++ b/rigs/kenwood/ts870s.c
@@ -18,6 +18,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -53,6 +54,7 @@
 static struct kenwood_priv_caps  ts870s_priv_caps  =
 {
     .cmdtrm =  EOM_KEN,
+    .tone_table_base = 1,
 };
 
 /* only the ts870s and ts2000 support get_vfo with the 'FR;' command

--- a/rigs/kenwood/ts890s.c
+++ b/rigs/kenwood/ts890s.c
@@ -510,6 +510,7 @@ struct rig_caps ts890s_caps =
         RIG_FLT_END,
     },
     .vfo_ops = TS890_VFO_OPS,
+    .ctcss_list = kenwood51_ctcss_list,
 
     .swr_cal = TS890_SWR_CAL,
 
@@ -529,6 +530,8 @@ struct rig_caps ts890s_caps =
     .get_vfo = kenwood_get_vfo_if,
     .set_split_vfo = kenwood_set_split_vfo,
     .get_split_vfo = kenwood_get_split_vfo_if,
+    .set_ctcss_tone = kenwood_set_ctcss_tone_tn,
+    .get_ctcss_tone = kenwood_get_ctcss_tone,
     .get_ptt = kenwood_get_ptt,
     .set_ptt = kenwood_set_ptt,
     .get_dcd = kenwood_get_dcd,

--- a/rigs/kenwood/ts890s.c
+++ b/rigs/kenwood/ts890s.c
@@ -37,7 +37,7 @@
 
 #define TS890_LEVEL_SET (RIG_LEVEL_RFPOWER|RIG_LEVEL_AF|RIG_LEVEL_RF|RIG_LEVEL_SQL|RIG_LEVEL_AGC|RIG_LEVEL_KEYSPD|RIG_LEVEL_CWPITCH|RIG_LEVEL_ATT|RIG_LEVEL_USB_AF|RIG_LEVEL_USB_AF_INPUT)
 #define TS890_LEVEL_GET (RIG_LEVEL_RFPOWER|RIG_LEVEL_AF|RIG_LEVEL_RF|RIG_LEVEL_SQL|RIG_LEVEL_AGC|RIG_LEVEL_KEYSPD|RIG_LEVEL_ALC|RIG_LEVEL_SWR|RIG_LEVEL_COMP_METER|RIG_LEVEL_ID_METER|RIG_LEVEL_VD_METER|RIG_LEVEL_TEMP_METER|RIG_LEVEL_CWPITCH|RIG_LEVEL_RAWSTR|RIG_LEVEL_STRENGTH|RIG_LEVEL_ATT|RIG_LEVEL_USB_AF|RIG_LEVEL_USB_AF_INPUT)
-#define TS890_FUNC_ALL (RIG_FUNC_NB|RIG_FUNC_NB2|RIG_FUNC_COMP|RIG_FUNC_VOX|RIG_FUNC_NR|RIG_FUNC_BC|RIG_FUNC_BC2|RIG_FUNC_RIT|RIG_FUNC_XIT|RIG_FUNC_TUNER|RIG_FUNC_SEND_MORSE)
+#define TS890_FUNC_ALL (RIG_FUNC_NB|RIG_FUNC_NB2|RIG_FUNC_COMP|RIG_FUNC_VOX|RIG_FUNC_NR|RIG_FUNC_BC|RIG_FUNC_BC2|RIG_FUNC_RIT|RIG_FUNC_XIT|RIG_FUNC_TUNER|RIG_FUNC_SEND_MORSE|RIG_FUNC_TONE|RIG_FUNC_TSQL)
 
 #define TS890_VFO_OPS (RIG_OP_UP|RIG_OP_DOWN|RIG_OP_BAND_UP|RIG_OP_BAND_DOWN|RIG_OP_CPY|RIG_OP_TUNE)
 
@@ -370,9 +370,64 @@ int kenwood_ts890_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     return -RIG_EINTERNAL;
 }
 
+int ts890_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
+{
+    int mask, retval;
+    char current[4];
+
+    switch (func)
+      {
+      case RIG_FUNC_TONE:
+	mask = 1;
+	break;
+      case RIG_FUNC_TSQL:
+	mask = 2;
+	break;
+      default:
+	  return (kenwood_set_func(rig, vfo, func, status));
+      }
+
+    retval = kenwood_safe_transaction(rig, "TO", current, sizeof(current), 3);
+    if (retval != RIG_OK)
+	{
+	  return (retval);
+	}
+    current[2] &= ~mask;
+    current[2] |= status == 0 ? 0 : mask;
+    return kenwood_transaction(rig, current, NULL, 0);
+}
+
+int ts890_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
+{
+    int mask, retval;
+    char current[4];
+    
+    switch (func)
+      {
+      case RIG_FUNC_TONE:
+	mask = 1;
+	break;
+      case RIG_FUNC_TSQL:
+	mask = 2;
+	break;
+      default:
+	return (kenwood_get_func(rig, vfo, func, status));
+      }
+
+    retval = kenwood_safe_transaction(rig, "TO", current, sizeof(current), 3);
+    if (retval != RIG_OK)
+      {
+	return retval;
+      }
+    *status = current[2] & mask ? 1 : 0;
+    return RIG_OK;
+}
+
+
 static struct kenwood_priv_caps ts890s_priv_caps =
 {
     .cmdtrm = EOM_KEN,
+    .tone_table_base = 0,
 };
 
 /* SWR meter calibration table */
@@ -532,6 +587,8 @@ struct rig_caps ts890s_caps =
     .get_split_vfo = kenwood_get_split_vfo_if,
     .set_ctcss_tone = kenwood_set_ctcss_tone_tn,
     .get_ctcss_tone = kenwood_get_ctcss_tone,
+    .set_ctcss_sql = kenwood_set_ctcss_sql,
+    .get_ctcss_sql = kenwood_get_ctcss_sql,
     .get_ptt = kenwood_get_ptt,
     .set_ptt = kenwood_set_ptt,
     .get_dcd = kenwood_get_dcd,
@@ -562,7 +619,7 @@ struct rig_caps ts890s_caps =
     },
     .has_get_func = TS890_FUNC_ALL,
     .has_set_func = TS890_FUNC_ALL,
-    .set_func = kenwood_set_func,
-    .get_func = kenwood_get_func,
+    .set_func = ts890_set_func,
+    .get_func = ts890_get_func,
     .hamlib_check_rig_caps = HAMLIB_CHECK_RIG_CAPS
 };

--- a/rigs/kenwood/ts940.c
+++ b/rigs/kenwood/ts940.c
@@ -63,7 +63,8 @@ static rmode_t ts940_mode_table[KENWOOD_MODE_TABLE_MAX] =
 static struct kenwood_priv_caps  ts940_priv_caps  =
 {
     .cmdtrm =  EOM_KEN,
-    .mode_table = ts940_mode_table
+    .mode_table = ts940_mode_table,
+    .tone_table_base = 1,
 };
 
 /*

--- a/rigs/kenwood/ts950.c
+++ b/rigs/kenwood/ts950.c
@@ -18,6 +18,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 /*
  * Edited by Martin Ewing AA6E, March, 2012
@@ -52,6 +53,7 @@
 static struct kenwood_priv_caps  ts950_priv_caps  =
 {
     .cmdtrm =  EOM_KEN,
+    .tone_table_base = 1,
 };
 
 /*

--- a/rigs/kenwood/ts990s.c
+++ b/rigs/kenwood/ts990s.c
@@ -19,6 +19,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include <stdlib.h>
 #include <string.h>
@@ -120,6 +121,7 @@ static struct kenwood_priv_caps  ts990s_priv_caps  =
 {
     .cmdtrm =  EOM_KEN,
     .mode_table = ts990s_mode_table,
+    .tone_table_base = 0,
 };
 
 

--- a/rigs/kenwood/tx500.c
+++ b/rigs/kenwood/tx500.c
@@ -94,6 +94,7 @@ tone_t tx500_dcs_list[] =
 static struct kenwood_priv_caps  tx500_priv_caps  =
 {
     .cmdtrm =  EOM_KEN,
+    .tone_table_base = 1,     /* TS-2000 compatible ??? */
 };
 
 /* memory capabilities */


### PR DESCRIPTION
Implement CTCSS & TONE functions of TS-890S

Fix off-by-one error for newer Kenwood radios.
