### PR TITLE
Convert all port references to pointers

### DIFF
--- a/extra/gnuradio/gnuradio.cc
+++ b/extra/gnuradio/gnuradio.cc
@@ -132,7 +132,7 @@ int gr_init(RIG *rig)
   rig->state.priv = (void*)priv;
 
   rig_debug(RIG_DEBUG_VERBOSE,"%s called\n", __FUNCTION__ );
-  rig->state.rigport.type.rig = RIG_PORT_NONE;
+  RIGORT(rig)->type.rig = RIG_PORT_NONE;
 
   memset(priv->parms, 0, RIG_SETTING_MAX*sizeof(value_t));
 

--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -2490,6 +2490,7 @@ typedef hamlib_port_t port_t;
 #define AMPPORT(a) (&a->state.ampport)
 #define ROTPORT(r) (&r->state.rotport)
 #define ROTPORT2(r) (&r->state.rotport2)
+#define STATE(r) (&r->state)
 /* Then when the rigport address is stored as a pointer somewhere else(say,
  *  in the rig structure itself), the definition could be changed to
  *  #define RIGPORT(r) r->somewhereelse
@@ -2504,6 +2505,7 @@ typedef hamlib_port_t port_t;
 #define HAMLIB_AMPPORT(a) ((hamlib_port_t *)amp_data_pointer(a, RIG_PTRX_AMPPORT))
 #define HAMLIB_ROTPORT(r) ((hamlib_port_t *)rot_data_pointer(r, RIG_PTRX_ROTPORT))
 #define HAMLIB_ROTPORT2(r) ((hamlib_port_t *)rot_data_pointer(r, RIG_PTRX_ROTPORT2))
+#define HAMLIB_STATE(r) ((struct rig_state *)rig_data_pointer(r, RIG_PTRX_STATE))
 #endif
 
 typedef enum {
@@ -2515,6 +2517,7 @@ typedef enum {
     RIG_PTRX_AMPPORT,
     RIG_PTRX_ROTPORT,
     RIG_PTRX_ROTPORT2,
+    RIG_PTRX_STATE,
 // New entries go directly above this line====================
     RIG_PTRX_MAXIMUM
 } rig_ptrx_t;

--- a/src/misc.c
+++ b/src/misc.c
@@ -2005,7 +2005,9 @@ vfo_t HAMLIB_API vfo_fixup2a(RIG *rig, vfo_t vfo, split_t split,
 // We need to add some exceptions to this like the ID-5100
 vfo_t HAMLIB_API vfo_fixup(RIG *rig, vfo_t vfo, split_t split)
 {
-    vfo_t currvfo = rig->state.current_vfo;
+    struct rig_state *rs = STATE(rig);
+    vfo_t currvfo = rs->current_vfo;
+
     rig_debug(RIG_DEBUG_TRACE, "%s:(from %s:%d) vfo=%s, vfo_curr=%s, split=%d\n",
               __func__, funcname, linenum,
               rig_strvfo(vfo), rig_strvfo(currvfo), split);
@@ -2013,8 +2015,6 @@ vfo_t HAMLIB_API vfo_fixup(RIG *rig, vfo_t vfo, split_t split)
     if (rig->caps->rig_model == RIG_MODEL_ID5100
             || rig->caps->rig_model == RIG_MODEL_IC9700)
     {
-        struct rig_state *rs = &rig->state;
-
         // dualwatch on ID5100 is TX=Main, RX=Sub
         if (rig->caps->rig_model == RIG_MODEL_ID5100 && rs->dual_watch)
         {
@@ -2032,7 +2032,7 @@ vfo_t HAMLIB_API vfo_fixup(RIG *rig, vfo_t vfo, split_t split)
             vfo = RIG_VFO_MAIN_A;
 
             // only have Main/Sub when in satmode
-            if (rig->state.cache.satmode) { vfo = RIG_VFO_MAIN; }
+            if (CACHE(rig)->satmode) { vfo = RIG_VFO_MAIN; }
         }
         else if (vfo == RIG_VFO_B && (currvfo == RIG_VFO_MAIN
                                       || currvfo == RIG_VFO_MAIN_A))
@@ -2061,7 +2061,7 @@ vfo_t HAMLIB_API vfo_fixup(RIG *rig, vfo_t vfo, split_t split)
 
     if (vfo == RIG_VFO_OTHER)
     {
-        switch (rig->state.current_vfo)
+        switch (rs->current_vfo)
         {
         case RIG_VFO_A:
             return RIG_VFO_B;
@@ -2085,7 +2085,7 @@ vfo_t HAMLIB_API vfo_fixup(RIG *rig, vfo_t vfo, split_t split)
 
     if (vfo == RIG_VFO_RX)
     {
-        vfo = rig->state.rx_vfo;
+        vfo = rs->rx_vfo;
     }
     else if (vfo == RIG_VFO_A || vfo == RIG_VFO_MAIN)
     {
@@ -2098,7 +2098,7 @@ vfo_t HAMLIB_API vfo_fixup(RIG *rig, vfo_t vfo, split_t split)
         int satmode = CACHE(rig)->satmode;
 
         rig_debug(RIG_DEBUG_VERBOSE, "%s(%d): split=%d, vfo==%s tx_vfo=%s\n", __func__,
-                  __LINE__, split, rig_strvfo(vfo), rig_strvfo(rig->state.tx_vfo));
+                  __LINE__, split, rig_strvfo(vfo), rig_strvfo(rs->tx_vfo));
 
         if (VFO_HAS_MAIN_SUB_ONLY && !split && !satmode && vfo != RIG_VFO_B) { vfo = RIG_VFO_MAIN; }
 

--- a/tests/ampctl.c
+++ b/tests/ampctl.c
@@ -328,7 +328,7 @@ int main(int argc, char *argv[])
 
     if (amp_file)
     {
-        strncpy(my_amp->state.ampport.pathname, amp_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(AMPPORT(my_amp)->pathname, amp_file, HAMLIB_FILPATHLEN - 1);
         strncpy(my_amp->state.ampport_deprecated.pathname, amp_file,
                 HAMLIB_FILPATHLEN - 1);
     }
@@ -336,7 +336,7 @@ int main(int argc, char *argv[])
     /* FIXME: bound checking and port type == serial */
     if (serial_rate != 0)
     {
-        my_amp->state.ampport.parm.serial.rate = serial_rate;
+        AMPPORT(my_amp)->parm.serial.rate = serial_rate;
         my_amp->state.ampport_deprecated.parm.serial.rate = serial_rate;
     }
 

