### PR TITLE
tests: fix compilation with modern compilers

### DIFF
--- a/tests/memload.c
+++ b/tests/memload.c
@@ -18,6 +18,8 @@
  *
  */
 
+#include <stdlib.h>
+
 #include <hamlib/rig.h>
 
 #ifdef HAVE_XML2


### PR DESCRIPTION
GCC 14 and clang 16, after 20+ years, finally enforce c99 language requirements. Previously, to keep old code compiling, the use of K&R C constructs was simply allowed despite the standard, and so users could accidentally use those constructs without realizing it or being warned.

Now, the compiler fatally errors out when encountering the problematic code. This can also be observed in older versions of the compiler by using the following flags:

```
-Werror=implicit-function-declaration -Werror=implicit-int -Werror=int-conversion -Werror=incompatible-pointer-types
```

In hamlib's case, the use of a function without declaring it is illegal. It's also a very simple fix though -- the standard header which declared the stdlib exit() function was forgotten and never included. Simply add the missing include, and make the source code automatically compliant.

Bug: https://bugs.gentoo.org/923108