### PR TITLE
Convert all rigs/*/*.c to use pointers for ports

### DIFF
--- a/rigs/adat/adat.c
+++ b/rigs/adat/adat.c
@@ -1233,7 +1233,7 @@ int adat_send(RIG  *pRig,
               char *pcData)
 {
     int               nRC       = RIG_OK;
-    struct rig_state *pRigState = &pRig->state;
+    hamlib_port_t *pRigPort = RIGPORT(pRig);
 
     gFnLevel++;
 
@@ -1241,9 +1241,9 @@ int adat_send(RIG  *pRig,
               "*** ADAT: %d %s (%s:%d): ENTRY. Params: pRig = %p, pcData = %s\n",
               gFnLevel, __func__, __FILE__, __LINE__, pRig, pcData);
 
-    rig_flush(&pRigState->rigport);
+    rig_flush(pRigPort);
 
-    nRC = write_block(&pRigState->rigport, (unsigned char *) pcData,
+    nRC = write_block(pRigPort, (unsigned char *) pcData,
                       strlen(pcData));
 
     rig_debug(RIG_DEBUG_TRACE,
@@ -1264,7 +1264,6 @@ int adat_receive(RIG  *pRig,
                  char *pcData)
 {
     int               nRC       = RIG_OK;
-    struct rig_state *pRigState = &pRig->state;
 
     gFnLevel++;
 
@@ -1272,7 +1271,7 @@ int adat_receive(RIG  *pRig,
               "*** ADAT: %d %s (%s:%d): ENTRY. Params: pRig = %p\n",
               gFnLevel, __func__, __FILE__, __LINE__, pRig);
 
-    nRC = read_string(&pRigState->rigport, (unsigned char *) pcData, ADAT_RESPSZ,
+    nRC = read_string(RIGPORT(pRig), (unsigned char *) pcData, ADAT_RESPSZ,
                       ADAT_EOL, 1, 0, 1);
 
     if (nRC > 0)
@@ -1428,7 +1427,6 @@ int adat_get_single_cmd_result(RIG *pRig)
     else
     {
         adat_priv_data_ptr   pPriv     = (adat_priv_data_ptr) pRig->state.priv;
-        struct rig_state    *pRigState = &pRig->state;
 
         nRC = adat_send(pRig, pPriv->acCmd);
 
@@ -1526,7 +1524,7 @@ int adat_get_single_cmd_result(RIG *pRig)
             }
         }
 
-        rig_flush(&pRigState->rigport);
+        rig_flush(RIGPORT(pRig));
 
         pPriv->nRC = nRC;
     }

--- a/rigs/alinco/dx77.c
+++ b/rigs/alinco/dx77.c
@@ -301,7 +301,7 @@ int dx77_transaction(RIG *rig,
 {
 
     int retval;
-    struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
     char echobuf[BUFSZ + 1];
 
     if (cmd == NULL)
@@ -311,11 +311,9 @@ int dx77_transaction(RIG *rig,
         return -RIG_EINTERNAL;
     }
 
-    rs = &rig->state;
+    rig_flush(rp);
 
-    rig_flush(&rs->rigport);
-
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, cmd_len);
+    retval = write_block(rp, (unsigned char *) cmd, cmd_len);
 
     if (retval != RIG_OK)
     {
@@ -326,7 +324,7 @@ int dx77_transaction(RIG *rig,
      * Transceiver sends an echo of cmd followed by a CR/LF
      * TODO: check whether cmd and echobuf match (optional)
      */
-    retval = read_string(&rs->rigport, (unsigned char *) echobuf, BUFSZ,
+    retval = read_string(rp, (unsigned char *) echobuf, BUFSZ,
                          LF, strlen(LF), 0, 1);
 
     if (retval < 0)
@@ -343,7 +341,7 @@ int dx77_transaction(RIG *rig,
     /* no data expected, check for OK returned */
     if (data == NULL)
     {
-        retval = read_string(&rs->rigport, (unsigned char *) echobuf, BUFSZ,
+        retval = read_string(rp, (unsigned char *) echobuf, BUFSZ,
                              LF, strlen(LF), 0, 1);
 
         if (retval < 0)
@@ -365,7 +363,7 @@ int dx77_transaction(RIG *rig,
         }
     }
 
-    retval = read_string(&rs->rigport, (unsigned char *) data, BUFSZ,
+    retval = read_string(rp, (unsigned char *) data, BUFSZ,
                          LF, strlen(LF), 0, 1);
 
     if (retval < 0)

--- a/rigs/alinco/dxsr8.c
+++ b/rigs/alinco/dxsr8.c
@@ -235,7 +235,7 @@ int dxsr8_transaction(RIG *rig,
 {
 
     int retval;
-    struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
     char replybuf[BUFSZ + 1];
     int reply_len;
 
@@ -246,11 +246,9 @@ int dxsr8_transaction(RIG *rig,
         return -RIG_EINTERNAL;
     }
 
-    rs = &rig->state;
+    rig_flush(rp);
 
-    rig_flush(&rs->rigport);
-
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, cmd_len);
+    retval = write_block(rp, (unsigned char *) cmd, cmd_len);
 
     if (retval != RIG_OK)
     {
@@ -261,7 +259,7 @@ int dxsr8_transaction(RIG *rig,
      * Transceiver sends an echo of cmd followed by a CR/LF
      * TODO: check whether cmd and echobuf match (optional)
      */
-    retval = read_string(&rs->rigport, (unsigned char *) replybuf, BUFSZ,
+    retval = read_string(rp, (unsigned char *) replybuf, BUFSZ,
                          LF, strlen(LF), 0, 1);
 
     if (retval < 0)
@@ -270,7 +268,7 @@ int dxsr8_transaction(RIG *rig,
     }
 
 
-    retval = read_string(&rs->rigport, (unsigned char *) replybuf, BUFSZ,
+    retval = read_string(rp, (unsigned char *) replybuf, BUFSZ,
                          LF, strlen(LF), 0, 1);
 
     if (retval < 0)

--- a/rigs/aor/aor.c
+++ b/rigs/aor/aor.c
@@ -67,15 +67,13 @@ static int aor_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
                            int *data_len)
 {
     int retval;
-    struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
     char ackbuf[BUFSZ];
     int ack_len;
 
-    rs = &rig->state;
+    rig_flush(rp);
 
-    rig_flush(&rs->rigport);
-
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, cmd_len);
+    retval = write_block(rp, (unsigned char *) cmd, cmd_len);
 
     if (retval != RIG_OK)
     {
@@ -95,7 +93,7 @@ static int aor_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
     /*
      * Do wait for a reply
      */
-    retval = read_string(&rs->rigport, (unsigned char *) data, BUFSZ, EOM,
+    retval = read_string(rp, (unsigned char *) data, BUFSZ, EOM,
                          strlen(EOM), 0, 1);
 
     if (retval < 0)
@@ -124,7 +122,7 @@ static int aor_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
     if (retval >= 1 && data[0] == '?')
     {
         /* command failed? resync with radio */
-        write_block(&rs->rigport, (unsigned char *) EOM, 1);
+        write_block(rp, (unsigned char *) EOM, 1);
 
         return -RIG_EPROTO;
     }
@@ -144,7 +142,7 @@ int aor_close(RIG *rig)
      * since no reply is to be expected.
      */
 
-    return write_block(&rig->state.rigport, (unsigned char *) "EX" EOM, 3);
+    return write_block(RIGPORT(rig), (unsigned char *) "EX" EOM, 3);
 }
 
 static int format_freq(char *buf, int buf_len, freq_t freq)
@@ -1423,7 +1421,7 @@ int aor_get_chan_all_cb(RIG *rig, vfo_t vfo, chan_cb_t chan_cb, rig_ptr_t arg)
             /*
              * get next line
              */
-            retval = read_string(&rig->state.rigport, (unsigned char *) chanbuf, BUFSZ,
+            retval = read_string(RIGPORT(rig), (unsigned char *) chanbuf, BUFSZ,
                                  EOM, strlen(EOM), 0, 1);
 
             if (retval < 0)

--- a/rigs/aor/ar3000.c
+++ b/rigs/aor/ar3000.c
@@ -185,13 +185,11 @@ static int ar3k_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
                             int *data_len)
 {
     int retval;
-    struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
 
-    rs = &rig->state;
+    rig_flush(rp);
 
-    rig_flush(&rs->rigport);
-
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, cmd_len);
+    retval = write_block(rp, (unsigned char *) cmd, cmd_len);
 
     if (retval != RIG_OK)
     {
@@ -204,7 +202,7 @@ static int ar3k_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
         return RIG_OK;
     }
 
-    retval = read_string(&rs->rigport, (unsigned char *) data, BUFSZ,
+    retval = read_string(rp, (unsigned char *) data, BUFSZ,
                          EOM, strlen(EOM), 0, 1);
 
     if (retval == -RIG_ETIMEOUT)

--- a/rigs/aor/ar3030.c
+++ b/rigs/aor/ar3030.c
@@ -216,22 +216,20 @@ static int ar3030_transaction(RIG *rig, const char *cmd, int cmd_len,
                               char *data, int *data_len)
 {
     int retval;
-    struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
     int retry = 3;
     char tmpdata[BUFSZ];
-
-    rs = &rig->state;
 
     if (data == NULL)
     {
         data = tmpdata;
     }
 
-    rig_flush(&rs->rigport);
+    rig_flush(rp);
 
     do
     {
-        retval = write_block(&rs->rigport, (unsigned char *) cmd, cmd_len);
+        retval = write_block(rp, (unsigned char *) cmd, cmd_len);
 
         if (retval != RIG_OK)
         {
@@ -242,7 +240,7 @@ static int ar3030_transaction(RIG *rig, const char *cmd, int cmd_len,
         if (data)
         {
             /* expecting 0x0d0x0a on all commands so wait for the 0x0a */
-            retval = read_string(&rs->rigport, (unsigned char *) data, BUFSZ,
+            retval = read_string(rp, (unsigned char *) data, BUFSZ,
                                  "\x0a", 1, 0, 1);
 
             if (retval == -RIG_ETIMEOUT)
@@ -307,12 +305,10 @@ int ar3030_cleanup(RIG *rig)
 int ar3030_close(RIG *rig)
 {
     int retval;
-    struct rig_state *rs;
 
     rig_debug(RIG_DEBUG_TRACE, "%s:\n", __func__);
 
-    rs = &rig->state;
-    rig_flush(&rs->rigport);
+    rig_flush(RIGPORT(rig));
 
     retval = ar3030_transaction(rig, "Q" CR, strlen("Q" CR), NULL, NULL);
     rig_debug(RIG_DEBUG_TRACE, "%s: retval=%d\n", __func__, retval);

--- a/rigs/aor/ar7030.c
+++ b/rigs/aor/ar7030.c
@@ -66,7 +66,7 @@
 
 static int rxr_writeByte(RIG *rig, unsigned char c)
 {
-    return write_block(&rig->state.rigport, &c, 1);
+    return write_block(RIGPORT(rig), &c, 1);
 }
 
 
@@ -75,14 +75,14 @@ static int rxr_readByte(RIG *rig)
     unsigned char response[1];
     const unsigned char buf[] = {0x71}; // Read command
     int retval;
-    retval = write_block(&rig->state.rigport, buf, 1);
+    retval = write_block(RIGPORT(rig), buf, 1);
 
     if (retval != RIG_OK)
     {
         return retval;
     }
 
-    retval = read_block(&rig->state.rigport, response, 1);
+    retval = read_block(RIGPORT(rig), response, 1);
 
     if (retval != RIG_OK)
     {
@@ -270,16 +270,17 @@ static void Execute_Routine_6_1(RIG *rig, char mp, char ad, int numSteps)
 static int Execute_Routine_14(RIG *rig)
 {
     unsigned char response[1];
+    hamlib_port_t *rp = RIGPORT(rig);
     const unsigned char buf[] = {0x2e}; // Read command
     int retval;
-    retval = write_block(&rig->state.rigport, buf, 1);
+    retval = write_block(rp, buf, 1);
 
     if (retval != RIG_OK)
     {
         return retval;
     }
 
-    retval = read_block(&rig->state.rigport, response, 1);
+    retval = read_block(rp, response, 1);
 
     if (retval != RIG_OK)
     {

--- a/rigs/aor/ar7030p.c
+++ b/rigs/aor/ar7030p.c
@@ -266,7 +266,7 @@ static int ar7030p_init(RIG *rig)
 
         rig->state.priv = (void *) priv;
 
-        rig->state.rigport.type.rig = RIG_PORT_SERIAL;
+        RIGPORT(rig)->type.rig = RIG_PORT_SERIAL;
 
         priv->powerstat = RIG_POWER_ON;
         priv->bank = 0;

--- a/rigs/aor/ar7030p_utils.c
+++ b/rigs/aor/ar7030p_utils.c
@@ -56,7 +56,7 @@ int NOP(RIG *rig, unsigned char x)
 
     assert(NULL != rig);
 
-    rc = write_block(&rig->state.rigport, (char *) &op, 1);
+    rc = write_block(RIGPORT(rig), (char *) &op, 1);
 
     if (0 != rc)
     {
@@ -78,7 +78,7 @@ int SRH(RIG *rig, unsigned char x)
 
     assert(NULL != rig);
 
-    rc = write_block(&rig->state.rigport, (char *) &op, 1);
+    rc = write_block(RIGPORT(rig), (char *) &op, 1);
 
     if (0 != rc)
     {
@@ -108,7 +108,7 @@ int PGE(RIG *rig, enum PAGE_e page)
     case EEPROM2:
     case EEPROM3:
     case ROM:
-        rc = write_block(&rig->state.rigport, (char *) &op, 1);
+        rc = write_block(RIGPORT(rig), (char *) &op, 1);
 
         if (0 != rc)
         {
@@ -141,7 +141,7 @@ int ADR(RIG *rig, unsigned char x)
 
     assert(NULL != rig);
 
-    rc = write_block(&rig->state.rigport, (char *) &op, 1);
+    rc = write_block(RIGPORT(rig), (char *) &op, 1);
 
     if (0 != rc)
     {
@@ -163,7 +163,7 @@ int ADH(RIG *rig, unsigned char x)
 
     assert(NULL != rig);
 
-    rc = write_block(&rig->state.rigport, (char *) &op, 1);
+    rc = write_block(RIGPORT(rig), (char *) &op, 1);
 
     if (0 != rc)
     {
@@ -187,7 +187,7 @@ int WRD(RIG *rig, unsigned char out)
 
     assert(NULL != rig);
 
-    rc = write_block(&rig->state.rigport, (char *) &op, 1);
+    rc = write_block(RIGPORT(rig), (char *) &op, 1);
 
     if (0 != rc)
     {
@@ -210,7 +210,7 @@ int MSK(RIG *rig, unsigned char mask)
 
     assert(NULL != rig);
 
-    rc = write_block(&rig->state.rigport, (char *) &op, 1);
+    rc = write_block(RIGPORT(rig), (char *) &op, 1);
 
     if (0 != rc)
     {
@@ -248,7 +248,7 @@ int EXE(RIG *rig, enum ROUTINE_e routine)
     case DISP_BUFF:
     case READ_SIGNAL:
     case READ_BTNS:
-        rc = write_block(&rig->state.rigport, (char *) &op, 1);
+        rc = write_block(RIGPORT(rig), (char *) &op, 1);
 
         if (0 != rc)
         {
@@ -280,7 +280,7 @@ int RDD(RIG *rig, unsigned char len)
 
     assert(NULL != rig);
 
-    rc = write_block(&rig->state.rigport, (char *) &op, 1);
+    rc = write_block(RIGPORT(rig), (char *) &op, 1);
 
     if (0 != rc)
     {
@@ -288,7 +288,7 @@ int RDD(RIG *rig, unsigned char len)
     }
     else
     {
-        rc = read_block(&rig->state.rigport, (char *) &inChr, len);
+        rc = read_block(RIGPORT(rig), (char *) &inChr, len);
 
         if (1 != rc)
         {
@@ -321,7 +321,7 @@ int LOC(RIG *rig, enum LOCK_LVL_e level)
     case LOCK_1:
     case LOCK_2:
     case LOCK_3:
-        rc = write_block(&rig->state.rigport, (char *) &op, 1);
+        rc = write_block(RIGPORT(rig), (char *) &op, 1);
 
         if (0 != rc)
         {
@@ -366,7 +366,7 @@ int BUT(RIG *rig, enum BUTTON_e button)
     case BTN_STAR:
     case BTN_MENU:
     case BTN_POWER:
-        rc = write_block(&rig->state.rigport, (char *) &op, 1);
+        rc = write_block(RIGPORT(rig), (char *) &op, 1);
 
         if (0 != rc)
         {
@@ -403,7 +403,7 @@ int execRoutine(RIG *rig, enum ROUTINE_e rtn)
 
     assert(NULL != rig);
 
-    if (0 == write_block(&rig->state.rigport, &v, 1))
+    if (0 == write_block(RIGPORT(rig), &v, 1))
     {
         rc = RIG_OK;
 
@@ -428,6 +428,7 @@ int execRoutine(RIG *rig, enum ROUTINE_e rtn)
 static int setAddr(RIG *rig, enum PAGE_e page, unsigned int addr)
 {
     int rc = RIG_OK;
+    hamlib_port_t *rp = RIGPORT(rig);
     unsigned char v;
 
     assert(NULL != rig);
@@ -440,7 +441,7 @@ static int setAddr(RIG *rig, enum PAGE_e page, unsigned int addr)
             {
                 v = PGE(page);
 
-                if (0 == write_block(&rig->state.rigport, &v, 1))
+                if (0 == write_block(rp, &v, 1))
                 {
                     curPage = page;
                     rc = RIG_OK;
@@ -457,7 +458,7 @@ static int setAddr(RIG *rig, enum PAGE_e page, unsigned int addr)
             {
                 v = SRH((0x0f0 & addr) >> 4);
 
-                rc = write_block(&rig->state.rigport, &v, 1);
+                rc = write_block(rp, &v, 1);
 
                 if (rc != RIG_OK)
                 {
@@ -466,13 +467,13 @@ static int setAddr(RIG *rig, enum PAGE_e page, unsigned int addr)
 
                 v = ADR((0x00f & addr));
 
-                if (0 == write_block(&rig->state.rigport, &v, 1))
+                if (0 == write_block(rp, &v, 1))
                 {
                     if (0xff < addr)
                     {
                         v = ADH((0xf00 & addr) >> 8);
 
-                        if (0 == write_block(&rig->state.rigport, &v, 1))
+                        if (0 == write_block(rp, &v, 1))
                         {
                             curAddr = addr;
                             rc = RIG_OK;
@@ -525,6 +526,7 @@ static int setAddr(RIG *rig, enum PAGE_e page, unsigned int addr)
 int writeByte(RIG *rig, enum PAGE_e page, unsigned int addr, unsigned char x)
 {
     int rc;
+    hamlib_port_t *rp = RIGPORT(rig);
     unsigned char hi = SRH((x & 0xf0) >> 4);
     unsigned char lo = WRD(x & 0x0f);
 
@@ -536,9 +538,9 @@ int writeByte(RIG *rig, enum PAGE_e page, unsigned int addr, unsigned char x)
     {
         rc = -RIG_EIO;
 
-        if (0 == write_block(&rig->state.rigport, &hi, 1))
+        if (0 == write_block(rp, &hi, 1))
         {
-            if (0 == write_block(&rig->state.rigport, &lo, 1))
+            if (0 == write_block(rp, &lo, 1))
             {
                 rc = RIG_OK;
                 curAddr++;
@@ -667,6 +669,7 @@ int writeInt(RIG *rig, enum PAGE_e page, unsigned int addr, unsigned int x)
 int readByte(RIG *rig, enum PAGE_e page, unsigned int addr, unsigned char *x)
 {
     int rc = RIG_OK;
+    hamlib_port_t *rp = RIGPORT(rig);
     unsigned char v = RDD(1);   // Read command
 
     assert(NULL != rig);
@@ -678,9 +681,9 @@ int readByte(RIG *rig, enum PAGE_e page, unsigned int addr, unsigned char *x)
     {
         rc = -RIG_EIO;
 
-        if (0 == write_block(&rig->state.rigport, &v, 1))
+        if (0 == write_block(rp, &v, 1))
         {
-            if (1 == read_block(&rig->state.rigport, x, 1))
+            if (1 == read_block(rp, x, 1))
             {
                 curAddr++;
                 rc = RIG_OK;
@@ -841,7 +844,7 @@ int readSignal(RIG *rig, unsigned char *x)
 
     if (RIG_OK == rc)
     {
-        if (1 == read_block(&rig->state.rigport, x, 1))
+        if (1 == read_block(RIGPORT(rig), x, 1))
         {
             rc = RIG_OK;
 
@@ -867,7 +870,7 @@ int flushBuffer(RIG *rig)
 
     assert(NULL != rig);
 
-    if (0 == write_block(&rig->state.rigport, &v, 1))
+    if (0 == write_block(RIGPORT(rig), &v, 1))
     {
         rc = RIG_OK;
     }
@@ -896,7 +899,7 @@ int lockRx(RIG *rig, enum LOCK_LVL_e level)
         {
             v = LOC(level);
 
-            if (0 == write_block(&rig->state.rigport, &v, 1))
+            if (0 == write_block(RIGPORT(rig), &v, 1))
             {
                 rc = RIG_OK;
 

--- a/rigs/aor/sr2200.c
+++ b/rigs/aor/sr2200.c
@@ -274,15 +274,13 @@ static int sr2200_transaction(RIG *rig, const char *cmd, int cmd_len,
                               char *data, int *data_len)
 {
     int retval;
-    struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
     char ackbuf[BUFSZ];
     int ack_len;
 
-    rs = &rig->state;
+    rig_flush(rp);
 
-    rig_flush(&rs->rigport);
-
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, cmd_len);
+    retval = write_block(rp, (unsigned char *) cmd, cmd_len);
 
     if (retval != RIG_OK)
     {
@@ -302,7 +300,7 @@ static int sr2200_transaction(RIG *rig, const char *cmd, int cmd_len,
     /*
      * Do wait for a reply
      */
-    retval = read_string(&rs->rigport, (unsigned char *) data, BUFSZ, EOM,
+    retval = read_string(rp, (unsigned char *) data, BUFSZ, EOM,
                          strlen(EOM), 0, 1);
 
     if (retval < 0)
@@ -324,7 +322,7 @@ static int sr2200_transaction(RIG *rig, const char *cmd, int cmd_len,
     if (data[0] == '?')
     {
         /* command failed? resync with radio */
-        write_block(&rs->rigport, (unsigned char *) EOM, 1);
+        write_block(rp, (unsigned char *) EOM, 1);
 
         return -RIG_EPROTO;
     }

--- a/rigs/barrett/barrett.c
+++ b/rigs/barrett/barrett.c
@@ -58,12 +58,11 @@ DECLARE_INITRIG_BACKEND(barrett)
 int barrett_transaction2(RIG *rig, char *cmd, int expected, char **result)
 {
     char cmd_buf[MAXCMDLEN];
-    struct rig_state *rs = &rig->state;
     struct barrett_priv_data *priv = rig->state.priv;
     int retval;
 
     SNPRINTF(cmd_buf, sizeof(cmd_buf), "%c%s%s", 0x0a, cmd, EOM);
-    retval = read_block(&rs->rigport, (unsigned char *) priv->ret_data, expected);
+    retval = read_block(RIGPORT(rig), (unsigned char *) priv->ret_data, expected);
 
     if (retval < 0)
     {
@@ -80,7 +79,7 @@ int barrett_transaction(RIG *rig, char *cmd, int expected, char **result)
     char *p;
     char xon;
     char xoff;
-    struct rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
     struct barrett_priv_data *priv = rig->state.priv;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: cmd=%s\n", __func__, cmd);
@@ -93,8 +92,8 @@ int barrett_transaction(RIG *rig, char *cmd, int expected, char **result)
         SNPRINTF(cmd_buf, sizeof(cmd_buf), "%s%s", cmd, EOM);
     }
 
-    rig_flush(&rs->rigport);
-    retval = write_block(&rs->rigport, (unsigned char *) cmd_buf, strlen(cmd_buf));
+    rig_flush(rp);
+    retval = write_block(rp, (unsigned char *) cmd_buf, strlen(cmd_buf));
 
     if (retval < 0)
     {
@@ -104,7 +103,7 @@ int barrett_transaction(RIG *rig, char *cmd, int expected, char **result)
     if (expected == 0)
     {
         // response format is 0x11,data...,0x0d,0x0a,0x13
-        retval = read_string(&rs->rigport, (unsigned char *) priv->ret_data,
+        retval = read_string(rp, (unsigned char *) priv->ret_data,
                              sizeof(priv->ret_data),
                              "\x11", 1, 0, 1);
         rig_debug(RIG_DEBUG_VERBOSE, "%s: resultlen=%d\n", __func__,
@@ -118,7 +117,7 @@ int barrett_transaction(RIG *rig, char *cmd, int expected, char **result)
     }
     else
     {
-        retval = read_block(&rs->rigport, (unsigned char *) priv->ret_data, expected);
+        retval = read_block(rp, (unsigned char *) priv->ret_data, expected);
 
         if (retval < 0)
         {
@@ -704,7 +703,7 @@ int barrett_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 int barrett_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
     char cmd_buf[MAXCMDLEN];
-    struct rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
     int retval;
 
     switch (level)
@@ -716,8 +715,8 @@ int barrett_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
     default: return -RIG_ENIMPL;
     }
 
-    rig_flush(&rs->rigport);
-    retval = write_block(&rs->rigport, (unsigned char *) cmd_buf, strlen(cmd_buf));
+    rig_flush(rp);
+    retval = write_block(rp, (unsigned char *) cmd_buf, strlen(cmd_buf));
 
     if (retval < 0)
     {

--- a/rigs/codan/codan.c
+++ b/rigs/codan/codan.c
@@ -46,7 +46,7 @@ int codan_transaction(RIG *rig, char *cmd, int expected, char **result)
 {
     char cmd_buf[MAXCMDLEN];
     int retval;
-    struct rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
     struct codan_priv_data *priv = rig->state.priv;
     //int retry = 3;
 
@@ -54,8 +54,8 @@ int codan_transaction(RIG *rig, char *cmd, int expected, char **result)
 
     SNPRINTF(cmd_buf, sizeof(cmd_buf), "%s%s", cmd, EOM);
 
-    rig_flush(&rs->rigport);
-    retval = write_block(&rs->rigport, (unsigned char *) cmd_buf, strlen(cmd_buf));
+    rig_flush(rp);
+    retval = write_block(rp, (unsigned char *) cmd_buf, strlen(cmd_buf));
     hl_usleep(rig->caps->post_write_delay);
 
     if (retval < 0)
@@ -66,7 +66,7 @@ int codan_transaction(RIG *rig, char *cmd, int expected, char **result)
     if (expected == 0)
     {
         // response format is response...0x0d0x0a
-        retval = read_string(&rs->rigport, (unsigned char *) priv->ret_data,
+        retval = read_string(rp, (unsigned char *) priv->ret_data,
                              sizeof(priv->ret_data),
                              "\x0a", 1, 0, 1);
         rig_debug(RIG_DEBUG_VERBOSE, "%s: result=%s, resultlen=%d\n", __func__,
@@ -79,7 +79,7 @@ int codan_transaction(RIG *rig, char *cmd, int expected, char **result)
     }
     else
     {
-        retval = read_string(&rs->rigport, (unsigned char *) priv->ret_data,
+        retval = read_string(rp, (unsigned char *) priv->ret_data,
                              sizeof(priv->ret_data),
                              "\x0a", 1, 0, 1);
 
@@ -91,7 +91,7 @@ int codan_transaction(RIG *rig, char *cmd, int expected, char **result)
         if (strncmp(priv->ret_data, "LEVELS:", 7) == 0)
         {
             rig_debug(RIG_DEBUG_VERBOSE, "%s: %s\n", __func__, priv->ret_data);
-            retval = read_string(&rs->rigport, (unsigned char *) priv->ret_data,
+            retval = read_string(rp, (unsigned char *) priv->ret_data,
                                  sizeof(priv->ret_data),
                                  "\x0a", 1, 0, 1);
             rig_debug(RIG_DEBUG_VERBOSE, "%s: %s\n", __func__, priv->ret_data);
@@ -105,7 +105,7 @@ int codan_transaction(RIG *rig, char *cmd, int expected, char **result)
             && sscanf(priv->ret_data, "%d:%d:%d", &hr, &min, &sec) != 3)
     {
         char tmpbuf[256];
-        retval = read_string(&rs->rigport, (unsigned char *) tmpbuf,
+        retval = read_string(rp, (unsigned char *) tmpbuf,
                              sizeof(priv->ret_data),
                              "\x0a", 1, 0, 1);
 

--- a/rigs/dorji/dra818.c
+++ b/rigs/dorji/dra818.c
@@ -52,7 +52,7 @@ struct dra818_priv
 static int dra818_response(RIG *rig, const char *expected)
 {
     char response[80];
-    int r = read_string(&rig->state.rigport, (unsigned char *) response,
+    int r = read_string(RIGPORT(rig), (unsigned char *) response,
                         sizeof(response),
                         "\n", 1, 0, 1);
 
@@ -114,7 +114,7 @@ static int dra818_setgroup(RIG *rig)
              (int)(priv->tx_freq / 1000000), (int)((priv->tx_freq % 1000000) / 100),
              (int)(priv->rx_freq / 1000000), (int)((priv->rx_freq % 1000000) / 100),
              subtx, priv->sql, subrx);
-    write_block(&rig->state.rigport, (unsigned char *) cmd, strlen(cmd));
+    write_block(RIGPORT(rig), (unsigned char *) cmd, strlen(cmd));
 
     return dra818_response(rig, dra818_setgroup_res);
 }
@@ -125,7 +125,7 @@ static int dra818_setvolume(RIG *rig)
     char cmd[80];
 
     SNPRINTF(cmd, sizeof(cmd), "AT+DMOSETVOLUME=%1d\r\n", priv->vol);
-    write_block(&rig->state.rigport, (unsigned char *) cmd, strlen(cmd));
+    write_block(RIGPORT(rig), (unsigned char *) cmd, strlen(cmd));
 
     return dra818_response(rig, dra818_setvolume_res);
 }
@@ -186,7 +186,7 @@ int dra818_open(RIG *rig)
 
     for (i = 0; i < 3; i++)
     {
-        write_block(&rig->state.rigport, (unsigned char *) dra818_handshake_cmd,
+        write_block(RIGPORT(rig), (unsigned char *) dra818_handshake_cmd,
                     strlen(dra818_handshake_cmd));
 
         r = dra818_response(rig, dra818_handshake_res);
@@ -281,15 +281,16 @@ int dra818_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
 int dra818_get_dcd(RIG *rig, vfo_t vfo, dcd_t *dcd)
 {
     const struct dra818_priv *priv = rig->state.priv;
+    hamlib_port_t *rp = RIGPORT(rig);
     char cmd[80];
     char response[8];
     int r;
 
     SNPRINTF(cmd, sizeof(cmd), "S+%03d.%04d\r\n",
              (int)(priv->rx_freq / 1000000), (int)((priv->rx_freq % 1000000) / 100));
-    write_block(&rig->state.rigport, (unsigned char *) cmd, strlen(cmd));
+    write_block(rp, (unsigned char *) cmd, strlen(cmd));
 
-    r = read_string(&rig->state.rigport, (unsigned char *) response,
+    r = read_string(rp, (unsigned char *) response,
                     sizeof(response),
                     "\n", 1, 0, 1);
 

--- a/rigs/drake/drake.c
+++ b/rigs/drake/drake.c
@@ -59,13 +59,11 @@ int drake_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
                       int *data_len)
 {
     int retval;
-    struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
 
-    rs = &rig->state;
+    rig_flush(rp);
 
-    rig_flush(&rs->rigport);
-
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, cmd_len);
+    retval = write_block(rp, (unsigned char *) cmd, cmd_len);
 
     if (retval != RIG_OK)
     {
@@ -78,7 +76,7 @@ int drake_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
         return 0;
     }
 
-    retval = read_string(&rs->rigport, (unsigned char *) data, BUFSZ,
+    retval = read_string(rp, (unsigned char *) data, BUFSZ,
                          LF, 1, 0, 1);
 
     if (retval == -RIG_ETIMEOUT)

--- a/rigs/dummy/aclog.c
+++ b/rigs/dummy/aclog.c
@@ -137,7 +137,6 @@ static int read_transaction(RIG *rig, char *xml, int xml_len)
     int retry;
     char *delims;
     char *terminator = "</CMD>\r\n";
-    struct rig_state *rs = &rig->state;
 
     ENTERFUNC;
 
@@ -154,7 +153,7 @@ static int read_transaction(RIG *rig, char *xml, int xml_len)
             rig_debug(RIG_DEBUG_WARN, "%s: retry needed? retry=%d\n", __func__, retry);
         }
 
-        int len = read_string(&rs->rigport, (unsigned char *) tmp_buf, sizeof(tmp_buf),
+        int len = read_string(RIGPORT(rig), (unsigned char *) tmp_buf, sizeof(tmp_buf),
                               delims,
                               strlen(delims), 0, 1);
         rig_debug(RIG_DEBUG_TRACE, "%s: string='%s'\n", __func__, tmp_buf);
@@ -215,12 +214,9 @@ static int read_transaction(RIG *rig, char *xml, int xml_len)
 */
 static int write_transaction(RIG *rig, char *xml, int xml_len)
 {
-
     int try = rig->caps->retry;
-
     int retval = -RIG_EPROTO;
-
-    struct rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     ENTERFUNC;
 
@@ -234,11 +230,11 @@ static int write_transaction(RIG *rig, char *xml, int xml_len)
 
     // appears we can lose sync if we don't clear things out
     // shouldn't be anything for us now anyways
-    rig_flush(&rig->state.rigport);
+    rig_flush(rp);
 
     while (try-- >= 0 && retval != RIG_OK)
         {
-            retval = write_block(&rs->rigport, (unsigned char *) xml, strlen(xml));
+            retval = write_block(rp, (unsigned char *) xml, strlen(xml));
 
             if (retval  < 0)
             {
@@ -320,6 +316,7 @@ static int aclog_transaction(RIG *rig, char *cmd, char *value,
 static int aclog_init(RIG *rig)
 {
     struct aclog_priv_data *priv;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s version %s\n", __func__, rig->caps->version);
@@ -353,8 +350,7 @@ static int aclog_init(RIG *rig)
         RETURNFUNC(-RIG_EINVAL);
     }
 
-    strncpy(rig->state.rigport.pathname, DEFAULTPATH,
-            sizeof(rig->state.rigport.pathname));
+    strncpy(rp->pathname, DEFAULTPATH, sizeof(rp->pathname));
 
     RETURNFUNC(RIG_OK);
 }

--- a/rigs/dummy/amp_dummy.c
+++ b/rigs/dummy/amp_dummy.c
@@ -62,7 +62,7 @@ static int dummy_amp_init(AMP *amp)
 
     priv = amp->state.priv;
 
-    amp->state.ampport.type.rig = RIG_PORT_NONE;
+    AMPPORT(amp)->type.rig = RIG_PORT_NONE;
 
     priv->freq = 0;
 

--- a/rigs/dummy/dummy.c
+++ b/rigs/dummy/dummy.c
@@ -231,7 +231,7 @@ static int dummy_init(RIG *rig)
     rig->state.priv = (void *)priv;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
-    rig->state.rigport.type.rig = RIG_PORT_NONE;
+    RIGPORT(rig)->type.rig = RIG_PORT_NONE;
 
     priv->split = RIG_SPLIT_OFF;
     priv->ptt = RIG_PTT_OFF;
@@ -743,6 +743,7 @@ static int dummy_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 static int dummy_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
 {
     const struct dummy_priv_data *priv = (struct dummy_priv_data *)rig->state.priv;
+    hamlib_port_t *pttp = PTTPORT(rig);
     int rc;
     int status = 0;
 
@@ -751,12 +752,12 @@ static int dummy_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
 
     // sneak a look at the hardware PTT and OR that in with our result
     // as if it had keyed us
-    switch (rig->state.pttport.type.ptt)
+    switch (pttp->type.ptt)
     {
     case RIG_PTT_SERIAL_DTR:
-        if (rig->state.pttport.fd >= 0)
+        if (pttp->fd >= 0)
         {
-            if (RIG_OK != (rc = ser_get_dtr(&rig->state.pttport, &status))) { RETURNFUNC(rc); }
+            if (RIG_OK != (rc = ser_get_dtr(pttp, &status))) { RETURNFUNC(rc); }
 
             *ptt = status ? RIG_PTT_ON : RIG_PTT_OFF;
         }
@@ -768,9 +769,9 @@ static int dummy_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
         break;
 
     case RIG_PTT_SERIAL_RTS:
-        if (rig->state.pttport.fd >= 0)
+        if (pttp->fd >= 0)
         {
-            if (RIG_OK != (rc = ser_get_rts(&rig->state.pttport, &status))) { RETURNFUNC(rc); }
+            if (RIG_OK != (rc = ser_get_rts(pttp, &status))) { RETURNFUNC(rc); }
 
             *ptt = status ? RIG_PTT_ON : RIG_PTT_OFF;
         }
@@ -782,26 +783,26 @@ static int dummy_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
         break;
 
     case RIG_PTT_PARALLEL:
-        if (rig->state.pttport.fd >= 0)
+        if (pttp->fd >= 0)
         {
-            if (RIG_OK != (rc = par_ptt_get(&rig->state.pttport, ptt))) { RETURNFUNC(rc); }
+            if (RIG_OK != (rc = par_ptt_get(pttp, ptt))) { RETURNFUNC(rc); }
         }
 
         break;
 
     case RIG_PTT_CM108:
-        if (rig->state.pttport.fd >= 0)
+        if (pttp->fd >= 0)
         {
-            if (RIG_OK != (rc = cm108_ptt_get(&rig->state.pttport, ptt))) { RETURNFUNC(rc); }
+            if (RIG_OK != (rc = cm108_ptt_get(pttp, ptt))) { RETURNFUNC(rc); }
         }
 
         break;
 
     case RIG_PTT_GPIO:
     case RIG_PTT_GPION:
-        if (rig->state.pttport.fd >= 0)
+        if (pttp->fd >= 0)
         {
-            if (RIG_OK != (rc = gpio_ptt_get(&rig->state.pttport, ptt))) { RETURNFUNC(rc); }
+            if (RIG_OK != (rc = gpio_ptt_get(pttp, ptt))) { RETURNFUNC(rc); }
         }
 
         break;

--- a/rigs/dummy/flrig.c
+++ b/rigs/dummy/flrig.c
@@ -297,7 +297,7 @@ static char *xml_build(RIG *rig, char *cmd, char *value, char *xmlbuf,
 
     SNPRINTF(xml, sizeof(xml),
              "<?xml version=\"1.0\"?>\r\n<?clientid=\"hamlib(%d)\"?>\r\n",
-             rig->state.rigport.client_port);
+             RIGPORT(rig)->client_port);
 
     strncat(xml, "<methodCall><methodName>", sizeof(xml) - 1);
     strncat(xml, cmd, sizeof(xml) - strlen(xml) - 1);
@@ -430,7 +430,6 @@ static int read_transaction(RIG *rig, char *xml, int xml_len)
     int retry;
     char *delims;
     char *terminator = "</methodResponse>";
-    struct rig_state *rs = &rig->state;
 
     ENTERFUNC;
 
@@ -448,7 +447,7 @@ static int read_transaction(RIG *rig, char *xml, int xml_len)
         }
 
         rig_debug(RIG_DEBUG_TRACE, "%s: before read_string\n", __func__);
-        int len = read_string(&rs->rigport, (unsigned char *) tmp_buf, sizeof(tmp_buf),
+        int len = read_string(RIGPORT(rig), (unsigned char *) tmp_buf, sizeof(tmp_buf),
                               delims,
                               strlen(delims), 0, 1);
 //                              "</methodResponse>", 17,0,1);
@@ -517,7 +516,7 @@ static int write_transaction(RIG *rig, char *xml, int xml_len)
 
     int retval = -RIG_EPROTO;
 
-    struct rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     ENTERFUNC;
 
@@ -531,11 +530,11 @@ static int write_transaction(RIG *rig, char *xml, int xml_len)
 
     // appears we can lose sync if we don't clear things out
     // shouldn't be anything for us now anyways
-    rig_flush(&rig->state.rigport);
+    rig_flush(rp);
 
     while (try-- >= 0 && retval != RIG_OK)
         {
-            retval = write_block(&rs->rigport, (unsigned char *) xml, strlen(xml));
+            retval = write_block(rp, (unsigned char *) xml, strlen(xml));
 
             if (retval  < 0)
             {
@@ -619,6 +618,7 @@ static int flrig_transaction(RIG *rig, char *cmd, char *cmd_arg, char *value,
 static int flrig_init(RIG *rig)
 {
     struct flrig_priv_data *priv;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s version %s\n", __func__, rig->caps->version);
@@ -653,8 +653,7 @@ static int flrig_init(RIG *rig)
         RETURNFUNC(-RIG_EINVAL);
     }
 
-    strncpy(rig->state.rigport.pathname, DEFAULTPATH,
-            sizeof(rig->state.rigport.pathname));
+    strncpy(rp->pathname, DEFAULTPATH, sizeof(rp->pathname));
 
     priv->ext_parms = alloc_init_ext(flrig_ext_parms);
 

--- a/rigs/dummy/netampctl.c
+++ b/rigs/dummy/netampctl.c
@@ -34,15 +34,16 @@
 static int netampctl_transaction(AMP *amp, char *cmd, int len, char *buf)
 {
     int ret;
+    hamlib_port_t *ampp = AMPPORT(amp);
 
-    ret = write_block(&amp->state.ampport, (unsigned char *) cmd, len);
+    ret = write_block(ampp, (unsigned char *) cmd, len);
 
     if (ret != RIG_OK)
     {
         return ret;
     }
 
-    ret = read_string(&amp->state.ampport, (unsigned char *) buf, BUF_MAX, "\n",
+    ret = read_string(ampp, (unsigned char *) buf, BUF_MAX, "\n",
                       sizeof("\n"), 0, 1);
 
     if (ret < 0)
@@ -62,6 +63,7 @@ static int netampctl_open(AMP *amp)
 {
     int ret;
     //struct amp_state *rs = &amp->state;
+    hamlib_port_t *ampp = AMPPORT(amp);
     int pamp_ver;
     char cmd[CMD_MAX];
     char buf[BUF_MAX];
@@ -86,9 +88,10 @@ static int netampctl_open(AMP *amp)
         return -RIG_EPROTO;
     }
 
-    ret = read_string(&amp->state.ampport, (unsigned char *) buf, BUF_MAX, "\n",
+    ret = read_string(ampp, (unsigned char *) buf, BUF_MAX, "\n",
                       sizeof("\n"), 0, 1);
 
+    
     if (ret <= 0)
     {
         return (ret < 0) ? ret : -RIG_EPROTO;
@@ -96,7 +99,7 @@ static int netampctl_open(AMP *amp)
 
     do
     {
-        ret = read_string(&amp->state.ampport, (unsigned char *) buf, BUF_MAX, "\n",
+        ret = read_string(ampp, (unsigned char *) buf, BUF_MAX, "\n",
                           sizeof("\n"), 0, 1);
 
         if (ret > 0)
@@ -120,7 +123,7 @@ static int netampctl_close(AMP *amp)
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
     /* clean signoff, no read back */
-    write_block(&amp->state.ampport, (unsigned char *) "q\n", 2);
+    write_block(AMPPORT(amp), (unsigned char *) "q\n", 2);
 
     return RIG_OK;
 }

--- a/rigs/dummy/netrigctl.c
+++ b/rigs/dummy/netrigctl.c
@@ -58,21 +58,21 @@ int netrigctl_get_vfo_mode(RIG *rig)
 static int netrigctl_transaction(RIG *rig, char *cmd, int len, char *buf)
 {
     int ret;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: called len=%d\n", __func__, len);
 
     /* flush anything in the read buffer before command is sent */
-    rig_flush(&rig->state.rigport);
+    rig_flush(rp);
 
-    ret = write_block(&rig->state.rigport, (unsigned char *) cmd, len);
+    ret = write_block(rp, (unsigned char *) cmd, len);
 
     if (ret != RIG_OK)
     {
         return ret;
     }
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret < 0)
     {
@@ -248,6 +248,7 @@ static int netrigctl_open(RIG *rig)
 {
     int ret, i;
     struct rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
     int prot_ver;
     char cmd[CMD_MAX];
     char buf[BUF_MAX];
@@ -303,16 +304,14 @@ static int netrigctl_open(RIG *rig)
         RETURNFUNC(-RIG_EPROTO);
     }
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
         RETURNFUNC((ret < 0) ? ret : -RIG_EPROTO);
     }
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -323,8 +322,7 @@ static int netrigctl_open(RIG *rig)
 
     for (i = 0; i < HAMLIB_FRQRANGESIZ; i++)
     {
-        ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                          0, 1);
+        ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
         if (ret <= 0)
         {
@@ -354,8 +352,7 @@ static int netrigctl_open(RIG *rig)
 
     for (i = 0; i < HAMLIB_FRQRANGESIZ; i++)
     {
-        ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                          0, 1);
+        ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
         if (ret <= 0)
         {
@@ -397,8 +394,7 @@ static int netrigctl_open(RIG *rig)
 
     for (i = 0; i < HAMLIB_TSLSTSIZ; i++)
     {
-        ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                          0, 1);
+        ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
         if (ret <= 0)
         {
@@ -422,8 +418,7 @@ static int netrigctl_open(RIG *rig)
 
     for (i = 0; i < HAMLIB_FLTLSTSIZ; i++)
     {
-        ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                          0, 1);
+        ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
         if (ret <= 0)
         {
@@ -450,8 +445,7 @@ static int netrigctl_open(RIG *rig)
     chan_t chan_list[HAMLIB_CHANLSTSIZ]; /*!< Channel list, zero ended */
 #endif
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -460,8 +454,7 @@ static int netrigctl_open(RIG *rig)
 
     rig->caps->max_rit = rs->max_rit = atol(buf);
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -470,8 +463,7 @@ static int netrigctl_open(RIG *rig)
 
     rig->caps->max_xit = rs->max_xit = atol(buf);
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -480,8 +472,7 @@ static int netrigctl_open(RIG *rig)
 
     rig->caps->max_ifshift = rs->max_ifshift = atol(buf);
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -490,8 +481,7 @@ static int netrigctl_open(RIG *rig)
 
     rs->announces = atoi(buf);
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -518,8 +508,7 @@ static int netrigctl_open(RIG *rig)
 
     rig->caps->preamp[ret] = rs->preamp[ret] = RIG_DBLST_END;
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -546,8 +535,7 @@ static int netrigctl_open(RIG *rig)
 
     rig->caps->attenuator[ret] = rs->attenuator[ret] = RIG_DBLST_END;
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -556,8 +544,7 @@ static int netrigctl_open(RIG *rig)
 
     rig->caps->has_get_func = rs->has_get_func = strtoll(buf, NULL, 0);
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -566,8 +553,7 @@ static int netrigctl_open(RIG *rig)
 
     rig->caps->has_set_func = rs->has_set_func = strtoll(buf, NULL, 0);
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -589,8 +575,7 @@ static int netrigctl_open(RIG *rig)
 
 #endif
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -599,8 +584,7 @@ static int netrigctl_open(RIG *rig)
 
     rig->caps->has_set_level = rs->has_set_level = strtoll(buf, NULL, 0);
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -609,8 +593,7 @@ static int netrigctl_open(RIG *rig)
 
     rs->has_get_parm = strtoll(buf, NULL, 0);
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -648,8 +631,8 @@ static int netrigctl_open(RIG *rig)
     do
     {
         char setting[32], value[1024];
-        ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                          0, 1);
+	hamlib_port_t *pttp = PTTPORT(rig);
+        ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
         strtok(buf, "\r\n"); // chop the EOL
 
         if (ret <= 0)
@@ -672,7 +655,7 @@ static int netrigctl_open(RIG *rig)
                 ptt_type_t temp = (ptt_type_t)strtol(value, NULL, 0);
                 rig_debug(RIG_DEBUG_VERBOSE, "%s: ptt_type='%s'(%d)\n", __func__, value, temp);
 
-                if (RIG_PTT_RIG_MICDATA == rig->state.pttport.type.ptt
+                if (RIG_PTT_RIG_MICDATA == pttp->type.ptt
                         || temp == RIG_PTT_RIG_MICDATA)
                 {
                     /*
@@ -680,15 +663,15 @@ static int netrigctl_open(RIG *rig)
                      * if there is any PTT capability and we have not
                      * locally overridden it
                      */
-                    rig->state.pttport.type.ptt = RIG_PTT_RIG_MICDATA;
+                    pttp->type.ptt = RIG_PTT_RIG_MICDATA;
                     rig->caps->ptt_type = RIG_PTT_RIG_MICDATA;
                     rig_debug(RIG_DEBUG_TRACE, "%s: %s set to %d\n", __func__, setting,
-                              rig->state.pttport.type.ptt);
+                              pttp->type.ptt);
                 }
                 else
                 {
                     rig_debug(RIG_DEBUG_VERBOSE, "%s: ptt_type= %d\n", __func__, temp);
-                    rig->state.pttport.type.ptt = temp;
+                    pttp->type.ptt = temp;
                     rig->caps->ptt_type = temp;
                 }
             }
@@ -1016,7 +999,7 @@ static int netrigctl_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
     CHKSCN1ARG(num_sscanf(buf, "%"SCNfreq, freq));
 
 #if 0 // implement set_freq VFO later if it can be detected
-    ret = read_string(&rig->state.rigport, buf, BUF_MAX, "\n", 1, 0, 1);
+    ret = read_string(RIGPORT(rig), buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -1087,7 +1070,7 @@ static int netrigctl_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode,
 
     *mode = rig_parse_mode(buf);
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
+    ret = read_string(RIGPORT(rig), (unsigned char *) buf, BUF_MAX, "\n", 1,
                       0, 1);
 
     if (ret <= 0)
@@ -1170,12 +1153,13 @@ static int netrigctl_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
     char cmd[CMD_MAX];
     char buf[BUF_MAX];
     char vfostr[16] = "";
+    hamlib_port_t *pttp = PTTPORT(rig);
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called vfo=%s, ptt=%d, ptt_type=%d\n",
               __func__,
-              rig_strvfo(vfo), ptt, rig->state.pttport.type.ptt);
+              rig_strvfo(vfo), ptt, pttp->type.ptt);
 
-    if (rig->state.pttport.type.ptt == RIG_PTT_NONE) { return RIG_OK; }
+    if (pttp->type.ptt == RIG_PTT_NONE) { return RIG_OK; }
 
     ret = netrigctl_vfostr(rig, vfostr, sizeof(vfostr), RIG_VFO_A);
 
@@ -1703,7 +1687,7 @@ static int netrigctl_get_split_mode(RIG *rig, vfo_t vfo, rmode_t *tx_mode,
 
     *tx_mode = rig_parse_mode(buf);
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
+    ret = read_string(RIGPORT(rig), (unsigned char *) buf, BUF_MAX, "\n", 1,
                       0, 1);
 
     if (ret <= 0)
@@ -1771,7 +1755,7 @@ static int netrigctl_get_split_vfo(RIG *rig, vfo_t vfo, split_t *split,
 
     *split = atoi(buf);
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
+    ret = read_string(RIGPORT(rig), (unsigned char *) buf, BUF_MAX, "\n", 1,
                       0, 1);
 
     if (ret <= 0)
@@ -2318,7 +2302,7 @@ static int netrigctl_get_ant(RIG *rig, vfo_t vfo, ant_t ant, value_t *option,
                   ret);
     }
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
+    ret = read_string(RIGPORT(rig), (unsigned char *) buf, BUF_MAX, "\n", 1,
                       0, 1);
 
     if (ret <= 0)

--- a/rigs/dummy/quisk.c
+++ b/rigs/dummy/quisk.c
@@ -61,20 +61,21 @@ int quisk_get_vfo_mode(RIG *rig)
 static int quisk_transaction(RIG *rig, char *cmd, int len, char *buf)
 {
     int ret;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: called len=%d\n", __func__, len);
 
     /* flush anything in the read buffer before command is sent */
-    rig_flush(&rig->state.rigport);
+    rig_flush(rp);
 
-    ret = write_block(&rig->state.rigport, (unsigned char *) cmd, len);
+    ret = write_block(rp, (unsigned char *) cmd, len);
 
     if (ret != RIG_OK)
     {
         return ret;
     }
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1,
                       0, 1);
 
     if (ret < 0)
@@ -212,6 +213,7 @@ static int quisk_open(RIG *rig)
     char cmd[CMD_MAX];
     char buf[BUF_MAX];
     struct quisk_priv_data *priv;
+    hamlib_port_t *rp = RIGPORT(rig);
 
 
     ENTERFUNC;
@@ -237,16 +239,14 @@ static int quisk_open(RIG *rig)
         RETURNFUNC(-RIG_EPROTO);
     }
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
         RETURNFUNC((ret < 0) ? ret : -RIG_EPROTO);
     }
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -257,8 +257,7 @@ static int quisk_open(RIG *rig)
 
     for (i = 0; i < HAMLIB_FRQRANGESIZ; i++)
     {
-        ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                          0, 1);
+        ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
         if (ret <= 0)
         {
@@ -288,8 +287,7 @@ static int quisk_open(RIG *rig)
 
     for (i = 0; i < HAMLIB_FRQRANGESIZ; i++)
     {
-        ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                          0, 1);
+        ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
         if (ret <= 0)
         {
@@ -331,8 +329,7 @@ static int quisk_open(RIG *rig)
 
     for (i = 0; i < HAMLIB_TSLSTSIZ; i++)
     {
-        ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                          0, 1);
+        ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
         if (ret <= 0)
         {
@@ -356,8 +353,7 @@ static int quisk_open(RIG *rig)
 
     for (i = 0; i < HAMLIB_FLTLSTSIZ; i++)
     {
-        ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                          0, 1);
+        ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
         if (ret <= 0)
         {
@@ -384,8 +380,7 @@ static int quisk_open(RIG *rig)
     chan_t chan_list[HAMLIB_CHANLSTSIZ]; /*!< Channel list, zero ended */
 #endif
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -394,8 +389,7 @@ static int quisk_open(RIG *rig)
 
     rig->caps->max_rit = rs->max_rit = atol(buf);
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -404,8 +398,7 @@ static int quisk_open(RIG *rig)
 
     rig->caps->max_xit = rs->max_xit = atol(buf);
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -414,8 +407,7 @@ static int quisk_open(RIG *rig)
 
     rig->caps->max_ifshift = rs->max_ifshift = atol(buf);
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -424,8 +416,7 @@ static int quisk_open(RIG *rig)
 
     rs->announces = atoi(buf);
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -452,8 +443,7 @@ static int quisk_open(RIG *rig)
 
     rig->caps->preamp[ret] = rs->preamp[ret] = RIG_DBLST_END;
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -480,8 +470,7 @@ static int quisk_open(RIG *rig)
 
     rig->caps->attenuator[ret] = rs->attenuator[ret] = RIG_DBLST_END;
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -491,8 +480,7 @@ static int quisk_open(RIG *rig)
     rig->caps->has_get_func = rs->has_get_func = strtoll(buf, NULL, 0);
 
     HAMLIB_TRACE;
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -502,8 +490,7 @@ static int quisk_open(RIG *rig)
     rig->caps->has_set_func = rs->has_set_func = strtoll(buf, NULL, 0);
 
     HAMLIB_TRACE;
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -526,8 +513,7 @@ static int quisk_open(RIG *rig)
 #endif
 
     HAMLIB_TRACE;
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -537,8 +523,7 @@ static int quisk_open(RIG *rig)
     rig->caps->has_set_level = rs->has_set_level = strtoll(buf, NULL, 0);
 
     HAMLIB_TRACE;
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -549,8 +534,7 @@ static int quisk_open(RIG *rig)
 
 #if 0
     HAMLIB_TRACE;
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -599,8 +583,8 @@ static int quisk_open(RIG *rig)
     do
     {
         char setting[32], value[1024];
-        ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                          0, 1);
+	hamlib_port_t *pttp = PTTPORT(rig);
+        ret = read_string(rp, (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
         strtok(buf, "\r\n"); // chop the EOL
 
         if (ret <= 0)
@@ -623,7 +607,7 @@ static int quisk_open(RIG *rig)
                 ptt_type_t temp = (ptt_type_t)strtol(value, NULL, 0);
                 rig_debug(RIG_DEBUG_VERBOSE, "%s: ptt_type='%s'(%d)\n", __func__, value, temp);
 
-                if (RIG_PTT_RIG_MICDATA == rig->state.pttport.type.ptt
+                if (RIG_PTT_RIG_MICDATA == pttp->type.ptt
                         || temp == RIG_PTT_RIG_MICDATA)
                 {
                     /*
@@ -631,15 +615,15 @@ static int quisk_open(RIG *rig)
                      * if there is any PTT capability and we have not
                      * locally overridden it
                      */
-                    rig->state.pttport.type.ptt = RIG_PTT_RIG_MICDATA;
+                    pttp->type.ptt = RIG_PTT_RIG_MICDATA;
                     rig->caps->ptt_type = RIG_PTT_RIG_MICDATA;
                     rig_debug(RIG_DEBUG_TRACE, "%s: %s set to %d\n", __func__, setting,
-                              rig->state.pttport.type.ptt);
+                              pttp->type.ptt);
                 }
                 else
                 {
                     rig_debug(RIG_DEBUG_VERBOSE, "%s: ptt_type= %d\n", __func__, temp);
-                    rig->state.pttport.type.ptt = temp;
+                    pttp->type.ptt = temp;
                     rig->caps->ptt_type = temp;
                 }
             }
@@ -955,7 +939,7 @@ static int quisk_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
     CHKSCN1ARG(num_sscanf(buf, "%"SCNfreq, freq));
 
 #if 0 // implement set_freq VFO later if it can be detected
-    ret = read_string(&rig->state.rigport, buf, BUF_MAX, "\n", 1, 0, 1);
+    ret = read_string(RIGPORT(rig), buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -1026,7 +1010,7 @@ static int quisk_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode,
 
     *mode = rig_parse_mode(buf);
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
+    ret = read_string(RIGPORT(rig), (unsigned char *) buf, BUF_MAX, "\n", 1,
                       0, 1);
 
     if (ret <= 0)
@@ -1114,9 +1098,9 @@ static int quisk_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called vfo=%s, ptt=%d, ptt_type=%d\n",
               __func__,
-              rig_strvfo(vfo), ptt, rig->state.pttport.type.ptt);
+              rig_strvfo(vfo), ptt, PTTPORT(rig)->type.ptt);
 
-    if (rig->state.pttport.type.ptt == RIG_PTT_NONE) { return RIG_OK; }
+    if (PTTPORT(rig)->type.ptt == RIG_PTT_NONE) { return RIG_OK; }
 
     ret = quisk_vfostr(rig, vfostr, sizeof(vfostr), RIG_VFO_A);
 
@@ -1645,8 +1629,7 @@ static int quisk_get_split_mode(RIG *rig, vfo_t vfo, rmode_t *tx_mode,
 
     *tx_mode = rig_parse_mode(buf);
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(RIGPORT(rig), (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -1713,8 +1696,7 @@ static int quisk_get_split_vfo(RIG *rig, vfo_t vfo, split_t *split,
 
     *split = atoi(buf);
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(RIGPORT(rig), (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {
@@ -2268,8 +2250,7 @@ static int quisk_get_ant(RIG *rig, vfo_t vfo, ant_t ant, value_t *option,
                   ret);
     }
 
-    ret = read_string(&rig->state.rigport, (unsigned char *) buf, BUF_MAX, "\n", 1,
-                      0, 1);
+    ret = read_string(RIGPORT(rig), (unsigned char *) buf, BUF_MAX, "\n", 1, 0, 1);
 
     if (ret <= 0)
     {

--- a/rigs/dummy/rot_dummy.c
+++ b/rigs/dummy/rot_dummy.c
@@ -151,7 +151,7 @@ static int dummy_rot_init(ROT *rot)
         return -RIG_ENOMEM;
     }
 
-    rot->state.rotport.type.rig = RIG_PORT_NONE;
+    ROTPORT(rot)->type.rig = RIG_PORT_NONE;
 
     priv->az = priv->el = 0;
 

--- a/rigs/dummy/sdrsharp.c
+++ b/rigs/dummy/sdrsharp.c
@@ -101,7 +101,6 @@ static int read_transaction(RIG *rig, char *xml, int xml_len)
     int retry;
     char *delims;
     char *terminator = "\n";
-    struct rig_state *rs = &rig->state;
 
     ENTERFUNC;
 
@@ -118,7 +117,7 @@ static int read_transaction(RIG *rig, char *xml, int xml_len)
             rig_debug(RIG_DEBUG_WARN, "%s: retry needed? retry=%d\n", __func__, retry);
         }
 
-        int len = read_string(&rs->rigport, (unsigned char *) tmp_buf, sizeof(tmp_buf),
+        int len = read_string(RIGPORT(rig), (unsigned char *) tmp_buf, sizeof(tmp_buf),
                               delims,
                               strlen(delims), 0, 1);
 
@@ -175,7 +174,7 @@ static int write_transaction(RIG *rig, char *xml, int xml_len)
 
     int retval = -RIG_EPROTO;
 
-    struct rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     ENTERFUNC;
 
@@ -189,11 +188,11 @@ static int write_transaction(RIG *rig, char *xml, int xml_len)
 
     // appears we can lose sync if we don't clear things out
     // shouldn't be anything for us now anyways
-    rig_flush(&rig->state.rigport);
+    rig_flush(rp);
 
     while (try-- >= 0 && retval != RIG_OK)
         {
-            retval = write_block(&rs->rigport, (unsigned char *) xml, strlen(xml));
+            retval = write_block(rp, (unsigned char *) xml, strlen(xml));
 
             if (retval  < 0)
             {
@@ -270,6 +269,7 @@ static int sdrsharp_transaction(RIG *rig, char *cmd, char *value,
 static int sdrsharp_init(RIG *rig)
 {
     struct sdrsharp_priv_data *priv;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s version %s\n", __func__, rig->caps->version);
@@ -303,8 +303,7 @@ static int sdrsharp_init(RIG *rig)
         RETURNFUNC(-RIG_EINVAL);
     }
 
-    strncpy(rig->state.rigport.pathname, DEFAULTPATH,
-            sizeof(rig->state.rigport.pathname));
+    strncpy(rp->pathname, DEFAULTPATH, sizeof(rp->pathname));
 
     RETURNFUNC(RIG_OK);
 }

--- a/rigs/dummy/tci1x.c
+++ b/rigs/dummy/tci1x.c
@@ -273,7 +273,6 @@ static int check_vfo(vfo_t vfo)
 static int read_transaction(RIG *rig, unsigned char *buf, int buf_len)
 {
     int retry;
-    struct rig_state *rs = &rig->state;
     char *delims = ";";
 
     ENTERFUNC;
@@ -287,7 +286,7 @@ static int read_transaction(RIG *rig, unsigned char *buf, int buf_len)
             rig_debug(RIG_DEBUG_WARN, "%s: retry needed? retry=%d\n", __func__, retry);
         }
 
-        int len = read_string(&rs->rigport, buf, buf_len, delims,
+        int len = read_string(RIGPORT(rig), buf, buf_len, delims,
                               strlen(delims), 0, 1);
         rig_debug(RIG_DEBUG_TRACE, "%s: string='%s'\n", __func__, buf);
 
@@ -320,7 +319,7 @@ static int write_transaction(RIG *rig, const unsigned char *buf, int buf_len)
 
     int retval = -RIG_EPROTO;
 
-    struct rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     ENTERFUNC;
 
@@ -334,11 +333,11 @@ static int write_transaction(RIG *rig, const unsigned char *buf, int buf_len)
 
     // appears we can lose sync if we don't clear things out
     // shouldn't be anything for us now anyways
-    rig_flush(&rig->state.rigport);
+    rig_flush(rp);
 
     while (try-- >= 0 && retval != RIG_OK)
         {
-            retval = write_block(&rs->rigport, buf, buf_len);
+            retval = write_block(rp, buf, buf_len);
 
             if (retval  < 0)
             {
@@ -420,6 +419,7 @@ static int tci1x_transaction(RIG *rig, char *cmd, char *cmd_arg, char *value,
 static int tci1x_init(RIG *rig)
 {
     struct tci1x_priv_data *priv;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s version %s\n", __func__, rig->caps->version);
@@ -453,8 +453,7 @@ static int tci1x_init(RIG *rig)
         RETURNFUNC(-RIG_EINVAL);
     }
 
-    strncpy(rig->state.rigport.pathname, DEFAULTPATH,
-            sizeof(rig->state.rigport.pathname));
+    strncpy(rp->pathname, DEFAULTPATH, sizeof(rp->pathname));
 
     priv->ext_parms = alloc_init_ext(tci1x_ext_parms);
 

--- a/rigs/dummy/trxmanager.c
+++ b/rigs/dummy/trxmanager.c
@@ -228,13 +228,12 @@ static int vfo_curr(RIG *rig, vfo_t vfo)
  */
 static int read_transaction(RIG *rig, char *response, int response_len)
 {
-    struct rig_state *rs = &rig->state;
     const char *delims = "\n";
     int len;
 
     rig_debug(RIG_DEBUG_TRACE, "%s\n", __func__);
 
-    len = read_string(&rs->rigport, (unsigned char *) response, response_len,
+    len = read_string(RIGPORT(rig), (unsigned char *) response, response_len,
                       delims,
                       strlen(delims), 0, 1);
 
@@ -254,6 +253,7 @@ static int read_transaction(RIG *rig, char *response, int response_len)
 static int trxmanager_init(RIG *rig)
 {
     struct trxmanager_priv_data *priv;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     rig_debug(RIG_DEBUG_TRACE, "%s version %s\n", __func__, BACKEND_VER);
 
@@ -280,8 +280,7 @@ static int trxmanager_init(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    strncpy(rig->state.rigport.pathname, DEFAULTPATH,
-            sizeof(rig->state.rigport.pathname));
+    strncpy(rp->pathname, DEFAULTPATH, sizeof(rp->pathname));
 
     return RIG_OK;
 }
@@ -296,13 +295,13 @@ static int trxmanager_open(RIG *rig)
     char *cmd;
     char *saveptr;
     char response[MAXCMDLEN] = "";
-    struct rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
     struct trxmanager_priv_data *priv = (struct trxmanager_priv_data *)
                                         rig->state.priv;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s version %s\n", __func__, BACKEND_VER);
 
-    rs->rigport.timeout = 10000; // long timeout for antenna switching/tuning
+    rp->timeout = 10000; // long timeout for antenna switching/tuning
     retval = read_transaction(rig, response, sizeof(response));
 
     if (retval != RIG_OK)
@@ -323,7 +322,7 @@ static int trxmanager_open(RIG *rig)
 
     // Turn off active messages
     cmd = "AI0;";
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, strlen(cmd));
+    retval = write_block(rp, (unsigned char *) cmd, strlen(cmd));
 
     if (retval < 0)
     {
@@ -346,7 +345,7 @@ static int trxmanager_open(RIG *rig)
     rig_debug(RIG_DEBUG_VERBOSE, "%s AI response=%s\n", __func__, response);
 
     cmd = "FN;";
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, strlen(cmd));
+    retval = write_block(rp, (unsigned char *) cmd, strlen(cmd));
 
     if (retval != RIG_OK)
     {
@@ -405,7 +404,6 @@ static int trxmanager_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
     char vfoab;
     char cmd[MAXCMDLEN];
     char response[MAXCMDLEN] = "";
-    struct rig_state *rs = &rig->state;
     struct trxmanager_priv_data *priv = (struct trxmanager_priv_data *)
                                         rig->state.priv;
 
@@ -434,7 +432,7 @@ static int trxmanager_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
     vfoab = vfo == RIG_VFO_A ? 'R' : 'T';
     SNPRINTF(cmd, sizeof(cmd), "X%c;", vfoab);
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, strlen(cmd));
+    retval = write_block(RIGPORT(rig), (unsigned char *) cmd, strlen(cmd));
 
     if (retval < 0)
     {
@@ -475,7 +473,6 @@ static int trxmanager_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     char vfoab;
     char cmd[MAXCMDLEN];
     char response[MAXCMDLEN] = "";
-    struct rig_state *rs = &rig->state;
     const struct trxmanager_priv_data *priv = (struct trxmanager_priv_data *)
             rig->state.priv;
 
@@ -504,7 +501,7 @@ static int trxmanager_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
     vfoab = vfo == RIG_VFO_A ? 'A' : 'B';
     SNPRINTF(cmd, sizeof(cmd), "F%c%011lu;", vfoab, (unsigned long)freq);
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, strlen(cmd));
+    retval = write_block(RIGPORT(rig), (unsigned char *) cmd, strlen(cmd));
 
     if (retval < 0)
     {
@@ -531,7 +528,6 @@ static int trxmanager_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
     int retval;
     char cmd[MAXCMDLEN];
     char response[MAXCMDLEN] = "";
-    struct rig_state *rs = &rig->state;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: ptt=%d\n", __func__, ptt);
 
@@ -543,7 +539,7 @@ static int trxmanager_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
     }
 
     SNPRINTF(cmd, sizeof(cmd), "%s;", ptt == 1 ? "TX" : "RX");
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, strlen(cmd));
+    retval = write_block(RIGPORT(rig), (unsigned char *) cmd, strlen(cmd));
 
     if (retval < 0)
     {
@@ -576,13 +572,12 @@ static int trxmanager_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
     char cptt;
     char cmd[MAXCMDLEN];
     char response[MAXCMDLEN] = "";
-    struct rig_state *rs = &rig->state;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s\n", __func__,
               rig_strvfo(vfo));
 
     SNPRINTF(cmd, sizeof(cmd), "IF;");
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, strlen(cmd));
+    retval = write_block(RIGPORT(rig), (unsigned char *) cmd, strlen(cmd));
 
     if (retval < 0)
     {
@@ -635,7 +630,6 @@ static int trxmanager_set_mode(RIG *rig, vfo_t vfo, rmode_t mode,
     char ttmode;
     char cmd[MAXCMDLEN];
     char response[MAXCMDLEN] = "";
-    struct rig_state *rs = &rig->state;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s mode=%s width=%d\n",
               __func__, rig_strvfo(vfo), rig_strrmode(mode), (int)width);
@@ -707,7 +701,7 @@ static int trxmanager_set_mode(RIG *rig, vfo_t vfo, rmode_t mode,
     }
 
     SNPRINTF(cmd, sizeof(cmd), "MD%c;", ttmode);
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, strlen(cmd));
+    retval = write_block(RIGPORT(rig), (unsigned char *) cmd, strlen(cmd));
 
     if (retval < 0)
     {
@@ -742,7 +736,7 @@ static int trxmanager_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode,
     char tmode;
     char cmd[MAXCMDLEN];
     char response[MAXCMDLEN] = "";
-    struct rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
     struct trxmanager_priv_data *priv = (struct trxmanager_priv_data *)
                                         rig->state.priv;
 
@@ -770,7 +764,7 @@ static int trxmanager_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode,
               rig_strvfo(vfo));
 
     SNPRINTF(cmd, sizeof(cmd), "MD;");
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, strlen(cmd));
+    retval = write_block(rp, (unsigned char *) cmd, strlen(cmd));
 
     if (retval < 0)
     {
@@ -843,7 +837,7 @@ static int trxmanager_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode,
 
     // now get the bandwidth
     SNPRINTF(cmd, sizeof(cmd), "BW;");
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, strlen(cmd));
+    retval = write_block(rp, (unsigned char *) cmd, strlen(cmd));
 
     if (retval < 0)
     {
@@ -910,7 +904,7 @@ static int trxmanager_set_vfo(RIG *rig, vfo_t vfo)
     }
 
     SNPRINTF(cmd, sizeof(cmd), "FN%d;", vfo == RIG_VFO_A ? 0 : 1);
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, strlen(cmd));
+    retval = write_block(RIGPORT(rig), (unsigned char *) cmd, strlen(cmd));
 
     if (retval < 0)
     {
@@ -982,7 +976,6 @@ static int trxmanager_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
     int retval;
     char cmd[MAXCMDLEN];
     char response[MAXCMDLEN] = "";
-    struct rig_state *rs = &rig->state;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s freq=%.1f\n", __func__,
               rig_strvfo(vfo), tx_freq);
@@ -995,7 +988,7 @@ static int trxmanager_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
     }
 
     SNPRINTF(cmd, sizeof(cmd), "XT%011lu;", (unsigned long) tx_freq);
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, strlen(cmd));
+    retval = write_block(RIGPORT(rig), (unsigned char *) cmd, strlen(cmd));
 
     if (retval < 0)
     {
@@ -1038,7 +1031,6 @@ static int trxmanager_set_split_vfo(RIG *rig, vfo_t vfo, split_t split,
     char response[MAXCMDLEN] = "";
     split_t tsplit;
     vfo_t ttx_vfo;
-    struct rig_state *rs = &rig->state;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: tx_vfo=%s\n", __func__,
               rig_strvfo(tx_vfo));
@@ -1063,7 +1055,7 @@ static int trxmanager_set_split_vfo(RIG *rig, vfo_t vfo, split_t split,
     if (tsplit == split) { return RIG_OK; } // don't need to change it
 
     SNPRINTF(cmd, sizeof(cmd), "SP%c;", split ? '1' : '0');
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, strlen(cmd));
+    retval = write_block(RIGPORT(rig), (unsigned char *) cmd, strlen(cmd));
 
     if (retval < 0)
     {
@@ -1099,13 +1091,12 @@ static int trxmanager_get_split_vfo(RIG *rig, vfo_t vfo, split_t *split,
     int n;
     char cmd[MAXCMDLEN];
     char response[MAXCMDLEN] = "";
-    struct rig_state *rs = &rig->state;
     struct trxmanager_priv_data *priv = (struct trxmanager_priv_data *)
                                         rig->state.priv;
 
     rig_debug(RIG_DEBUG_TRACE, "%s\n", __func__);
     SNPRINTF(cmd, sizeof(cmd), "SP;");
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, strlen(cmd));
+    retval = write_block(RIGPORT(rig), (unsigned char *) cmd, strlen(cmd));
 
     if (retval < 0)
     {
@@ -1144,7 +1135,6 @@ static int trxmanager_set_split_freq_mode(RIG *rig, vfo_t vfo, freq_t freq,
     int retval;
     char cmd[MAXCMDLEN];
     char response[MAXCMDLEN] = "";
-    struct rig_state *rs = &rig->state;
     struct trxmanager_priv_data *priv = (struct trxmanager_priv_data *)
                                         rig->state.priv;
 
@@ -1158,7 +1148,7 @@ static int trxmanager_set_split_freq_mode(RIG *rig, vfo_t vfo, freq_t freq,
     // assume split is on B
     //
     SNPRINTF(cmd, sizeof(cmd), "XT%011lu;", (unsigned long)freq);
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, strlen(cmd));
+    retval = write_block(RIGPORT(rig), (unsigned char *) cmd, strlen(cmd));
 
     if (retval < 0)
     {

--- a/rigs/flexradio/sdr1k.c
+++ b/rigs/flexradio/sdr1k.c
@@ -216,7 +216,7 @@ int sdr1k_init(RIG *rig)
 static void pdelay(RIG *rig)
 {
     unsigned char r;
-    par_read_data(&rig->state.rigport, &r); /* ~1us */
+    par_read_data(RIGPORT(rig), &r); /* ~1us */
 }
 
 int sdr1k_open(RIG *rig)
@@ -453,7 +453,7 @@ int
 write_latch(RIG *rig, latch_t which, unsigned value, unsigned mask)
 {
     struct sdr1k_priv_data *priv = (struct sdr1k_priv_data *)rig->state.priv;
-    hamlib_port_t *pport = &rig->state.rigport;
+    hamlib_port_t *pport = RIGPORT(rig);
 
     if (!(L_EXT <= which && which <= L_DDS1))
     {

--- a/rigs/gomspace/gs100.c
+++ b/rigs/gomspace/gs100.c
@@ -110,7 +110,7 @@ static int gs100_init(RIG *rig)
     rig->state.priv = (void *)priv;
 
 #ifdef _LOCAL_SIMULATION_
-    rig->state.rigport.type.rig = RIG_PORT_NONE;  // just simulation
+    RIGPORT(rig)->type.rig = RIG_PORT_NONE;  // just simulation
     priv->freq_rx = rig->caps->rx_range_list1->startf;
     priv->freq_tx = rig->caps->tx_range_list1->startf;
 #endif
@@ -520,7 +520,7 @@ static int gomx_get(RIG *rig, int table, char *varname, const char *varvalue,
 /* Sends a message to the GS100 and parses response lines */
 static int gomx_transaction(RIG *rig, char *message, char *response)
 {
-    struct rig_state *rs;
+    hamlib_port_t *rp;
     int retval, n = 0;
     char buf[BUFSZ];
 
@@ -531,18 +531,18 @@ static int gomx_transaction(RIG *rig, char *message, char *response)
     rig_debug(RIG_DEBUG_TRACE, "%s: msg='%s'\n", __func__,
               message == NULL ? "NULL" : message);
 
-    rs = &rig->state;
+    rp = RIGPORT(rig);
 
     // send message to the transceiver
-    rig_flush(&rs->rigport);
-    retval = write_block(&rs->rigport, (uint8_t *)message, strlen(message));
+    rig_flush(rp);
+    retval = write_block(rp, (uint8_t *)message, strlen(message));
 
     if (retval != RIG_OK) { return (retval); }
 
     while (1)
     {
         // read the response line
-        retval = read_string(&rs->rigport, (unsigned char *)buf, BUFSZ,
+        retval = read_string(rp, (unsigned char *)buf, BUFSZ,
                              (const char *)GOM_STOPSET, 0, strlen(GOM_STOPSET), 0);
 
         if (retval < 0) { return (retval); }

--- a/rigs/icmarine/icmarine.c
+++ b/rigs/icmarine/icmarine.c
@@ -241,6 +241,7 @@ int icmarine_transaction(RIG *rig, const char *cmd, const char *param,
     struct icmarine_priv_data *priv;
     int i, retval;
     struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
     char cmdbuf[BUFSZ + 1];
     char respbuf[BUFSZ + 1];
     char *p;
@@ -254,7 +255,7 @@ int icmarine_transaction(RIG *rig, const char *cmd, const char *param,
     rs = &rig->state;
     priv = (struct icmarine_priv_data *)rs->priv;
 
-    rig_flush(&rs->rigport);
+    rig_flush(rp);
 
     /* command formatting */
     SNPRINTF(cmdbuf, BUFSZ, "$PICOA,%02d,%02u,%s",
@@ -277,7 +278,7 @@ int icmarine_transaction(RIG *rig, const char *cmd, const char *param,
     cmd_len += snprintf(cmdbuf + cmd_len, BUFSZ - cmd_len, "*%02X" EOM, csum);
 
     /* I/O */
-    retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, cmd_len);
+    retval = write_block(rp, (unsigned char *) cmdbuf, cmd_len);
 
     if (retval != RIG_OK)
     {
@@ -287,7 +288,7 @@ int icmarine_transaction(RIG *rig, const char *cmd, const char *param,
     /*
      * Transceiver sends an echo of cmd followed by a CR/LF
      */
-    retval = read_string(&rs->rigport, (unsigned char *) respbuf, BUFSZ, LF,
+    retval = read_string(rp, (unsigned char *) respbuf, BUFSZ, LF,
                          strlen(LF), 0, 1);
 
     if (retval < 0)

--- a/rigs/icom/optoscan.c
+++ b/rigs/icom/optoscan.c
@@ -611,6 +611,7 @@ int optoscan_scan(RIG *rig, vfo_t vfo, scan_t scan, int ch)
     pltune_cb_t cb;
     int rc, pin_state;
     struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     if (scan != RIG_SCAN_PLT)
     {
@@ -630,7 +631,7 @@ int optoscan_scan(RIG *rig, vfo_t vfo, scan_t scan, int ch)
     {
         /* time for CIV command to be sent. this is subtracted from */
         /* rcvr settle time */
-        state->usleep_time = (1000000 / (rig->state.rigport.parm.serial.rate))
+        state->usleep_time = (1000000 / (rp->parm.serial.rate))
                              * 13 * 9;
 
         rc = cb(rig, vfo, &(state->next_freq), &(state->next_mode),
@@ -666,7 +667,7 @@ int optoscan_scan(RIG *rig, vfo_t vfo, scan_t scan, int ch)
 
         optoscan_wait_timer(rig, state); /*Step 5*/
 
-        ser_get_car(&rs->rigport, &pin_state);
+        ser_get_car(rp, &pin_state);
 
         if (pin_state)   /*Step 6*/
         {
@@ -795,12 +796,11 @@ static int optoscan_send_freq(RIG *rig, vfo_t vfo, const pltstate_t *state)
 
 static int optoscan_RTS_toggle(RIG *rig)
 {
-    struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
     int state = 0;
 
-    rs = &rig->state;
-    ser_get_rts(&rs->rigport, &state);
-    ser_set_rts(&rs->rigport, !state);
+    ser_get_rts(rp, &state);
+    ser_set_rts(rp, !state);
 
     return RIG_OK;
 }

--- a/rigs/jrc/jrc.c
+++ b/rigs/jrc/jrc.c
@@ -67,15 +67,13 @@ int jrc_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
                     int *data_len)
 {
     int retval;
-    struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
 
-    rs = &rig->state;
-
-    rig_flush(&rs->rigport);
+    rig_flush(rp);
 
     set_transaction_active(rig);
 
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, cmd_len);
+    retval = write_block(rp, (unsigned char *) cmd, cmd_len);
 
     if (retval != RIG_OK)
     {
@@ -89,7 +87,7 @@ int jrc_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
         return 0;
     }
 
-    retval = read_string(&rs->rigport, (unsigned char *) data, BUFSZ, EOM,
+    retval = read_string(rp, (unsigned char *) data, BUFSZ, EOM,
                          strlen(EOM), 0, 1);
 
     set_transaction_inactive(rig);
@@ -1612,7 +1610,6 @@ int jrc_scan(RIG *rig, vfo_t vfo, scan_t scan, int ch)
 int jrc_decode_event(RIG *rig)
 {
     const struct jrc_priv_caps *priv = (struct jrc_priv_caps *)rig->caps->priv;
-    struct rig_state *rs;
     freq_t freq;
     rmode_t mode;
     pbwidth_t width;
@@ -1621,13 +1618,11 @@ int jrc_decode_event(RIG *rig)
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: jrc_decode called\n", __func__);
 
-    rs = &rig->state;
-
     /* "Iabdfg"CR */
     //#define SETUP_STATUS_LEN 17
 
-    //count = read_string(&rs->rigport, buf, SETUP_STATUS_LEN, "", 0);
-    count = read_string(&rs->rigport, (unsigned char *) buf, priv->info_len, "", 0,
+    //count = read_string(RIGPORT(rig), buf, SETUP_STATUS_LEN, "", 0);
+    count = read_string(RIGPORT(rig), (unsigned char *) buf, priv->info_len, "", 0,
                         0, 1);
 
     if (count < 0)

--- a/rigs/jrc/jst145.c
+++ b/rigs/jrc/jst145.c
@@ -298,7 +298,7 @@ static int jst145_open(RIG *rig)
     pbwidth_t width;
     struct jst145_priv_data *priv = rig->state.priv;
 
-    retval = write_block(&rig->state.rigport, (unsigned char *) "H1\r", 3);
+    retval = write_block(RIGPORT(rig), (unsigned char *) "H1\r", 3);
 
     if (retval != RIG_OK)
     {
@@ -317,7 +317,7 @@ static int jst145_open(RIG *rig)
 
 static int jst145_close(RIG *rig)
 {
-    return write_block(&rig->state.rigport, (unsigned char *) "H0\r", 3);
+    return write_block(RIGPORT(rig), (unsigned char *) "H0\r", 3);
 }
 
 static int jst145_set_vfo(RIG *rig, vfo_t vfo)
@@ -325,7 +325,7 @@ static int jst145_set_vfo(RIG *rig, vfo_t vfo)
     char cmd[MAX_LEN];
     SNPRINTF(cmd, sizeof(cmd), "F%c\r", vfo == RIG_VFO_A ? 'A' : 'B');
 
-    return write_block(&rig->state.rigport, (unsigned char *) cmd, strlen(cmd));
+    return write_block(RIGPORT(rig), (unsigned char *) cmd, strlen(cmd));
 }
 
 static int jst145_get_vfo(RIG *rig, vfo_t *vfo)
@@ -388,7 +388,7 @@ static int jst145_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
         priv->freqA = freq;
     }
 
-    retval = write_block(&rig->state.rigport, (unsigned char *) freqbuf,
+    retval = write_block(RIGPORT(rig), (unsigned char *) freqbuf,
                          strlen(freqbuf));
 
     if (retval != RIG_OK)
@@ -475,7 +475,7 @@ static int jst145_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         return -RIG_EINVAL;
     }
 
-    retval = write_block(&rig->state.rigport, (unsigned char *) modestr,
+    retval = write_block(RIGPORT(rig), (unsigned char *) modestr,
                          strlen(modestr));
 
     if (retval != RIG_OK)
@@ -542,7 +542,7 @@ static int jst145_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
     {
         char *cmd = val.i == RIG_AGC_SLOW ? "G0\r" : (val.i == RIG_AGC_FAST ? "G1\r" :
                     "G2\r");
-        return write_block(&rig->state.rigport, (unsigned char *) cmd, 3);
+        return write_block(RIGPORT(rig), (unsigned char *) cmd, 3);
     }
 
     default:
@@ -558,7 +558,7 @@ static int jst145_set_mem(RIG *rig, vfo_t vfo, int ch)
 
     SNPRINTF(membuf, sizeof(membuf), "C%03d\r", ch);
 
-    return write_block(&rig->state.rigport, (unsigned char *) membuf,
+    return write_block(RIGPORT(rig), (unsigned char *) membuf,
                        strlen(membuf));
 }
 
@@ -567,7 +567,7 @@ static int jst145_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op)
     switch (op)
     {
     case RIG_OP_FROM_VFO:
-        return write_block(&rig->state.rigport, (unsigned char *) "E1\r", 3);
+        return write_block(RIGPORT(rig), (unsigned char *) "E1\r", 3);
 
     default:
         return -RIG_EINVAL;
@@ -583,7 +583,7 @@ static int jst145_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
     rig_debug(RIG_DEBUG_TRACE, "%s: entered\n", __func__);
     SNPRINTF(cmd, sizeof(cmd), "X%c\r", ptt ? '1' : '0');
     priv->ptt = ptt;
-    return write_block(&rig->state.rigport, (unsigned char *) cmd, strlen(cmd));
+    return write_block(RIGPORT(rig), (unsigned char *) cmd, strlen(cmd));
 }
 
 static int jst145_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)

--- a/rigs/jrc/nrd525.c
+++ b/rigs/jrc/nrd525.c
@@ -151,12 +151,12 @@ struct rig_caps nrd525_caps =
 
 static int nrd525_open(RIG *rig)
 {
-    return write_block(&rig->state.rigport, (unsigned char *) "H1", 2);
+    return write_block(RIGPORT(rig), (unsigned char *) "H1", 2);
 }
 
 static int nrd525_close(RIG *rig)
 {
-    return write_block(&rig->state.rigport, (unsigned char *) "H0", 2);
+    return write_block(RIGPORT(rig), (unsigned char *) "H0", 2);
 }
 
 static int nrd525_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
@@ -165,7 +165,7 @@ static int nrd525_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
     SNPRINTF(freqbuf, sizeof(freqbuf), "F%08u", (unsigned)(freq / 10));
 
-    return write_block(&rig->state.rigport, (unsigned char *) freqbuf,
+    return write_block(RIGPORT(rig), (unsigned char *) freqbuf,
                        strlen(freqbuf));
 }
 
@@ -194,7 +194,7 @@ static int nrd525_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         return -RIG_EINVAL;
     }
 
-    retval = write_block(&rig->state.rigport, (unsigned char *) modestr,
+    retval = write_block(RIGPORT(rig), (unsigned char *) modestr,
                          strlen(modestr));
 
     if (retval != RIG_OK)
@@ -219,11 +219,11 @@ static int nrd525_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
     switch (level)
     {
     case RIG_LEVEL_ATT:
-        return write_block(&rig->state.rigport,
+        return write_block(RIGPORT(rig),
                            (unsigned char *)(val.i != 0 ? "A1" : "A0"), 2);
 
     case RIG_LEVEL_AGC:
-        return write_block(&rig->state.rigport,
+        return write_block(RIGPORT(rig),
                            (unsigned char *)(val.i == RIG_AGC_SLOW ? "G0" :
                                              (val.i == RIG_AGC_FAST ? "G1" : "G2")), 2);
 
@@ -238,7 +238,7 @@ static int nrd525_set_mem(RIG *rig, vfo_t vfo, int ch)
 
     SNPRINTF(membuf, sizeof(membuf), "C%03d", ch);
 
-    return write_block(&rig->state.rigport, (unsigned char *) membuf,
+    return write_block(RIGPORT(rig), (unsigned char *) membuf,
                        strlen(membuf));
 }
 
@@ -247,7 +247,7 @@ static int nrd525_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op)
     switch (op)
     {
     case RIG_OP_FROM_VFO:
-        return write_block(&rig->state.rigport, (unsigned char *) "E1", 2);
+        return write_block(RIGPORT(rig), (unsigned char *) "E1", 2);
 
     default:
         return -RIG_EINVAL;

--- a/rigs/kachina/kachina.c
+++ b/rigs/kachina/kachina.c
@@ -65,26 +65,24 @@
 static int kachina_transaction(RIG *rig, unsigned char cmd1, unsigned char cmd2)
 {
     int count, retval;
-    struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
     unsigned char buf4[4];
-
-    rs = &rig->state;
 
     buf4[0] = STX;
     buf4[1] = cmd1;
     buf4[2] = cmd2;
     buf4[3] = ETX;
 
-    rig_flush(&rs->rigport);
+    rig_flush(rp);
 
-    retval = write_block(&rs->rigport, buf4, 4);
+    retval = write_block(rp, buf4, 4);
 
     if (retval != RIG_OK)
     {
         return retval;
     }
 
-    count = read_string(&rs->rigport, buf4, 1, "", 0, 0, 1);
+    count = read_string(rp, buf4, 1, "", 0, 0, 1);
 
     if (count != 1)
     {
@@ -98,10 +96,8 @@ static int kachina_trans_n(RIG *rig, unsigned char cmd1, const char *data,
                            int data_len)
 {
     int cmd_len, count, retval;
-    struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
     unsigned char buf[16];
-
-    rs = &rig->state;
 
     buf[0] = STX;
     buf[1] = cmd1;
@@ -110,16 +106,16 @@ static int kachina_trans_n(RIG *rig, unsigned char cmd1, const char *data,
 
     cmd_len = data_len + 3;
 
-    rig_flush(&rs->rigport);
+    rig_flush(rp);
 
-    retval = write_block(&rs->rigport, buf, cmd_len);
+    retval = write_block(rp, buf, cmd_len);
 
     if (retval != RIG_OK)
     {
         return retval;
     }
 
-    count = read_string(&rs->rigport, buf, 1, "", 0, 0, 1);
+    count = read_string(rp, buf, 1, "", 0, 0, 1);
 
     if (count != 1)
     {
@@ -229,6 +225,7 @@ int kachina_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
     int i, count;
     unsigned char buf[32];
+    hamlib_port_t *rp = RIGPORT(rig);
 
     static const char rcv_signal_range[128] =
     {
@@ -261,9 +258,9 @@ int kachina_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 
     /* telemetry sent to the PC automatically at a 50msec rate */
 
-    rig_flush(&rig->state.rigport);
+    rig_flush(rp);
 
-    count = read_string(&rig->state.rigport, buf, 31, rcv_signal_range,
+    count = read_string(rp, buf, 31, rcv_signal_range,
                         128, 0, 1);
 
     if (count < 1)

--- a/rigs/kit/dds60.c
+++ b/rigs/kit/dds60.c
@@ -348,7 +348,7 @@ int dds60_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     unsigned long frg;
     unsigned char control;
     struct dds60_priv_data *priv;
-    hamlib_port_t *port = &rig->state.rigport;
+    hamlib_port_t *port = RIGPORT(rig);
     freq_t osc_ref;
 
     priv = (struct dds60_priv_data *)rig->state.priv;
@@ -379,7 +379,7 @@ int dds60_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
 int dds60_open(RIG *rig)
 {
-    hamlib_port_t *port = &rig->state.rigport;
+    hamlib_port_t *port = RIGPORT(rig);
 
     /* lock the parallel port */
     par_lock(port);

--- a/rigs/kit/drt1.c
+++ b/rigs/kit/drt1.c
@@ -412,7 +412,7 @@ int drt1_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     unsigned cfr2;
 
     struct drt1_priv_data *priv;
-    hamlib_port_t *port = &rig->state.rigport;
+    hamlib_port_t *port = RIGPORT(rig);
 
     priv = (struct drt1_priv_data *)rig->state.priv;
 

--- a/rigs/kit/dwt.c
+++ b/rigs/kit/dwt.c
@@ -621,7 +621,7 @@ struct rig_caps dwt_caps =
 
 int dwt_init(RIG *rig)
 {
-    hamlib_port_t *rp = &rig->state.rigport;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     rp->parm.usb.vid = USB_VID_CT;
     rp->parm.usb.pid = USB_PID_CT_DWT;
@@ -635,7 +635,7 @@ int dwt_init(RIG *rig)
 #define MSG_LEN 16
 int dwt_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-    libusb_device_handle *udh = rig->state.rigport.handle;
+    libusb_device_handle *udh = RIGPORT(rig)->handle;
     int request, value, index;
     unsigned char buf[MSG_LEN] = { 0x4a, 0x00, 0x03, 0x00, 0xff, 0xff, 0x32 };
     int requesttype, r;
@@ -668,7 +668,7 @@ int dwt_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 const char *dwt_get_info(RIG *rig)
 {
     static char buf[64];
-    libusb_device_handle *udh = rig->state.rigport.handle;
+    libusb_device_handle *udh = RIGPORT(rig)->handle;
     struct libusb_device_descriptor desc;
 
     /* always succeeds since libusb-1.0.16 */

--- a/rigs/kit/elektor304.c
+++ b/rigs/kit/elektor304.c
@@ -342,7 +342,7 @@ int elektor304_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     unsigned fhl, fhh, fll, flh;
 
     struct elektor304_priv_data *priv;
-    hamlib_port_t *port = &rig->state.rigport;
+    hamlib_port_t *port = RIGPORT(rig);
 
     priv = (struct elektor304_priv_data *)rig->state.priv;
 

--- a/rigs/kit/elektor507.c
+++ b/rigs/kit/elektor507.c
@@ -373,7 +373,7 @@ const char *elektor507_get_info(RIG *rig)
  */
 int elektor507_init(RIG *rig)
 {
-    hamlib_port_t *rp = &rig->state.rigport;
+    hamlib_port_t *rp = RIGPORT(rig);
     struct elektor507_priv_data *priv;
 
     rig->state.priv = (struct elektor507_priv_data *)calloc(sizeof(struct
@@ -426,7 +426,7 @@ int elektor507_cleanup(RIG *rig)
 const char *elektor507_get_info(RIG *rig)
 {
     static char buf[64];
-    libusb_device_handle *udh = rig->state.rigport.handle;
+    libusb_device_handle *udh = RIGPORT(rig)->handle;
     struct libusb_device_descriptor desc;
 
     /* always succeeds since libusb-1.0.16 */
@@ -439,7 +439,7 @@ const char *elektor507_get_info(RIG *rig)
 
 int elektor507_libusb_setup(RIG *rig)
 {
-    libusb_device_handle *udh = rig->state.rigport.handle;
+    libusb_device_handle *udh = RIGPORT(rig)->handle;
     int ret;
     unsigned short index = 0, usb_val;
 
@@ -500,7 +500,7 @@ int elektor507_libusb_setup(RIG *rig)
 int elektor507_ftdi_write_data(RIG *rig, void *FTOutBuf,
                                unsigned long BufferSize)
 {
-    libusb_device_handle *udh = rig->state.rigport.handle;
+    libusb_device_handle *udh = RIGPORT(rig)->handle;
     int ret, actual_length;
 
     rig_debug(RIG_DEBUG_TRACE, "%s called, %lu bytes\n", __func__, BufferSize);

--- a/rigs/kit/fifisdr.c
+++ b/rigs/kit/fifisdr.c
@@ -276,12 +276,12 @@ static int fifisdr_usb_write(RIG *rig,
                              unsigned char *bytes, int size)
 {
     int ret;
-    libusb_device_handle *udh = rig->state.rigport.handle;
+    libusb_device_handle *udh = RIGPORT(rig)->handle;
 
     ret = libusb_control_transfer(udh,
                                   LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | LIBUSB_ENDPOINT_OUT,
                                   request, value, index,
-                                  bytes, size, rig->state.rigport.timeout);
+                                  bytes, size, RIGPORT(rig)->timeout);
 
     if (ret != size)
     {
@@ -303,12 +303,12 @@ static int fifisdr_usb_read(RIG *rig,
                             unsigned char *bytes, int size)
 {
     int ret;
-    libusb_device_handle *udh = rig->state.rigport.handle;
+    libusb_device_handle *udh = RIGPORT(rig)->handle;
 
     ret = libusb_control_transfer(udh,
                                   LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | LIBUSB_ENDPOINT_IN,
                                   request, value, index,
-                                  bytes, size, rig->state.rigport.timeout);
+                                  bytes, size, RIGPORT(rig)->timeout);
 
     if (ret != size)
     {
@@ -326,7 +326,7 @@ static int fifisdr_usb_read(RIG *rig,
 
 int fifisdr_init(RIG *rig)
 {
-    hamlib_port_t *rp = &rig->state.rigport;
+    hamlib_port_t *rp = RIGPORT(rig);
     struct fifisdr_priv_instance_data *priv;
 
     rig->state.priv = (struct fifisdr_priv_instance_data *)calloc(sizeof(

--- a/rigs/kit/funcube.c
+++ b/rigs/kit/funcube.c
@@ -225,7 +225,7 @@ struct rig_caps funcubeplus_caps =
 
 int funcube_init(RIG *rig)
 {
-    hamlib_port_t *rp = &rig->state.rigport;
+    hamlib_port_t *rp = RIGPORT(rig);
     struct funcube_priv_data *priv;
 
     rig->state.priv = (struct funcube_priv_data *)calloc(sizeof(
@@ -255,7 +255,7 @@ int funcube_init(RIG *rig)
 
 int funcubeplus_init(RIG *rig)
 {
-    hamlib_port_t *rp = &rig->state.rigport;
+    hamlib_port_t *rp = RIGPORT(rig);
     struct funcube_priv_data *priv;
 
     rig->state.priv = (struct funcube_priv_data *)calloc(sizeof(
@@ -304,7 +304,7 @@ int funcube_cleanup(RIG *rig)
 const char *funcube_get_info(RIG *rig)
 {
     static char buf[64];
-    libusb_device_handle *udh = rig->state.rigport.handle;
+    libusb_device_handle *udh = RIGPORT(rig)->handle;
     struct libusb_device_descriptor desc;
 
     /* always succeeds since libusb-1.0.16 */
@@ -427,12 +427,14 @@ int set_freq_v1(libusb_device_handle *udh, unsigned int f, int timeout)
 int funcube_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
     struct funcube_priv_data *priv = (struct funcube_priv_data *)rig->state.priv;
-    libusb_device_handle *udh = rig->state.rigport.handle;
+    hamlib_port_t *rp = RIGPORT(rig);
+    libusb_device_handle *udh = rp->handle;
+
     int ret;
 
-    if ((ret = set_freq_v1(udh, freq, rig->state.rigport.timeout)) != RIG_OK)
+    if ((ret = set_freq_v1(udh, freq, rp->timeout)) != RIG_OK)
     {
-        if ((ret = set_freq_v0(udh, freq, rig->state.rigport.timeout)) == RIG_OK)
+        if ((ret = set_freq_v0(udh, freq, rp->timeout)) == RIG_OK)
         {
             priv->freq = freq;
         }
@@ -460,7 +462,8 @@ int get_freq_v0(RIG *rig, vfo_t vfo, freq_t *freq)
 
 int get_freq_v1(RIG *rig, vfo_t vfo, freq_t *freq)
 {
-    libusb_device_handle *udh = rig->state.rigport.handle;
+    hamlib_port_t *rp = RIGPORT(rig);
+    libusb_device_handle *udh = rp->handle;
     int ret;
     unsigned int f;
     int actual_length;
@@ -475,7 +478,7 @@ int get_freq_v1(RIG *rig, vfo_t vfo, freq_t *freq)
               au8BufOut[3] & 0xFF);
 
     ret = libusb_interrupt_transfer(udh, OUTPUT_ENDPOINT, au8BufOut,
-                                    sizeof(au8BufOut), &actual_length, rig->state.rigport.timeout);
+                                    sizeof(au8BufOut), &actual_length, rp->timeout);
 
     if (ret < 0)
     {
@@ -485,7 +488,7 @@ int get_freq_v1(RIG *rig, vfo_t vfo, freq_t *freq)
     }
 
     ret = libusb_interrupt_transfer(udh, INPUT_ENDPOINT, au8BufIn, sizeof(au8BufIn),
-                                    &actual_length, rig->state.rigport.timeout);
+                                    &actual_length, rp->timeout);
 
     if (ret < 0 || actual_length != sizeof(au8BufIn))
     {
@@ -528,7 +531,8 @@ int funcube_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
 int funcube_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
-    libusb_device_handle *udh = rig->state.rigport.handle;
+    hamlib_port_t *rp = RIGPORT(rig);
+    libusb_device_handle *udh = rp->handle;
     int ret;
     int actual_length;
     unsigned char au8BufOut[64] = "\0\0\0\0"; // endpoint size
@@ -601,7 +605,7 @@ int funcube_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
               au8BufOut[3] & 0xFF);
 
     ret = libusb_interrupt_transfer(udh, OUTPUT_ENDPOINT, au8BufOut,
-                                    sizeof(au8BufOut), &actual_length, rig->state.rigport.timeout);
+                                    sizeof(au8BufOut), &actual_length, rp->timeout);
 
     if (ret < 0)
     {
@@ -611,7 +615,7 @@ int funcube_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
     }
 
     ret = libusb_interrupt_transfer(udh, INPUT_ENDPOINT, au8BufIn, sizeof(au8BufIn),
-                                    &actual_length, rig->state.rigport.timeout);
+                                    &actual_length, rp->timeout);
 
     if (ret < 0 || actual_length != sizeof(au8BufIn))
     {
@@ -635,7 +639,8 @@ int funcube_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
 int funcube_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
-    libusb_device_handle *udh = rig->state.rigport.handle;
+    hamlib_port_t *rp = RIGPORT(rig);
+    libusb_device_handle *udh = rp->handle;
     int ret;
     int actual_length;
     unsigned char au8BufOut[64] = "\0\0\0\0"; // endpoint size
@@ -663,7 +668,7 @@ int funcube_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
               au8BufOut[3] & 0xFF);
 
     ret = libusb_interrupt_transfer(udh, OUTPUT_ENDPOINT, au8BufOut,
-                                    sizeof(au8BufOut), &actual_length, rig->state.rigport.timeout);
+                                    sizeof(au8BufOut), &actual_length, rp->timeout);
 
     if (ret < 0)
     {
@@ -673,7 +678,7 @@ int funcube_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     }
 
     ret = libusb_interrupt_transfer(udh, INPUT_ENDPOINT, au8BufIn, sizeof(au8BufIn),
-                                    &actual_length, rig->state.rigport.timeout);
+                                    &actual_length, rp->timeout);
 
     if (ret < 0 || actual_length != sizeof(au8BufIn))
     {
@@ -760,7 +765,8 @@ int funcube_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 int funcube_hid_cmd(RIG *rig, unsigned char *au8BufOut, unsigned char *au8BufIn,
                     int inputSize)
 {
-    libusb_device_handle *udh = rig->state.rigport.handle;
+    hamlib_port_t *rp = RIGPORT(rig);
+    libusb_device_handle *udh = rp->handle;
     int ret;
     int actual_length;
     rig_debug(RIG_DEBUG_TRACE, "%s: HID packet set to %02x%02x%02x%02x\n",
@@ -768,7 +774,7 @@ int funcube_hid_cmd(RIG *rig, unsigned char *au8BufOut, unsigned char *au8BufIn,
               au8BufOut[3] & 0xFF);
 
     ret = libusb_interrupt_transfer(udh, OUTPUT_ENDPOINT, au8BufOut,
-                                    sizeof(au8BufOut), &actual_length, rig->state.rigport.timeout);
+                                    sizeof(au8BufOut), &actual_length, rp->timeout);
 
     if (ret < 0)
     {
@@ -778,7 +784,7 @@ int funcube_hid_cmd(RIG *rig, unsigned char *au8BufOut, unsigned char *au8BufIn,
     }
 
     ret = libusb_interrupt_transfer(udh, INPUT_ENDPOINT, au8BufIn, inputSize,
-                                    &actual_length, rig->state.rigport.timeout);
+                                    &actual_length, rp->timeout);
 
     if (ret < 0 || actual_length != inputSize)
     {

--- a/rigs/kit/hiqsdr.c
+++ b/rigs/kit/hiqsdr.c
@@ -192,10 +192,10 @@ static int send_command(RIG *rig)
                                           rig->state.priv;
     int ret;
 
-    ret = write_block(&rig->state.rigport, (unsigned char *) priv->control_frame,
+    ret = write_block(RIGPORT(rig), (unsigned char *) priv->control_frame,
                       CTRL_FRAME_LEN);
 #if 0
-    ret = read_block(&rig->state.rigport, (unsigned char *) priv->control_frame,
+    ret = read_block(RIGPORT(rig), (unsigned char *) priv->control_frame,
                      CTRL_FRAME_LEN);
 
     if (ret != CTRL_FRAME_LEN)
@@ -306,7 +306,7 @@ int hiqsdr_init(RIG *rig)
     priv->split = RIG_SPLIT_OFF;
     priv->ref_clock = REFCLOCK;
     priv->sample_rate = DEFAULT_SAMPLE_RATE;
-    strncpy(rig->state.rigport.pathname, "192.168.2.196:48248",
+    strncpy(RIGPORT(rig)->pathname, "192.168.2.196:48248",
             HAMLIB_FILPATHLEN - 1);
 
     return RIG_OK;
@@ -347,7 +347,7 @@ int hiqsdr_open(RIG *rig)
 
 #if 0
     /* Send the samples to me. FIXME: send to port 48247 */
-    ret = write_block(&rig->state.rigport, buf_send_to_me, sizeof(buf_send_to_me));
+    ret = write_block(RIGPORT(rig), buf_send_to_me, sizeof(buf_send_to_me));
 
     if (ret != RIG_OK)
     {

--- a/rigs/kit/miniVNA.c
+++ b/rigs/kit/miniVNA.c
@@ -33,18 +33,18 @@ static int miniVNA_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     char fstr[20];
     char cmdstr[40];
     int retval;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     sprintf_freq(fstr, sizeof(fstr), freq);
     rig_debug(RIG_DEBUG_TRACE, "%s called: %s %s\n", __func__,
               rig_strvfo(vfo), fstr);
 
-    rig_flush(&rig->state.rigport);
+    rig_flush(rp);
 
     SNPRINTF(cmdstr, sizeof(cmdstr), "0\r%lu\r1\r0\r",
              (unsigned long int)(freq * DDS_RATIO));
 
-    retval = write_block(&rig->state.rigport, (unsigned char *) cmdstr,
-                         strlen(cmdstr));
+    retval = write_block(rp, (unsigned char *) cmdstr, strlen(cmdstr));
 
     if (retval != RIG_OK)
     {

--- a/rigs/kit/pcrotor.c
+++ b/rigs/kit/pcrotor.c
@@ -54,7 +54,7 @@ static int
 pcrotor_stop(ROT *rot)
 {
     /* CW=0, CCW=0, Power-up=0 */
-    return setDirection(&rot->state.rotport, 0);
+    return setDirection(ROTPORT(rot), 0);
 }
 
 static int
@@ -83,7 +83,7 @@ pcrotor_move(ROT *rot, int direction, int speed)
         return -RIG_EINVAL;
     }
 
-    return setDirection(&rot->state.rotport, outputvalue);
+    return setDirection(ROTPORT(rot), outputvalue);
 }
 
 

--- a/rigs/kit/si570avrusb.c
+++ b/rigs/kit/si570avrusb.c
@@ -566,7 +566,7 @@ static uint32_t getLongWord(unsigned char const *bytes)
  */
 int si570avrusb_init(RIG *rig)
 {
-    hamlib_port_t *rp = &rig->state.rigport;
+    hamlib_port_t *rp = RIGPORT(rig);
     struct si570xxxusb_priv_data *priv;
 
     rig->state.priv = (struct si570xxxusb_priv_data *)calloc(sizeof(struct
@@ -607,7 +607,7 @@ int si570avrusb_init(RIG *rig)
  */
 int si570peaberry1_init(RIG *rig)
 {
-    hamlib_port_t *rp = &rig->state.rigport;
+    hamlib_port_t *rp = RIGPORT(rig);
     struct si570xxxusb_priv_data *priv;
 
     rig->state.priv = (struct si570xxxusb_priv_data *)calloc(sizeof(struct
@@ -648,7 +648,7 @@ int si570peaberry1_init(RIG *rig)
  */
 int si570peaberry2_init(RIG *rig)
 {
-    hamlib_port_t *rp = &rig->state.rigport;
+    hamlib_port_t *rp = RIGPORT(rig);
     struct si570xxxusb_priv_data *priv;
 
     rig->state.priv = (struct si570xxxusb_priv_data *)calloc(sizeof(struct
@@ -689,7 +689,7 @@ int si570peaberry2_init(RIG *rig)
  */
 int si570picusb_init(RIG *rig)
 {
-    hamlib_port_t *rp = &rig->state.rigport;
+    hamlib_port_t *rp = RIGPORT(rig);
     struct si570xxxusb_priv_data *priv;
 
     rig->state.priv = (struct si570xxxusb_priv_data *)calloc(sizeof(struct
@@ -730,7 +730,7 @@ int si570picusb_init(RIG *rig)
 
 int fasdr_init(RIG *rig)
 {
-    hamlib_port_t *rp = &rig->state.rigport;
+    hamlib_port_t *rp = RIGPORT(rig);
     struct si570xxxusb_priv_data *priv;
 
     rig->state.priv = (struct si570xxxusb_priv_data *)calloc(sizeof(struct
@@ -771,7 +771,7 @@ int fasdr_open(RIG *rig)
 {
     struct si570xxxusb_priv_data *priv = (struct si570xxxusb_priv_data *)
                                          rig->state.priv;
-    libusb_device_handle *udh = rig->state.rigport.handle;
+    libusb_device_handle *udh = RIGPORT(rig)->handle;
     int ret, i;
     double f;
     unsigned char buffer[4];
@@ -781,7 +781,7 @@ int fasdr_open(RIG *rig)
 
     ret = libusb_control_transfer(udh, REQUEST_TYPE_IN,
                                   REQUEST_READ_VERSION, 0x0E00, 0,
-                                  buffer, 2, rig->state.rigport.timeout);
+                                  buffer, 2, RIGPORT(rig)->timeout);
 
     if (ret != 2)
     {
@@ -797,7 +797,7 @@ int fasdr_open(RIG *rig)
     ret = libusb_control_transfer(udh,
                                   REQUEST_TYPE_IN,
                                   REQUEST_READ_EEPROM, F_CAL_STATUS, 0, buffer, 1,
-                                  rig->state.rigport.timeout);
+                                  RIGPORT(rig)->timeout);
 
     if (ret != 1)
     {
@@ -810,7 +810,7 @@ int fasdr_open(RIG *rig)
 //        ret = libusb_control_transfer(udh,
 //                REQUEST_TYPE_IN,
 //                REQUEST_READ_XTALL, 0, 0, (unsigned char *) &iFreq, sizeof(iFreq),
-//                rig->state.rigport.timeout);
+//                RIGPORT(rig)->timeout);
     if (buffer[0] == 0xFF)
     {
         rig_debug(RIG_DEBUG_VERBOSE, "%s: Device not calibrated", __func__);
@@ -822,7 +822,7 @@ int fasdr_open(RIG *rig)
         ret = libusb_control_transfer(udh,
                                       REQUEST_TYPE_IN,
                                       REQUEST_READ_EEPROM, F_CRYST + i, 0, &buffer[i], 1,
-                                      rig->state.rigport.timeout);
+                                      RIGPORT(rig)->timeout);
 
         if (ret != 1)
         {
@@ -963,7 +963,7 @@ int si570xxxusb_get_conf(RIG *rig, hamlib_token_t token, char *val)
 
 static int setBPF(RIG *rig, int enable)
 {
-    libusb_device_handle *udh = rig->state.rigport.handle;
+    libusb_device_handle *udh = RIGPORT(rig)->handle;
     /* allocate enough space for up to 16 filters */
     unsigned short FilterCrossOver[16];
     int nBytes;
@@ -974,7 +974,7 @@ static int setBPF(RIG *rig, int enable)
     nBytes = libusb_control_transfer(udh, REQUEST_TYPE_IN,
                                      REQUEST_FILTERS, 0, 255,
                                      (unsigned char *) FilterCrossOver, sizeof(FilterCrossOver),
-                                     rig->state.rigport.timeout);
+                                     RIGPORT(rig)->timeout);
 
     if (nBytes < 0)
     {
@@ -987,7 +987,7 @@ static int setBPF(RIG *rig, int enable)
         int retval = libusb_control_transfer(udh, REQUEST_TYPE_IN,
                                              REQUEST_FILTERS, enable, (nBytes / 2) - 1,
                                              (unsigned char *) FilterCrossOver, sizeof(FilterCrossOver),
-                                             rig->state.rigport.timeout);
+                                             RIGPORT(rig)->timeout);
 
         if (retval < 2)
         {
@@ -1015,7 +1015,7 @@ int si570xxxusb_open(RIG *rig)
 {
     struct si570xxxusb_priv_data *priv = (struct si570xxxusb_priv_data *)
                                          rig->state.priv;
-    libusb_device_handle *udh = rig->state.rigport.handle;
+    libusb_device_handle *udh = RIGPORT(rig)->handle;
     int ret;
     unsigned char buffer[4];
 
@@ -1027,7 +1027,7 @@ int si570xxxusb_open(RIG *rig)
 
     ret = libusb_control_transfer(udh, REQUEST_TYPE_IN,
                                   REQUEST_READ_VERSION, 0x0E00, 0,
-                                  buffer, 2, rig->state.rigport.timeout);
+                                  buffer, 2, RIGPORT(rig)->timeout);
 
     if (ret != 2)
     {
@@ -1048,7 +1048,7 @@ int si570xxxusb_open(RIG *rig)
         ret = libusb_control_transfer(udh,
                                       REQUEST_TYPE_IN,
                                       REQUEST_READ_XTALL, 0, 0, buffer, sizeof(buffer),
-                                      rig->state.rigport.timeout);
+                                      RIGPORT(rig)->timeout);
 
         if (ret != 4)
         {
@@ -1080,14 +1080,14 @@ int si570xxxusb_open(RIG *rig)
 const char *si570xxxusb_get_info(RIG *rig)
 {
     static char buf[64];
-    libusb_device_handle *udh = rig->state.rigport.handle;
+    libusb_device_handle *udh = RIGPORT(rig)->handle;
     struct libusb_device_descriptor desc;
     int ret;
     unsigned char buffer[2];
 
     ret = libusb_control_transfer(udh, REQUEST_TYPE_IN,
                                   REQUEST_READ_VERSION, 0x0E00, 0,
-                                  buffer, sizeof(buffer), rig->state.rigport.timeout);
+                                  buffer, sizeof(buffer), RIGPORT(rig)->timeout);
 
     if (ret != 2)
     {
@@ -1195,7 +1195,7 @@ int si570xxxusb_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
     const struct si570xxxusb_priv_data *priv = (struct si570xxxusb_priv_data *)
             rig->state.priv;
-    libusb_device_handle *udh = rig->state.rigport.handle;
+    libusb_device_handle *udh = RIGPORT(rig)->handle;
     int ret;
     unsigned char buffer[6];
     int request = REQUEST_SET_FREQ;
@@ -1235,7 +1235,7 @@ int si570xxxusb_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     buffer[0] = buffer[0] + (theSolution.HS_DIV << 5);
 
     ret = libusb_control_transfer(udh, REQUEST_TYPE_OUT,
-                                  request, value, index, buffer, sizeof(buffer), rig->state.rigport.timeout);
+                                  request, value, index, buffer, sizeof(buffer), RIGPORT(rig)->timeout);
 
     rig_debug(RIG_DEBUG_TRACE,
               "%s: Freq=%.6f MHz, Real=%.6f MHz, buf=%02x%02x%02x%02x%02x%02x\n",
@@ -1261,7 +1261,7 @@ int si570xxxusb_set_freq_by_value(RIG *rig, vfo_t vfo, freq_t freq)
 {
     const struct si570xxxusb_priv_data *priv = (struct si570xxxusb_priv_data *)
             rig->state.priv;
-    libusb_device_handle *udh = rig->state.rigport.handle;
+    libusb_device_handle *udh = RIGPORT(rig)->handle;
     int ret;
 
     unsigned char buffer[4];
@@ -1280,7 +1280,7 @@ int si570xxxusb_set_freq_by_value(RIG *rig, vfo_t vfo, freq_t freq)
               buffer[0], buffer[1], buffer[2], buffer[3]);
 
     ret = libusb_control_transfer(udh, REQUEST_TYPE_OUT,
-                                  request, value, index, buffer, sizeof(buffer), rig->state.rigport.timeout);
+                                  request, value, index, buffer, sizeof(buffer), RIGPORT(rig)->timeout);
 
     if (!ret)
     {
@@ -1331,7 +1331,7 @@ int si570xxxusb_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
     struct si570xxxusb_priv_data *priv = (struct si570xxxusb_priv_data *)
                                          rig->state.priv;
-    libusb_device_handle *udh = rig->state.rigport.handle;
+    libusb_device_handle *udh = RIGPORT(rig)->handle;
     unsigned char buffer[6];
     int ret;
 
@@ -1344,7 +1344,7 @@ int si570xxxusb_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
     ret = libusb_control_transfer(udh, REQUEST_TYPE_IN,
                                   REQUEST_READ_REGISTERS, priv->i2c_addr, 0,
-                                  buffer, sizeof(buffer), rig->state.rigport.timeout);
+                                  buffer, sizeof(buffer), RIGPORT(rig)->timeout);
 
     if (ret <= 0)
     {
@@ -1363,14 +1363,14 @@ int si570xxxusb_get_freq_by_value(RIG *rig, vfo_t vfo, freq_t *freq)
 {
     const struct si570xxxusb_priv_data *priv = (struct si570xxxusb_priv_data *)
             rig->state.priv;
-    libusb_device_handle *udh = rig->state.rigport.handle;
+    libusb_device_handle *udh = RIGPORT(rig)->handle;
     int ret;
     unsigned char buffer[4];
     uint32_t iFreq;
 
     ret = libusb_control_transfer(udh, REQUEST_TYPE_IN,
                                   REQUEST_READ_FREQUENCY, 0, 0,
-                                  buffer, sizeof(buffer), rig->state.rigport.timeout);
+                                  buffer, sizeof(buffer), RIGPORT(rig)->timeout);
 
     if (ret != 4)
     {
@@ -1392,7 +1392,7 @@ int si570xxxusb_get_freq_by_value(RIG *rig, vfo_t vfo, freq_t *freq)
 
 int si570xxxusb_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 {
-    libusb_device_handle *udh = rig->state.rigport.handle;
+    libusb_device_handle *udh = RIGPORT(rig)->handle;
     int ret;
     unsigned char buffer[3];
 
@@ -1404,7 +1404,7 @@ int si570xxxusb_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 
     ret = libusb_control_transfer(udh, REQUEST_TYPE_IN,
                                   REQUEST_SET_PTT, (ptt == RIG_PTT_ON) ? 1 : 0, 0,
-                                  buffer, sizeof(buffer), rig->state.rigport.timeout);
+                                  buffer, sizeof(buffer), RIGPORT(rig)->timeout);
 
     if (ret < 0)
     {

--- a/rigs/lowe/lowe.c
+++ b/rigs/lowe/lowe.c
@@ -52,13 +52,11 @@ int lowe_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
                      int *data_len)
 {
     int retval;
-    struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
 
-    rs = &rig->state;
+    rig_flush(rp);
 
-    rig_flush(&rs->rigport);
-
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, cmd_len);
+    retval = write_block(rp, (unsigned char *) cmd, cmd_len);
 
     if (retval != RIG_OK)
     {
@@ -72,7 +70,7 @@ int lowe_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
         return 0;
     }
 
-    retval = read_string(&rs->rigport, (unsigned char *) data, BUFSZ, CR, 1, 0, 1);
+    retval = read_string(rp, (unsigned char *) data, BUFSZ, CR, 1, 0, 1);
 
     if (retval == -RIG_ETIMEOUT)
     {

--- a/rigs/mds/mds.c
+++ b/rigs/mds/mds.c
@@ -50,15 +50,15 @@ int mds_transaction(RIG *rig, char *cmd, int expected, char **result)
 {
     char cmd_buf[MAXCMDLEN];
     int retval;
-    struct rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
     struct mds_priv_data *priv = rig->state.priv;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: cmd=%s\n", __func__, cmd);
 
     SNPRINTF(cmd_buf, sizeof(cmd_buf), "%s\n", cmd);
 
-    rig_flush(&rs->rigport);
-    retval = write_block(&rs->rigport, (unsigned char *) cmd_buf, strlen(cmd_buf));
+    rig_flush(rp);
+    retval = write_block(rp, (unsigned char *) cmd_buf, strlen(cmd_buf));
 
     if (retval < 0)
     {
@@ -74,7 +74,7 @@ int mds_transaction(RIG *rig, char *cmd, int expected, char **result)
         char cmdtrm_str[2];   /* Default Command/Reply termination char */
         cmdtrm_str[0] = 0x0d;
         cmdtrm_str[1] = 0x00;
-        retval = read_string(&rs->rigport, (unsigned char *) priv->ret_data,
+        retval = read_string(rp, (unsigned char *) priv->ret_data,
                              sizeof(priv->ret_data), cmdtrm_str, strlen(cmdtrm_str), 0, expected);
 
         if (retval < 0)

--- a/rigs/racal/ra37xx.c
+++ b/rigs/racal/ra37xx.c
@@ -70,7 +70,7 @@ static int ra37xx_one_transaction(RIG *rig, const char *cmd, char *data,
 {
     const struct ra37xx_priv_data *priv = (struct ra37xx_priv_data *)
                                           rig->state.priv;
-    struct rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
     char cmdbuf[BUFSZ];
     char respbuf[BUFSZ];
     int retval;
@@ -95,9 +95,9 @@ static int ra37xx_one_transaction(RIG *rig, const char *cmd, char *data,
         SNPRINTF(cmdbuf, sizeof(cmdbuf), SOM "%s" EOM, cmd);
     }
 
-    rig_flush(&rs->rigport);
+    rig_flush(rp);
 
-    retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+    retval = write_block(rp, (unsigned char *) cmdbuf, strlen(cmdbuf));
 
     if (retval != RIG_OK)
     {
@@ -113,7 +113,7 @@ static int ra37xx_one_transaction(RIG *rig, const char *cmd, char *data,
 
     do
     {
-        retval = read_string(&rs->rigport, (unsigned char *) respbuf, BUFSZ, EOM,
+        retval = read_string(rp, (unsigned char *) respbuf, BUFSZ, EOM,
                              strlen(EOM), 0, 1);
 
         if (retval < 0)
@@ -124,7 +124,7 @@ static int ra37xx_one_transaction(RIG *rig, const char *cmd, char *data,
         /* drop short/invalid packets */
         if (retval <= pkt_header_len + 1 || respbuf[0] != '\x0a')
         {
-            if (!rig_check_cache_timeout(&tv, rs->rigport.timeout))
+            if (!rig_check_cache_timeout(&tv, rp->timeout))
             {
                 continue;
             }
@@ -137,7 +137,7 @@ static int ra37xx_one_transaction(RIG *rig, const char *cmd, char *data,
         /* drop other receiver id, and "pause" (empty) packets */
         if ((priv->receiver_id != -1 && (respbuf[1] - '0') != priv->receiver_id))
         {
-            if (!rig_check_cache_timeout(&tv, rs->rigport.timeout))
+            if (!rig_check_cache_timeout(&tv, rp->timeout))
             {
                 continue;
             }
@@ -165,7 +165,7 @@ static int ra37xx_one_transaction(RIG *rig, const char *cmd, char *data,
             rig_debug(RIG_DEBUG_WARN, "%s: unexpected revertive frame\n",
                       __func__);
 
-            if (!rig_check_cache_timeout(&tv, rs->rigport.timeout))
+            if (!rig_check_cache_timeout(&tv, rp->timeout))
             {
                 continue;
             }
@@ -189,7 +189,7 @@ static int ra37xx_transaction(RIG *rig, const char *cmd, char *data,
 {
     int retval, retry;
 
-    retry = rig->state.rigport.retry;
+    retry = RIGPORT(rig)->retry;
 
     do
     {

--- a/rigs/racal/racal.c
+++ b/rigs/racal/racal.c
@@ -69,15 +69,15 @@ static int racal_transaction(RIG *rig, const char *cmd, char *data,
                              int *data_len)
 {
     const struct racal_priv_data *priv = (struct racal_priv_data *)rig->state.priv;
-    struct rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
     char cmdbuf[BUFSZ + 1];
     int retval;
 
     SNPRINTF(cmdbuf, sizeof(cmdbuf), SOM "%u%s" EOM, priv->receiver_id, cmd);
 
-    rig_flush(&rs->rigport);
+    rig_flush(rp);
 
-    retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+    retval = write_block(rp, (unsigned char *) cmdbuf, strlen(cmdbuf));
 
     if (retval != RIG_OK)
     {
@@ -91,7 +91,7 @@ static int racal_transaction(RIG *rig, const char *cmd, char *data,
         return retval;
     }
 
-    retval = read_string(&rs->rigport, (unsigned char *) data, BUFSZ, EOM,
+    retval = read_string(rp, (unsigned char *) data, BUFSZ, EOM,
                          strlen(EOM), 0, 1);
 
     if (retval <= 0)

--- a/rigs/rft/rft.c
+++ b/rigs/rft/rft.c
@@ -42,13 +42,11 @@ int rft_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
                     int *data_len)
 {
     int retval;
-    struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
 
-    rs = &rig->state;
+    rig_flush(rp);
 
-    rig_flush(&rs->rigport);
-
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, cmd_len);
+    retval = write_block(rp, (unsigned char *) cmd, cmd_len);
 
     if (retval != RIG_OK)
     {
@@ -62,7 +60,7 @@ int rft_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
         return 0;
     }
 
-    retval = read_string(&rs->rigport, (unsigned char *) data, BUFSZ, CR, 1, 0, 1);
+    retval = read_string(rp, (unsigned char *) data, BUFSZ, CR, 1, 0, 1);
 
     if (retval == -RIG_ETIMEOUT)
     {

--- a/rigs/rs/ek89x.c
+++ b/rigs/rs/ek89x.c
@@ -54,18 +54,16 @@ ek89x_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
                   int *data_len)
 {
     int retval;
-    struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: len=%d,cmd=%s\n", __func__, cmd_len,
               cmd);
 
-    rs = &rig->state;
-
-    rig_flush(&rs->rigport);
+    rig_flush(rp);
 
     rig_debug(RIG_DEBUG_VERBOSE, "ek89x_transaction: len=%d,cmd=%s\n",
               cmd_len, cmd);
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, cmd_len);
+    retval = write_block(rp, (unsigned char *) cmd, cmd_len);
 
     if (retval != RIG_OK)
     {
@@ -79,7 +77,7 @@ ek89x_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
         return RIG_OK;
     }
 
-    retval = read_string(&rs->rigport, (unsigned char *) data, RESPSZ,
+    retval = read_string(rp, (unsigned char *) data, RESPSZ,
                          CR, 1, 0, 1);
 
     if (retval < 0)

--- a/rigs/rs/gp2000.c
+++ b/rigs/rs/gp2000.c
@@ -59,18 +59,16 @@ gp2000_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
                    int *data_len)
 {
     int retval;
-    struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: len=%d,cmd=%s\n", __func__, cmd_len,
               cmd);
 
-    rs = &rig->state;
-
-    rig_flush(&rs->rigport);
+    rig_flush(rp);
 
     rig_debug(RIG_DEBUG_VERBOSE, "gp2000_transaction: len=%d,cmd=%s\n",
               cmd_len, cmd);
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, cmd_len);
+    retval = write_block(rp, (unsigned char *) cmd, cmd_len);
 
     if (retval != RIG_OK)
     {
@@ -84,7 +82,7 @@ gp2000_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
         return RIG_OK;
     }
 
-    retval = read_string(&rs->rigport, (unsigned char *) data, RESPSZ,
+    retval = read_string(rp, (unsigned char *) data, RESPSZ,
                          CR, 1, 0, 1);
 
     if (retval < 0)

--- a/rigs/rs/rs.c
+++ b/rigs/rs/rs.c
@@ -56,13 +56,11 @@ int rs_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
                    int *data_len)
 {
     int retval;
-    struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
 
-    rs = &rig->state;
+    rig_flush(rp);
 
-    rig_flush(&rs->rigport);
-
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, cmd_len);
+    retval = write_block(rp, (unsigned char *) cmd, cmd_len);
 
     if (retval != RIG_OK)
     {
@@ -76,7 +74,7 @@ int rs_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
         return RIG_OK;
     }
 
-    retval = read_string(&rs->rigport, (unsigned char *) data, BUFSZ, CR, 1, 0, 1);
+    retval = read_string(rp, (unsigned char *) data, BUFSZ, CR, 1, 0, 1);
 
     if (retval < 0)
     {

--- a/rigs/skanti/skanti.c
+++ b/rigs/skanti/skanti.c
@@ -59,13 +59,11 @@ static int skanti_transaction(RIG *rig, const char *cmd, int cmd_len,
                               char *data, int *data_len)
 {
     int retval;
-    struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
 
-    rs = &rig->state;
+    rig_flush(rp);
 
-    rig_flush(&rs->rigport);
-
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, cmd_len);
+    retval = write_block(rp, (unsigned char *) cmd, cmd_len);
 
     if (retval != RIG_OK)
     {
@@ -80,7 +78,7 @@ static int skanti_transaction(RIG *rig, const char *cmd, int cmd_len,
         * Transceiver sends back ">"
         */
         char retbuf[BUFSZ + 1];
-        retval = read_string(&rs->rigport, (unsigned char *) retbuf, BUFSZ, PROMPT,
+        retval = read_string(rp, (unsigned char *) retbuf, BUFSZ, PROMPT,
                              strlen(PROMPT), 0, 1);
 
         if (retval < 0)
@@ -100,7 +98,7 @@ static int skanti_transaction(RIG *rig, const char *cmd, int cmd_len,
         }
     }
 
-    retval = read_string(&rs->rigport, (unsigned char *) data, BUFSZ, LF,
+    retval = read_string(rp, (unsigned char *) data, BUFSZ, LF,
                          strlen(LF), 0, 1);
 
     if (retval == -RIG_ETIMEOUT)

--- a/rigs/skanti/trp8255.c
+++ b/rigs/skanti/trp8255.c
@@ -180,18 +180,19 @@ static int cu_transaction(RIG *rig, const char *cmd, int cmd_len)
 {
     int i;
     char retchar;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     for (i = 0; i < cmd_len; i++)
     {
 
-        int ret = write_block(&rig->state.rigport, (unsigned char *) &cmd[i], 1);
+        int ret = write_block(rp, (unsigned char *) &cmd[i], 1);
 
         if (ret != RIG_OK)
         {
             return ret;
         }
 
-        ret = read_block(&rig->state.rigport, (unsigned char *) &retchar, 1);
+        ret = read_block(rp, (unsigned char *) &retchar, 1);
 
         switch (retchar)
         {

--- a/rigs/tapr/tapr.c
+++ b/rigs/tapr/tapr.c
@@ -45,12 +45,10 @@ static int tapr_cmd(RIG *rig, unsigned char cmd, unsigned char c1,
                     unsigned char c2, unsigned char c3, unsigned char c4)
 {
     int retval;
-    struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
     unsigned char cmdbuf[CMD_LEN];
 
-    rs = &rig->state;
-
-    rig_flush(&rs->rigport);
+    rig_flush(rp);
 
     cmdbuf[0] = ESC;
     cmdbuf[1] = cmd;
@@ -59,7 +57,7 @@ static int tapr_cmd(RIG *rig, unsigned char cmd, unsigned char c1,
     cmdbuf[4] = c3;
     cmdbuf[5] = c4;
 
-    retval = write_block(&rs->rigport, cmdbuf, 6);
+    retval = write_block(rp, cmdbuf, 6);
 
     if (retval != RIG_OK)
     {

--- a/rigs/tentec/omnivii.c
+++ b/rigs/tentec/omnivii.c
@@ -257,19 +257,19 @@ static int tt588_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
                              const int *data_len)
 {
     int i, retval = -RIG_EINTERNAL;
-    struct  rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     // The original file had "A few XX's" due to sync problems
     // So I put this in a try loop which should, hopefully, never be seen
     for (i = 0; i < 3; ++i) // We'll try 3 times
     {
         char xxbuf[32];
-        rig_flush(&rs->rigport);
+        rig_flush(rp);
 
         // We add 1 to data_len here for the null byte inserted by read_string eventually
         // That way all the callers can use the expected response length for the cmd_len parameter here
         // Callers all need to ensure they have enough room in data for this
-        retval = write_block(&rs->rigport, (unsigned char *) cmd, cmd_len);
+        retval = write_block(rp, (unsigned char *) cmd, cmd_len);
 
         if (retval == RIG_OK)
         {
@@ -284,7 +284,7 @@ static int tt588_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
 
             if (data)
             {
-                retval = read_string(&rs->rigport, (unsigned char *) data, (*data_len) + 1,
+                retval = read_string(rp, (unsigned char *) data, (*data_len) + 1,
                                      term, strlen(term), 0,
                                      1);
 
@@ -307,9 +307,9 @@ static int tt588_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
             rig_debug(RIG_DEBUG_ERR, "%s: write_block failed, try#%d\n", __func__, i + 1);
         }
 
-        write_block(&rs->rigport, (unsigned char *) "XX" EOM,
+        write_block(rp, (unsigned char *) "XX" EOM,
                     3); // we wont' worry about the response here
-        retval = read_string(&rs->rigport, (unsigned char *) xxbuf, sizeof(xxbuf), "",
+        retval = read_string(rp, (unsigned char *) xxbuf, sizeof(xxbuf), "",
                              0, 0, 1); // this should timeout
 
         if (retval != RIG_OK)

--- a/rigs/tentec/paragon.c
+++ b/rigs/tentec/paragon.c
@@ -275,7 +275,7 @@ int tt585_set_vfo(RIG *rig, vfo_t vfo)
     }
 
     /* toggle VFOs */
-    return write_block(&rig->state.rigport, (unsigned char *) "F", 1);
+    return write_block(RIGPORT(rig), (unsigned char *) "F", 1);
 }
 
 int tt585_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t txvfo)
@@ -297,7 +297,7 @@ int tt585_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t txvfo)
     }
 
     /* toggle split mode */
-    return write_block(&rig->state.rigport, (unsigned char *) "J", 1);
+    return write_block(RIGPORT(rig), (unsigned char *) "J", 1);
 }
 
 int tt585_get_split_vfo(RIG *rig, vfo_t vfo, split_t *split, vfo_t *txvfo)
@@ -370,7 +370,7 @@ int tt585_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
     rig_force_cache_timeout(&priv->status_tv);
 
-    return write_block(&rig->state.rigport, (unsigned char *) buf, strlen(buf));
+    return write_block(RIGPORT(rig), (unsigned char *) buf, strlen(buf));
 }
 
 /*
@@ -455,6 +455,7 @@ int tt585_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     struct tt585_priv_data *priv = (struct tt585_priv_data *)rig->state.priv;
     const char *mcmd, *wcmd;
     int ret;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     switch (mode)
     {
@@ -476,7 +477,7 @@ int tt585_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 
     rig_force_cache_timeout(&priv->status_tv);
 
-    ret =  write_block(&rig->state.rigport, (unsigned char *) mcmd, strlen(mcmd));
+    ret =  write_block(rp, (unsigned char *) mcmd, strlen(mcmd));
 
     if (ret < 0)
     {
@@ -511,7 +512,7 @@ int tt585_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         wcmd = "R";
     }
 
-    return write_block(&rig->state.rigport, (unsigned char *) wcmd, strlen(mcmd));
+    return write_block(rp, (unsigned char *) wcmd, strlen(mcmd));
 }
 
 int tt585_set_mem(RIG *rig, vfo_t vfo, int ch)
@@ -529,7 +530,7 @@ int tt585_set_mem(RIG *rig, vfo_t vfo, int ch)
     /* does it work without a command after the channel number? */
     SNPRINTF(buf, sizeof(buf), ":%02d", ch);
 
-    return write_block(&rig->state.rigport, (unsigned char *) buf, strlen(buf));
+    return write_block(RIGPORT(rig), (unsigned char *) buf, strlen(buf));
 }
 
 int tt585_get_mem(RIG *rig, vfo_t vfo, int *ch)
@@ -568,7 +569,7 @@ int tt585_get_status_data(RIG *rig)
     hamlib_port_t *rigport;
     int ret;
 
-    rigport = &rig->state.rigport;
+    rigport = RIGPORT(rig);
 
     if (!rig_check_cache_timeout(&priv->status_tv, TT585_CACHE_TIMEOUT))
     {
@@ -608,7 +609,7 @@ int tt585_set_parm(RIG *rig, setting_t parm, value_t val)
     {
     case RIG_PARM_ANN:
         /* FIXME: > is a toggle command only */
-        ret = write_block(&rig->state.rigport, (unsigned char *) ">", 1);
+        ret = write_block(RIGPORT(rig), (unsigned char *) ">", 1);
 
         if (ret < 0)
         {
@@ -678,5 +679,5 @@ int tt585_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op)
 
     rig_force_cache_timeout(&priv->status_tv);
 
-    return write_block(&rig->state.rigport, (unsigned char *) cmd, strlen(cmd));
+    return write_block(RIGPORT(rig), (unsigned char *) cmd, strlen(cmd));
 }

--- a/rigs/tentec/rx331.c
+++ b/rigs/tentec/rx331.c
@@ -242,15 +242,13 @@ static int rx331_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
     int retval;
     char str[BUFSZ];
     char fmt[16];
-    struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
     const struct rx331_priv_data *priv = (struct rx331_priv_data *)rig->state.priv;
 
-    rs = &rig->state;
-
-    rig_flush(&rs->rigport);
+    rig_flush(rp);
 
     num_snprintf(str, BUFSZ, "$%u%s", priv->receiver_id, cmd);
-    retval = write_block(&rs->rigport, (unsigned char *) str, strlen(str));
+    retval = write_block(rp, (unsigned char *) str, strlen(str));
 
     if (retval != RIG_OK)
     {
@@ -263,7 +261,7 @@ static int rx331_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
         return RIG_OK;
     }
 
-    retval = read_string(&rs->rigport, (unsigned char *) data, BUFSZ, EOM, 1, 0, 1);
+    retval = read_string(rp, (unsigned char *) data, BUFSZ, EOM, 1, 0, 1);
 
     if (retval < 0)
     {
@@ -395,14 +393,13 @@ int rx331_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
     const struct rx331_priv_data *priv = (struct rx331_priv_data *)rig->state.priv;
 
-    struct rig_state *rs = &rig->state;
     int freq_len, retval;
     char freqbuf[16];
 
     freq_len = num_snprintf(freqbuf, sizeof(freqbuf), "$%uF%.6f" EOM,
                             priv->receiver_id, freq / 1e6);
 
-    retval = write_block(&rs->rigport, (unsigned char *) freqbuf, freq_len);
+    retval = write_block(RIGPORT(rig), (unsigned char *) freqbuf, freq_len);
 
     return retval;
 }
@@ -443,7 +440,6 @@ int rx331_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 int rx331_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
     const struct rx331_priv_data *priv = (struct rx331_priv_data *)rig->state.priv;
-    struct rig_state *rs = &rig->state;
     char dmode;
     int mdbuf_len, retval;
     char mdbuf[32];
@@ -494,7 +490,7 @@ int rx331_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
                                  dmode);
     }
 
-    retval = write_block(&rs->rigport, (unsigned char *) mdbuf, mdbuf_len);
+    retval = write_block(RIGPORT(rig), (unsigned char *) mdbuf, mdbuf_len);
 
     return retval;
 }
@@ -565,7 +561,6 @@ int rx331_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
 int rx331_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
     const struct rx331_priv_data *priv = (struct rx331_priv_data *)rig->state.priv;
-    struct rig_state *rs = &rig->state;
     int retval = RIG_OK;
     char cmdbuf[32];
 
@@ -637,7 +632,7 @@ int rx331_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
         return -RIG_EINVAL;
     }
 
-    retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+    retval = write_block(RIGPORT(rig), (unsigned char *) cmdbuf, strlen(cmdbuf));
     return retval;
 }
 

--- a/rigs/tentec/rx340.c
+++ b/rigs/tentec/rx340.c
@@ -194,13 +194,11 @@ static int rx340_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
                              int *data_len)
 {
     int retval;
-    struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
 
-    rs = &rig->state;
+    rig_flush(rp);
 
-    rig_flush(&rs->rigport);
-
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, cmd_len);
+    retval = write_block(rp, (unsigned char *) cmd, cmd_len);
 
     if (retval != RIG_OK)
     {
@@ -213,7 +211,7 @@ static int rx340_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
         return RIG_OK;
     }
 
-    retval = read_string(&rs->rigport, (unsigned char *) data, BUFSZ, EOM, 1, 0, 1);
+    retval = read_string(rp, (unsigned char *) data, BUFSZ, EOM, 1, 0, 1);
 
     if (retval < 0)
     {
@@ -273,19 +271,17 @@ int rx340_cleanup(RIG *rig)
 
 int rx340_open(RIG *rig)
 {
-    struct rig_state *rs = &rig->state;
 
 #define REMOTE_CMD "*R1"EOM
-    return write_block(&rs->rigport, (unsigned char *) REMOTE_CMD,
+    return write_block(RIGPORT(rig), (unsigned char *) REMOTE_CMD,
                        strlen(REMOTE_CMD));
 }
 
 int rx340_close(RIG *rig)
 {
-    struct rig_state *rs = &rig->state;
 
 #define LOCAL_CMD "*R0"EOM
-    return write_block(&rs->rigport, (unsigned char *) LOCAL_CMD,
+    return write_block(RIGPORT(rig), (unsigned char *) LOCAL_CMD,
                        strlen(LOCAL_CMD));
 }
 
@@ -294,13 +290,12 @@ int rx340_close(RIG *rig)
  */
 int rx340_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-    struct rig_state *rs = &rig->state;
     int retval;
     char freqbuf[16];
 
     SNPRINTF(freqbuf, sizeof(freqbuf), "F%.6f" EOM, freq / 1e6);
 
-    retval = write_block(&rs->rigport, (unsigned char *) freqbuf, strlen(freqbuf));
+    retval = write_block(RIGPORT(rig), (unsigned char *) freqbuf, strlen(freqbuf));
 
     return retval;
 }
@@ -341,7 +336,6 @@ int rx340_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
  */
 int rx340_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
-    struct rig_state *rs = &rig->state;
     char dmode;
     int retval;
     char mdbuf[32];
@@ -390,7 +384,7 @@ int rx340_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         SNPRINTF(mdbuf, sizeof(mdbuf),  "D%c" EOM, dmode);
     }
 
-    retval = write_block(&rs->rigport, (unsigned char *) mdbuf, strlen(mdbuf));
+    retval = write_block(RIGPORT(rig), (unsigned char *) mdbuf, strlen(mdbuf));
 
     return retval;
 }
@@ -462,7 +456,6 @@ int rx340_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
  */
 int rx340_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
-    struct rig_state *rs = &rig->state;
     int retval = RIG_OK;
     char cmdbuf[32];
 
@@ -510,7 +503,7 @@ int rx340_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
         return -RIG_EINVAL;
     }
 
-    retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+    retval = write_block(RIGPORT(rig), (unsigned char *) cmdbuf, strlen(cmdbuf));
     return retval;
 }
 

--- a/rigs/tentec/tentec.c
+++ b/rigs/tentec/tentec.c
@@ -59,13 +59,11 @@ int tentec_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
                        int *data_len)
 {
     int retval;
-    struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
 
-    rs = &rig->state;
+    rig_flush(rp);
 
-    rig_flush(&rs->rigport);
-
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, cmd_len);
+    retval = write_block(rp, (unsigned char *) cmd, cmd_len);
 
     if (retval != RIG_OK)
     {
@@ -78,7 +76,7 @@ int tentec_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
         return 0;
     }
 
-    retval = read_string(&rs->rigport, (unsigned char *) data, *data_len, NULL, 0,
+    retval = read_string(rp, (unsigned char *) data, *data_len, NULL, 0,
                          0, 1);
 
     if (retval == -RIG_ETIMEOUT)
@@ -229,7 +227,6 @@ static void tentec_tuning_factor_calc(RIG *rig)
 int tentec_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
     struct tentec_priv_data *priv;
-    struct rig_state *rs = &rig->state;
     int retval;
     char freqbuf[16];
     freq_t old_freq;
@@ -245,7 +242,7 @@ int tentec_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
              priv->ftf >> 8, priv->ftf & 0xff,
              priv->btf >> 8, priv->btf & 0xff);
 
-    retval = write_block(&rs->rigport, (unsigned char *) freqbuf, strlen(freqbuf));
+    retval = write_block(RIGPORT(rig), (unsigned char *) freqbuf, strlen(freqbuf));
 
     if (retval != RIG_OK)
     {
@@ -277,7 +274,7 @@ int tentec_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 int tentec_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
     struct tentec_priv_data *priv = (struct tentec_priv_data *)rig->state.priv;
-    struct rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
     char ttmode;
     rmode_t saved_mode;
     pbwidth_t saved_width;
@@ -347,7 +344,7 @@ int tentec_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
                  priv->ftf >> 8, priv->ftf & 0xff,
                  priv->btf >> 8, priv->btf & 0xff,
                  ttmode);
-        retval = write_block(&rs->rigport, (unsigned char *) mdbuf, strlen(mdbuf));
+        retval = write_block(rp, (unsigned char *) mdbuf, strlen(mdbuf));
 
         if (retval != RIG_OK)
         {
@@ -365,7 +362,7 @@ int tentec_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
                  priv->ftf >> 8, priv->ftf & 0xff,
                  priv->btf >> 8, priv->btf & 0xff,
                  ttmode);
-        retval = write_block(&rs->rigport, (unsigned char *) mdbuf, strlen(mdbuf));
+        retval = write_block(rp, (unsigned char *) mdbuf, strlen(mdbuf));
 
         if (retval != RIG_OK)
         {
@@ -401,7 +398,7 @@ int tentec_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
 int tentec_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
     struct tentec_priv_data *priv = (struct tentec_priv_data *)rig->state.priv;
-    struct rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
     int retval = RIG_OK;
     char cmdbuf[32];
 
@@ -415,7 +412,7 @@ int tentec_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
         SNPRINTF(cmdbuf, sizeof(cmdbuf), "G%c" EOM,
                  val.i == RIG_AGC_SLOW ? '1' : (
                      val.i == RIG_AGC_FAST ? '3' : '2'));
-        retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+        retval = write_block(rp, (unsigned char *) cmdbuf, strlen(cmdbuf));
 
         if (retval == RIG_OK)
         {
@@ -429,7 +426,7 @@ int tentec_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
          * -> need to create RIG_LEVEL_LINEOUT ?
          */
         SNPRINTF(cmdbuf, sizeof(cmdbuf), "C\x7f%c" EOM, (int)((1.0 - val.f) * 63.0));
-        retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+        retval = write_block(rp, (unsigned char *) cmdbuf, strlen(cmdbuf));
 
         if (retval == RIG_OK)
         {

--- a/rigs/tentec/tt550.c
+++ b/rigs/tentec/tt550.c
@@ -66,9 +66,7 @@ tt550_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
                   int *data_len)
 {
     int retval;
-    struct rig_state *rs;
-
-    rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     /*
      * set_transaction_active keeps the asynchronous decode routine from being called
@@ -76,9 +74,9 @@ tt550_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
      */
     set_transaction_active(rig);
 
-    rig_flush(&rs->rigport);
+    rig_flush(rp);
 
-    retval = write_block(&rs->rigport, (unsigned char *) cmd, strlen(cmd));
+    retval = write_block(rp, (unsigned char *) cmd, strlen(cmd));
 
     if (retval != RIG_OK)
     {
@@ -95,7 +93,7 @@ tt550_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
         return 0;
     }
 
-    retval = read_string(&rs->rigport, (unsigned char *) data, *data_len, NULL, 0,
+    retval = read_string(rp, (unsigned char *) data, *data_len, NULL, 0,
                          0, 1);
 
     if (retval == -RIG_ETIMEOUT)
@@ -126,12 +124,11 @@ tt550_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
 int
 tt550_tx_control(RIG *rig, char oper)
 {
-    struct rig_state *rs = &rig->state;
     int retval;
     char cmdbuf[4];
 
     SNPRINTF(cmdbuf, sizeof(cmdbuf), "#%c" EOM, oper);
-    retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+    retval = write_block(RIGPORT(rig), (unsigned char *) cmdbuf, strlen(cmdbuf));
     /*
      * if (retval == RIG_OK) not currently saving the state of these operations I'm
      * not sure we need to, but if so, this is where it would go.
@@ -598,7 +595,6 @@ int
 tt550_set_rx_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
     struct tt550_priv_data *priv;
-    struct rig_state *rs = &rig->state;
     int retval;
     char freqbuf[16];
 
@@ -612,7 +608,7 @@ tt550_set_rx_freq(RIG *rig, vfo_t vfo, freq_t freq)
              priv->ctf >> 8, priv->ctf & 0xff, priv->ftf >> 8,
              priv->ftf & 0xff, priv->btf >> 8, priv->btf & 0xff);
 
-    retval = write_block(&rs->rigport, (unsigned char *) freqbuf, strlen(freqbuf));
+    retval = write_block(RIGPORT(rig), (unsigned char *) freqbuf, strlen(freqbuf));
 
     if (retval != RIG_OK)
     {
@@ -632,7 +628,6 @@ int
 tt550_set_tx_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
     struct tt550_priv_data *priv;
-    struct rig_state *rs = &rig->state;
     int retval;
     char freqbuf[16];
 
@@ -646,7 +641,7 @@ tt550_set_tx_freq(RIG *rig, vfo_t vfo, freq_t freq)
              priv->ctf >> 8, priv->ctf & 0xff, priv->ftf >> 8,
              priv->ftf & 0xff, priv->btf >> 8, priv->btf & 0xff);
 
-    retval = write_block(&rs->rigport, (unsigned char *) freqbuf, strlen(freqbuf));
+    retval = write_block(RIGPORT(rig), (unsigned char *) freqbuf, strlen(freqbuf));
 
     if (retval != RIG_OK)
     {
@@ -681,7 +676,7 @@ int
 tt550_set_rx_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
     struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
-    struct rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
     char ttmode;
     rmode_t saved_mode;
     pbwidth_t saved_width;
@@ -756,7 +751,7 @@ tt550_set_rx_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     tt550_tuning_factor_calc(rig, RECEIVE);
 
     SNPRINTF(mdbuf, sizeof(mdbuf), "M%c%c" EOM, ttmode, ttmode);
-    retval = write_block(&rs->rigport, (unsigned char *) mdbuf, strlen(mdbuf));
+    retval = write_block(rp, (unsigned char *) mdbuf, strlen(mdbuf));
 
     if (retval != RIG_OK)
     {
@@ -772,7 +767,7 @@ tt550_set_rx_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
                  ttfilter,
                  priv->ctf >> 8, priv->ctf & 0xff, priv->ftf >> 8,
                  priv->ftf & 0xff, priv->btf >> 8, priv->btf & 0xff);
-        retval = write_block(&rs->rigport, (unsigned char *) mdbuf, strlen(mdbuf));
+        retval = write_block(rp, (unsigned char *) mdbuf, strlen(mdbuf));
 
         if (retval != RIG_OK)
         {
@@ -796,7 +791,7 @@ int
 tt550_set_tx_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
     struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
-    struct rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
     char ttmode;
     rmode_t saved_mode;
     pbwidth_t saved_width;
@@ -889,7 +884,7 @@ tt550_set_tx_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     tt550_tuning_factor_calc(rig, TRANSMIT);
 
     SNPRINTF(mdbuf, sizeof(mdbuf), "M%c%c" EOM, ttmode, ttmode);
-    retval = write_block(&rs->rigport, (unsigned char *) mdbuf, strlen(mdbuf));
+    retval = write_block(rp, (unsigned char *) mdbuf, strlen(mdbuf));
 
     if (retval != RIG_OK)
     {
@@ -905,7 +900,7 @@ tt550_set_tx_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
                  ttfilter,
                  priv->ctf >> 8, priv->ctf & 0xff, priv->ftf >> 8,
                  priv->ftf & 0xff, priv->btf >> 8, priv->btf & 0xff);
-        retval = write_block(&rs->rigport, (unsigned char *) mdbuf, strlen(mdbuf));
+        retval = write_block(rp, (unsigned char *) mdbuf, strlen(mdbuf));
 
         if (retval != RIG_OK)
         {
@@ -994,7 +989,7 @@ int
 tt550_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
     struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
-    struct rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
     int retval, ditfactor, dahfactor, spcfactor;
     char cmdbuf[32];
 
@@ -1003,7 +998,7 @@ tt550_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
     case RIG_LEVEL_AGC:
         SNPRINTF(cmdbuf, sizeof(cmdbuf), "G%c" EOM,
                  val.i >= 3 ? '3' : (val.i < 2 ? '1' : '2'));
-        retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+        retval = write_block(rp, (unsigned char *) cmdbuf, strlen(cmdbuf));
 
         if (retval == RIG_OK)
         {
@@ -1014,7 +1009,7 @@ tt550_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
     case RIG_LEVEL_AF:
         SNPRINTF(cmdbuf, sizeof(cmdbuf), "V%c" EOM, (int)(val.f * 255));
-        retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+        retval = write_block(rp, (unsigned char *) cmdbuf, strlen(cmdbuf));
 
         if (retval == RIG_OK)
         {
@@ -1026,7 +1021,7 @@ tt550_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
     case RIG_LEVEL_LINEOUT:
         SNPRINTF(cmdbuf, sizeof(cmdbuf), "L%c" EOM, (int)(val.f * 63));
-        retval = write_block(&rs->rigport, cmdbuf, strlen(cmdbuf));
+        retval = write_block(rp, cmdbuf, strlen(cmdbuf));
 
         if (retval == RIG_OK)
         {
@@ -1038,7 +1033,7 @@ tt550_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
     case RIG_LEVEL_RF:
         SNPRINTF(cmdbuf, sizeof(cmdbuf), "A%c" EOM, (int)(val.f * 255));
-        retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+        retval = write_block(rp, (unsigned char *) cmdbuf, strlen(cmdbuf));
 
         if (retval == RIG_OK)
         {
@@ -1049,7 +1044,7 @@ tt550_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
     case RIG_LEVEL_SQL:
         SNPRINTF(cmdbuf, sizeof(cmdbuf), "S%c" EOM, (int)(val.f * 19));
-        retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+        retval = write_block(rp, (unsigned char *) cmdbuf, strlen(cmdbuf));
 
         if (retval == RIG_OK)
         {
@@ -1060,7 +1055,7 @@ tt550_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
     case RIG_LEVEL_NR:
         SNPRINTF(cmdbuf, sizeof(cmdbuf), "D%c" EOM, (int)(val.f * 7));
-        retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+        retval = write_block(rp, (unsigned char *) cmdbuf, strlen(cmdbuf));
 
         if (retval == RIG_OK)
         {
@@ -1074,7 +1069,7 @@ tt550_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
          * attenuator is either on or off
          */
         SNPRINTF(cmdbuf, sizeof(cmdbuf), "B%c" EOM, val.i < 15 ? '0' : '1');
-        retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+        retval = write_block(rp, (unsigned char *) cmdbuf, strlen(cmdbuf));
 
         if (retval == RIG_OK)
         {
@@ -1093,7 +1088,7 @@ tt550_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
                  ditfactor >> 8, ditfactor & 0xff, dahfactor >> 8,
                  dahfactor & 0xff, spcfactor >> 8,
                  spcfactor & 0xff);
-        retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+        retval = write_block(rp, (unsigned char *) cmdbuf, strlen(cmdbuf));
 
         if (retval == RIG_OK)
         {
@@ -1104,7 +1099,7 @@ tt550_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
     case RIG_LEVEL_RFPOWER:
         SNPRINTF(cmdbuf, sizeof(cmdbuf), "P%c" EOM, (int)(val.f * 255));
-        retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+        retval = write_block(rp, (unsigned char *) cmdbuf, strlen(cmdbuf));
 
         if (retval == RIG_OK)
         {
@@ -1115,7 +1110,7 @@ tt550_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
     case RIG_LEVEL_VOXGAIN:
         SNPRINTF(cmdbuf, sizeof(cmdbuf), "UG%c" EOM, (int)(val.f * 255));
-        retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+        retval = write_block(rp, (unsigned char *) cmdbuf, strlen(cmdbuf));
 
         if (retval == RIG_OK)
         {
@@ -1126,7 +1121,7 @@ tt550_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
     case RIG_LEVEL_VOXDELAY:
         SNPRINTF(cmdbuf, sizeof(cmdbuf), "UH%c" EOM, (int)(val.f * 255));
-        retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+        retval = write_block(rp, (unsigned char *) cmdbuf, strlen(cmdbuf));
 
         if (retval == RIG_OK)
         {
@@ -1137,7 +1132,7 @@ tt550_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
     case RIG_LEVEL_ANTIVOX:
         SNPRINTF(cmdbuf, sizeof(cmdbuf), "UA%c" EOM, (int)(val.f * 255));
-        retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+        retval = write_block(rp, (unsigned char *) cmdbuf, strlen(cmdbuf));
 
         if (retval == RIG_OK)
         {
@@ -1148,7 +1143,7 @@ tt550_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
     case RIG_LEVEL_COMP:
         SNPRINTF(cmdbuf, sizeof(cmdbuf), "Y%c" EOM, (int)(val.f * 127));
-        retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+        retval = write_block(rp, (unsigned char *) cmdbuf, strlen(cmdbuf));
 
         if (retval == RIG_OK)
         {
@@ -1159,7 +1154,7 @@ tt550_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
     case RIG_LEVEL_MICGAIN:
         SNPRINTF(cmdbuf, sizeof(cmdbuf), "O1%c%c" EOM, 0, (int)(val.f * 15));
-        retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+        retval = write_block(rp, (unsigned char *) cmdbuf, strlen(cmdbuf));
 
         if (retval == RIG_OK)
         {
@@ -1170,7 +1165,7 @@ tt550_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
     case RIG_LEVEL_BKINDL:
         SNPRINTF(cmdbuf, sizeof(cmdbuf), "UQ%c" EOM, (int)(val.f * 255));
-        retval = write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf));
+        retval = write_block(rp, (unsigned char *) cmdbuf, strlen(cmdbuf));
 
         if (retval == RIG_OK)
         {
@@ -1368,11 +1363,10 @@ tt550_get_info(RIG *rig)
 int
 tt550_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 {
-    struct rig_state *rs = &rig->state;
     char cmdbuf[16];
 
     SNPRINTF(cmdbuf, sizeof(cmdbuf), "Q%c" EOM, ptt == 0 ? '0' : '1');
-    return (write_block(&rs->rigport, (unsigned char *) cmdbuf, strlen(cmdbuf)));
+    return (write_block(RIGPORT(rig), (unsigned char *) cmdbuf, strlen(cmdbuf)));
 
 }
 
@@ -1442,7 +1436,7 @@ tt550_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
 {
     unsigned char fctbuf[16];
     struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
-    struct rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     /* Optimize:
      *   sort the switch cases with the most frequent first
@@ -1452,20 +1446,20 @@ tt550_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
     case RIG_FUNC_VOX:
         SNPRINTF((char *) fctbuf, sizeof(fctbuf), "U%c" EOM, status == 0 ? '0' : '1');
         priv->vox = status;
-        return write_block(&rs->rigport, fctbuf, strlen((char *)fctbuf));
+        return write_block(rp, fctbuf, strlen((char *)fctbuf));
 
     case RIG_FUNC_NR:
         SNPRINTF((char *) fctbuf, sizeof(fctbuf), "K%c%c" EOM, status == 0 ? '0' : '1',
                  priv->anf == 0 ? '0' : '1');
         priv->en_nr = status;
-        return write_block(&rs->rigport, fctbuf, strlen((char *)fctbuf));
+        return write_block(rp, fctbuf, strlen((char *)fctbuf));
 
     case RIG_FUNC_ANF:
         SNPRINTF((char *) fctbuf, sizeof(fctbuf), "K%c%c" EOM,
                  priv->en_nr == 0 ? '0' : '1',
                  status == 0 ? '0' : '1');
         priv->anf = status;
-        return write_block(&rs->rigport, fctbuf, strlen((char *)fctbuf));
+        return write_block(rp, fctbuf, strlen((char *)fctbuf));
 
 
     case RIG_FUNC_TUNER:
@@ -1681,8 +1675,7 @@ tt550_decode_event(RIG *rig)
     rs = &rig->state;
     priv = (struct tt550_priv_data *) rs->priv;
 
-
-    data_len = read_string(&rs->rigport, buf, MAXFRAMELEN, "\n\r", 2, 0,
+    data_len = read_string(RIGPORT(rig), buf, MAXFRAMELEN, "\n\r", 2, 0,
                            1);
 
 

--- a/rigs/uniden/uniden.c
+++ b/rigs/uniden/uniden.c
@@ -116,6 +116,7 @@ uniden_transaction(RIG *rig, const char *cmdstr, int cmd_len,
                    char *data, size_t *datasize)
 {
     struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
     int retval;
     int retry_read = 0;
     char replybuf[BUFSZ];
@@ -126,11 +127,11 @@ uniden_transaction(RIG *rig, const char *cmdstr, int cmd_len,
 
 transaction_write:
 
-    rig_flush(&rs->rigport);
+    rig_flush(rp);
 
     if (cmdstr)
     {
-        retval = write_block(&rs->rigport, (unsigned char *) cmdstr, strlen(cmdstr));
+        retval = write_block(rp, (unsigned char *) cmdstr, strlen(cmdstr));
 
         if (retval != RIG_OK)
         {
@@ -150,12 +151,12 @@ transaction_write:
     }
 
     memset(data, 0, *datasize);
-    retval = read_string(&rs->rigport, (unsigned char *) data, *datasize, EOM,
+    retval = read_string(rp, (unsigned char *) data, *datasize, EOM,
                          strlen(EOM), 0, 1);
 
     if (retval < 0)
     {
-        if (retry_read++ < rig->state.rigport.retry)
+        if (retry_read++ < rp->retry)
         {
             goto transaction_write;
         }
@@ -173,7 +174,7 @@ transaction_write:
         rig_debug(RIG_DEBUG_ERR, "%s: Command is not correctly terminated '%s'\n",
                   __func__, data);
 
-        if (retry_read++ < rig->state.rigport.retry)
+        if (retry_read++ < rp->retry)
         {
             goto transaction_write;
         }
@@ -251,7 +252,7 @@ transaction_write:
          */
         rig_debug(RIG_DEBUG_ERR, "%s: Unexpected reply '%s'\n", __func__, data);
 
-        if (retry_read++ < rig->state.rigport.retry)
+        if (retry_read++ < rp->retry)
         {
             goto transaction_write;
         }

--- a/rigs/uniden/uniden_digital.c
+++ b/rigs/uniden/uniden_digital.c
@@ -97,6 +97,7 @@ uniden_digital_transaction(RIG *rig, const char *cmdstr, int cmd_len,
                            char *data, size_t *datasize)
 {
     struct rig_state *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
     int retval;
     int retry_read = 0;
     char replybuf[BUFSZ];
@@ -107,11 +108,11 @@ uniden_digital_transaction(RIG *rig, const char *cmdstr, int cmd_len,
 
 transaction_write:
 
-    rig_flush(&rs->rigport);
+    rig_flush(rp);
 
     if (cmdstr)
     {
-        retval = write_block(&rs->rigport, (unsigned char *) cmdstr, strlen(cmdstr));
+        retval = write_block(rp, (unsigned char *) cmdstr, strlen(cmdstr));
 
         if (retval != RIG_OK)
         {
@@ -131,12 +132,12 @@ transaction_write:
     }
 
     memset(data, 0, *datasize);
-    retval = read_string(&rs->rigport, (unsigned char *) data, *datasize, EOM,
+    retval = read_string(rp, (unsigned char *) data, *datasize, EOM,
                          strlen(EOM), 0, 1);
 
     if (retval < 0)
     {
-        if (retry_read++ < rig->state.rigport.retry)
+        if (retry_read++ < rp->retry)
         {
             goto transaction_write;
         }
@@ -154,7 +155,7 @@ transaction_write:
      * ie: STS command will not return either "\r" or "\n"! */
     /*if (strchr(EOM, data[strlen(data)-1])==NULL) {
         rig_debug(RIG_DEBUG_ERR, "%s: Command is not correctly terminated '%s'\n", __func__, data);
-        if (retry_read++ < rig->state.rigport.retry)
+        if (retry_read++ < rp->retry)
             goto transaction_write;
         retval = -RIG_EPROTO;
         goto transaction_quit;
@@ -245,7 +246,7 @@ transaction_write:
          */
         rig_debug(RIG_DEBUG_ERR, "%s: Unexpected reply '%s'\n", __func__, data);
 
-        if (retry_read++ < rig->state.rigport.retry)
+        if (retry_read++ < rp->retry)
         {
             goto transaction_write;
         }

--- a/rigs/winradio/g303.c
+++ b/rigs/winradio/g303.c
@@ -243,7 +243,7 @@ int g3_open(RIG *rig)
     struct g3_priv_data *priv = (struct g3_priv_data *)rig->state.priv;
     int device_num;
 
-    device_num = atoi(rig->state.rigport.pathname);
+    device_num = atoi(RIGPORT(rig)->pathname);
 
     /* Open Winradio receiver handle */
     priv->hRadio = priv->OpenRadioDevice(device_num);

--- a/rigs/winradio/g305.c
+++ b/rigs/winradio/g305.c
@@ -244,7 +244,7 @@ int g3_open(RIG *rig)
     struct g3_priv_data *priv = (struct g3_priv_data *)rig->state.priv;
     int device_num;
 
-    device_num = atoi(rig->state.rigport.pathname);
+    device_num = atoi(RIGPORT(rig)->pathname);
 
     /* Open Winradio receiver handle */
     priv->hRadio = priv->OpenRadioDevice(device_num);

--- a/rigs/winradio/g313-posix.c
+++ b/rigs/winradio/g313-posix.c
@@ -178,9 +178,9 @@ int g313_open(RIG *rig)
     rig_debug(RIG_DEBUG_VERBOSE, "%s: found %d rigs 0 is %s\n", __func__, Count,
               List[0].Path);
 
-    if (rig->state.rigport.pathname[0])
+    if (RIGPORT(rig)->pathname[0])
     {
-        priv->hRadio = OpenDevice(rig->state.rigport.pathname);
+        priv->hRadio = OpenDevice(RIGPORT(rig)->pathname);
     }
     else
     {

--- a/rigs/winradio/g313-win.c
+++ b/rigs/winradio/g313-win.c
@@ -379,7 +379,7 @@ int g313_open(RIG *rig)
     int Count;
     int id;
 
-    device_num = atoi(rig->state.rigport.pathname);
+    device_num = atoi(RIGPORT(rig)->pathname);
 
     Count = priv->waveOutGetNumDevs();
 

--- a/rigs/winradio/winradio.c
+++ b/rigs/winradio/winradio.c
@@ -44,9 +44,9 @@
 
 int wr_rig_init(RIG *rig)
 {
-    rig->state.rigport.type.rig = RIG_PORT_DEVICE;
-    strncpy(rig->state.rigport.pathname, DEFAULT_WINRADIO_PATH,
-            HAMLIB_FILPATHLEN - 1);
+    hamlib_port_t *rp = RIGPORT(rig);
+    rp->type.rig = RIG_PORT_DEVICE;
+    strncpy(rp->pathname, DEFAULT_WINRADIO_PATH, HAMLIB_FILPATHLEN - 1);
 
     return RIG_OK;
 }
@@ -62,7 +62,7 @@ int wr_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
     f = (unsigned long)freq;
 
-    if (ioctl(rig->state.rigport.fd, RADIO_SET_FREQ, &f)) { return -RIG_EINVAL; }
+    if (ioctl(RIGPORT(rig)->fd, RADIO_SET_FREQ, &f)) { return -RIG_EINVAL; }
 
     return RIG_OK;
 }
@@ -71,7 +71,7 @@ int wr_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
     unsigned long f;
 
-    if (ioctl(rig->state.rigport.fd, RADIO_GET_FREQ, &f) < 0) { return -RIG_EINVAL; }
+    if (ioctl(RIGPORT(rig)->fd, RADIO_GET_FREQ, &f) < 0) { return -RIG_EINVAL; }
 
     *freq = (freq_t)f;
     return RIG_OK;
@@ -112,7 +112,7 @@ int wr_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     default: return -RIG_EINVAL;
     }
 
-    if (ioctl(rig->state.rigport.fd, RADIO_SET_MODE, &m)) { return -RIG_EINVAL; }
+    if (ioctl(RIGPORT(rig)->fd, RADIO_SET_MODE, &m)) { return -RIG_EINVAL; }
 
     return  RIG_OK;
 }
@@ -121,7 +121,7 @@ int wr_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
 {
     unsigned long m;
 
-    if (ioctl(rig->state.rigport.fd, RADIO_GET_MODE, &m)) { return -RIG_EINVAL; }
+    if (ioctl(RIGPORT(rig)->fd, RADIO_GET_MODE, &m)) { return -RIG_EINVAL; }
 
     *width = RIG_PASSBAND_NORMAL;
 
@@ -159,7 +159,7 @@ int wr_set_powerstat(RIG *rig, powerstat_t status)
     unsigned long p = 1;
     p = status == RIG_POWER_ON ? 1 : 0;
 
-    if (ioctl(rig->state.rigport.fd, RADIO_SET_POWER, &p)) { return -RIG_EINVAL; }
+    if (ioctl(RIGPORT(rig)->fd, RADIO_SET_POWER, &p)) { return -RIG_EINVAL; }
 
     return RIG_OK;
 }
@@ -167,7 +167,7 @@ int wr_get_powerstat(RIG *rig, powerstat_t *status)
 {
     unsigned long p;
 
-    if (ioctl(rig->state.rigport.fd, RADIO_GET_POWER, &p)) { return -RIG_EINVAL; }
+    if (ioctl(RIGPORT(rig)->fd, RADIO_GET_POWER, &p)) { return -RIG_EINVAL; }
 
     *status = p ? RIG_POWER_ON : RIG_POWER_OFF;
     return RIG_OK;
@@ -181,7 +181,7 @@ int wr_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
     {
         unsigned long v = status ? 1 : 0;
 
-        if (ioctl(rig->state.rigport.fd, RADIO_SET_AGC, &v)) { return -RIG_EINVAL; }
+        if (ioctl(RIGPORT(rig)->fd, RADIO_SET_AGC, &v)) { return -RIG_EINVAL; }
 
         return RIG_OK;
     }
@@ -199,7 +199,7 @@ int wr_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
     {
         unsigned long v;
 
-        if (ioctl(rig->state.rigport.fd, RADIO_GET_AGC, &v)) { return -RIG_EINVAL; }
+        if (ioctl(RIGPORT(rig)->fd, RADIO_GET_AGC, &v)) { return -RIG_EINVAL; }
 
         *status = v;
         return RIG_OK;
@@ -213,17 +213,18 @@ int wr_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
 
 int wr_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
+    hamlib_port_t *rp = RIGPORT(rig);
     switch (level)
     {
     case RIG_LEVEL_AF:
     {
         unsigned long v;
 
-        if (ioctl(rig->state.rigport.fd, RADIO_GET_MAXVOL, &v)) { return -RIG_EINVAL; }
+        if (ioctl(rp->fd, RADIO_GET_MAXVOL, &v)) { return -RIG_EINVAL; }
 
         v *= val.f;
 
-        if (ioctl(rig->state.rigport.fd, RADIO_SET_VOL, &v)) { return -RIG_EINVAL; }
+        if (ioctl(rp->fd, RADIO_SET_VOL, &v)) { return -RIG_EINVAL; }
 
         return RIG_OK;
     }
@@ -232,7 +233,7 @@ int wr_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
     {
         unsigned long v = val.i ? 1 : 0;
 
-        if (ioctl(rig->state.rigport.fd, RADIO_SET_ATTN, &v)) { return -RIG_EINVAL; }
+        if (ioctl(rp->fd, RADIO_SET_ATTN, &v)) { return -RIG_EINVAL; }
 
         return RIG_OK;
     }
@@ -241,7 +242,7 @@ int wr_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
     {
         long v = val.i;
 
-        if (ioctl(rig->state.rigport.fd, RADIO_SET_IFS, &v)) { return -RIG_EINVAL; }
+        if (ioctl(rp->fd, RADIO_SET_IFS, &v)) { return -RIG_EINVAL; }
 
         return RIG_OK;
     }
@@ -250,7 +251,7 @@ int wr_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
     {
         long v = val.f * 100; /* iMaxIFGain on wHWVer > RHV_3150 */
 
-        if (ioctl(rig->state.rigport.fd, RADIO_SET_IFG, &v)) { return -RIG_EINVAL; }
+        if (ioctl(rp->fd, RADIO_SET_IFG, &v)) { return -RIG_EINVAL; }
 
         return RIG_OK;
     }
@@ -262,15 +263,16 @@ int wr_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
 int wr_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
+    hamlib_port_t *rp = RIGPORT(rig);
     switch (level)
     {
     case RIG_LEVEL_AF:
     {
         unsigned long v, mv;
 
-        if (ioctl(rig->state.rigport.fd, RADIO_GET_MAXVOL, &mv)) { return -RIG_EINVAL; }
+        if (ioctl(rp->fd, RADIO_GET_MAXVOL, &mv)) { return -RIG_EINVAL; }
 
-        if (ioctl(rig->state.rigport.fd, RADIO_GET_VOL, &v)) { return -RIG_EINVAL; }
+        if (ioctl(rp->fd, RADIO_GET_VOL, &v)) { return -RIG_EINVAL; }
 
         val->f = (float)v / mv;
         return RIG_OK;
@@ -280,7 +282,7 @@ int wr_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     {
         unsigned long v;
 
-        if (ioctl(rig->state.rigport.fd, RADIO_GET_VOL, &v)) { return -RIG_EINVAL; }
+        if (ioctl(rp->fd, RADIO_GET_VOL, &v)) { return -RIG_EINVAL; }
 
         val->i = v ? rig->state.attenuator[0] : 0;
         return RIG_OK;
@@ -290,7 +292,7 @@ int wr_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     {
         unsigned long v;
 
-        if (ioctl(rig->state.rigport.fd, RADIO_GET_SS, &v)) { return -RIG_EINVAL; }
+        if (ioctl(rp->fd, RADIO_GET_SS, &v)) { return -RIG_EINVAL; }
 
         val->i = v - 60; /* 0..120, Hamlib assumes S9 = 0dB */
         return RIG_OK;
@@ -300,7 +302,7 @@ int wr_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     {
         long v;
 
-        if (ioctl(rig->state.rigport.fd, RADIO_GET_IFS, &v)) { return -RIG_EINVAL; }
+        if (ioctl(rp->fd, RADIO_GET_IFS, &v)) { return -RIG_EINVAL; }
 
         val->i = v;
         return RIG_OK;
@@ -310,7 +312,7 @@ int wr_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     {
         long v;
 
-        if (ioctl(rig->state.rigport.fd, RADIO_GET_IFG, &v)) { return -RIG_EINVAL; }
+        if (ioctl(rp->fd, RADIO_GET_IFG, &v)) { return -RIG_EINVAL; }
 
         val->f = (float)v / 100; /* iMaxIFGain on wHWVer > RHV_3150 */
         return RIG_OK;
@@ -328,7 +330,7 @@ const char *wr_get_info(RIG *rig)
 {
     static char buf[100];
 
-    if (ioctl(rig->state.rigport.fd, RADIO_GET_DESCR, buf) < 0) { return "?"; }
+    if (ioctl(RIGPORT(rig)->fd, RADIO_GET_DESCR, buf) < 0) { return "?"; }
 
     return buf;
 }

--- a/rigs/wj/wj.c
+++ b/rigs/wj/wj.c
@@ -67,6 +67,7 @@ const struct confparams wj_cfg_params[] =
 static int wj_transaction(RIG *rig, int monitor)
 {
     struct wj_priv_data *priv = (struct wj_priv_data *)rig->state.priv;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     unsigned char buf[CMDSZ] = { 0x8, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
     unsigned char rxbuf[CMDSZ];
@@ -169,9 +170,9 @@ static int wj_transaction(RIG *rig, int monitor)
 
     /* buf[9]: not used if command byte, but must be transmitted */
 
-    rig_flush(&rig->state.rigport);
+    rig_flush(rp);
 
-    retval = write_block(&rig->state.rigport, buf, CMDSZ);
+    retval = write_block(rp, buf, CMDSZ);
 
     if (retval != RIG_OK)
     {
@@ -183,7 +184,7 @@ static int wj_transaction(RIG *rig, int monitor)
         /*
         * Transceiver sends back ">"
         */
-        retval = read_block(&rig->state.rigport, rxbuf, CMDSZ);
+        retval = read_block(rp, rxbuf, CMDSZ);
 
         if (retval < 0 || retval > CMDSZ)
         {

--- a/rigs/yaesu/frg8800.c
+++ b/rigs/yaesu/frg8800.c
@@ -160,7 +160,7 @@ int frg8800_open(RIG *rig)
     rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 
     /* send Ext Cntl ON: Activate CAT */
-    return write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
 
 }
 
@@ -171,7 +171,7 @@ int frg8800_close(RIG *rig)
     rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 
     /* send Ext Cntl OFF: Deactivate CAT */
-    return write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
 
 }
 
@@ -189,7 +189,7 @@ int frg8800_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     cmd[0] = (cmd[0] & 0xf0) | (1 << ((((long long)freq) % 100) / 25));
 
     /* Frequency set */
-    return write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
 }
 
 
@@ -232,7 +232,7 @@ int frg8800_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     cmd[3] = md;
 
     /* Mode set */
-    return write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
 }
 
 
@@ -246,6 +246,6 @@ int frg8800_set_powerstat(RIG *rig, powerstat_t status)
     cmd[3] = status == RIG_POWER_OFF ? 0xff : 0xfe;
 
     /* Frequency set */
-    return write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
 }
 

--- a/rigs/yaesu/frg9600.c
+++ b/rigs/yaesu/frg9600.c
@@ -148,7 +148,7 @@ int frg9600_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     to_bcd_be(cmd + 1, freq / 10, 8);
 
     /* Frequency set */
-    return write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
 }
 
 
@@ -191,6 +191,6 @@ int frg9600_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     cmd[0] = md;
 
     /* Mode set */
-    return write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
 }
 

--- a/rigs/yaesu/ft100.c
+++ b/rigs/yaesu/ft100.c
@@ -526,20 +526,21 @@ static int ft100_send_priv_cmd(RIG *rig, unsigned char cmd_index)
 
     if (!rig) { return -RIG_EINVAL; }
 
-    return write_block(&rig->state.rigport, (unsigned char *) &ncmd[cmd_index].nseq,
+    return write_block(RIGPORT(rig), (unsigned char *) &ncmd[cmd_index].nseq,
                        YAESU_CMD_LENGTH);
 }
 
 static int ft100_read_status(RIG *rig)
 {
     struct ft100_priv_data *priv;
+    hamlib_port_t *rp = RIGPORT(rig);
     int ret;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
     priv = (struct ft100_priv_data *)rig->state.priv;
 
-    rig_flush(&rig->state.rigport);
+    rig_flush(rp);
 
     ret = ft100_send_priv_cmd(rig, FT100_NATIVE_CAT_READ_STATUS);
 
@@ -548,7 +549,7 @@ static int ft100_read_status(RIG *rig)
         return ret;
     }
 
-    ret = read_block(&rig->state.rigport, (unsigned char *) &priv->status,
+    ret = read_block(rp, (unsigned char *) &priv->status,
                      sizeof(FT100_STATUS_INFO));
     rig_debug(RIG_DEBUG_VERBOSE, "%s: read status=%i \n", __func__, ret);
 
@@ -564,10 +565,11 @@ static int ft100_read_flags(RIG *rig)
 {
     struct ft100_priv_data *priv = (struct ft100_priv_data *)rig->state.priv;
     int ret;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    rig_flush(&rig->state.rigport);
+    rig_flush(rp);
 
     ret = ft100_send_priv_cmd(rig, FT100_NATIVE_CAT_READ_FLAGS);
 
@@ -576,7 +578,7 @@ static int ft100_read_flags(RIG *rig)
         return ret;
     }
 
-    ret = read_block(&rig->state.rigport, (unsigned char *) &priv->flags,
+    ret = read_block(rp, (unsigned char *) &priv->flags,
                      sizeof(FT100_FLAG_INFO));
     rig_debug(RIG_DEBUG_VERBOSE, "%s: read flags=%i \n", __func__, ret);
 
@@ -605,7 +607,7 @@ int ft100_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     freq = (int) freq / 10;
     to_bcd(p_cmd, freq, 8); /* store bcd format in in p_cmd */
 
-    return write_block(&rig->state.rigport, p_cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), p_cmd, YAESU_CMD_LENGTH);
 }
 
 int ft100_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
@@ -731,7 +733,7 @@ int ft100_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         else if (width <= 2400) { p_cmd[3] = 0x00; }
         else { p_cmd[3] = 0x01; }
 
-        ret = write_block(&rig->state.rigport, p_cmd, YAESU_CMD_LENGTH);
+        ret = write_block(RIGPORT(rig), p_cmd, YAESU_CMD_LENGTH);
 
         if (ret != RIG_OK)
         {
@@ -992,7 +994,7 @@ int ft100_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         return ret;
     }
 
-    ret = read_block(&rig->state.rigport, (unsigned char *) &ft100_meter,
+    ret = read_block(RIGPORT(rig), (unsigned char *) &ft100_meter,
                      sizeof(FT100_METER_INFO));
     rig_debug(RIG_DEBUG_VERBOSE, "%s: read meters=%d\n", __func__, ret);
 
@@ -1209,7 +1211,7 @@ int ft100_set_dcs_code(RIG *rig, vfo_t vfo, tone_t code)
 
     p_cmd[3] = (char)pcode;
 
-    return write_block(&rig->state.rigport, p_cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), p_cmd, YAESU_CMD_LENGTH);
 }
 
 int ft100_get_dcs_code(RIG *rig, vfo_t vfo, tone_t *code)
@@ -1263,7 +1265,7 @@ int ft100_set_ctcss_tone(RIG *rig, vfo_t vfo, tone_t tone)
 
     p_cmd[3] = (char)ptone;
 
-    return write_block(&rig->state.rigport, p_cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), p_cmd, YAESU_CMD_LENGTH);
 }
 
 int ft100_get_ctcss_tone(RIG *rig, vfo_t vfo, tone_t *tone)

--- a/rigs/yaesu/ft600.c
+++ b/rigs/yaesu/ft600.c
@@ -389,20 +389,21 @@ static int ft600_send_priv_cmd(RIG *rig, unsigned char cmd_index)
 
     if (!rig) { return -RIG_EINVAL; }
 
-    return write_block(&rig->state.rigport, (unsigned char *) &ncmd[cmd_index].nseq,
+    return write_block(RIGPORT(rig), (unsigned char *) &ncmd[cmd_index].nseq,
                        YAESU_CMD_LENGTH);
 }
 
 static int ft600_read_status(RIG *rig)
 {
     struct ft600_priv_data *priv;
+    hamlib_port_t *rp = RIGPORT(rig);
     int ret;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
     priv = (struct ft600_priv_data *)rig->state.priv;
 
-    rig_flush(&rig->state.rigport);
+    rig_flush(rp);
 
     ret = ft600_send_priv_cmd(rig, FT600_NATIVE_CAT_READ_STATUS);
 
@@ -412,8 +413,8 @@ static int ft600_read_status(RIG *rig)
     }
 
 
-    ret = read_block(&rig->state.rigport,
-                     (unsigned char *) &priv->status, FT600_STATUS_UPDATE_DATA_LENGTH);
+    ret = read_block(rp, (unsigned char *) &priv->status,
+		     FT600_STATUS_UPDATE_DATA_LENGTH);
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: read status=%i \n", __func__, ret);
 
@@ -444,7 +445,7 @@ static int ft600_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: read tx status=%i \n", __func__, ret);
 
-    ret = read_block(&rig->state.rigport, &priv->s_meter, 5);
+    ret = read_block(RIGPORT(rig), &priv->s_meter, 5);
 
     if (ret < 0)
     {
@@ -475,7 +476,7 @@ static int ft600_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     freq = (int)freq / 10;
     to_bcd(p_cmd, freq, 8); /* store bcd format in in p_cmd */
 
-    return write_block(&rig->state.rigport, p_cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), p_cmd, YAESU_CMD_LENGTH);
 }
 
 static int ft600_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
@@ -643,7 +644,7 @@ static int ft600_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         else if (width <= 2400) { p_cmd[3] = 0x00; }
         else { p_cmd[3] = 0x01; }
 
-        ret = write_block(&rig->state.rigport, p_cmd, YAESU_CMD_LENGTH);
+        ret = write_block(RIGPORT(rig), p_cmd, YAESU_CMD_LENGTH);
 
         if (ret != RIG_OK)
         {

--- a/rigs/yaesu/ft736.c
+++ b/rigs/yaesu/ft736.c
@@ -240,7 +240,7 @@ int ft736_open(RIG *rig)
 
 
     /* send Ext Cntl ON: Activate CAT */
-    ret = write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    ret = write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
 
     if (ret != RIG_OK)
     {
@@ -259,7 +259,7 @@ int ft736_close(RIG *rig)
     free(rig->state.priv);
 
     /* send Ext Cntl OFF: Deactivate CAT */
-    return write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
 
 }
 
@@ -287,7 +287,7 @@ int ft736_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
         cmd[0] = (cmd[0] & 0x0f) | 0xc0;
     }
 
-    retval = write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    retval = write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
 
     if (retval == RIG_OK) { rig_set_cache_freq(rig, vfo, freq); }
 
@@ -358,7 +358,7 @@ int ft736_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     cmd[0] = md;
 
     /* Mode set */
-    return write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
 }
 
 
@@ -375,7 +375,7 @@ int ft736_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
      */
     cmd[4] = split == RIG_SPLIT_ON ? 0x0e : 0x8e;
 
-    ret = write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    ret = write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
 
     if (ret == RIG_OK)
     {
@@ -403,7 +403,7 @@ int ft736_set_split_freq(RIG *rig, vfo_t vfo, freq_t freq)
     }
 
     /* Frequency set */
-    return write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
 }
 
 
@@ -444,7 +444,7 @@ int ft736_set_split_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     cmd[0] = md;
 
     /* Mode set */
-    return write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
 }
 
 
@@ -457,17 +457,18 @@ int ft736_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
     cmd[4] = ptt == RIG_PTT_ON ? 0x08 : 0x88;
 
     /* Tx/Rx set */
-    return write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
 }
 
 int ft736_get_dcd(RIG *rig, vfo_t vfo, dcd_t *dcd)
 {
     unsigned char cmd[YAESU_CMD_LENGTH] = { 0x00, 0x00, 0x00, 0x00, 0xe7};
     int retval;
+    hamlib_port_t *rp = RIGPORT(rig);
 
-    rig_flush(&rig->state.rigport);
+    rig_flush(rp);
 
-    retval = write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    retval = write_block(rp, cmd, YAESU_CMD_LENGTH);
 
     if (retval < 0)
     {
@@ -475,7 +476,7 @@ int ft736_get_dcd(RIG *rig, vfo_t vfo, dcd_t *dcd)
     }
 
     /* read back the 1 byte */
-    retval = read_block(&rig->state.rigport, cmd, 5);
+    retval = read_block(rp, cmd, 5);
 
     if (retval < 1)
     {
@@ -494,16 +495,17 @@ int ft736_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
     unsigned char cmd[YAESU_CMD_LENGTH] = { 0x00, 0x00, 0x00, 0x00, 0xf7};
     int retval;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     if (level != RIG_LEVEL_RAWSTR)
     {
         return -RIG_EINVAL;
     }
 
-    rig_flush(&rig->state.rigport);
+    rig_flush(rp);
 
     /* send Test S-meter cmd to rig  */
-    retval = write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    retval = write_block(rp, cmd, YAESU_CMD_LENGTH);
 
     if (retval < 0)
     {
@@ -511,7 +513,7 @@ int ft736_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     }
 
     /* read back the 1 byte */
-    retval = read_block(&rig->state.rigport, cmd, 5);
+    retval = read_block(rp, cmd, 5);
 
     if (retval < 1)
     {
@@ -553,7 +555,7 @@ int ft736_set_rptr_shift(RIG *rig, vfo_t vfo, rptr_shift_t shift)
         return -RIG_EINVAL;
     }
 
-    return write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
 }
 
 int ft736_set_rptr_offs(RIG *rig, vfo_t vfo, shortfreq_t offs)
@@ -564,7 +566,7 @@ int ft736_set_rptr_offs(RIG *rig, vfo_t vfo, shortfreq_t offs)
     to_bcd_be(cmd, offs / 10, 8);
 
     /* Offset set */
-    return write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
 }
 
 int ft736_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
@@ -585,7 +587,7 @@ int ft736_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
         return -RIG_EINVAL;
     }
 
-    return write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
 }
 
 int ft736_set_ctcss_tone(RIG *rig, vfo_t vfo, tone_t tone)
@@ -608,7 +610,7 @@ int ft736_set_ctcss_tone(RIG *rig, vfo_t vfo, tone_t tone)
 
     cmd[0] = 0x3e - i;
 
-    return write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
 }
 
 int ft736_set_ctcss_sql(RIG *rig, vfo_t vfo, tone_t tone)

--- a/rigs/yaesu/ft747.c
+++ b/rigs/yaesu/ft747.c
@@ -483,17 +483,17 @@ int ft747_cleanup(RIG *rig)
 int ft747_open(RIG *rig)
 {
     struct rig_state *rig_s;
+    hamlib_port_t *rp = RIGPORT(rig);
     struct ft747_priv_data *p;
     int ret;
-
 
     rig_s = &rig->state;
     p = (struct ft747_priv_data *)rig_s->priv;
 
     rig_debug(RIG_DEBUG_VERBOSE, "ft747:rig_open: write_delay = %i msec \n",
-              rig_s->rigport.write_delay);
+              rp->write_delay);
     rig_debug(RIG_DEBUG_VERBOSE, "ft747:rig_open: post_write_delay = %i msec \n",
-              rig_s->rigport.post_write_delay);
+              rp->post_write_delay);
 
     /*
     * Copy native cmd PACING  to private cmd storage area
@@ -507,7 +507,7 @@ int ft747_open(RIG *rig)
 
     /* send PACING cmd to rig, once for all */
 
-    ret = write_block(&rig->state.rigport, p->p_cmd, YAESU_CMD_LENGTH);
+    ret = write_block(rp, p->p_cmd, YAESU_CMD_LENGTH);
 
     if (ret < 0)
     {
@@ -568,7 +568,7 @@ int ft747_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     rig_force_cache_timeout(&p->status_tv);
 
     cmd = p->p_cmd; /* get native sequence */
-    return write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
 }
 
 
@@ -958,7 +958,7 @@ int ft747_set_mem(RIG *rig, vfo_t vfo, int ch)
 
     rig_force_cache_timeout(&p->status_tv);
 
-    return write_block(&rig->state.rigport, p->p_cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), p->p_cmd, YAESU_CMD_LENGTH);
 }
 
 int ft747_get_mem(RIG *rig, vfo_t vfo, int *ch)
@@ -1003,7 +1003,7 @@ static int ft747_get_update_data(RIG *rig)
     //unsigned char last_byte;
 
     p = (struct ft747_priv_data *)rig->state.priv;
-    rigport = &rig->state.rigport;
+    rigport = RIGPORT(rig);
 
     if (rig->state.cache.ptt == RIG_PTT_ON
             || !rig_check_cache_timeout(&p->status_tv, FT747_CACHE_TIMEOUT))
@@ -1064,7 +1064,7 @@ static int ft747_send_priv_cmd(RIG *rig, unsigned char ci)
         return -RIG_EINVAL;
     }
 
-    return write_block(&rig->state.rigport, ft747_ncmd[ci].nseq, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), ft747_ncmd[ci].nseq, YAESU_CMD_LENGTH);
 
 }
 

--- a/rigs/yaesu/ft767gx.c
+++ b/rigs/yaesu/ft767gx.c
@@ -456,7 +456,7 @@ int ft767_open(RIG *rig)
     struct ft767_priv_data *priv = (struct ft767_priv_data *)rig->state.priv;
     int retval;
 
-    rig_flush(&rig->state.rigport);
+    rig_flush(RIGPORT(rig));
 
     /* send 0 delay PACING cmd to rig  */
     retval = ft767_enter_CAT(rig);
@@ -1232,7 +1232,7 @@ int ft767_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
             return -RIG_EINVAL;       /* sorry, wrong VFO */
         }
 
-        rig_flush(&rig->state.rigport);
+        rig_flush(RIGPORT(rig));
 
         retval = ft767_enter_CAT(rig);
 
@@ -1407,6 +1407,7 @@ int ft767_leave_CAT(RIG *rig)
 int ft767_send_block_and_ack(RIG *rig, unsigned char *cmd, size_t length)
 {
     struct ft767_priv_data *priv = (struct ft767_priv_data *)rig->state.priv;
+    hamlib_port_t *rp = RIGPORT(rig);
     size_t replylen, cpycnt;
     unsigned char cmd_echo_buf[5];
     int retval;
@@ -1480,12 +1481,10 @@ int ft767_send_block_and_ack(RIG *rig, unsigned char *cmd, size_t length)
     }
 
     /* send the command block */
-    write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    write_block(rp, cmd, YAESU_CMD_LENGTH);
 
     /* read back the command block echo */
-    retval = read_block(&rig->state.rigport,
-                        cmd_echo_buf,
-                        YAESU_CMD_LENGTH);
+    retval = read_block(rp, cmd_echo_buf, YAESU_CMD_LENGTH);
 
     if (retval < 0)
     {
@@ -1503,12 +1502,10 @@ int ft767_send_block_and_ack(RIG *rig, unsigned char *cmd, size_t length)
     }
 
     /* send the ACK */
-    write_block(&rig->state.rigport, priv->ack_cmd, YAESU_CMD_LENGTH);
+    write_block(rp, priv->ack_cmd, YAESU_CMD_LENGTH);
 
     /* read back the response (status bytes) */
-    retval = read_block(&rig->state.rigport,
-                        priv->rx_data,
-                        replylen);
+    retval = read_block(rp, priv->rx_data, replylen);
 
     // update data
     if (retval != replylen)
@@ -1545,7 +1542,7 @@ int ft767_get_update_data(RIG *rig)
     struct ft767_priv_data *priv = (struct ft767_priv_data *)rig->state.priv;
     int retval;
 
-    rig_flush(&rig->state.rigport);
+    rig_flush(RIGPORT(rig));
 
     /* Entering CAT updates our data structures */
     retval = ft767_enter_CAT(rig);
@@ -1576,7 +1573,7 @@ int ft767_set_split(RIG *rig, unsigned int split)
     int retval;
     unsigned int curr_split;
 
-    rig_flush(&rig->state.rigport);
+    rig_flush(RIGPORT(rig));
 
     /* Entering CAT updates our data structures */
     retval = ft767_enter_CAT(rig);

--- a/rigs/yaesu/ft840.c
+++ b/rigs/yaesu/ft840.c
@@ -440,7 +440,6 @@ static int ft840_cleanup(RIG *rig)
 
 static int ft840_open(RIG *rig)
 {
-    struct rig_state *rig_s;
     struct ft840_priv_data *priv;
     int err;
 
@@ -452,12 +451,11 @@ static int ft840_open(RIG *rig)
     }
 
     priv = (struct ft840_priv_data *)rig->state.priv;
-    rig_s = &rig->state;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: write_delay = %i msec\n",
-              __func__, rig_s->rigport.write_delay);
+              __func__, RIGPORT(rig)->write_delay);
     rig_debug(RIG_DEBUG_TRACE, "%s: post_write_delay = %i msec\n",
-              __func__, rig_s->rigport.post_write_delay);
+              __func__, RIGPORT(rig)->post_write_delay);
     rig_debug(RIG_DEBUG_TRACE,
               "%s: read pacing = %i\n", __func__, priv->pacing);
 
@@ -1746,7 +1744,7 @@ static int ft840_get_update_data(RIG *rig, unsigned char ci, unsigned char rl)
         return err;
     }
 
-    n = read_block(&rig->state.rigport, priv->update_data, rl);
+    n = read_block(RIGPORT(rig), priv->update_data, rl);
 
     if (n < 0)
     {
@@ -1789,7 +1787,7 @@ static int ft840_send_static_cmd(RIG *rig, unsigned char ci)
         return -RIG_EINVAL;
     }
 
-    err = write_block(&rig->state.rigport, ncmd[ci].nseq,
+    err = write_block(RIGPORT(rig), ncmd[ci].nseq,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -1850,7 +1848,7 @@ static int ft840_send_dynamic_cmd(RIG *rig, unsigned char ci,
     priv->p_cmd[P3] = p3;
     priv->p_cmd[P4] = p4;
 
-    err = write_block(&rig->state.rigport, (unsigned char *) &priv->p_cmd,
+    err = write_block(RIGPORT(rig), (unsigned char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -1911,7 +1909,7 @@ static int ft840_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
     rig_debug(RIG_DEBUG_TRACE, fmt, __func__, (int64_t)from_bcd(priv->p_cmd,
               FT840_BCD_DIAL) * 10);
 
-    err = write_block(&rig->state.rigport, (unsigned char *) &priv->p_cmd,
+    err = write_block(RIGPORT(rig), (unsigned char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -1993,7 +1991,7 @@ static int ft840_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
     priv->p_cmd[P1] = p1;         /* ick */
     priv->p_cmd[P2] = p2;
 
-    err = write_block(&rig->state.rigport, (char *) &priv->p_cmd,
+    err = write_block(RIGPORT(rig), (char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)

--- a/rigs/yaesu/ft847.c
+++ b/rigs/yaesu/ft847.c
@@ -1119,7 +1119,7 @@ static int ft847_send_priv_cmd(RIG *rig, int cmd_index)
         return -RIG_EINVAL;
     }
 
-    return write_block(&rig->state.rigport, ncmd[cmd_index].nseq,
+    return write_block(RIGPORT(rig), ncmd[cmd_index].nseq,
                        YAESU_CMD_LENGTH);
 }
 
@@ -1213,7 +1213,7 @@ static int ft847_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
         }
     }
 
-    return write_block(&rig->state.rigport, p_cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), p_cmd, YAESU_CMD_LENGTH);
 }
 
 #define MD_LSB  0x00
@@ -1230,7 +1230,7 @@ static int ft847_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 static int get_freq_and_mode(RIG *rig, vfo_t vfo, freq_t *freq, rmode_t *mode,
                              pbwidth_t *width)
 {
-    struct rig_state *rs = &rig->state;
+    hamlib_port_t *rp = RIGPORT(rig);
     unsigned char p_cmd[YAESU_CMD_LENGTH]; /* sequence to send */
     unsigned char cmd_index;  /* index of sequence to send */
     unsigned char data[8];
@@ -1270,14 +1270,14 @@ static int get_freq_and_mode(RIG *rig, vfo_t vfo, freq_t *freq, rmode_t *mode,
         return n;
     }
 
-    n = write_block(&rs->rigport, p_cmd, YAESU_CMD_LENGTH);
+    n = write_block(rp, p_cmd, YAESU_CMD_LENGTH);
 
     if (n < 0)
     {
         return n;
     }
 
-    n = read_block(&rs->rigport, data, YAESU_CMD_LENGTH);
+    n = read_block(rp, data, YAESU_CMD_LENGTH);
 
     if (n != YAESU_CMD_LENGTH)
     {
@@ -1358,7 +1358,6 @@ static int ft847_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 static int ft847_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
     unsigned char cmd_index;  /* index of sequence to send */
-    struct rig_state *rs = &rig->state;
     unsigned char p_cmd[YAESU_CMD_LENGTH]; /* sequence to send */
     int ret;
 
@@ -1467,7 +1466,7 @@ static int ft847_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         return ret;
     }
 
-    return write_block(&rs->rigport, p_cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), p_cmd, YAESU_CMD_LENGTH);
 }
 
 static int ft847_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
@@ -1595,6 +1594,7 @@ static int ft847_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 static int ft847_get_status(RIG *rig, int status_ci)
 {
     struct ft847_priv_data *p = (struct ft847_priv_data *) rig->state.priv;
+    hamlib_port_t *rp = RIGPORT(rig);
     unsigned char *data;
     int len;
     int n;
@@ -1621,17 +1621,16 @@ static int ft847_get_status(RIG *rig, int status_ci)
         return -RIG_EINTERNAL;
     }
 
-    rig_flush(&rig->state.rigport);
+    rig_flush(rp);
 
-    n = write_block(&rig->state.rigport, ncmd[status_ci].nseq,
-                    YAESU_CMD_LENGTH);
+    n = write_block(rp, ncmd[status_ci].nseq, YAESU_CMD_LENGTH);
 
     if (n < 0)
     {
         return n;
     }
 
-    n = read_block(&rig->state.rigport, data, len);
+    n = read_block(rp, data, len);
 
     if (n < 0)
     {
@@ -1873,7 +1872,7 @@ static int ft847_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
         return ret;
     }
 
-    return write_block(&rig->state.rigport, p_cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), p_cmd, YAESU_CMD_LENGTH);
 }
 
 
@@ -1918,7 +1917,7 @@ static int ft847_set_ctcss_tone(RIG *rig, vfo_t vfo, tone_t tone)
     /* get associated CAT code */
     p_cmd[0] = ft847_ctcss_cat[i];
 
-    return write_block(&rig->state.rigport, p_cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), p_cmd, YAESU_CMD_LENGTH);
 }
 
 static int ft847_set_ctcss_sql(RIG *rig, vfo_t vfo, tone_t tone)
@@ -1944,7 +1943,7 @@ static int ft847_set_dcs_sql(RIG *rig, vfo_t vfo, tone_t code)
     /* DCS Code # (i.e. 07, 54=DCS Code 754) */
     to_bcd_be(p_cmd, code, 4); /* store bcd format in in p_cmd */
 
-    return write_block(&rig->state.rigport, p_cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), p_cmd, YAESU_CMD_LENGTH);
 
 }
 
@@ -1987,6 +1986,6 @@ static int ft847_set_rptr_offs(RIG *rig, vfo_t vfo, shortfreq_t rptr_offs)
 
     to_bcd_be(p_cmd, rptr_offs / 10, 8); /* store bcd format in in p_cmd */
 
-    return write_block(&rig->state.rigport, p_cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), p_cmd, YAESU_CMD_LENGTH);
 }
 

--- a/rigs/yaesu/ft857.c
+++ b/rigs/yaesu/ft857.c
@@ -470,6 +470,7 @@ static int check_cache_timeout(struct timeval *tv)
 static int ft857_read_eeprom(RIG *rig, unsigned short addr, unsigned char *out)
 {
     unsigned char data[YAESU_CMD_LENGTH];
+    hamlib_port_t *rp = RIGPORT(rig);
     int n;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: called \n", __func__);
@@ -479,9 +480,9 @@ static int ft857_read_eeprom(RIG *rig, unsigned short addr, unsigned char *out)
     data[0] = addr >> 8;
     data[1] = addr & 0xfe;
 
-    write_block(&rig->state.rigport, data, YAESU_CMD_LENGTH);
+    write_block(rp, data, YAESU_CMD_LENGTH);
 
-    if ((n = read_block(&rig->state.rigport, data, 2)) < 0)
+    if ((n = read_block(rp, data, 2)) < 0)
     {
         return n;
     }
@@ -499,6 +500,7 @@ static int ft857_read_eeprom(RIG *rig, unsigned short addr, unsigned char *out)
 static int ft857_get_status(RIG *rig, int status)
 {
     struct ft857_priv_data *p = (struct ft857_priv_data *) rig->state.priv;
+    hamlib_port_t *rp = RIGPORT(rig);
     struct timeval *tv;
     unsigned char *data;
     int len;
@@ -531,12 +533,11 @@ static int ft857_get_status(RIG *rig, int status)
         return -RIG_EINTERNAL;
     }
 
-    rig_flush(&rig->state.rigport);
+    rig_flush(rp);
 
-    write_block(&rig->state.rigport, ncmd[status].nseq,
-                YAESU_CMD_LENGTH);
+    write_block(rp, ncmd[status].nseq, YAESU_CMD_LENGTH);
 
-    if ((n = read_block(&rig->state.rigport, data, len)) < 0)
+    if ((n = read_block(rp, data, len)) < 0)
     {
         return n;
     }
@@ -575,7 +576,7 @@ static int ft857_send_cmd(RIG *rig, int index)
         return -RIG_EINTERNAL;
     }
 
-    write_block(&rig->state.rigport, ncmd[index].nseq, YAESU_CMD_LENGTH);
+    write_block(RIGPORT(rig), ncmd[index].nseq, YAESU_CMD_LENGTH);
     return ft817_read_ack(rig);
 }
 
@@ -597,7 +598,7 @@ static int ft857_send_icmd(RIG *rig, int index, const unsigned char *data)
     cmd[YAESU_CMD_LENGTH - 1] = ncmd[index].nseq[YAESU_CMD_LENGTH - 1];
     memcpy(cmd, data, YAESU_CMD_LENGTH - 1);
 
-    write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
     return ft817_read_ack(rig);
 }
 

--- a/rigs/yaesu/ft890.c
+++ b/rigs/yaesu/ft890.c
@@ -590,7 +590,7 @@ static int ft890_cleanup(RIG *rig)
 
 static int ft890_open(RIG *rig)
 {
-    struct rig_state *rig_s;
+    hamlib_port_t *rp = RIGPORT(rig);
     struct ft890_priv_data *priv;
     int err;
 
@@ -602,12 +602,11 @@ static int ft890_open(RIG *rig)
     }
 
     priv = (struct ft890_priv_data *)rig->state.priv;
-    rig_s = &rig->state;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: write_delay = %i msec\n",
-              __func__, rig_s->rigport.write_delay);
+              __func__, rp->write_delay);
     rig_debug(RIG_DEBUG_TRACE, "%s: post_write_delay = %i msec\n",
-              __func__, rig_s->rigport.post_write_delay);
+              __func__, rp->post_write_delay);
     rig_debug(RIG_DEBUG_TRACE,
               "%s: read pacing = %i\n", __func__, priv->pacing);
 
@@ -1899,7 +1898,7 @@ static int ft890_get_update_data(RIG *rig, unsigned char ci, unsigned char rl)
         return err;
     }
 
-    n = read_block(&rig->state.rigport, priv->update_data, rl);
+    n = read_block(RIGPORT(rig), priv->update_data, rl);
 
     if (n < 0)
     {
@@ -1942,7 +1941,7 @@ static int ft890_send_static_cmd(RIG *rig, unsigned char ci)
         return -RIG_EINVAL;
     }
 
-    err = write_block(&rig->state.rigport, ncmd[ci].nseq, YAESU_CMD_LENGTH);
+    err = write_block(RIGPORT(rig), ncmd[ci].nseq, YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
     {
@@ -2002,7 +2001,7 @@ static int ft890_send_dynamic_cmd(RIG *rig, unsigned char ci,
     priv->p_cmd[P3] = p3;
     priv->p_cmd[P4] = p4;
 
-    err = write_block(&rig->state.rigport, (unsigned char *) &priv->p_cmd,
+    err = write_block(RIGPORT(rig), (unsigned char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -2063,7 +2062,7 @@ static int ft890_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
     rig_debug(RIG_DEBUG_TRACE, fmt, __func__, (int64_t)from_bcd(priv->p_cmd,
               FT890_BCD_DIAL) * 10);
 
-    err = write_block(&rig->state.rigport, (unsigned char *) &priv->p_cmd,
+    err = write_block(RIGPORT(rig), (unsigned char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -2144,7 +2143,7 @@ static int ft890_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
     priv->p_cmd[P1] = p1;         /* ick */
     priv->p_cmd[P2] = p2;
 
-    err = write_block(&rig->state.rigport, (unsigned char *) &priv->p_cmd,
+    err = write_block(RIGPORT(rig), (unsigned char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)

--- a/rigs/yaesu/ft891.c
+++ b/rigs/yaesu/ft891.c
@@ -357,7 +357,6 @@ struct rig_caps ft891_caps =
 static int ft891_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
 {
     struct newcat_priv_data *priv;
-    struct rig_state *state;
     unsigned char ci;
     int err;
 
@@ -373,7 +372,6 @@ static int ft891_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
     rig_debug(RIG_DEBUG_TRACE, "%s: passed tx_vfo = 0x%02x\n", __func__, tx_vfo);
 
     priv = (struct newcat_priv_data *)rig->state.priv;
-    state = &rig->state;
 
     // RX VFO and TX VFO cannot be the same, no support for MEM as TX VFO
     if (vfo == tx_vfo || tx_vfo == RIG_VFO_MEM)
@@ -397,7 +395,7 @@ static int ft891_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
 
     SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "ST%c;", ci);
 
-    if (RIG_OK != (err = write_block(&state->rigport,
+    if (RIG_OK != (err = write_block(RIGPORT(rig),
                                      (unsigned char *) priv->cmd_str, strlen(priv->cmd_str))))
     {
         rig_debug(RIG_DEBUG_ERR, "%s: write_block err = %d\n", __func__, err);
@@ -533,7 +531,6 @@ static int ft891_set_split_mode(RIG *rig, vfo_t vfo, rmode_t tx_mode,
                                 pbwidth_t tx_width)
 {
     struct newcat_priv_data *priv;
-    struct rig_state *state;
     freq_t b_freq;
     int err;
 
@@ -543,8 +540,6 @@ static int ft891_set_split_mode(RIG *rig, vfo_t vfo, rmode_t tx_mode,
     {
         return -RIG_EINVAL;
     }
-
-    state = &rig->state;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: passed vfo = %s\n", __func__, rig_strvfo(vfo));
     rig_debug(RIG_DEBUG_TRACE, "%s: passed mode = %s\n", __func__,
@@ -569,7 +564,7 @@ static int ft891_set_split_mode(RIG *rig, vfo_t vfo, rmode_t tx_mode,
     // Copy A to B
     SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "AB;");
 
-    if (RIG_OK != (err = write_block(&state->rigport,
+    if (RIG_OK != (err = write_block(RIGPORT(rig),
                                      (unsigned char *) priv->cmd_str, strlen(priv->cmd_str))))
     {
         rig_debug(RIG_DEBUG_VERBOSE, "%s:%d write_block err = %d\n", __func__, __LINE__,

--- a/rigs/yaesu/ft897.c
+++ b/rigs/yaesu/ft897.c
@@ -623,6 +623,7 @@ static int ft897_read_eeprom(RIG *rig, unsigned short addr, unsigned char *out)
 {
     unsigned char data[YAESU_CMD_LENGTH];
     int n;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: called\n", __func__);
     memcpy(data, (char *)ncmd[FT897_NATIVE_CAT_EEPROM_READ].nseq,
@@ -631,9 +632,9 @@ static int ft897_read_eeprom(RIG *rig, unsigned short addr, unsigned char *out)
     data[0] = addr >> 8;
     data[1] = addr & 0xfe;
 
-    write_block(&rig->state.rigport, data, YAESU_CMD_LENGTH);
+    write_block(rp, data, YAESU_CMD_LENGTH);
 
-    if ((n = read_block(&rig->state.rigport, data, 2)) < 0)
+    if ((n = read_block(rp, data, 2)) < 0)
     {
         return n;
     }
@@ -651,6 +652,7 @@ static int ft897_read_eeprom(RIG *rig, unsigned short addr, unsigned char *out)
 static int ft897_get_status(RIG *rig, int status)
 {
     struct ft897_priv_data *p = (struct ft897_priv_data *) rig->state.priv;
+    hamlib_port_t *rp = RIGPORT(rig);
     struct timeval *tv;
     unsigned char *data;
     int len;
@@ -690,12 +692,11 @@ static int ft897_get_status(RIG *rig, int status)
         return -RIG_EINTERNAL;
     }
 
-    rig_flush(&rig->state.rigport);
+    rig_flush(rp);
 
-    write_block(&rig->state.rigport, ncmd[status].nseq,
-                YAESU_CMD_LENGTH);
+    write_block(rp, ncmd[status].nseq, YAESU_CMD_LENGTH);
 
-    if ((n = read_block(&rig->state.rigport, data, len)) < 0)
+    if ((n = read_block(rp, data, len)) < 0)
     {
         return n;
     }
@@ -1054,7 +1055,7 @@ static int ft897_send_cmd(RIG *rig, int index)
         return -RIG_EINTERNAL;
     }
 
-    write_block(&rig->state.rigport, ncmd[index].nseq, YAESU_CMD_LENGTH);
+    write_block(RIGPORT(rig), ncmd[index].nseq, YAESU_CMD_LENGTH);
     return ft817_read_ack(rig);
 }
 
@@ -1076,7 +1077,7 @@ static int ft897_send_icmd(RIG *rig, int index, const unsigned char *data)
     cmd[YAESU_CMD_LENGTH - 1] = ncmd[index].nseq[YAESU_CMD_LENGTH - 1];
     memcpy(cmd, data, YAESU_CMD_LENGTH - 1);
 
-    write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
     return ft817_read_ack(rig);
 }
 

--- a/rigs/yaesu/ft900.c
+++ b/rigs/yaesu/ft900.c
@@ -612,7 +612,6 @@ static int ft900_cleanup(RIG *rig)
 
 static int ft900_open(RIG *rig)
 {
-    struct rig_state *rig_s;
     struct ft900_priv_data *priv;
     int err;
 
@@ -624,12 +623,11 @@ static int ft900_open(RIG *rig)
     }
 
     priv = (struct ft900_priv_data *)rig->state.priv;
-    rig_s = &rig->state;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: write_delay = %i msec\n",
-              __func__, rig_s->rigport.write_delay);
+              __func__, RIGPORT(rig)->write_delay);
     rig_debug(RIG_DEBUG_TRACE, "%s: post_write_delay = %i msec\n",
-              __func__, rig_s->rigport.post_write_delay);
+              __func__, RIGPORT(rig)->post_write_delay);
     rig_debug(RIG_DEBUG_TRACE,
               "%s: read pacing = %i\n", __func__, priv->pacing);
 
@@ -1921,7 +1919,7 @@ static int ft900_get_update_data(RIG *rig, unsigned char ci, unsigned char rl)
         return err;
     }
 
-    n = read_block(&rig->state.rigport, priv->update_data, rl);
+    n = read_block(RIGPORT(rig), priv->update_data, rl);
 
     if (n < 0)
     {
@@ -1964,7 +1962,7 @@ static int ft900_send_static_cmd(RIG *rig, unsigned char ci)
         return -RIG_EINVAL;
     }
 
-    err = write_block(&rig->state.rigport, ncmd[ci].nseq, YAESU_CMD_LENGTH);
+    err = write_block(RIGPORT(rig), ncmd[ci].nseq, YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
     {
@@ -2024,7 +2022,7 @@ static int ft900_send_dynamic_cmd(RIG *rig, unsigned char ci,
     priv->p_cmd[P3] = p3;
     priv->p_cmd[P4] = p4;
 
-    err = write_block(&rig->state.rigport, (unsigned char *) &priv->p_cmd,
+    err = write_block(RIGPORT(rig), (unsigned char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -2085,7 +2083,7 @@ static int ft900_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
     rig_debug(RIG_DEBUG_TRACE, fmt, __func__, (int64_t)from_bcd(priv->p_cmd,
               FT900_BCD_DIAL) * 10);
 
-    err = write_block(&rig->state.rigport, (unsigned char *) &priv->p_cmd,
+    err = write_block(RIGPORT(rig), (unsigned char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -2166,7 +2164,7 @@ static int ft900_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
     priv->p_cmd[P1] = p1;         /* ick */
     priv->p_cmd[P2] = p2;
 
-    err = write_block(&rig->state.rigport, (unsigned char *) &priv->p_cmd,
+    err = write_block(RIGPORT(rig), (unsigned char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)

--- a/rigs/yaesu/ft920.c
+++ b/rigs/yaesu/ft920.c
@@ -686,7 +686,7 @@ static int ft920_cleanup(RIG *rig)
 
 static int ft920_open(RIG *rig)
 {
-    struct rig_state *rig_s;
+    hamlib_port_t *rp = RIGPORT(rig);
     struct ft920_priv_data *priv;
     int err;
 
@@ -698,12 +698,11 @@ static int ft920_open(RIG *rig)
     }
 
     priv = (struct ft920_priv_data *)rig->state.priv;
-    rig_s = &rig->state;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: write_delay = %i msec\n",
-              __func__, rig_s->rigport.write_delay);
+              __func__, rp->write_delay);
     rig_debug(RIG_DEBUG_TRACE, "%s: post_write_delay = %i msec\n",
-              __func__, rig_s->rigport.post_write_delay);
+              __func__, rp->post_write_delay);
 
     /* Copy native cmd PACING to private cmd storage area */
     memcpy(&priv->p_cmd, &ncmd[FT920_NATIVE_PACING].nseq, YAESU_CMD_LENGTH);
@@ -713,7 +712,7 @@ static int ft920_open(RIG *rig)
 
     rig_debug(RIG_DEBUG_TRACE, "%s: read pacing = %i\n", __func__, priv->pacing);
 
-    err = write_block(&rig->state.rigport, priv->p_cmd, YAESU_CMD_LENGTH);
+    err = write_block(rp, priv->p_cmd, YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
     {
@@ -2632,7 +2631,7 @@ static int ft920_get_update_data(RIG *rig, unsigned char ci, unsigned char rl)
         return err;
     }
 
-    n = read_block(&rig->state.rigport, priv->update_data, rl);
+    n = read_block(RIGPORT(rig), priv->update_data, rl);
 
     if (n < 0)
     {
@@ -2679,7 +2678,7 @@ static int ft920_send_static_cmd(RIG *rig, unsigned char ci)
         return -RIG_EINVAL;
     }
 
-    err = write_block(&rig->state.rigport, ncmd[ci].nseq, YAESU_CMD_LENGTH);
+    err = write_block(RIGPORT(rig), ncmd[ci].nseq, YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
     {
@@ -2744,7 +2743,7 @@ static int ft920_send_dynamic_cmd(RIG *rig, unsigned char ci,
     priv->p_cmd[P3] = p3;
     priv->p_cmd[P4] = p4;
 
-    err = write_block(&rig->state.rigport, (unsigned char *) &priv->p_cmd,
+    err = write_block(RIGPORT(rig), (unsigned char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -2809,7 +2808,7 @@ static int ft920_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
     rig_debug(RIG_DEBUG_TRACE, fmt, __func__, (int64_t)from_bcd(priv->p_cmd,
               FT920_BCD_DIAL) * 10);
 
-    err = write_block(&rig->state.rigport, (unsigned char *) &priv->p_cmd,
+    err = write_block(RIGPORT(rig), (unsigned char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -2893,7 +2892,7 @@ static int ft920_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
     priv->p_cmd[P1] = p1;               /* ick */
     priv->p_cmd[P2] = p2;
 
-    err = write_block(&rig->state.rigport, (unsigned char *) &priv->p_cmd,
+    err = write_block(RIGPORT(rig), (unsigned char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)

--- a/rigs/yaesu/ft980.c
+++ b/rigs/yaesu/ft980.c
@@ -560,20 +560,21 @@ int ft980_transaction(RIG *rig, const unsigned char *cmd, unsigned char *data,
                       int expected_len)
 {
     int retval;
+    hamlib_port_t *rp = RIGPORT(rig);
     unsigned char echo_back[YAESU_CMD_LENGTH];
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    rig_flush(&rig->state.rigport);
+    rig_flush(rp);
 
-    retval = write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    retval = write_block(rp, cmd, YAESU_CMD_LENGTH);
 
     if (retval < 0)
     {
         return retval;
     }
 
-    retval = read_block(&rig->state.rigport, echo_back, YAESU_CMD_LENGTH);
+    retval = read_block(rp, echo_back, YAESU_CMD_LENGTH);
 
     if (retval < 0)
     {
@@ -586,14 +587,14 @@ int ft980_transaction(RIG *rig, const unsigned char *cmd, unsigned char *data,
         return -RIG_EPROTO;
     }
 
-    retval = write_block(&rig->state.rigport, cmd_OK, YAESU_CMD_LENGTH);
+    retval = write_block(rp, cmd_OK, YAESU_CMD_LENGTH);
 
     if (retval < 0)
     {
         return retval;
     }
 
-    retval = read_block(&rig->state.rigport, data, expected_len);
+    retval = read_block(rp, data, expected_len);
 
     if (retval < 0)
     {
@@ -733,6 +734,7 @@ int ft980_open(RIG *rig)
 {
     unsigned char echo_back[YAESU_CMD_LENGTH];
     struct ft980_priv_data *priv;
+    hamlib_port_t *rp = RIGPORT(rig);
     int retry_count1 = 0;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
@@ -747,18 +749,17 @@ int ft980_open(RIG *rig)
 
         do
         {
-            write_block(&rig->state.rigport, cmd_ON_OFF,
-                        YAESU_CMD_LENGTH);
-            retval = read_block(&rig->state.rigport, echo_back, YAESU_CMD_LENGTH);
+            write_block(rp, cmd_ON_OFF, YAESU_CMD_LENGTH);
+            retval = read_block(rp, echo_back, YAESU_CMD_LENGTH);
         }
-        while (retval != 5 && retry_count2++ < rig->state.rigport.retry);
+        while (retval != 5 && retry_count2++ < rp->retry);
 
-        write_block(&rig->state.rigport, cmd_OK, YAESU_CMD_LENGTH);
-        read_block(&rig->state.rigport, (unsigned char *) &priv->update_data,
+        write_block(rp, cmd_OK, YAESU_CMD_LENGTH);
+        read_block(rp, (unsigned char *) &priv->update_data,
                    FT980_ALL_STATUS_LENGTH);
     }
     while (!priv->update_data.ext_ctl_flag
-            && retry_count1++ < rig->state.rigport.retry);
+            && retry_count1++ < rp->retry);
 
     return RIG_OK;
 }
@@ -782,6 +783,7 @@ int ft980_close(RIG *rig)
 {
     unsigned char echo_back[YAESU_CMD_LENGTH];
     struct ft980_priv_data *priv = (struct ft980_priv_data *)rig->state.priv;
+    hamlib_port_t *rp = RIGPORT(rig);
     int retry_count1 = 0;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
@@ -793,18 +795,17 @@ int ft980_close(RIG *rig)
 
         do
         {
-            write_block(&rig->state.rigport, cmd_ON_OFF,
-                        YAESU_CMD_LENGTH);
-            retval = read_block(&rig->state.rigport, echo_back, YAESU_CMD_LENGTH);
+            write_block(rp, cmd_ON_OFF, YAESU_CMD_LENGTH);
+            retval = read_block(rp, echo_back, YAESU_CMD_LENGTH);
         }
-        while (retval != 5 && retry_count2++ < rig->state.rigport.retry);
+        while (retval != 5 && retry_count2++ < rp->retry);
 
-        write_block(&rig->state.rigport, cmd_OK, YAESU_CMD_LENGTH);
-        read_block(&rig->state.rigport, (unsigned char *) &priv->update_data,
+        write_block(rp, cmd_OK, YAESU_CMD_LENGTH);
+        read_block(rp, (unsigned char *) &priv->update_data,
                    FT980_ALL_STATUS_LENGTH);
     }
     while (priv->update_data.ext_ctl_flag
-            && retry_count1++ < rig->state.rigport.retry);
+            && retry_count1++ < rp->retry);
 
     return RIG_OK;
 }
@@ -1217,7 +1218,7 @@ int ft980_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
      */
     cmd[4] = split == RIG_SPLIT_ON ? 0x0e : 0x8e;
 
-    return write_block(&rig->state.rigport, (char *) cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), (char *) cmd, YAESU_CMD_LENGTH);
 #endif
 }
 

--- a/rigs/yaesu/ft990.c
+++ b/rigs/yaesu/ft990.c
@@ -446,7 +446,6 @@ int ft990_cleanup(RIG *rig)
  */
 int  ft990_open(RIG *rig)
 {
-    struct rig_state *rig_s;
     struct ft990_priv_data *priv;
     int err;
 
@@ -458,12 +457,11 @@ int  ft990_open(RIG *rig)
     }
 
     priv = (struct ft990_priv_data *)rig->state.priv;
-    rig_s = &rig->state;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: write_delay = %i msec\n",
-              __func__, rig_s->rigport.write_delay);
+              __func__, RIGPORT(rig)->write_delay);
     rig_debug(RIG_DEBUG_TRACE, "%s: post_write_delay = %i msec\n",
-              __func__, rig_s->rigport.post_write_delay);
+              __func__, RIGPORT(rig)->post_write_delay);
     rig_debug(RIG_DEBUG_TRACE,
               "%s: read pacing = %i\n", __func__, priv->pacing);
 
@@ -2430,7 +2428,7 @@ int ft990_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *value)
         return err;
     }
 
-    err = read_block(&rig->state.rigport, mdata, FT990_READ_METER_LENGTH);
+    err = read_block(RIGPORT(rig), mdata, FT990_READ_METER_LENGTH);
 
     if (err < 0)
     {
@@ -3297,7 +3295,7 @@ int ft990_get_update_data(RIG *rig, unsigned char ci, unsigned short ch)
         return -RIG_EINVAL;
     }
 
-    n = read_block(&rig->state.rigport, p, rl);
+    n = read_block(RIGPORT(rig), p, rl);
 
     if (n < 0)
     {
@@ -3343,7 +3341,7 @@ int ft990_send_static_cmd(RIG *rig, unsigned char ci)
         return -RIG_EINVAL;
     }
 
-    err = write_block(&rig->state.rigport, ncmd[ci].nseq, YAESU_CMD_LENGTH);
+    err = write_block(RIGPORT(rig), ncmd[ci].nseq, YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
     {
@@ -3401,7 +3399,7 @@ int ft990_send_dynamic_cmd(RIG *rig, unsigned char ci,
     priv->p_cmd[1] = p3;
     priv->p_cmd[0] = p4;
 
-    err = write_block(&rig->state.rigport, (unsigned char *) &priv->p_cmd,
+    err = write_block(RIGPORT(rig), (unsigned char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -3460,7 +3458,7 @@ int ft990_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
     rig_debug(RIG_DEBUG_TRACE, fmt, __func__, (int64_t)from_bcd(priv->p_cmd,
               FT990_BCD_DIAL) * 10);
 
-    err = write_block(&rig->state.rigport, (unsigned char *) &priv->p_cmd,
+    err = write_block(RIGPORT(rig), (unsigned char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -3525,7 +3523,7 @@ int ft990_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
     // Store bcd format into privat command storage area
     to_bcd(priv->p_cmd, labs(rit) / 10, FT990_BCD_RIT);
 
-    err = write_block(&rig->state.rigport, (unsigned char *) &priv->p_cmd,
+    err = write_block(RIGPORT(rig), (unsigned char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)

--- a/rigs/yaesu/ft990v12.c
+++ b/rigs/yaesu/ft990v12.c
@@ -461,7 +461,6 @@ int ft990v12_cleanup(RIG *rig)
  */
 int  ft990v12_open(RIG *rig)
 {
-    struct rig_state *rig_s;
     struct ft990v12_priv_data *priv;
     int err;
 
@@ -473,12 +472,11 @@ int  ft990v12_open(RIG *rig)
     }
 
     priv = (struct ft990v12_priv_data *)rig->state.priv;
-    rig_s = &rig->state;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: write_delay = %i msec\n",
-              __func__, rig_s->rigport.write_delay);
+              __func__, RIGPORT(rig)->write_delay);
     rig_debug(RIG_DEBUG_TRACE, "%s: post_write_delay = %i msec\n",
-              __func__, rig_s->rigport.post_write_delay);
+              __func__, RIGPORT(rig)->post_write_delay);
     rig_debug(RIG_DEBUG_TRACE,
               "%s: read pacing = %i\n", __func__, priv->pacing);
 
@@ -2462,7 +2460,7 @@ int ft990v12_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *value)
         return err;
     }
 
-    err = read_block(&rig->state.rigport, mdata, FT990_READ_METER_LENGTH);
+    err = read_block(RIGPORT(rig), mdata, FT990_READ_METER_LENGTH);
 
     if (err < 0)
     {
@@ -3318,7 +3316,7 @@ int ft990v12_get_update_data(RIG *rig, unsigned char ci, unsigned short ch)
                 p = (unsigned char *)
                     &priv->update_data; // K1MMI: This seems like 1492 will be saved here
 
-                n = read_block(&rig->state.rigport, p, rl); /* M0EZP: copied here from below */
+                n = read_block(RIGPORT(rig), p, rl); /* M0EZP: copied here from below */
                 return RIG_OK;
                 break;
 
@@ -3382,7 +3380,7 @@ int ft990v12_get_update_data(RIG *rig, unsigned char ci, unsigned short ch)
 
         p = (unsigned char *)&priv->update_data;
         rl = FT990_STATUS_FLAGS_LENGTH; // 5
-        n = read_block(&rig->state.rigport, (unsigned char *)&temp,
+        n = read_block(RIGPORT(rig), (unsigned char *)&temp,
                        rl); /* M0EZP: copied here from below */
 
         if (n < 0)
@@ -3437,7 +3435,7 @@ int ft990v12_send_static_cmd(RIG *rig, unsigned char ci)
         return -RIG_EINVAL;
     }
 
-    err = write_block(&rig->state.rigport, ncmd[ci].nseq, YAESU_CMD_LENGTH);
+    err = write_block(RIGPORT(rig), ncmd[ci].nseq, YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
     {
@@ -3495,7 +3493,7 @@ int ft990v12_send_dynamic_cmd(RIG *rig, unsigned char ci,
     priv->p_cmd[1] = p3;
     priv->p_cmd[0] = p4;
 
-    err = write_block(&rig->state.rigport, (unsigned char *) &priv->p_cmd,
+    err = write_block(RIGPORT(rig), (unsigned char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -3554,7 +3552,7 @@ int ft990v12_send_dial_freq(RIG *rig, unsigned char ci, freq_t freq)
     rig_debug(RIG_DEBUG_TRACE, fmt, __func__, (int64_t)from_bcd(priv->p_cmd,
               FT990_BCD_DIAL) * 10);
 
-    err = write_block(&rig->state.rigport, (unsigned char *) &priv->p_cmd,
+    err = write_block(RIGPORT(rig), (unsigned char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)
@@ -3619,7 +3617,7 @@ int ft990v12_send_rit_freq(RIG *rig, unsigned char ci, shortfreq_t rit)
     // Store bcd format into privat command storage area
     to_bcd(priv->p_cmd, labs(rit) / 10, FT990_BCD_RIT);
 
-    err = write_block(&rig->state.rigport, (unsigned char *) &priv->p_cmd,
+    err = write_block(RIGPORT(rig), (unsigned char *) &priv->p_cmd,
                       YAESU_CMD_LENGTH);
 
     if (err != RIG_OK)

--- a/rigs/yaesu/vr5000.c
+++ b/rigs/yaesu/vr5000.c
@@ -279,13 +279,14 @@ int vr5000_cleanup(RIG *rig)
 int vr5000_open(RIG *rig)
 {
     struct vr5000_priv_data *priv = rig->state.priv;
+    hamlib_port_t *rp = RIGPORT(rig);
     const unsigned char cmd[YAESU_CMD_LENGTH]   = { 0x00, 0x00, 0x00, 0x00, 0x00};
     const unsigned char b_off[YAESU_CMD_LENGTH] = { 0x00, 0x00, 0x00, 0x00, 0x31};
 
     int retval;
 
     /* CAT write command on */
-    retval =  write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    retval =  write_block(rp, cmd, YAESU_CMD_LENGTH);
 
     if (retval != RIG_OK)
     {
@@ -293,7 +294,7 @@ int vr5000_open(RIG *rig)
     }
 
     /* disable RIG_VFO_B  (only on display) */
-    retval =  write_block(&rig->state.rigport, b_off, YAESU_CMD_LENGTH);
+    retval =  write_block(rp, b_off, YAESU_CMD_LENGTH);
 
     if (retval != RIG_OK)
     {
@@ -324,7 +325,7 @@ int vr5000_close(RIG *rig)
 {
     const unsigned char cmd[YAESU_CMD_LENGTH] = { 0x00, 0x00, 0x00, 0x00, 0x80};
 
-    return write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    return write_block(RIGPORT(rig), cmd, YAESU_CMD_LENGTH);
 }
 
 
@@ -402,16 +403,17 @@ int vr5000_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
     unsigned char cmd[YAESU_CMD_LENGTH] = { 0x00, 0x00, 0x00, 0x00, 0xe7};
     int retval;
+    hamlib_port_t *rp = RIGPORT(rig);
 
     if (level != RIG_LEVEL_RAWSTR)
     {
         return -RIG_EINVAL;
     }
 
-    rig_flush(&rig->state.rigport);
+    rig_flush(rp);
 
     /* send READ STATUS(Meter only) cmd to rig  */
-    retval = write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    retval = write_block(rp, cmd, YAESU_CMD_LENGTH);
 
     if (retval < 0)
     {
@@ -419,7 +421,7 @@ int vr5000_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     }
 
     /* read back the 1 byte */
-    retval = read_block(&rig->state.rigport, cmd, 1);
+    retval = read_block(rp, cmd, 1);
 
     if (retval < 1)
     {
@@ -432,7 +434,6 @@ int vr5000_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     val->i = cmd[0] & 0x3f;
     rig_debug(RIG_DEBUG_ERR, "Read(%x) RawValue(%x): \n", cmd[0], val->i);
 
-
     return RIG_OK;
 }
 
@@ -441,11 +442,12 @@ int vr5000_get_dcd(RIG *rig, vfo_t vfo, dcd_t *dcd)
 {
     unsigned char cmd[YAESU_CMD_LENGTH] = { 0x00, 0x00, 0x00, 0x00, 0xe7};
     int retval;
+    hamlib_port_t *rp = RIGPORT(rig);
 
-    rig_flush(&rig->state.rigport);
+    rig_flush(rp);
 
     /* send READ STATUS(Meter only) cmd to rig  */
-    retval = write_block(&rig->state.rigport, cmd, YAESU_CMD_LENGTH);
+    retval = write_block(rp, cmd, YAESU_CMD_LENGTH);
 
     if (retval < 0)
     {
@@ -453,7 +455,7 @@ int vr5000_get_dcd(RIG *rig, vfo_t vfo, dcd_t *dcd)
     }
 
     /* read back the 1 byte */
-    retval = read_block(&rig->state.rigport, cmd, 1);
+    retval = read_block(rp, cmd, 1);
 
     if (retval < 1)
     {
@@ -571,6 +573,7 @@ int set_vr5000(RIG *rig, vfo_t vfo, freq_t freq, rmode_t mode, pbwidth_t width,
                shortfreq_t ts)
 {
     struct vr5000_priv_data *priv = rig->state.priv;
+    hamlib_port_t *rp = RIGPORT(rig);
     unsigned char cmd_mode_ts[YAESU_CMD_LENGTH] = { 0x00, 0x00, 0x00, 0x00, 0x07};
     unsigned char cmd_freq[YAESU_CMD_LENGTH]    = { 0x00, 0x00, 0x00, 0x00, 0x01};
     static const unsigned char steps[] =
@@ -613,8 +616,7 @@ int set_vr5000(RIG *rig, vfo_t vfo, freq_t freq, rmode_t mode, pbwidth_t width,
     /* fill in m2 */
     cmd_mode_ts[1] = steps[i];
 
-    retval =  write_block(&rig->state.rigport, cmd_mode_ts,
-                          YAESU_CMD_LENGTH);
+    retval =  write_block(rp, cmd_mode_ts, YAESU_CMD_LENGTH);
 
     if (retval != RIG_OK)
     {
@@ -633,7 +635,7 @@ int set_vr5000(RIG *rig, vfo_t vfo, freq_t freq, rmode_t mode, pbwidth_t width,
     cmd_freq[3] = frq & 0xff;
 
     /* frequency set */
-    return write_block(&rig->state.rigport, cmd_freq, YAESU_CMD_LENGTH);
+    return write_block(rp, cmd_freq, YAESU_CMD_LENGTH);
 }
 
 

--- a/rigs/yaesu/vx1700.c
+++ b/rigs/yaesu/vx1700.c
@@ -336,7 +336,7 @@ static int vx1700_do_transaction(RIG *rig,
                                  const unsigned char cmd[YAESU_CMD_LENGTH],
                                  unsigned char *retbuf, size_t retbuf_len)
 {
-    struct rig_state    *rs;
+    hamlib_port_t *rp = RIGPORT(rig);
     unsigned char   default_retbuf[1];
     int         retval;
 
@@ -346,15 +346,14 @@ static int vx1700_do_transaction(RIG *rig,
         retbuf_len = sizeof(default_retbuf);
     }
 
-    rs = &rig->state;
     memset(retbuf, 0, retbuf_len);
 
-    rig_flush(&rs->rigport);
-    retval = write_block(&rs->rigport, cmd, YAESU_CMD_LENGTH);
+    rig_flush(rp);
+    retval = write_block(rp, cmd, YAESU_CMD_LENGTH);
 
     if (retval != RIG_OK) { return retval; }
 
-    retval = read_block(&rs->rigport, retbuf, retbuf_len);
+    retval = read_block(rp, retbuf, retbuf_len);
 
     if (retval != retbuf_len)
     {

--- a/src/amp_conf.c
+++ b/src/amp_conf.c
@@ -18,6 +18,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 /**
  * \addtogroup amplifier
@@ -108,6 +109,7 @@ static const struct confparams ampfrontend_serial_cfg_params[] =
 int frontamp_set_conf(AMP *amp, hamlib_token_t token, const char *val)
 {
     struct amp_state *rs;
+    hamlib_port_t *ampp = AMPPORT(amp);
     int val_i;
 
     rs = &amp->state;
@@ -117,7 +119,7 @@ int frontamp_set_conf(AMP *amp, hamlib_token_t token, const char *val)
     switch (token)
     {
     case TOK_PATHNAME:
-        strncpy(rs->ampport.pathname, val, HAMLIB_FILPATHLEN - 1);
+        strncpy(ampp->pathname, val, HAMLIB_FILPATHLEN - 1);
         strncpy(rs->ampport_deprecated.pathname, val, HAMLIB_FILPATHLEN - 1);
         break;
 
@@ -127,7 +129,7 @@ int frontamp_set_conf(AMP *amp, hamlib_token_t token, const char *val)
             return -RIG_EINVAL;
         }
 
-        rs->ampport.write_delay = val_i;
+        ampp->write_delay = val_i;
         rs->ampport_deprecated.write_delay = val_i;
         break;
 
@@ -137,7 +139,7 @@ int frontamp_set_conf(AMP *amp, hamlib_token_t token, const char *val)
             return -RIG_EINVAL;
         }
 
-        rs->ampport.post_write_delay = val_i;
+        ampp->post_write_delay = val_i;
         rs->ampport_deprecated.post_write_delay = val_i;
         break;
 
@@ -147,7 +149,7 @@ int frontamp_set_conf(AMP *amp, hamlib_token_t token, const char *val)
             return -RIG_EINVAL;
         }
 
-        rs->ampport.timeout = val_i;
+        ampp->timeout = val_i;
         rs->ampport_deprecated.timeout = val_i;
         break;
 
@@ -157,12 +159,12 @@ int frontamp_set_conf(AMP *amp, hamlib_token_t token, const char *val)
             return -RIG_EINVAL;
         }
 
-        rs->ampport.retry = val_i;
+        ampp->retry = val_i;
         rs->ampport_deprecated.retry = val_i;
         break;
 
     case TOK_SERIAL_SPEED:
-        if (rs->ampport.type.rig != RIG_PORT_SERIAL)
+        if (ampp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
@@ -172,12 +174,12 @@ int frontamp_set_conf(AMP *amp, hamlib_token_t token, const char *val)
             return -RIG_EINVAL;
         }
 
-        rs->ampport.parm.serial.rate = val_i;
+        ampp->parm.serial.rate = val_i;
         rs->ampport_deprecated.parm.serial.rate = val_i;
         break;
 
     case TOK_DATA_BITS:
-        if (rs->ampport.type.rig != RIG_PORT_SERIAL)
+        if (ampp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
@@ -187,12 +189,12 @@ int frontamp_set_conf(AMP *amp, hamlib_token_t token, const char *val)
             return -RIG_EINVAL;
         }
 
-        rs->ampport.parm.serial.data_bits = val_i;
+        ampp->parm.serial.data_bits = val_i;
         rs->ampport_deprecated.parm.serial.data_bits = val_i;
         break;
 
     case TOK_STOP_BITS:
-        if (rs->ampport.type.rig != RIG_PORT_SERIAL)
+        if (ampp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
@@ -202,127 +204,123 @@ int frontamp_set_conf(AMP *amp, hamlib_token_t token, const char *val)
             return -RIG_EINVAL;
         }
 
-        rs->ampport.parm.serial.stop_bits = val_i;
+        ampp->parm.serial.stop_bits = val_i;
         rs->ampport_deprecated.parm.serial.stop_bits = val_i;
         break;
 
     case TOK_PARITY:
-        if (rs->ampport.type.rig != RIG_PORT_SERIAL)
+        if (ampp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
         if (!strcmp(val, "None"))
         {
-            rs->ampport.parm.serial.parity = RIG_PARITY_NONE;
-            rs->ampport_deprecated.parm.serial.parity = RIG_PARITY_NONE;
+            val_i = RIG_PARITY_NONE;
         }
         else if (!strcmp(val, "Odd"))
         {
-            rs->ampport.parm.serial.parity = RIG_PARITY_ODD;
-            rs->ampport_deprecated.parm.serial.parity = RIG_PARITY_ODD;
+            val_i = RIG_PARITY_ODD;
         }
         else if (!strcmp(val, "Even"))
         {
-            rs->ampport.parm.serial.parity = RIG_PARITY_EVEN;
-            rs->ampport_deprecated.parm.serial.parity = RIG_PARITY_EVEN;
+            val_i = RIG_PARITY_EVEN;
         }
         else if (!strcmp(val, "Mark"))
         {
-            rs->ampport.parm.serial.parity = RIG_PARITY_MARK;
-            rs->ampport_deprecated.parm.serial.parity = RIG_PARITY_MARK;
+            val_i = RIG_PARITY_MARK;
         }
         else if (!strcmp(val, "Space"))
         {
-            rs->ampport.parm.serial.parity = RIG_PARITY_SPACE;
-            rs->ampport_deprecated.parm.serial.parity = RIG_PARITY_SPACE;
+            val_i = RIG_PARITY_SPACE;
         }
         else
         {
             return -RIG_EINVAL;
         }
 
+        ampp->parm.serial.parity = val_i;
+        rs->ampport_deprecated.parm.serial.parity = val_i;
         break;
 
     case TOK_HANDSHAKE:
-        if (rs->ampport.type.rig != RIG_PORT_SERIAL)
+        if (ampp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
         if (!strcmp(val, "None"))
         {
-            rs->ampport.parm.serial.handshake = RIG_HANDSHAKE_NONE;
+            val_i = RIG_HANDSHAKE_NONE;
         }
         else if (!strcmp(val, "XONXOFF"))
         {
-            rs->ampport.parm.serial.handshake = RIG_HANDSHAKE_XONXOFF;
+            val_i = RIG_HANDSHAKE_XONXOFF;
         }
         else if (!strcmp(val, "Hardware"))
         {
-            rs->ampport.parm.serial.handshake = RIG_HANDSHAKE_HARDWARE;
+            val_i = RIG_HANDSHAKE_HARDWARE;
         }
         else
         {
             return -RIG_EINVAL;
         }
 
+        ampp->parm.serial.handshake = val_i;
         break;
 
     case TOK_RTS_STATE:
-        if (rs->ampport.type.rig != RIG_PORT_SERIAL)
+        if (ampp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
         if (!strcmp(val, "Unset"))
         {
-            rs->ampport.parm.serial.rts_state = RIG_SIGNAL_UNSET;
-            rs->ampport_deprecated.parm.serial.rts_state = RIG_SIGNAL_UNSET;
+            val_i = RIG_SIGNAL_UNSET;
         }
         else if (!strcmp(val, "ON"))
         {
-            rs->ampport.parm.serial.rts_state = RIG_SIGNAL_ON;
-            rs->ampport_deprecated.parm.serial.rts_state = RIG_SIGNAL_ON;
+            val_i = RIG_SIGNAL_ON;
         }
         else if (!strcmp(val, "OFF"))
         {
-            rs->ampport.parm.serial.rts_state = RIG_SIGNAL_OFF;
-            rs->ampport_deprecated.parm.serial.rts_state = RIG_SIGNAL_OFF;
+            val_i = RIG_SIGNAL_OFF;
         }
         else
         {
             return -RIG_EINVAL;
         }
 
+        ampp->parm.serial.rts_state = val_i;
+        rs->ampport_deprecated.parm.serial.rts_state = val_i;
         break;
 
     case TOK_DTR_STATE:
-        if (rs->ampport.type.rig != RIG_PORT_SERIAL)
+        if (ampp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
         if (!strcmp(val, "Unset"))
         {
-            rs->ampport.parm.serial.dtr_state = RIG_SIGNAL_UNSET;
-            rs->ampport_deprecated.parm.serial.dtr_state = RIG_SIGNAL_UNSET;
+            val_i = RIG_SIGNAL_UNSET;
         }
         else if (!strcmp(val, "ON"))
         {
-            rs->ampport.parm.serial.dtr_state = RIG_SIGNAL_ON;
-            rs->ampport_deprecated.parm.serial.dtr_state = RIG_SIGNAL_ON;
+            val_i = RIG_SIGNAL_ON;
         }
         else if (!strcmp(val, "OFF"))
         {
-            rs->ampport.parm.serial.dtr_state = RIG_SIGNAL_OFF;
-            rs->ampport_deprecated.parm.serial.dtr_state = RIG_SIGNAL_OFF;
+            val_i = RIG_SIGNAL_OFF;
         }
         else
         {
             return -RIG_EINVAL;
         }
 
+        ampp->parm.serial.dtr_state = val_i;
+        rs->ampport_deprecated.parm.serial.dtr_state = val_i;
         break;
 
 
@@ -373,69 +371,67 @@ int frontamp_set_conf(AMP *amp, hamlib_token_t token, const char *val)
  */
 int frontamp_get_conf2(AMP *amp, hamlib_token_t token, char *val, int val_len)
 {
-    struct amp_state *rs;
+    hamlib_port_t *ampp = AMPPORT(amp);
     const char *s;
-
-    rs = &amp->state;
 
     amp_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
     switch (token)
     {
     case TOK_PATHNAME:
-        strncpy(val, rs->ampport.pathname, val_len - 1);
+        strncpy(val, ampp->pathname, val_len - 1);
         break;
 
     case TOK_WRITE_DELAY:
-        SNPRINTF(val, val_len, "%d", rs->ampport.write_delay);
+        SNPRINTF(val, val_len, "%d", ampp->write_delay);
         break;
 
     case TOK_POST_WRITE_DELAY:
-        SNPRINTF(val, val_len, "%d", rs->ampport.post_write_delay);
+        SNPRINTF(val, val_len, "%d", ampp->post_write_delay);
         break;
 
     case TOK_TIMEOUT:
-        SNPRINTF(val, val_len, "%d", rs->ampport.timeout);
+        SNPRINTF(val, val_len, "%d", ampp->timeout);
         break;
 
     case TOK_RETRY:
-        SNPRINTF(val, val_len, "%d", rs->ampport.retry);
+        SNPRINTF(val, val_len, "%d", ampp->retry);
         break;
 
     case TOK_SERIAL_SPEED:
-        if (rs->ampport.type.rig != RIG_PORT_SERIAL)
+        if (ampp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
-        SNPRINTF(val, val_len, "%d", rs->ampport.parm.serial.rate);
+        SNPRINTF(val, val_len, "%d", ampp->parm.serial.rate);
         break;
 
     case TOK_DATA_BITS:
-        if (rs->ampport.type.rig != RIG_PORT_SERIAL)
+        if (ampp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
-        SNPRINTF(val, val_len, "%d", rs->ampport.parm.serial.data_bits);
+        SNPRINTF(val, val_len, "%d", ampp->parm.serial.data_bits);
         break;
 
     case TOK_STOP_BITS:
-        if (rs->ampport.type.rig != RIG_PORT_SERIAL)
+        if (ampp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
-        SNPRINTF(val, val_len, "%d", rs->ampport.parm.serial.stop_bits);
+        SNPRINTF(val, val_len, "%d", ampp->parm.serial.stop_bits);
         break;
 
     case TOK_PARITY:
-        if (rs->ampport.type.rig != RIG_PORT_SERIAL)
+        if (ampp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
-        switch (rs->ampport.parm.serial.parity)
+        switch (ampp->parm.serial.parity)
         {
         case RIG_PARITY_NONE:
             s = "None";
@@ -465,12 +461,12 @@ int frontamp_get_conf2(AMP *amp, hamlib_token_t token, char *val, int val_len)
         break;
 
     case TOK_HANDSHAKE:
-        if (rs->ampport.type.rig != RIG_PORT_SERIAL)
+        if (ampp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
-        switch (rs->ampport.parm.serial.handshake)
+        switch (ampp->parm.serial.handshake)
         {
         case RIG_HANDSHAKE_NONE:
             s = "None";

--- a/src/cache.c
+++ b/src/cache.c
@@ -65,12 +65,12 @@ int rig_set_cache_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 
     if (vfo == rig->state.current_vfo)
     {
-        rig->state.cache.modeCurr = mode;
+        cachep->modeCurr = mode;
         if (width > 0)
         {
-            rig->state.cache.widthCurr = width;
+            cachep->widthCurr = width;
         }
-        elapsed_ms(&rig->state.cache.time_modeCurr, HAMLIB_ELAPSED_SET);
+        elapsed_ms(&cachep->time_modeCurr, HAMLIB_ELAPSED_SET);
     }
 
     switch (vfo)

--- a/src/cache.c
+++ b/src/cache.c
@@ -19,6 +19,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include "cache.h"
 #include "misc.h"
@@ -33,6 +34,8 @@
 
 int rig_set_cache_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
+    struct rig_cache *cachep = CACHE(rig);
+  
     ENTERFUNC;
 
     rig_cache_show(rig, __func__, __LINE__);
@@ -56,9 +59,9 @@ int rig_set_cache_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     // pick a sane default
     if (vfo == RIG_VFO_NONE || vfo == RIG_VFO_CURR) { vfo = RIG_VFO_A; }
 
-    if (vfo == RIG_VFO_SUB && rig->state.cache.satmode) { vfo = RIG_VFO_SUB_A; };
+    if (vfo == RIG_VFO_SUB && cachep->satmode) { vfo = RIG_VFO_SUB_A; };
 
-    if (vfo == RIG_VFO_OTHER) { vfo = vfo_fixup(rig, vfo, rig->state.cache.split); }
+    if (vfo == RIG_VFO_OTHER) { vfo = vfo_fixup(rig, vfo, cachep->split); }
 
     if (vfo == rig->state.current_vfo)
     {
@@ -73,71 +76,71 @@ int rig_set_cache_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     switch (vfo)
     {
     case RIG_VFO_ALL: // we'll use NONE to reset all VFO caches
-        elapsed_ms(&rig->state.cache.time_modeMainA, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_modeMainB, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_modeMainC, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_modeSubA, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_modeSubB, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_modeSubC, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_widthMainA, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_widthMainB, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_widthMainC, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_widthSubA, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_widthSubB, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_widthSubC, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_modeMainA, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_modeMainB, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_modeMainC, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_modeSubA, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_modeSubB, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_modeSubC, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_widthMainA, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_widthMainB, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_widthMainC, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_widthSubA, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_widthSubB, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_widthSubC, HAMLIB_ELAPSED_INVALIDATE);
         break;
 
     case RIG_VFO_A:
     case RIG_VFO_VFO:
     case RIG_VFO_MAIN:
     case RIG_VFO_MAIN_A:
-        rig->state.cache.modeMainA = mode;
+        cachep->modeMainA = mode;
 
-        if (width > 0) { rig->state.cache.widthMainA = width; }
+        if (width > 0) { cachep->widthMainA = width; }
 
-        elapsed_ms(&rig->state.cache.time_modeMainA, HAMLIB_ELAPSED_SET);
-        elapsed_ms(&rig->state.cache.time_widthMainA, HAMLIB_ELAPSED_SET);
+        elapsed_ms(&cachep->time_modeMainA, HAMLIB_ELAPSED_SET);
+        elapsed_ms(&cachep->time_widthMainA, HAMLIB_ELAPSED_SET);
         break;
 
     case RIG_VFO_B:
     case RIG_VFO_SUB:
     case RIG_VFO_MAIN_B:
-        rig->state.cache.modeMainB = mode;
+        cachep->modeMainB = mode;
 
-        if (width > 0) { rig->state.cache.widthMainB = width; }
+        if (width > 0) { cachep->widthMainB = width; }
 
-        elapsed_ms(&rig->state.cache.time_modeMainB, HAMLIB_ELAPSED_SET);
-        elapsed_ms(&rig->state.cache.time_widthMainB, HAMLIB_ELAPSED_SET);
+        elapsed_ms(&cachep->time_modeMainB, HAMLIB_ELAPSED_SET);
+        elapsed_ms(&cachep->time_widthMainB, HAMLIB_ELAPSED_SET);
         break;
 
     case RIG_VFO_C:
     case RIG_VFO_MAIN_C:
-        rig->state.cache.modeMainC = mode;
+        cachep->modeMainC = mode;
 
-        if (width > 0) { rig->state.cache.widthMainC = width; }
+        if (width > 0) { cachep->widthMainC = width; }
 
-        elapsed_ms(&rig->state.cache.time_modeMainC, HAMLIB_ELAPSED_SET);
-        elapsed_ms(&rig->state.cache.time_widthMainC, HAMLIB_ELAPSED_SET);
+        elapsed_ms(&cachep->time_modeMainC, HAMLIB_ELAPSED_SET);
+        elapsed_ms(&cachep->time_widthMainC, HAMLIB_ELAPSED_SET);
         break;
 
     case RIG_VFO_SUB_A:
-        rig->state.cache.modeSubA = mode;
-        elapsed_ms(&rig->state.cache.time_modeSubA, HAMLIB_ELAPSED_SET);
+        cachep->modeSubA = mode;
+        elapsed_ms(&cachep->time_modeSubA, HAMLIB_ELAPSED_SET);
         break;
 
     case RIG_VFO_SUB_B:
-        rig->state.cache.modeSubB = mode;
-        elapsed_ms(&rig->state.cache.time_modeSubB, HAMLIB_ELAPSED_SET);
+        cachep->modeSubB = mode;
+        elapsed_ms(&cachep->time_modeSubB, HAMLIB_ELAPSED_SET);
         break;
 
     case RIG_VFO_SUB_C:
-        rig->state.cache.modeSubC = mode;
-        elapsed_ms(&rig->state.cache.time_modeSubC, HAMLIB_ELAPSED_SET);
+        cachep->modeSubC = mode;
+        elapsed_ms(&cachep->time_modeSubC, HAMLIB_ELAPSED_SET);
         break;
 
     case RIG_VFO_MEM:
-        rig->state.cache.modeMem = mode;
-        elapsed_ms(&rig->state.cache.time_modeMem, HAMLIB_ELAPSED_SET);
+        cachep->modeMem = mode;
+        elapsed_ms(&cachep->time_modeMem, HAMLIB_ELAPSED_SET);
         break;
 
     default:
@@ -153,6 +156,7 @@ int rig_set_cache_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 int rig_set_cache_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
     int flag = HAMLIB_ELAPSED_SET;
+    struct rig_cache *cachep = CACHE(rig);
 
     if (rig_need_debug(RIG_DEBUG_CACHE))
     {
@@ -175,7 +179,7 @@ int rig_set_cache_freq(RIG *rig, vfo_t vfo, freq_t freq)
     // pick a sane default
     if (vfo == RIG_VFO_NONE || vfo == RIG_VFO_CURR) { vfo = RIG_VFO_A; }
 
-    if (vfo == RIG_VFO_SUB && rig->state.cache.satmode) { vfo = RIG_VFO_SUB_A; };
+    if (vfo == RIG_VFO_SUB && cachep->satmode) { vfo = RIG_VFO_SUB_A; };
 
     if (rig_need_debug(RIG_DEBUG_CACHE))
     {
@@ -186,76 +190,76 @@ int rig_set_cache_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
     if (vfo == rig->state.current_vfo)
     {
-        rig->state.cache.freqCurr = freq;
-        elapsed_ms(&rig->state.cache.time_freqCurr, flag);
+        cachep->freqCurr = freq;
+        elapsed_ms(&cachep->time_freqCurr, flag);
     }
 
     switch (vfo)
     {
     case RIG_VFO_ALL: // we'll use NONE to reset all VFO caches
-        elapsed_ms(&rig->state.cache.time_freqMainA, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_freqMainB, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_freqMainC, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_freqSubA, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_freqSubB, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_freqSubC, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_freqMem, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_vfo, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_modeMainA, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_modeMainB, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_modeMainC, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_modeSubA, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_modeSubB, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_modeSubC, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_widthMainA, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_widthMainB, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_widthMainC, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_widthSubA, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_widthSubB, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_widthSubC, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_ptt, HAMLIB_ELAPSED_INVALIDATE);
-        elapsed_ms(&rig->state.cache.time_split, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_freqMainA, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_freqMainB, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_freqMainC, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_freqSubA, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_freqSubB, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_freqSubC, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_freqMem, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_vfo, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_modeMainA, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_modeMainB, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_modeMainC, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_modeSubA, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_modeSubB, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_modeSubC, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_widthMainA, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_widthMainB, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_widthMainC, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_widthSubA, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_widthSubB, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_widthSubC, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_ptt, HAMLIB_ELAPSED_INVALIDATE);
+        elapsed_ms(&cachep->time_split, HAMLIB_ELAPSED_INVALIDATE);
         break;
 
     case RIG_VFO_A:
     case RIG_VFO_VFO:
     case RIG_VFO_MAIN:
     case RIG_VFO_MAIN_A:
-        rig->state.cache.freqMainA = freq;
-        elapsed_ms(&rig->state.cache.time_freqMainA, flag);
+        cachep->freqMainA = freq;
+        elapsed_ms(&cachep->time_freqMainA, flag);
         break;
 
     case RIG_VFO_B:
     case RIG_VFO_MAIN_B:
     case RIG_VFO_SUB:
-        rig->state.cache.freqMainB = freq;
-        elapsed_ms(&rig->state.cache.time_freqMainB, flag);
+        cachep->freqMainB = freq;
+        elapsed_ms(&cachep->time_freqMainB, flag);
         break;
 
     case RIG_VFO_C:
     case RIG_VFO_MAIN_C:
-        rig->state.cache.freqMainC = freq;
-        elapsed_ms(&rig->state.cache.time_freqMainC, flag);
+        cachep->freqMainC = freq;
+        elapsed_ms(&cachep->time_freqMainC, flag);
         break;
 
     case RIG_VFO_SUB_A:
-        rig->state.cache.freqSubA = freq;
-        elapsed_ms(&rig->state.cache.time_freqSubA, flag);
+        cachep->freqSubA = freq;
+        elapsed_ms(&cachep->time_freqSubA, flag);
         break;
 
     case RIG_VFO_SUB_B:
-        rig->state.cache.freqSubB = freq;
-        elapsed_ms(&rig->state.cache.time_freqSubB, flag);
+        cachep->freqSubB = freq;
+        elapsed_ms(&cachep->time_freqSubB, flag);
         break;
 
     case RIG_VFO_SUB_C:
-        rig->state.cache.freqSubC = freq;
-        elapsed_ms(&rig->state.cache.time_freqSubC, flag);
+        cachep->freqSubC = freq;
+        elapsed_ms(&cachep->time_freqSubC, flag);
         break;
 
     case RIG_VFO_MEM:
-        rig->state.cache.freqMem = freq;
-        elapsed_ms(&rig->state.cache.time_freqMem, flag);
+        cachep->freqMem = freq;
+        elapsed_ms(&cachep->time_freqMem, flag);
         break;
 
     case RIG_VFO_OTHER:
@@ -302,6 +306,8 @@ int rig_set_cache_freq(RIG *rig, vfo_t vfo, freq_t freq)
 int rig_get_cache(RIG *rig, vfo_t vfo, freq_t *freq, int *cache_ms_freq,
                   rmode_t *mode, int *cache_ms_mode, pbwidth_t *width, int *cache_ms_width)
 {
+    struct rig_cache *cachep = CACHE(rig);
+  
     if (CHECK_RIG_ARG(rig) || !freq || !cache_ms_freq ||
             !mode || !cache_ms_mode || !width || !cache_ms_width)
     {
@@ -386,31 +392,31 @@ int rig_get_cache(RIG *rig, vfo_t vfo, freq_t *freq, int *cache_ms_freq,
     if (vfo == RIG_VFO_CURR || vfo == RIG_VFO_NONE) { vfo = RIG_VFO_A; }
 
     // If we're in satmode we map SUB to SUB_A
-    if (vfo == RIG_VFO_SUB && rig->state.cache.satmode) { vfo = RIG_VFO_SUB_A; };
+    if (vfo == RIG_VFO_SUB && cachep->satmode) { vfo = RIG_VFO_SUB_A; };
 
     switch (vfo)
     {
     case RIG_VFO_CURR:
-        *freq = rig->state.cache.freqCurr;
-        *mode = rig->state.cache.modeCurr;
-        *width = rig->state.cache.widthCurr;
-        *cache_ms_freq = elapsed_ms(&rig->state.cache.time_freqCurr,
+        *freq = cachep->freqCurr;
+        *mode = cachep->modeCurr;
+        *width = cachep->widthCurr;
+        *cache_ms_freq = elapsed_ms(&cachep->time_freqCurr,
                                     HAMLIB_ELAPSED_GET);
-        *cache_ms_mode = elapsed_ms(&rig->state.cache.time_modeCurr,
+        *cache_ms_mode = elapsed_ms(&cachep->time_modeCurr,
                                     HAMLIB_ELAPSED_GET);
-        *cache_ms_width = elapsed_ms(&rig->state.cache.time_widthCurr,
+        *cache_ms_width = elapsed_ms(&cachep->time_widthCurr,
                                      HAMLIB_ELAPSED_GET);
         break;
 
     case RIG_VFO_OTHER:
-        *freq = rig->state.cache.freqOther;
-        *mode = rig->state.cache.modeOther;
-        *width = rig->state.cache.widthOther;
-        *cache_ms_freq = elapsed_ms(&rig->state.cache.time_freqOther,
+        *freq = cachep->freqOther;
+        *mode = cachep->modeOther;
+        *width = cachep->widthOther;
+        *cache_ms_freq = elapsed_ms(&cachep->time_freqOther,
                                     HAMLIB_ELAPSED_GET);
-        *cache_ms_mode = elapsed_ms(&rig->state.cache.time_modeOther,
+        *cache_ms_mode = elapsed_ms(&cachep->time_modeOther,
                                     HAMLIB_ELAPSED_GET);
-        *cache_ms_width = elapsed_ms(&rig->state.cache.time_widthOther,
+        *cache_ms_width = elapsed_ms(&cachep->time_widthOther,
                                      HAMLIB_ELAPSED_GET);
         break;
 
@@ -418,87 +424,87 @@ int rig_get_cache(RIG *rig, vfo_t vfo, freq_t *freq, int *cache_ms_freq,
     case RIG_VFO_VFO:
     case RIG_VFO_MAIN:
     case RIG_VFO_MAIN_A:
-        *freq = rig->state.cache.freqMainA;
-        *mode = rig->state.cache.modeMainA;
-        *width = rig->state.cache.widthMainA;
-        *cache_ms_freq = elapsed_ms(&rig->state.cache.time_freqMainA,
+        *freq = cachep->freqMainA;
+        *mode = cachep->modeMainA;
+        *width = cachep->widthMainA;
+        *cache_ms_freq = elapsed_ms(&cachep->time_freqMainA,
                                     HAMLIB_ELAPSED_GET);
-        *cache_ms_mode = elapsed_ms(&rig->state.cache.time_modeMainA,
+        *cache_ms_mode = elapsed_ms(&cachep->time_modeMainA,
                                     HAMLIB_ELAPSED_GET);
-        *cache_ms_width = elapsed_ms(&rig->state.cache.time_widthMainA,
+        *cache_ms_width = elapsed_ms(&cachep->time_widthMainA,
                                      HAMLIB_ELAPSED_GET);
         break;
 
     case RIG_VFO_B:
     case RIG_VFO_SUB:
     case RIG_VFO_MAIN_B:
-        *freq = rig->state.cache.freqMainB;
-        *mode = rig->state.cache.modeMainB;
-        *width = rig->state.cache.widthMainB;
-        *cache_ms_freq = elapsed_ms(&rig->state.cache.time_freqMainB,
+        *freq = cachep->freqMainB;
+        *mode = cachep->modeMainB;
+        *width = cachep->widthMainB;
+        *cache_ms_freq = elapsed_ms(&cachep->time_freqMainB,
                                     HAMLIB_ELAPSED_GET);
-        *cache_ms_mode = elapsed_ms(&rig->state.cache.time_modeMainB,
+        *cache_ms_mode = elapsed_ms(&cachep->time_modeMainB,
                                     HAMLIB_ELAPSED_GET);
-        *cache_ms_width = elapsed_ms(&rig->state.cache.time_widthMainB,
+        *cache_ms_width = elapsed_ms(&cachep->time_widthMainB,
                                      HAMLIB_ELAPSED_GET);
         break;
 
     case RIG_VFO_SUB_A:
-        *freq = rig->state.cache.freqSubA;
-        *mode = rig->state.cache.modeSubA;
-        *width = rig->state.cache.widthSubA;
-        *cache_ms_freq = elapsed_ms(&rig->state.cache.time_freqSubA,
+        *freq = cachep->freqSubA;
+        *mode = cachep->modeSubA;
+        *width = cachep->widthSubA;
+        *cache_ms_freq = elapsed_ms(&cachep->time_freqSubA,
                                     HAMLIB_ELAPSED_GET);
-        *cache_ms_mode = elapsed_ms(&rig->state.cache.time_modeSubA,
+        *cache_ms_mode = elapsed_ms(&cachep->time_modeSubA,
                                     HAMLIB_ELAPSED_GET);
-        *cache_ms_width = elapsed_ms(&rig->state.cache.time_widthSubA,
+        *cache_ms_width = elapsed_ms(&cachep->time_widthSubA,
                                      HAMLIB_ELAPSED_GET);
         break;
 
     case RIG_VFO_SUB_B:
-        *freq = rig->state.cache.freqSubB;
-        *mode = rig->state.cache.modeSubB;
-        *width = rig->state.cache.widthSubB;
-        *cache_ms_freq = elapsed_ms(&rig->state.cache.time_freqSubB,
+        *freq = cachep->freqSubB;
+        *mode = cachep->modeSubB;
+        *width = cachep->widthSubB;
+        *cache_ms_freq = elapsed_ms(&cachep->time_freqSubB,
                                     HAMLIB_ELAPSED_GET);
-        *cache_ms_mode = elapsed_ms(&rig->state.cache.time_modeSubB,
+        *cache_ms_mode = elapsed_ms(&cachep->time_modeSubB,
                                     HAMLIB_ELAPSED_GET);
-        *cache_ms_width = elapsed_ms(&rig->state.cache.time_widthSubB,
+        *cache_ms_width = elapsed_ms(&cachep->time_widthSubB,
                                      HAMLIB_ELAPSED_GET);
         break;
 
     case RIG_VFO_C:
         //case RIG_VFO_MAINC: // not used by any rig yet
-        *freq = rig->state.cache.freqMainC;
-        *mode = rig->state.cache.modeMainC;
-        *width = rig->state.cache.widthMainC;
-        *cache_ms_freq = elapsed_ms(&rig->state.cache.time_freqMainC,
+        *freq = cachep->freqMainC;
+        *mode = cachep->modeMainC;
+        *width = cachep->widthMainC;
+        *cache_ms_freq = elapsed_ms(&cachep->time_freqMainC,
                                     HAMLIB_ELAPSED_GET);
-        *cache_ms_mode = elapsed_ms(&rig->state.cache.time_modeMainC,
+        *cache_ms_mode = elapsed_ms(&cachep->time_modeMainC,
                                     HAMLIB_ELAPSED_GET);
-        *cache_ms_width = elapsed_ms(&rig->state.cache.time_widthMainC,
+        *cache_ms_width = elapsed_ms(&cachep->time_widthMainC,
                                      HAMLIB_ELAPSED_GET);
         break;
 
     case RIG_VFO_SUB_C:
-        *freq = rig->state.cache.freqSubC;
-        *mode = rig->state.cache.modeSubC;
-        *width = rig->state.cache.widthSubC;
-        *cache_ms_freq = elapsed_ms(&rig->state.cache.time_freqSubC,
+        *freq = cachep->freqSubC;
+        *mode = cachep->modeSubC;
+        *width = cachep->widthSubC;
+        *cache_ms_freq = elapsed_ms(&cachep->time_freqSubC,
                                     HAMLIB_ELAPSED_GET);
-        *cache_ms_mode = elapsed_ms(&rig->state.cache.time_modeSubC,
+        *cache_ms_mode = elapsed_ms(&cachep->time_modeSubC,
                                     HAMLIB_ELAPSED_GET);
-        *cache_ms_width = elapsed_ms(&rig->state.cache.time_widthSubC,
+        *cache_ms_width = elapsed_ms(&cachep->time_widthSubC,
                                      HAMLIB_ELAPSED_GET);
         break;
 
     case RIG_VFO_MEM:
-        *freq = rig->state.cache.freqMem;
-        *mode = rig->state.cache.modeMem;
-        *width = rig->state.cache.widthMem;
-        *cache_ms_freq = elapsed_ms(&rig->state.cache.time_freqMem, HAMLIB_ELAPSED_GET);
-        *cache_ms_mode = elapsed_ms(&rig->state.cache.time_modeMem, HAMLIB_ELAPSED_GET);
-        *cache_ms_width = elapsed_ms(&rig->state.cache.time_widthMem,
+        *freq = cachep->freqMem;
+        *mode = cachep->modeMem;
+        *width = cachep->widthMem;
+        *cache_ms_freq = elapsed_ms(&cachep->time_freqMem, HAMLIB_ELAPSED_GET);
+        *cache_ms_mode = elapsed_ms(&cachep->time_modeMem, HAMLIB_ELAPSED_GET);
+        *cache_ms_width = elapsed_ms(&cachep->time_widthMem,
                                      HAMLIB_ELAPSED_GET);
         break;
 
@@ -557,25 +563,27 @@ int rig_get_cache_freq(RIG *rig, vfo_t vfo, freq_t *freq, int *cache_ms_freq_p)
 
 void rig_cache_show(RIG *rig, const char *func, int line)
 {
+    struct rig_cache *cachep = CACHE(rig);
+  
     rig_debug(RIG_DEBUG_CACHE,
               "%s(%d): freqMainA=%.0f, modeMainA=%s, widthMainA=%d\n", func, line,
-              rig->state.cache.freqMainA, rig_strrmode(rig->state.cache.modeMainA),
-              (int)rig->state.cache.widthMainA);
+              cachep->freqMainA, rig_strrmode(cachep->modeMainA),
+              (int)cachep->widthMainA);
     rig_debug(RIG_DEBUG_CACHE,
               "%s(%d): freqMainB=%.0f, modeMainB=%s, widthMainB=%d\n", func, line,
-              rig->state.cache.freqMainB, rig_strrmode(rig->state.cache.modeMainB),
-              (int)rig->state.cache.widthMainB);
+              cachep->freqMainB, rig_strrmode(cachep->modeMainB),
+              (int)cachep->widthMainB);
 
     if (rig->state.vfo_list & RIG_VFO_SUB_A)
     {
         rig_debug(RIG_DEBUG_CACHE,
                   "%s(%d): freqSubA=%.0f, modeSubA=%s, widthSubA=%d\n", func, line,
-                  rig->state.cache.freqSubA, rig_strrmode(rig->state.cache.modeSubA),
-                  (int)rig->state.cache.widthSubA);
+                  cachep->freqSubA, rig_strrmode(cachep->modeSubA),
+                  (int)cachep->widthSubA);
         rig_debug(RIG_DEBUG_CACHE,
                   "%s(%d): freqSubB=%.0f, modeSubB=%s, widthSubB=%d\n", func, line,
-                  rig->state.cache.freqSubB, rig_strrmode(rig->state.cache.modeSubB),
-                  (int)rig->state.cache.widthSubB);
+                  cachep->freqSubB, rig_strrmode(cachep->modeSubB),
+                  (int)cachep->widthSubB);
     }
 }
 

--- a/src/event.c
+++ b/src/event.c
@@ -69,6 +69,7 @@ void *rig_poll_routine(void *arg)
     rig_poll_routine_args *args = (rig_poll_routine_args *)arg;
     RIG *rig = args->rig;
     struct rig_state *rs = &rig->state;
+    struct rig_cache *cachep = CACHE(rig);
     int update_occurred;
 
     vfo_t vfo = RIG_VFO_NONE, tx_vfo = RIG_VFO_NONE;
@@ -109,123 +110,123 @@ void *rig_poll_routine(void *arg)
             update_occurred = 1;
         }
 
-        if (rig->state.cache.freqMainA != freq_main_a)
+        if (cachep->freqMainA != freq_main_a)
         {
-            freq_main_a = rig->state.cache.freqMainA;
+            freq_main_a = cachep->freqMainA;
             update_occurred = 1;
         }
 
-        if (rig->state.cache.freqMainB != freq_main_b)
+        if (cachep->freqMainB != freq_main_b)
         {
-            freq_main_b = rig->state.cache.freqMainB;
+            freq_main_b = cachep->freqMainB;
             update_occurred = 1;
         }
 
-        if (rig->state.cache.freqMainC != freq_main_c)
+        if (cachep->freqMainC != freq_main_c)
         {
-            freq_main_b = rig->state.cache.freqMainC;
+            freq_main_b = cachep->freqMainC;
             update_occurred = 1;
         }
 
-        if (rig->state.cache.freqSubA != freq_sub_a)
+        if (cachep->freqSubA != freq_sub_a)
         {
-            freq_sub_a = rig->state.cache.freqSubA;
+            freq_sub_a = cachep->freqSubA;
             update_occurred = 1;
         }
 
-        if (rig->state.cache.freqSubB != freq_sub_b)
+        if (cachep->freqSubB != freq_sub_b)
         {
-            freq_sub_b = rig->state.cache.freqSubB;
+            freq_sub_b = cachep->freqSubB;
             update_occurred = 1;
         }
 
-        if (rig->state.cache.freqSubC != freq_sub_c)
+        if (cachep->freqSubC != freq_sub_c)
         {
-            freq_sub_c = rig->state.cache.freqSubC;
+            freq_sub_c = cachep->freqSubC;
             update_occurred = 1;
         }
 
-        if (rig->state.cache.ptt != ptt)
+        if (cachep->ptt != ptt)
         {
-            ptt = rig->state.cache.ptt;
+            ptt = cachep->ptt;
             update_occurred = 1;
         }
 
-        if (rig->state.cache.split != split)
+        if (cachep->split != split)
         {
-            split = rig->state.cache.split;
+            split = cachep->split;
             update_occurred = 1;
         }
 
-        if (rig->state.cache.modeMainA != mode_main_a)
+        if (cachep->modeMainA != mode_main_a)
         {
-            mode_main_a = rig->state.cache.modeMainA;
+            mode_main_a = cachep->modeMainA;
             update_occurred = 1;
         }
 
-        if (rig->state.cache.modeMainB != mode_main_b)
+        if (cachep->modeMainB != mode_main_b)
         {
-            mode_main_b = rig->state.cache.modeMainB;
+            mode_main_b = cachep->modeMainB;
             update_occurred = 1;
         }
 
-        if (rig->state.cache.modeMainC != mode_main_c)
+        if (cachep->modeMainC != mode_main_c)
         {
-            mode_main_c = rig->state.cache.modeMainC;
+            mode_main_c = cachep->modeMainC;
             update_occurred = 1;
         }
 
-        if (rig->state.cache.modeSubA != mode_sub_a)
+        if (cachep->modeSubA != mode_sub_a)
         {
-            mode_sub_a = rig->state.cache.modeSubA;
+            mode_sub_a = cachep->modeSubA;
             update_occurred = 1;
         }
 
-        if (rig->state.cache.modeSubB != mode_sub_b)
+        if (cachep->modeSubB != mode_sub_b)
         {
-            mode_sub_b = rig->state.cache.modeSubB;
+            mode_sub_b = cachep->modeSubB;
             update_occurred = 1;
         }
 
-        if (rig->state.cache.modeSubC != mode_sub_c)
+        if (cachep->modeSubC != mode_sub_c)
         {
-            mode_sub_c = rig->state.cache.modeSubC;
+            mode_sub_c = cachep->modeSubC;
             update_occurred = 1;
         }
 
-        if (rig->state.cache.widthMainA != width_main_a)
+        if (cachep->widthMainA != width_main_a)
         {
-            width_main_a = rig->state.cache.widthMainA;
+            width_main_a = cachep->widthMainA;
             update_occurred = 1;
         }
 
-        if (rig->state.cache.widthMainB != width_main_b)
+        if (cachep->widthMainB != width_main_b)
         {
-            width_main_b = rig->state.cache.widthMainB;
+            width_main_b = cachep->widthMainB;
             update_occurred = 1;
         }
 
-        if (rig->state.cache.widthMainC != width_main_c)
+        if (cachep->widthMainC != width_main_c)
         {
-            width_main_c = rig->state.cache.widthMainC;
+            width_main_c = cachep->widthMainC;
             update_occurred = 1;
         }
 
-        if (rig->state.cache.widthSubA != width_sub_a)
+        if (cachep->widthSubA != width_sub_a)
         {
-            width_sub_a = rig->state.cache.widthSubA;
+            width_sub_a = cachep->widthSubA;
             update_occurred = 1;
         }
 
-        if (rig->state.cache.widthSubB != width_sub_b)
+        if (cachep->widthSubB != width_sub_b)
         {
-            width_sub_b = rig->state.cache.widthSubB;
+            width_sub_b = cachep->widthSubB;
             update_occurred = 1;
         }
 
-        if (rig->state.cache.widthSubC != width_sub_c)
+        if (cachep->widthSubC != width_sub_c)
         {
-            width_sub_c = rig->state.cache.widthSubC;
+            width_sub_c = cachep->widthSubC;
             update_occurred = 1;
         }
 
@@ -669,12 +670,13 @@ int rig_fire_mode_event(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 #if defined(HAVE_PTHREAD)
 int rig_fire_vfo_event(RIG *rig, vfo_t vfo)
 {
+    struct rig_cache *cachep = CACHE(rig);
     ENTERFUNC;
 
     rig_debug(RIG_DEBUG_TRACE, "Event: vfo changed to %s\n", rig_strvfo(vfo));
 
-    rig->state.cache.vfo = vfo;
-    elapsed_ms(&rig->state.cache.time_vfo, HAMLIB_ELAPSED_SET);
+    cachep->vfo = vfo;
+    elapsed_ms(&cachep->time_vfo, HAMLIB_ELAPSED_SET);
 
     network_publish_rig_transceive_data(rig);
 
@@ -691,13 +693,14 @@ int rig_fire_vfo_event(RIG *rig, vfo_t vfo)
 #if defined(HAVE_PTHREAD)
 int rig_fire_ptt_event(RIG *rig, vfo_t vfo, ptt_t ptt)
 {
+    struct rig_cache *cachep = CACHE(rig);
     ENTERFUNC;
 
     rig_debug(RIG_DEBUG_TRACE, "Event: PTT changed to %i on %s\n", ptt,
               rig_strvfo(vfo));
 
-    rig->state.cache.ptt = ptt;
-    elapsed_ms(&rig->state.cache.time_ptt, HAMLIB_ELAPSED_SET);
+    cachep->ptt = ptt;
+    elapsed_ms(&cachep->time_ptt, HAMLIB_ELAPSED_SET);
 
     network_publish_rig_transceive_data(rig);
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -1975,7 +1975,7 @@ double HAMLIB_API elapsed_ms(struct timespec *start, int option)
 int HAMLIB_API rig_get_cache_timeout_ms(RIG *rig, hamlib_cache_t selection)
 {
     rig_debug(RIG_DEBUG_TRACE, "%s: called selection=%d\n", __func__, selection);
-    return rig->state.cache.timeout_ms;
+    return CACHE(rig)->timeout_ms;
 }
 
 int HAMLIB_API rig_set_cache_timeout_ms(RIG *rig, hamlib_cache_t selection,
@@ -1983,7 +1983,7 @@ int HAMLIB_API rig_set_cache_timeout_ms(RIG *rig, hamlib_cache_t selection,
 {
     rig_debug(RIG_DEBUG_TRACE, "%s: called selection=%d, ms=%d\n", __func__,
               selection, ms);
-    rig->state.cache.timeout_ms = ms;
+    CACHE(rig)->timeout_ms = ms;
     return RIG_OK;
 }
 
@@ -2092,7 +2092,7 @@ vfo_t HAMLIB_API vfo_fixup(RIG *rig, vfo_t vfo, split_t split)
     }
     else if (vfo == RIG_VFO_TX)
     {
-        int satmode = rig->state.cache.satmode;
+        int satmode = CACHE(rig)->satmode;
 
         rig_debug(RIG_DEBUG_VERBOSE, "%s(%d): split=%d, vfo==%s tx_vfo=%s\n", __func__,
                   __LINE__, split, rig_strvfo(vfo), rig_strvfo(rig->state.tx_vfo));

--- a/src/misc.h
+++ b/src/misc.h
@@ -177,25 +177,25 @@ void errmsg(int err, char *s, const char *func, const char *file, int line);
                        } while(0);}
 
 #define CACHE_RESET {\
-    elapsed_ms(&rig->state.cache.time_freqMainA, HAMLIB_ELAPSED_INVALIDATE);\
-    elapsed_ms(&rig->state.cache.time_freqMainB, HAMLIB_ELAPSED_INVALIDATE);\
-    elapsed_ms(&rig->state.cache.time_freqSubA, HAMLIB_ELAPSED_INVALIDATE);\
-    elapsed_ms(&rig->state.cache.time_freqSubB, HAMLIB_ELAPSED_INVALIDATE);\
-    elapsed_ms(&rig->state.cache.time_vfo, HAMLIB_ELAPSED_INVALIDATE);\
-    elapsed_ms(&rig->state.cache.time_modeMainA, HAMLIB_ELAPSED_INVALIDATE);\
-    elapsed_ms(&rig->state.cache.time_modeMainB, HAMLIB_ELAPSED_INVALIDATE);\
-    elapsed_ms(&rig->state.cache.time_modeMainC, HAMLIB_ELAPSED_INVALIDATE);\
-    elapsed_ms(&rig->state.cache.time_modeSubA, HAMLIB_ELAPSED_INVALIDATE);\
-    elapsed_ms(&rig->state.cache.time_modeSubB, HAMLIB_ELAPSED_INVALIDATE);\
-    elapsed_ms(&rig->state.cache.time_modeSubC, HAMLIB_ELAPSED_INVALIDATE);\
-    elapsed_ms(&rig->state.cache.time_widthMainA, HAMLIB_ELAPSED_INVALIDATE);\
-    elapsed_ms(&rig->state.cache.time_widthMainB, HAMLIB_ELAPSED_INVALIDATE);\
-    elapsed_ms(&rig->state.cache.time_widthMainC, HAMLIB_ELAPSED_INVALIDATE);\
-    elapsed_ms(&rig->state.cache.time_widthSubA, HAMLIB_ELAPSED_INVALIDATE);\
-    elapsed_ms(&rig->state.cache.time_widthSubB, HAMLIB_ELAPSED_INVALIDATE);\
-    elapsed_ms(&rig->state.cache.time_widthSubC, HAMLIB_ELAPSED_INVALIDATE);\
-    elapsed_ms(&rig->state.cache.time_ptt, HAMLIB_ELAPSED_INVALIDATE);\
-    elapsed_ms(&rig->state.cache.time_split, HAMLIB_ELAPSED_INVALIDATE);\
+    elapsed_ms(&CACHE(rig)->time_freqMainA, HAMLIB_ELAPSED_INVALIDATE);\
+    elapsed_ms(&CACHE(rig)->time_freqMainB, HAMLIB_ELAPSED_INVALIDATE);\
+    elapsed_ms(&CACHE(rig)->time_freqSubA, HAMLIB_ELAPSED_INVALIDATE);\
+    elapsed_ms(&CACHE(rig)->time_freqSubB, HAMLIB_ELAPSED_INVALIDATE);\
+    elapsed_ms(&CACHE(rig)->time_vfo, HAMLIB_ELAPSED_INVALIDATE);\
+    elapsed_ms(&CACHE(rig)->time_modeMainA, HAMLIB_ELAPSED_INVALIDATE);\
+    elapsed_ms(&CACHE(rig)->time_modeMainB, HAMLIB_ELAPSED_INVALIDATE);\
+    elapsed_ms(&CACHE(rig)->time_modeMainC, HAMLIB_ELAPSED_INVALIDATE);\
+    elapsed_ms(&CACHE(rig)->time_modeSubA, HAMLIB_ELAPSED_INVALIDATE);\
+    elapsed_ms(&CACHE(rig)->time_modeSubB, HAMLIB_ELAPSED_INVALIDATE);\
+    elapsed_ms(&CACHE(rig)->time_modeSubC, HAMLIB_ELAPSED_INVALIDATE);\
+    elapsed_ms(&CACHE(rig)->time_widthMainA, HAMLIB_ELAPSED_INVALIDATE);\
+    elapsed_ms(&CACHE(rig)->time_widthMainB, HAMLIB_ELAPSED_INVALIDATE);\
+    elapsed_ms(&CACHE(rig)->time_widthMainC, HAMLIB_ELAPSED_INVALIDATE);\
+    elapsed_ms(&CACHE(rig)->time_widthSubA, HAMLIB_ELAPSED_INVALIDATE);\
+    elapsed_ms(&CACHE(rig)->time_widthSubB, HAMLIB_ELAPSED_INVALIDATE);\
+    elapsed_ms(&CACHE(rig)->time_widthSubC, HAMLIB_ELAPSED_INVALIDATE);\
+    elapsed_ms(&CACHE(rig)->time_ptt, HAMLIB_ELAPSED_INVALIDATE);\
+    elapsed_ms(&CACHE(rig)->time_split, HAMLIB_ELAPSED_INVALIDATE);\
      }
 
 

--- a/src/rig.c
+++ b/src/rig.c
@@ -3301,6 +3301,7 @@ int HAMLIB_API rig_set_vfo(RIG *rig, vfo_t vfo)
 int HAMLIB_API rig_get_vfo(RIG *rig, vfo_t *vfo)
 {
     const struct rig_caps *caps;
+    struct rig_cache *cachep = CACHE(rig);
     int retcode = -RIG_EINTERNAL;
     int cache_ms;
 

--- a/src/rig.c
+++ b/src/rig.c
@@ -4527,8 +4527,7 @@ int HAMLIB_API rig_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
     // Always use the previously selected TX VFO for split. The targeted VFO will have no effect.
     tx_vfo = rs->tx_vfo;
 
-    if (rs->cache.split == RIG_SPLIT_OFF || tx_vfo == RIG_VFO_NONE
-            || tx_vfo == RIG_VFO_CURR)
+    if (cachep->split == RIG_SPLIT_OFF || tx_vfo == RIG_VFO_NONE || tx_vfo == RIG_VFO_CURR)
     {
         // Turn split on if not enabled already
         retcode = rig_set_split_vfo(rig, rs->current_vfo, RIG_SPLIT_ON, vfo_fixup(rig,
@@ -4599,7 +4598,7 @@ int HAMLIB_API rig_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
 
     // Assisted mode: Swap VFOs and try either set_split_freq or set_freq
     curr_vfo = rs->current_vfo;
-    vfo = vfo_fixup(rig, vfo, rs->cache.split);
+    vfo = vfo_fixup(rig, vfo, cachep->split);
 
     if (caps->set_vfo)
     {
@@ -4692,6 +4691,7 @@ int HAMLIB_API rig_get_split_freq(RIG *rig, vfo_t vfo, freq_t *tx_freq)
 {
     const struct rig_caps *caps;
     const struct rig_state *rs;
+    struct rig_cache *cachep = CACHE(rig);
     int retcode = -RIG_EPROTO, rc2;
     vfo_t tx_vfo;
 
@@ -4716,8 +4716,7 @@ int HAMLIB_API rig_get_split_freq(RIG *rig, vfo_t vfo, freq_t *tx_freq)
     // Always use the previously selected TX VFO for split. The targeted VFO will have no effect.
     tx_vfo = rs->tx_vfo;
 
-    if (rs->cache.split == RIG_SPLIT_OFF || tx_vfo == RIG_VFO_NONE
-            || tx_vfo == RIG_VFO_CURR)
+    if (cachep->split == RIG_SPLIT_OFF || tx_vfo == RIG_VFO_NONE || tx_vfo == RIG_VFO_CURR)
     {
         // Split frequency not available if split is off
         *tx_freq = 0;
@@ -4756,7 +4755,7 @@ int HAMLIB_API rig_get_split_freq(RIG *rig, vfo_t vfo, freq_t *tx_freq)
     }
 
     // Assisted mode: Swap VFOs and try either get_split_freq or get_freq
-    vfo = vfo_fixup(rig, vfo, rs->cache.split);
+    vfo = vfo_fixup(rig, vfo, cachep->split);
 
     if (caps->set_vfo)
     {
@@ -4893,8 +4892,7 @@ int HAMLIB_API rig_set_split_mode(RIG *rig,
     // Always use the previously selected TX VFO for split. The targeted VFO will have no effect.
     tx_vfo = rs->tx_vfo;
 
-    if (rs->cache.split == RIG_SPLIT_OFF || tx_vfo == RIG_VFO_NONE
-            || tx_vfo == RIG_VFO_CURR)
+    if (cachep->split == RIG_SPLIT_OFF || tx_vfo == RIG_VFO_NONE || tx_vfo == RIG_VFO_CURR)
     {
         // Turn split on if not enabled already
         retcode = rig_set_split_vfo(rig, rs->current_vfo, RIG_SPLIT_ON, vfo_fixup(rig,
@@ -5105,6 +5103,7 @@ int HAMLIB_API rig_get_split_mode(RIG *rig, vfo_t vfo, rmode_t *tx_mode,
 {
     const struct rig_caps *caps;
     const struct rig_state *rs;
+    struct rig_cache *cachep = CACHE(rig);
     int retcode, rc2;
     vfo_t curr_vfo, tx_vfo;
 
@@ -5129,8 +5128,7 @@ int HAMLIB_API rig_get_split_mode(RIG *rig, vfo_t vfo, rmode_t *tx_mode,
     // Always use the previously selected TX VFO for split. The targeted VFO will have no effect.
     tx_vfo = rs->tx_vfo;
 
-    if (rs->cache.split == RIG_SPLIT_OFF || tx_vfo == RIG_VFO_NONE
-            || tx_vfo == RIG_VFO_CURR)
+    if (cachep->split == RIG_SPLIT_OFF || tx_vfo == RIG_VFO_NONE || tx_vfo == RIG_VFO_CURR)
     {
         // Split mode and filter width are not available if split is off
         *tx_mode = RIG_MODE_NONE;
@@ -5289,8 +5287,7 @@ int HAMLIB_API rig_set_split_freq_mode(RIG *rig,
     // Always use the previously selected TX VFO for split. The targeted VFO will have no effect.
     tx_vfo = rs->tx_vfo;
 
-    if (rs->cache.split == RIG_SPLIT_OFF || tx_vfo == RIG_VFO_NONE
-            || tx_vfo == RIG_VFO_CURR)
+    if (cachep->split == RIG_SPLIT_OFF || tx_vfo == RIG_VFO_NONE || tx_vfo == RIG_VFO_CURR)
     {
         // Turn split on if not enabled already
         retcode = rig_set_split_vfo(rig, rs->current_vfo, RIG_SPLIT_ON, vfo_fixup(rig,
@@ -5411,6 +5408,7 @@ int HAMLIB_API rig_get_split_freq_mode(RIG *rig,
 {
     const struct rig_caps *caps;
     const struct rig_state *rs;
+    struct rig_cache *cachep = CACHE(rig);
     vfo_t tx_vfo;
     int retcode;
 
@@ -5435,8 +5433,7 @@ int HAMLIB_API rig_get_split_freq_mode(RIG *rig,
     // Always use the previously selected TX VFO for split. The targeted VFO will have no effect.
     tx_vfo = rs->tx_vfo;
 
-    if (rs->cache.split == RIG_SPLIT_OFF || tx_vfo == RIG_VFO_NONE
-            || tx_vfo == RIG_VFO_CURR)
+    if (cachep->split == RIG_SPLIT_OFF || tx_vfo == RIG_VFO_NONE || tx_vfo == RIG_VFO_CURR)
     {
         // Split frequency, mode and filter width are not available if split is off
         *tx_freq = 0;
@@ -5634,17 +5631,16 @@ int HAMLIB_API rig_set_split_vfo(RIG *rig,
         {
             // Only update cache on success
             rs->rx_vfo = rs->current_vfo;
-            rs->cache.split = split;
-
+            cachep->split = split;
             if (split == RIG_SPLIT_OFF)
             {
                 rs->tx_vfo = rs->current_vfo;
-                rs->cache.split_vfo = rs->current_vfo;
+                cachep->split_vfo = rs->current_vfo;
             }
             else
             {
                 rs->tx_vfo = tx_vfo;
-                rs->cache.split_vfo = tx_vfo;
+                cachep->split_vfo = tx_vfo;
             }
         }
 
@@ -5693,28 +5689,27 @@ int HAMLIB_API rig_set_split_vfo(RIG *rig,
     if (retcode == RIG_OK)
     {
         // Only update cache on success
-        rs->cache.split = split;
-
+        cachep->split = split;
         if (split == RIG_SPLIT_OFF)
         {
             if (caps->targetable_vfo & RIG_TARGETABLE_FREQ)
             {
                 rs->rx_vfo = rx_vfo;
                 rs->tx_vfo = rx_vfo;
-                rs->cache.split_vfo = rx_vfo;
+                cachep->split_vfo = rx_vfo;
             }
             else
             {
                 rs->rx_vfo = rs->current_vfo;
                 rs->tx_vfo = rs->current_vfo;
-                rs->cache.split_vfo = rs->current_vfo;
+                cachep->split_vfo = rs->current_vfo;
             }
         }
         else
         {
             rs->rx_vfo = rx_vfo;
             rs->tx_vfo = tx_vfo;
-            rs->cache.split_vfo = tx_vfo;
+            cachep->split_vfo = tx_vfo;
         }
     }
 
@@ -5806,8 +5801,8 @@ int HAMLIB_API rig_get_split_vfo(RIG *rig,
     {
         // Only update cache on success
         rs->tx_vfo = *tx_vfo;
-        cachep-split = *split;
-        cachep-split_vfo = *tx_vfo;
+        cachep->split = *split;
+        cachep->split_vfo = *tx_vfo;
         elapsed_ms(&cachep->time_split, HAMLIB_ELAPSED_SET);
         rig_debug(RIG_DEBUG_TRACE, "%s(%d): cache.split=%d\n", __func__, __LINE__,
                   cachep->split);

--- a/src/rot_conf.c
+++ b/src/rot_conf.c
@@ -18,6 +18,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 /**
  * \addtogroup rotator
@@ -139,6 +140,7 @@ static const struct confparams rotfrontend_serial_cfg_params[] =
 int frontrot_set_conf(ROT *rot, hamlib_token_t token, const char *val)
 {
     struct rot_state *rs;
+    hamlib_port_t *rotp = ROTPORT(rot);
     int val_i;
 
     rs = &rot->state;
@@ -148,7 +150,7 @@ int frontrot_set_conf(ROT *rot, hamlib_token_t token, const char *val)
     switch (token)
     {
     case TOK_PATHNAME:
-        strncpy(rs->rotport.pathname, val, HAMLIB_FILPATHLEN - 1);
+        strncpy(rotp->pathname, val, HAMLIB_FILPATHLEN - 1);
         strncpy(rs->rotport_deprecated.pathname, val, HAMLIB_FILPATHLEN - 1);
         break;
 
@@ -158,7 +160,7 @@ int frontrot_set_conf(ROT *rot, hamlib_token_t token, const char *val)
             return -RIG_EINVAL;
         }
 
-        rs->rotport.write_delay = val_i;
+        rotp->write_delay = val_i;
         rs->rotport_deprecated.write_delay = val_i;
         break;
 
@@ -168,7 +170,7 @@ int frontrot_set_conf(ROT *rot, hamlib_token_t token, const char *val)
             return -RIG_EINVAL;
         }
 
-        rs->rotport.post_write_delay = val_i;
+        rotp->post_write_delay = val_i;
         rs->rotport_deprecated.post_write_delay = val_i;
         break;
 
@@ -178,7 +180,7 @@ int frontrot_set_conf(ROT *rot, hamlib_token_t token, const char *val)
             return -RIG_EINVAL;
         }
 
-        rs->rotport.timeout = val_i;
+        rotp->timeout = val_i;
         rs->rotport_deprecated.timeout = val_i;
         break;
 
@@ -188,12 +190,12 @@ int frontrot_set_conf(ROT *rot, hamlib_token_t token, const char *val)
             return -RIG_EINVAL;
         }
 
-        rs->rotport.retry = val_i;
+        rotp->retry = val_i;
         rs->rotport_deprecated.retry = val_i;
         break;
 
     case TOK_SERIAL_SPEED:
-        if (rs->rotport.type.rig != RIG_PORT_SERIAL)
+        if (rotp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
@@ -203,12 +205,12 @@ int frontrot_set_conf(ROT *rot, hamlib_token_t token, const char *val)
             return -RIG_EINVAL;
         }
 
-        rs->rotport.parm.serial.rate = val_i;
+        rotp->parm.serial.rate = val_i;
         rs->rotport_deprecated.parm.serial.rate = val_i;
         break;
 
     case TOK_DATA_BITS:
-        if (rs->rotport.type.rig != RIG_PORT_SERIAL)
+        if (rotp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
@@ -218,12 +220,12 @@ int frontrot_set_conf(ROT *rot, hamlib_token_t token, const char *val)
             return -RIG_EINVAL;
         }
 
-        rs->rotport.parm.serial.data_bits = val_i;
+        rotp->parm.serial.data_bits = val_i;
         rs->rotport_deprecated.parm.serial.data_bits = val_i;
         break;
 
     case TOK_STOP_BITS:
-        if (rs->rotport.type.rig != RIG_PORT_SERIAL)
+        if (rotp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
@@ -233,78 +235,74 @@ int frontrot_set_conf(ROT *rot, hamlib_token_t token, const char *val)
             return -RIG_EINVAL;
         }
 
-        rs->rotport.parm.serial.stop_bits = val_i;
+        rotp->parm.serial.stop_bits = val_i;
         rs->rotport_deprecated.parm.serial.stop_bits = val_i;
         break;
 
     case TOK_PARITY:
-        if (rs->rotport.type.rig != RIG_PORT_SERIAL)
+        if (rotp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
         if (!strcmp(val, "None"))
         {
-            rs->rotport.parm.serial.parity = RIG_PARITY_NONE;
-            rs->rotport_deprecated.parm.serial.parity = RIG_PARITY_NONE;
+            val_i = RIG_PARITY_NONE;
         }
         else if (!strcmp(val, "Odd"))
         {
-            rs->rotport.parm.serial.parity = RIG_PARITY_ODD;
-            rs->rotport_deprecated.parm.serial.parity = RIG_PARITY_ODD;
+            val_i = RIG_PARITY_ODD;
         }
         else if (!strcmp(val, "Even"))
         {
-            rs->rotport.parm.serial.parity = RIG_PARITY_EVEN;
-            rs->rotport_deprecated.parm.serial.parity = RIG_PARITY_EVEN;
+            val_i = RIG_PARITY_EVEN;
         }
         else if (!strcmp(val, "Mark"))
         {
-            rs->rotport.parm.serial.parity = RIG_PARITY_MARK;
-            rs->rotport_deprecated.parm.serial.parity = RIG_PARITY_MARK;
+            val_i = RIG_PARITY_MARK;
         }
         else if (!strcmp(val, "Space"))
         {
-            rs->rotport.parm.serial.parity = RIG_PARITY_SPACE;
-            rs->rotport_deprecated.parm.serial.parity = RIG_PARITY_SPACE;
+            val_i = RIG_PARITY_SPACE;
         }
         else
         {
             return -RIG_EINVAL;
         }
 
+        rotp->parm.serial.parity = val_i;
+        rs->rotport_deprecated.parm.serial.parity = val_i;
         break;
 
     case TOK_HANDSHAKE:
-        if (rs->rotport.type.rig != RIG_PORT_SERIAL)
+        if (rotp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
         if (!strcmp(val, "None"))
         {
-            rs->rotport.parm.serial.handshake = RIG_HANDSHAKE_NONE;
-            rs->rotport_deprecated.parm.serial.handshake = RIG_HANDSHAKE_NONE;
+            val_i = RIG_HANDSHAKE_NONE;
         }
         else if (!strcmp(val, "XONXOFF"))
         {
-            rs->rotport.parm.serial.handshake = RIG_HANDSHAKE_XONXOFF;
-            rs->rotport_deprecated.parm.serial.handshake = RIG_HANDSHAKE_XONXOFF;
+            val_i = RIG_HANDSHAKE_XONXOFF;
         }
         else if (!strcmp(val, "Hardware"))
         {
-            rs->rotport.parm.serial.handshake = RIG_HANDSHAKE_HARDWARE;
-            rs->rotport_deprecated.parm.serial.handshake = RIG_HANDSHAKE_HARDWARE;
+            val_i = RIG_HANDSHAKE_HARDWARE;
         }
         else
         {
             return -RIG_EINVAL;
         }
 
+        rotp->parm.serial.handshake = val_i;
+        rs->rotport_deprecated.parm.serial.handshake = val_i;
         break;
 
     case TOK_FLUSHX:
-        rs->rotport.flushx = atoi(val);
+        rotp->flushx = atoi(val);
         rs->rotport_deprecated.flushx = atoi(val);
         break;
 
@@ -330,59 +328,57 @@ int frontrot_set_conf(ROT *rot, hamlib_token_t token, const char *val)
 
 
     case TOK_RTS_STATE:
-        if (rs->rotport.type.rig != RIG_PORT_SERIAL)
+        if (rotp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
         if (!strcmp(val, "Unset"))
         {
-            rs->rotport.parm.serial.rts_state = RIG_SIGNAL_UNSET;
-            rs->rotport_deprecated.parm.serial.rts_state = RIG_SIGNAL_UNSET;
+            val_i = RIG_SIGNAL_UNSET;
         }
         else if (!strcmp(val, "ON"))
         {
-            rs->rotport.parm.serial.rts_state = RIG_SIGNAL_ON;
-            rs->rotport_deprecated.parm.serial.rts_state = RIG_SIGNAL_ON;
+            val_i = RIG_SIGNAL_ON;
         }
         else if (!strcmp(val, "OFF"))
         {
-            rs->rotport.parm.serial.rts_state = RIG_SIGNAL_OFF;
-            rs->rotport_deprecated.parm.serial.rts_state = RIG_SIGNAL_OFF;
+            val_i = RIG_SIGNAL_OFF;
         }
         else
         {
             return -RIG_EINVAL;
         }
 
+        rotp->parm.serial.rts_state = val_i;
+        rs->rotport_deprecated.parm.serial.rts_state = val_i;
         break;
 
     case TOK_DTR_STATE:
-        if (rs->rotport.type.rig != RIG_PORT_SERIAL)
+        if (rotp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
         if (!strcmp(val, "Unset"))
         {
-            rs->rotport.parm.serial.dtr_state = RIG_SIGNAL_UNSET;
-            rs->rotport_deprecated.parm.serial.dtr_state = RIG_SIGNAL_UNSET;
+            val_i = RIG_SIGNAL_UNSET;
         }
         else if (!strcmp(val, "ON"))
         {
-            rs->rotport.parm.serial.dtr_state = RIG_SIGNAL_ON;
-            rs->rotport_deprecated.parm.serial.dtr_state = RIG_SIGNAL_ON;
+            val_i = RIG_SIGNAL_ON;
         }
         else if (!strcmp(val, "OFF"))
         {
-            rs->rotport.parm.serial.dtr_state = RIG_SIGNAL_OFF;
-            rs->rotport_deprecated.parm.serial.dtr_state = RIG_SIGNAL_OFF;
+            val_i = RIG_SIGNAL_OFF;
         }
         else
         {
             return -RIG_EINVAL;
         }
 
+        rotp->parm.serial.dtr_state = val_i;
+        rs->rotport_deprecated.parm.serial.dtr_state = val_i;
         break;
 
 
@@ -413,6 +409,7 @@ int frontrot_set_conf(ROT *rot, hamlib_token_t token, const char *val)
 int frontrot_get_conf(ROT *rot, hamlib_token_t token, char *val, int val_len)
 {
     struct rot_state *rs;
+    hamlib_port_t *rotp = ROTPORT(rot);
     const char *s;
 
     rs = &rot->state;
@@ -422,59 +419,59 @@ int frontrot_get_conf(ROT *rot, hamlib_token_t token, char *val, int val_len)
     switch (token)
     {
     case TOK_PATHNAME:
-        strncpy(val, rs->rotport.pathname, val_len - 1);
+        strncpy(val, rotp->pathname, val_len - 1);
         break;
 
     case TOK_WRITE_DELAY:
-        SNPRINTF(val, val_len, "%d", rs->rotport.write_delay);
+        SNPRINTF(val, val_len, "%d", rotp->write_delay);
         break;
 
     case TOK_POST_WRITE_DELAY:
-        SNPRINTF(val, val_len, "%d", rs->rotport.post_write_delay);
+        SNPRINTF(val, val_len, "%d", rotp->post_write_delay);
         break;
 
     case TOK_TIMEOUT:
-        SNPRINTF(val, val_len, "%d", rs->rotport.timeout);
+        SNPRINTF(val, val_len, "%d", rotp->timeout);
         break;
 
     case TOK_RETRY:
-        SNPRINTF(val, val_len, "%d", rs->rotport.retry);
+        SNPRINTF(val, val_len, "%d", rotp->retry);
         break;
 
     case TOK_SERIAL_SPEED:
-        if (rs->rotport.type.rig != RIG_PORT_SERIAL)
+        if (rotp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
-        SNPRINTF(val, val_len, "%d", rs->rotport.parm.serial.rate);
+        SNPRINTF(val, val_len, "%d", rotp->parm.serial.rate);
         break;
 
     case TOK_DATA_BITS:
-        if (rs->rotport.type.rig != RIG_PORT_SERIAL)
+        if (rotp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
-        SNPRINTF(val, val_len, "%d", rs->rotport.parm.serial.data_bits);
+        SNPRINTF(val, val_len, "%d", rotp->parm.serial.data_bits);
         break;
 
     case TOK_STOP_BITS:
-        if (rs->rotport.type.rig != RIG_PORT_SERIAL)
+        if (rotp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
-        SNPRINTF(val, val_len, "%d", rs->rotport.parm.serial.stop_bits);
+        SNPRINTF(val, val_len, "%d", rotp->parm.serial.stop_bits);
         break;
 
     case TOK_PARITY:
-        if (rs->rotport.type.rig != RIG_PORT_SERIAL)
+        if (rotp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
-        switch (rs->rotport.parm.serial.parity)
+        switch (rotp->parm.serial.parity)
         {
         case RIG_PARITY_NONE:
             s = "None";
@@ -504,12 +501,12 @@ int frontrot_get_conf(ROT *rot, hamlib_token_t token, char *val, int val_len)
         break;
 
     case TOK_HANDSHAKE:
-        if (rs->rotport.type.rig != RIG_PORT_SERIAL)
+        if (rotp->type.rig != RIG_PORT_SERIAL)
         {
             return -RIG_EINVAL;
         }
 
-        switch (rs->rotport.parm.serial.handshake)
+        switch (rotp->parm.serial.handshake)
         {
         case RIG_HANDSHAKE_NONE:
             s = "None";

--- a/src/snapshot_data.c
+++ b/src/snapshot_data.c
@@ -19,6 +19,7 @@ static int snapshot_serialize_rig(cJSON *rig_node, RIG *rig)
 {
     cJSON *node;
     char buf[1024];
+    struct rig_cache *cachep = CACHE(rig);
 
     cJSON *id_node = cJSON_CreateObject();
     cJSON_AddStringToObject(id_node, "model", rig->caps->model_name);
@@ -51,7 +52,7 @@ static int snapshot_serialize_rig(cJSON *rig_node, RIG *rig)
     }
 
     node = cJSON_AddBoolToObject(rig_node, "split",
-                                 rig->state.cache.split == RIG_SPLIT_ON ? 1 : 0);
+                                 cachep->split == RIG_SPLIT_ON ? 1 : 0);
 
     if (node == NULL)
     {
@@ -59,7 +60,7 @@ static int snapshot_serialize_rig(cJSON *rig_node, RIG *rig)
     }
 
     node = cJSON_AddStringToObject(rig_node, "splitVfo",
-                                   rig_strvfo(rig->state.cache.split_vfo));
+                                   rig_strvfo(cachep->split_vfo));
 
     if (node == NULL)
     {
@@ -67,7 +68,7 @@ static int snapshot_serialize_rig(cJSON *rig_node, RIG *rig)
     }
 
     node = cJSON_AddBoolToObject(rig_node, "satMode",
-                                 rig->state.cache.satmode ? 1 : 0);
+                                 cachep->satmode ? 1 : 0);
 
     if (node == NULL)
     {
@@ -111,6 +112,7 @@ static int snapshot_serialize_vfo(cJSON *vfo_node, RIG *rig, vfo_t vfo)
     int result;
     int is_rx, is_tx;
     cJSON *node;
+    struct rig_cache *cachep = CACHE(rig);
 
     // TODO: This data should match rig_get_info command response
 
@@ -148,14 +150,14 @@ static int snapshot_serialize_vfo(cJSON *vfo_node, RIG *rig, vfo_t vfo)
         }
     }
 
-    split = rig->state.cache.split;
-    split_vfo = rig->state.cache.split_vfo;
+    split = cachep->split;
+    split_vfo = cachep->split_vfo;
 
     is_rx = (split == RIG_SPLIT_OFF && vfo == rig->state.current_vfo)
             || (split == RIG_SPLIT_ON && vfo != split_vfo);
     is_tx = (split == RIG_SPLIT_OFF && vfo == rig->state.current_vfo)
             || (split == RIG_SPLIT_ON && vfo == split_vfo);
-    ptt = rig->state.cache.ptt && is_tx;
+    ptt = cachep->ptt && is_tx;
 
     if (is_tx)
     {

--- a/tests/rigctl.c
+++ b/tests/rigctl.c
@@ -23,6 +23,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
 #include <hamlib/config.h>
 
 #include <stdio.h>
@@ -603,7 +605,7 @@ int main(int argc, char *argv[])
 
     if (dcd_type != RIG_DCD_NONE)
     {
-        my_rig->state.dcdport.type.dcd = dcd_type;
+        DCDPORT(my_rig)->type.dcd = dcd_type;
     }
 
     if (ptt_file)
@@ -613,7 +615,7 @@ int main(int argc, char *argv[])
 
     if (dcd_file)
     {
-        strncpy(my_rig->state.dcdport.pathname, dcd_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(DCDPORT(my_rig)->pathname, dcd_file, HAMLIB_FILPATHLEN - 1);
     }
 
     /* FIXME: bound checking and port type == serial */

--- a/tests/rigctlcom.c
+++ b/tests/rigctlcom.c
@@ -26,6 +26,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 
 #include <hamlib/config.h>
 
@@ -530,7 +531,7 @@ int main(int argc, char *argv[])
 
     if (dcd_type != RIG_DCD_NONE)
     {
-        my_rig->state.dcdport.type.dcd = dcd_type;
+        DCDPORT(my_rig)->type.dcd = dcd_type;
     }
 
     if (ptt_file)
@@ -540,7 +541,7 @@ int main(int argc, char *argv[])
 
     if (dcd_file)
     {
-        strncpy(my_rig->state.dcdport.pathname, dcd_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(DCDPORT(my_rig)->pathname, dcd_file, HAMLIB_FILPATHLEN - 1);
     }
 
     /* FIXME: bound checking and port type == serial */

--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -22,6 +22,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 
 #include <hamlib/config.h>
 
@@ -714,7 +715,7 @@ int main(int argc, char *argv[])
 
     if (dcd_type != RIG_DCD_NONE)
     {
-        my_rig->state.dcdport.type.dcd = dcd_type;
+        DCDPORT(my_rig)->type.dcd = dcd_type;
         my_rig->state.dcdport_deprecated.type.dcd = dcd_type;
     }
 
@@ -727,7 +728,7 @@ int main(int argc, char *argv[])
 
     if (dcd_file)
     {
-        strncpy(my_rig->state.dcdport.pathname, dcd_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(DCDPORT(my_rig)->pathname, dcd_file, HAMLIB_FILPATHLEN - 1);
         strncpy(my_rig->state.dcdport_deprecated.pathname, dcd_file,
                 HAMLIB_FILPATHLEN - 1);
     }

--- a/tests/rigctlsync.c
+++ b/tests/rigctlsync.c
@@ -23,6 +23,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 
 #include <hamlib/config.h>
 
@@ -557,7 +558,7 @@ int main(int argc, char *argv[])
 
     if (dcd_type != RIG_DCD_NONE)
     {
-        my_rig->state.dcdport.type.dcd = dcd_type;
+        DCDPORT(my_rig)->type.dcd = dcd_type;
     }
 
     if (ptt_file)
@@ -567,7 +568,7 @@ int main(int argc, char *argv[])
 
     if (dcd_file)
     {
-        strncpy(my_rig->state.dcdport.pathname, dcd_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(DCDPORT(my_rig)->pathname, dcd_file, HAMLIB_FILPATHLEN - 1);
     }
 
 #endif

--- a/tests/rigctltcp.c
+++ b/tests/rigctltcp.c
@@ -22,6 +22,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 
 #include <hamlib/config.h>
 
@@ -709,7 +710,7 @@ int main(int argc, char *argv[])
 
     if (dcd_type != RIG_DCD_NONE)
     {
-        my_rig->state.dcdport.type.dcd = dcd_type;
+        DCDPORT(my_rig)->type.dcd = dcd_type;
         my_rig->state.dcdport_deprecated.type.dcd = dcd_type;
     }
 
@@ -722,7 +723,7 @@ int main(int argc, char *argv[])
 
     if (dcd_file)
     {
-        strncpy(my_rig->state.dcdport.pathname, dcd_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(DCDPORT(my_rig)->pathname, dcd_file, HAMLIB_FILPATHLEN - 1);
         strncpy(my_rig->state.dcdport_deprecated.pathname, dcd_file,
                 HAMLIB_FILPATHLEN - 1);
     }


### PR DESCRIPTION
No more direct references in rigs/*/*.c to ports within rig->state; all converted to pointers.

This is pretty big, and I don't mind if it gets deferred until after 4.6 is cut. 



Parts of issues #1445, #1452, #1420, #536, #487
 