--- a/tests/ampctl_parse.c
+++ b/tests/ampctl_parse.c
@@ -1990,7 +1990,7 @@ declare_proto_amp(get_powerstat)
 declare_proto_amp(send_cmd)
 {
     int retval;
-    struct amp_state *rs;
+    hamlib_port_t *ampp = AMPPORT(amp);
     int backend_num, cmd_len;
 #define BUFSZ 128
     unsigned char bufcmd[BUFSZ];
@@ -2038,11 +2038,9 @@ declare_proto_amp(send_cmd)
         eom_buf[2] = send_cmd_term;
     }
 
-    rs = &amp->state;
+    rig_flush(ampp);
 
-    rig_flush(&rs->ampport);
-
-    retval = write_block(&rs->ampport, bufcmd, cmd_len);
+    retval = write_block(ampp, bufcmd, cmd_len);
 
     if (retval != RIG_OK)
     {
@@ -2060,7 +2058,7 @@ declare_proto_amp(send_cmd)
          * assumes CR or LF is end of line char
          * for all ascii protocols
          */
-        retval = read_string(&rs->ampport, buf, BUFSZ, eom_buf, strlen(eom_buf), 0, 1);
+        retval = read_string(ampp, buf, BUFSZ, eom_buf, strlen(eom_buf), 0, 1);
 
         if (retval < 0)
         {

--- a/tests/ampctld.c
+++ b/tests/ampctld.c
@@ -353,13 +353,13 @@ int main(int argc, char *argv[])
 
     if (amp_file)
     {
-        strncpy(my_amp->state.ampport.pathname, amp_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(AMPPORT(my_amp)->pathname, amp_file, HAMLIB_FILPATHLEN - 1);
     }
 
     /* FIXME: bound checking and port type == serial */
     if (serial_rate != 0)
     {
-        my_amp->state.ampport.parm.serial.rate = serial_rate;
+        AMPPORT(my_amp)->parm.serial.rate = serial_rate;
     }
 
     /*

--- a/tests/cachetest.c
+++ b/tests/cachetest.c
@@ -77,9 +77,9 @@ int main(int argc, char *argv[])
     /* Set up serial port, baud rate */
     rig_file = argv[2];        // your serial device
 
-    strncpy(my_rig->state.rigport.pathname, rig_file, HAMLIB_FILPATHLEN - 1);
+    strncpy(RIGPORT(my_rig)->pathname, rig_file, HAMLIB_FILPATHLEN - 1);
 
-    my_rig->state.rigport.parm.serial.rate = baud; // your baud rate
+    RIGPORT(my_rig)->parm.serial.rate = baud; // your baud rate
 
     /* Open my rig */
     retcode = rig_open(my_rig);

--- a/tests/cachetest2.c
+++ b/tests/cachetest2.c
@@ -44,7 +44,7 @@ int main(int argc, const char *argv[])
     /* Set up serial port, baud rate */
     rig_file = "127.0.0.1:4532";        // your serial device
 
-    strncpy(my_rig->state.rigport.pathname, rig_file, HAMLIB_FILPATHLEN - 1);
+    strncpy(RIGPORT(my_rig)->pathname, rig_file, HAMLIB_FILPATHLEN - 1);
 
     /* Open my rig */
     retcode = rig_open(my_rig);

--- a/tests/callback.c
+++ b/tests/callback.c
@@ -12,7 +12,7 @@ int callback(const struct rig_caps *caps, rig_ptr_t rigp)
     }
 
     const char *port = "/dev/pts/3";
-    strcpy(rig->state.rigport.pathname, port);
+    strcpy(RIGPORT(rig)->pathname, port);
 
     printf("%20s:", caps->model_name);
     fflush(stdout);

--- a/tests/dumpmem.c
+++ b/tests/dumpmem.c
@@ -57,7 +57,7 @@ int main(int argc, const char *argv[])
         exit(1); /* whoops! something went wrong (mem alloc?) */
     }
 
-    strncpy(my_rig->state.rigport.pathname, SERIAL_PORT, HAMLIB_FILPATHLEN - 1);
+    strncpy(RIGPORT(my_rig)->pathname, SERIAL_PORT, HAMLIB_FILPATHLEN - 1);
 
     if (rig_open(my_rig))
     {

--- a/tests/rig_bench.c
+++ b/tests/rig_bench.c
@@ -67,12 +67,12 @@ int main(int argc, const char *argv[])
            my_rig->caps->version,
            rig_strstatus(my_rig->caps->status));
 
-    printf("Serial speed: %d baud\n", my_rig->state.rigport.parm.serial.rate);
+    printf("Serial speed: %d baud\n", RIGPORT(my_rig)->parm.serial.rate);
 #if 0 // if we want to bench serial or network I/O use this time
     rig_set_cache_timeout_ms(my_rig, HAMLIB_CACHE_ALL, 0);
 #endif
 
-    strncpy(my_rig->state.rigport.pathname, SERIAL_PORT, HAMLIB_FILPATHLEN - 1);
+    strncpy(RIGPORT(my_rig)->pathname, SERIAL_PORT, HAMLIB_FILPATHLEN - 1);
 
     retcode = rig_open(my_rig);
 

--- a/tests/rigctl.c
+++ b/tests/rigctl.c
@@ -592,7 +592,7 @@ int main(int argc, char *argv[])
 
     if (rig_file)
     {
-        strncpy(my_rig->state.rigport.pathname, rig_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(RIGPORT(my_rig)->pathname, rig_file, HAMLIB_FILPATHLEN - 1);
     }
 
     /*
@@ -600,7 +600,7 @@ int main(int argc, char *argv[])
      */
     if (ptt_type != RIG_PTT_NONE)
     {
-        my_rig->state.pttport.type.ptt = ptt_type;
+        PTTPORT(my_rig)->type.ptt = ptt_type;
     }
 
     if (dcd_type != RIG_DCD_NONE)
@@ -610,7 +610,7 @@ int main(int argc, char *argv[])
 
     if (ptt_file)
     {
-        strncpy(my_rig->state.pttport.pathname, ptt_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(PTTPORT(my_rig)->pathname, ptt_file, HAMLIB_FILPATHLEN - 1);
     }
 
     if (dcd_file)
@@ -621,7 +621,7 @@ int main(int argc, char *argv[])
     /* FIXME: bound checking and port type == serial */
     if (serial_rate != 0)
     {
-        my_rig->state.rigport.parm.serial.rate = serial_rate;
+        RIGPORT(my_rig)->parm.serial.rate = serial_rate;
         my_rig->state.rigport_deprecated.parm.serial.rate = serial_rate;
     }
 

--- a/tests/rigctlcom.c
+++ b/tests/rigctlcom.c
@@ -512,7 +512,7 @@ int main(int argc, char *argv[])
 
     if (rig_file)
     {
-        strncpy(my_rig->state.rigport.pathname, rig_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(RIGPORT(my_rig)->pathname, rig_file, HAMLIB_FILPATHLEN - 1);
     }
 
     if (!rig_file2)
@@ -528,7 +528,7 @@ int main(int argc, char *argv[])
      */
     if (ptt_type != RIG_PTT_NONE)
     {
-        my_rig->state.pttport.type.ptt = ptt_type;
+        PTTPORT(my_rig)->type.ptt = ptt_type;
     }
 
     if (dcd_type != RIG_DCD_NONE)
@@ -538,7 +538,7 @@ int main(int argc, char *argv[])
 
     if (ptt_file)
     {
-        strncpy(my_rig->state.pttport.pathname, ptt_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(PTTPORT(my_rig)->pathname, ptt_file, HAMLIB_FILPATHLEN - 1);
     }
 
     if (dcd_file)
@@ -549,7 +549,7 @@ int main(int argc, char *argv[])
     /* FIXME: bound checking and port type == serial */
     if (serial_rate != 0)
     {
-        my_rig->state.rigport.parm.serial.rate = serial_rate;
+        RIGPORT(my_rig)->parm.serial.rate = serial_rate;
     }
 
     if (serial_rate2 != 0)

--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -691,7 +691,7 @@ int main(int argc, char *argv[])
 
     if (rig_file)
     {
-        strncpy(my_rig->state.rigport.pathname, rig_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(RIGPORT(my_rig)->pathname, rig_file, HAMLIB_FILPATHLEN - 1);
     }
 
     my_rig->state.twiddle_timeout = twiddle_timeout;
@@ -706,7 +706,7 @@ int main(int argc, char *argv[])
      */
     if (ptt_type != RIG_PTT_NONE)
     {
-        my_rig->state.pttport.type.ptt = ptt_type;
+        PTTPORT(my_rig)->type.ptt = ptt_type;
         my_rig->state.pttport_deprecated.type.ptt = ptt_type;
         // This causes segfault since backend rig_caps are const
         // rigctld will use the rig->state version of this for clients
@@ -721,7 +721,7 @@ int main(int argc, char *argv[])
 
     if (ptt_file)
     {
-        strncpy(my_rig->state.pttport.pathname, ptt_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(PTTPORT(my_rig)->pathname, ptt_file, HAMLIB_FILPATHLEN - 1);
         strncpy(my_rig->state.pttport_deprecated.pathname, ptt_file,
                 HAMLIB_FILPATHLEN - 1);
     }
@@ -736,7 +736,7 @@ int main(int argc, char *argv[])
     /* FIXME: bound checking and port type == serial */
     if (serial_rate != 0)
     {
-        my_rig->state.rigport.parm.serial.rate = serial_rate;
+        RIGPORT(my_rig)->parm.serial.rate = serial_rate;
         my_rig->state.rigport_deprecated.parm.serial.rate = serial_rate;
     }
 

--- a/tests/rigctlsync.c
+++ b/tests/rigctlsync.c
@@ -540,11 +540,11 @@ int main(int argc, char *argv[])
 
     if (rig_file)
     {
-        strncpy(my_rig->state.rigport.pathname, rig_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(RIGPORT(my_rig)->pathname, rig_file, HAMLIB_FILPATHLEN - 1);
     }
 
     fprintf(stderr, "rig to send frequency to: %s\n", rig_file2);
-    strncpy(my_rig_sync->state.rigport.pathname, rig_file2, HAMLIB_FILPATHLEN - 1);
+    strncpy(RIGPORT(my_rig_sync)->pathname, rig_file2, HAMLIB_FILPATHLEN - 1);
 
 #if 0
 
@@ -553,7 +553,7 @@ int main(int argc, char *argv[])
      */
     if (ptt_type != RIG_PTT_NONE)
     {
-        my_rig->state.pttport.type.ptt = ptt_type;
+        PTTPORT(my_rig)->type.ptt = ptt_type;
     }
 
     if (dcd_type != RIG_DCD_NONE)
@@ -563,7 +563,7 @@ int main(int argc, char *argv[])
 
     if (ptt_file)
     {
-        strncpy(my_rig->state.pttport.pathname, ptt_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(PTTPORT(my_rig)->pathname, ptt_file, HAMLIB_FILPATHLEN - 1);
     }
 
     if (dcd_file)
@@ -576,12 +576,12 @@ int main(int argc, char *argv[])
     /* FIXME: bound checking and port type == serial */
     if (serial_rate != 0)
     {
-        my_rig->state.rigport.parm.serial.rate = serial_rate;
+        RIGPORT(my_rig)->parm.serial.rate = serial_rate;
     }
 
     if (serial_rate2 != 0)
     {
-        my_rig_sync->state.rigport.parm.serial.rate = serial_rate2;
+        RIGPORT(my_rig_sync)->parm.serial.rate = serial_rate2;
     }
 
 

--- a/tests/rigctltcp.c
+++ b/tests/rigctltcp.c
@@ -686,7 +686,7 @@ int main(int argc, char *argv[])
 
     if (rig_file)
     {
-        strncpy(my_rig->state.rigport.pathname, rig_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(RIGPORT(my_rig)->pathname, rig_file, HAMLIB_FILPATHLEN - 1);
     }
 
     my_rig->state.twiddle_timeout = twiddle_timeout;
@@ -701,7 +701,7 @@ int main(int argc, char *argv[])
      */
     if (ptt_type != RIG_PTT_NONE)
     {
-        my_rig->state.pttport.type.ptt = ptt_type;
+        PTTPORT(my_rig)->type.ptt = ptt_type;
         my_rig->state.pttport_deprecated.type.ptt = ptt_type;
         // This causes segfault since backend rig_caps are const
         // rigctld will use the rig->state version of this for clients
@@ -716,7 +716,7 @@ int main(int argc, char *argv[])
 
     if (ptt_file)
     {
-        strncpy(my_rig->state.pttport.pathname, ptt_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(PTTPORT(my_rig)->pathname, ptt_file, HAMLIB_FILPATHLEN - 1);
         strncpy(my_rig->state.pttport_deprecated.pathname, ptt_file,
                 HAMLIB_FILPATHLEN - 1);
     }
@@ -731,7 +731,7 @@ int main(int argc, char *argv[])
     /* FIXME: bound checking and port type == serial */
     if (serial_rate != 0)
     {
-        my_rig->state.rigport.parm.serial.rate = serial_rate;
+        RIGPORT(my_rig)->parm.serial.rate = serial_rate;
         my_rig->state.rigport_deprecated.parm.serial.rate = serial_rate;
     }
 
@@ -1309,7 +1309,7 @@ void *handle_socket(void *arg)
             if (cmd[0] != 0)
             {
                 memset(reply, 0, sizeof(reply));
-                rig_flush(&my_rig->state.rigport);
+                rig_flush(RIGPORT(my_rig));
                 retcode = rig_send_raw(my_rig, cmd, nbytes, reply, sizeof(reply),
                                        term);
 

--- a/tests/rigfreqwalk.c
+++ b/tests/rigfreqwalk.c
@@ -82,7 +82,7 @@ int main(int argc, const char *argv[])
         exit(1); /* whoops! something went wrong (mem alloc?) */
     }
 
-    strncpy(my_rig->state.rigport.pathname, argv[2], HAMLIB_FILPATHLEN - 1);
+    rig_set_conf(my_rig, rig_token_lookup(my_rig, "rig_pathname"), argv[2]);
 
     retcode = rig_open(my_rig);
 

--- a/tests/rigmem.c
+++ b/tests/rigmem.c
@@ -283,13 +283,13 @@ int main(int argc, char *argv[])
 
     if (rig_file)
     {
-        strncpy(rig->state.rigport.pathname, rig_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(RIGPORT(rig)->pathname, rig_file, HAMLIB_FILPATHLEN - 1);
     }
 
     /* FIXME: bound checking and port type == serial */
     if (serial_rate != 0)
     {
-        rig->state.rigport.parm.serial.rate = serial_rate;
+        RIGPORT(rig)->parm.serial.rate = serial_rate;
     }
 
     if (civaddr)

--- a/tests/rigsmtr.c
+++ b/tests/rigsmtr.c
@@ -265,13 +265,13 @@ int main(int argc, char *argv[])
 
     if (rig_file)
     {
-        strncpy(rig->state.rigport.pathname, rig_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(RIGPORT(rig)->pathname, rig_file, HAMLIB_FILPATHLEN - 1);
     }
 
     /* FIXME: bound checking and port type == serial */
     if (serial_rate != 0)
     {
-        rig->state.rigport.parm.serial.rate = serial_rate;
+        RIGPORT(rig)->parm.serial.rate = serial_rate;
     }
 
     if (civaddr)
@@ -329,13 +329,13 @@ int main(int argc, char *argv[])
 
     if (rot_file)
     {
-        strncpy(rot->state.rotport.pathname, rot_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(ROTPORT(rot)->pathname, rot_file, HAMLIB_FILPATHLEN - 1);
     }
 
     /* FIXME: bound checking and port type == serial */
     if (rot_serial_rate != 0)
     {
-        rot->state.rotport.parm.serial.rate = rot_serial_rate;
+        ROTPORT(rot)->parm.serial.rate = rot_serial_rate;
     }
 
     retcode = rot_open(rot);

--- a/tests/rigswr.c
+++ b/tests/rigswr.c
@@ -257,23 +257,23 @@ int main(int argc, char *argv[])
 
     if (ptt_type != RIG_PTT_NONE)
     {
-        rig->state.pttport.type.ptt = ptt_type;
+        PTTPORT(rig)->type.ptt = ptt_type;
     }
 
     if (ptt_file)
     {
-        strncpy(rig->state.pttport.pathname, ptt_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(PTTPORT(rig)->pathname, ptt_file, HAMLIB_FILPATHLEN - 1);
     }
 
     if (rig_file)
     {
-        strncpy(rig->state.rigport.pathname, rig_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(RIGPORT(rig)->pathname, rig_file, HAMLIB_FILPATHLEN - 1);
     }
 
     /* FIXME: bound checking and port type == serial */
     if (serial_rate != 0)
     {
-        rig->state.rigport.parm.serial.rate = serial_rate;
+        RIGPORT(rig)->parm.serial.rate = serial_rate;
     }
 
     if (civaddr)
@@ -283,7 +283,7 @@ int main(int argc, char *argv[])
 
 
     if (!rig_has_get_level(rig, RIG_LEVEL_SWR)
-            || rig->state.pttport.type.ptt == RIG_PTT_NONE)
+	|| PTTPORT(rig)->type.ptt == RIG_PTT_NONE)
     {
 
         fprintf(stderr,

--- a/tests/rigtestmcast.c
+++ b/tests/rigtestmcast.c
@@ -25,11 +25,11 @@ int main(int argc, const char *argv[])
     }
 
 #ifdef _WIN32
-    strncpy(rig->state.rigport.pathname, "COM37", HAMLIB_FILPATHLEN - 1);
+    strncpy(RIGPORT(rig)->pathname, "COM37", HAMLIB_FILPATHLEN - 1);
 #else
-    strncpy(rig->state.rigport.pathname, "/dev/ttyUSB0", HAMLIB_FILPATHLEN - 1);
+    strncpy(RIGPORT(rig)->pathname, "/dev/ttyUSB0", HAMLIB_FILPATHLEN - 1);
 #endif
-    rig->state.rigport.parm.serial.rate = 38400;
+    RIGPORT(rig)->parm.serial.rate = 38400;
     rig_open(rig);
     // disabled until we change this to the other multicast capability
 #if 0

--- a/tests/rotctl.c
+++ b/tests/rotctl.c
@@ -368,26 +368,26 @@ int main(int argc, char *argv[])
         token = strtok(NULL, ",");
     }
 
+    hamlib_port_t *rotp = ROTPORT(my_rot);
+    hamlib_port_t *rotp2 = ROTPORT2(my_rot);
     if (rot_file)
     {
-        strncpy(my_rot->state.rotport.pathname, rot_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(rotp->pathname, rot_file, HAMLIB_FILPATHLEN - 1);
     }
 
     if (rot_file2)
     {
-        strncpy(my_rot->state.rotport2.pathname, rot_file2, HAMLIB_FILPATHLEN - 1);
+        strncpy(rotp2->pathname, rot_file2, HAMLIB_FILPATHLEN - 1);
     }
 
     /* FIXME: bound checking and port type == serial */
-    my_rot->state.rotport2.parm.serial.rate =
-        my_rot->state.rotport.parm.serial.rate;
-    my_rot->state.rotport2.parm.serial.data_bits =
-        my_rot->state.rotport.parm.serial.data_bits;
+    rotp2->parm.serial.rate = rotp->parm.serial.rate;
+    rotp2->parm.serial.data_bits = rotp->parm.serial.data_bits;
 
     if (serial_rate != 0)
     {
-        my_rot->state.rotport.parm.serial.rate = serial_rate;
-        my_rot->state.rotport2.parm.serial.rate = serial_rate;
+        rotp->parm.serial.rate = serial_rate;
+        rotp2->parm.serial.rate = serial_rate;
     }
 
     /*

--- a/tests/rotctl_parse.c
+++ b/tests/rotctl_parse.c
@@ -2507,7 +2507,7 @@ declare_proto_rot(dump_state)
 declare_proto_rot(send_cmd)
 {
     int retval;
-    struct rot_state *rs;
+    hamlib_port_t *rotp = ROTPORT(rot);
     int backend_num, cmd_len;
 #define BUFSZ 128
     unsigned char bufcmd[BUFSZ];
@@ -2555,11 +2555,9 @@ declare_proto_rot(send_cmd)
         eom_buf[2] = send_cmd_term;
     }
 
-    rs = &rot->state;
+    rig_flush(rotp);
 
-    rig_flush(&rs->rotport);
-
-    retval = write_block(&rs->rotport, bufcmd, cmd_len);
+    retval = write_block(rotp, bufcmd, cmd_len);
 
     if (retval != RIG_OK)
     {
@@ -2577,7 +2575,7 @@ declare_proto_rot(send_cmd)
          * assumes CR or LF is end of line char
          * for all ascii protocols
          */
-        retval = read_string(&rs->rotport, buf, BUFSZ, eom_buf, strlen(eom_buf), 0, 1);
+        retval = read_string(rotp, buf, BUFSZ, eom_buf, strlen(eom_buf), 0, 1);
 
         if (retval < 0)
         {

--- a/tests/rotctld.c
+++ b/tests/rotctld.c
@@ -376,18 +376,18 @@ int main(int argc, char *argv[])
 
     if (rot_file)
     {
-        strncpy(my_rot->state.rotport.pathname, rot_file, HAMLIB_FILPATHLEN - 1);
+        strncpy(ROTPORT(my_rot)->pathname, rot_file, HAMLIB_FILPATHLEN - 1);
     }
 
     if (rot_file2)
     {
-        strncpy(my_rot->state.rotport2.pathname, rot_file2, HAMLIB_FILPATHLEN - 1);
+        strncpy(ROTPORT2(my_rot)->pathname, rot_file2, HAMLIB_FILPATHLEN - 1);
     }
 
     /* FIXME: bound checking and port type == serial */
     if (serial_rate != 0)
     {
-        my_rot->state.rotport.parm.serial.rate = serial_rate;
+        ROTPORT(my_rot)->parm.serial.rate = serial_rate;
     }
 
     /*

--- a/tests/sendraw.c
+++ b/tests/sendraw.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <hamlib/rig.h>
+#define PATH "/dev/pts/4"
 
 int
 main()
@@ -15,7 +16,7 @@ main()
     int retcode;
 
     my_rig = rig_init(2048);
-    strcpy(my_rig->state.rigport.pathname, "/dev/pts/4");
+    rig_set_conf(my_rig, rig_token_lookup(my_rig, "rig_pathname"), PATH);
 
     retcode = rig_open(my_rig);
 

--- a/tests/testcache.c
+++ b/tests/testcache.c
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
 
     /* Set up serial port, baud rate */
 
-    strncpy(my_rig->state.rigport.pathname, rig_file, HAMLIB_FILPATHLEN - 1);
+    rig_set_conf(my_rig, rig_token_lookup(my_rig, "rig_pathname"), rig_file);
 
     /* Open my rig */
     retcode = rig_open(my_rig);

--- a/tests/testrig.c
+++ b/tests/testrig.c
@@ -68,7 +68,7 @@ int main(int argc, const char *argv[])
         exit(1); /* whoops! something went wrong (mem alloc?) */
     }
 
-    //strncpy(my_rig->state.rigport.pathname, SERIAL_PORT, HAMLIB_FILPATHLEN - 1);
+    //strncpy(RIGPORT(my_rig)->pathname, SERIAL_PORT, HAMLIB_FILPATHLEN - 1);
 
     retcode = rig_open(my_rig);
 

--- a/tests/testrigopen.c
+++ b/tests/testrigopen.c
@@ -30,7 +30,7 @@ int callback(struct rig_caps *caps, rig_ptr_t rigp)
     }
 
     const char *port = "/dev/pts/3";
-    strcpy(rig->state.rigport.pathname, port);
+    rig_set_conf(rig, rig_token_lookup(rig, "rig_pathname"), port);
 
     printf("%20s:", caps->model_name);
     fflush(stdout);

--- a/tests/testtrn.c
+++ b/tests/testtrn.c
@@ -52,7 +52,7 @@ int main(int argc, const  char *argv[])
         exit(1);    /* whoops! something went wrong (mem alloc?) */
     }
 
-    strncpy(my_rig->state.rigport.pathname, SERIAL_PORT, HAMLIB_FILPATHLEN - 1);
+    rig_set_conf(my_rig, rig_token_lookup(my_rig, "rig_pathname"), SERIAL_PORT);
 
     if (rig_open(my_rig))
     {


### PR DESCRIPTION
No more embedded port references - only pointers.

Steps 3&4 of issue #1445
