### PR TITLE
Refactoring GPIO push-to-talk logic to use libgpiod rather than the d…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -529,6 +529,9 @@ AS_IF([test x"${cf_with_xml_support}" = "xyes"], [
 AC_SUBST([LIBXML2_LIBS])
 AC_SUBST([LIBXML2_CFLAGS])
 
+# TODO: I don't know how to use autoconf
+LIBS="$LIBS -lgpiod"
+
 
 ## ----------------- ##
 ## Language bindings ##

--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -2340,6 +2340,7 @@ typedef struct hamlib_port {
 
     int fd;                 /*!< File descriptor */
     void *handle;           /*!< handle for USB */
+    void *gpio;             /*!< handle for GPIO */
 
     int write_delay;        /*!< Delay between each byte sent out, in mS */
     int post_write_delay;   /*!< Delay between each commands send out, in mS */

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -19,134 +19,90 @@
  *
  */
 
-#include <string.h>
-#include <errno.h>
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-
 #include "gpio.h"
 
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <gpiod.h>
+
+#ifndef GPIOD_PATH
+// This is what's used on the Raspberry Pi 4; I'm not sure about others
+#define GPIO_CHIP_NAME "gpiochip0"
+#endif
+
+#define GPIO_CHIP_CONSUMER "Hamlib"
 
 int gpio_open(hamlib_port_t *port, int output, int on_value)
 {
-    char pathname[HAMLIB_FILPATHLEN * 2];
-    FILE *fexp, *fdir;
-    int fd;
-    char *dir;
+    struct gpiod_chip *chip;
+    struct gpiod_line *line;
 
     port->parm.gpio.on_value = on_value;
 
-    SNPRINTF(pathname, HAMLIB_FILPATHLEN, "/sys/class/gpio/export");
-    fexp = fopen(pathname, "w");
+    chip = gpiod_chip_open_by_name(GPIO_CHIP_NAME);
 
-    if (!fexp)
+    if (!chip)
     {
-        rig_debug(RIG_DEBUG_ERR,
-                  "Export GPIO%s (using %s): %s\n",
-                  port->pathname,
-                  pathname,
-                  strerror(errno));
+        rig_debug(RIG_DEBUG_ERR, "Failed to open GPIO chip %s: %s\n", GPIO_CHIP_NAME, strerror(errno));
         return -RIG_EIO;
     }
 
-    fprintf(fexp, "%s\n", port->pathname);
-    fclose(fexp);
-
-    SNPRINTF(pathname,
-             sizeof(pathname),
-             "/sys/class/gpio/gpio%s/direction",
-             port->pathname);
-    fdir = fopen(pathname, "w");
-
-    if (!fdir)
+    line = gpiod_chip_get_line(chip, atoi(port->pathname));
+    if (!line)
     {
-        rig_debug(RIG_DEBUG_ERR,
-                  "GPIO%s direction (using %s): %s\n",
-                  port->pathname,
-                  pathname,
-                  strerror(errno));
+        rig_debug(RIG_DEBUG_ERR, "Failed to acquire GPIO%s: %s\n", port->pathname, strerror(errno));
+        gpiod_chip_close(chip);
         return -RIG_EIO;
     }
 
-    dir = output ? "out" : "in";
-    rig_debug(RIG_DEBUG_VERBOSE, "Setting direction of GPIO%s to %s\n",
-              port->pathname, dir);
-    fprintf(fdir, "%s\n", dir);
-    fclose(fdir);
-
-    SNPRINTF(pathname,
-             sizeof(pathname),
-             "/sys/class/gpio/gpio%s/value",
-             port->pathname);
-    fd = open(pathname, O_RDWR);
-
-    if (fd < 0)
+    if ((output && gpiod_line_request_output(line, GPIO_CHIP_CONSUMER, 0) < 0) ||
+        (!output && gpiod_line_request_input(line, GPIO_CHIP_CONSUMER) < 0))
     {
-        rig_debug(RIG_DEBUG_ERR,
-                  "GPIO%s opening value file %s: %s\n",
-                  port->pathname,
-                  pathname,
-                  strerror(errno));
+        rig_debug(RIG_DEBUG_ERR, "Failed to set GPIO%s to %s mode: %s\n",
+                port->pathname, (output ? "OUTPUT" : "INPUT"), strerror(errno));
+        gpiod_line_release(line);
+        gpiod_chip_close(chip);
         return -RIG_EIO;
     }
 
-    port->fd = fd;
-    return fd;
+    port->gpio = line;
+
+    return RIG_OK;
 }
-
 
 int gpio_close(hamlib_port_t *port)
 {
-    int retval;
-    char pathname[HAMLIB_FILPATHLEN * 2];
-    FILE *fexp;
-
-    retval = close(port->fd);
-
-    SNPRINTF(pathname, HAMLIB_FILPATHLEN, "/sys/class/gpio/unexport");
-    fexp = fopen(pathname, "w");
-
-    if (!fexp)
-    {
-        rig_debug(RIG_DEBUG_ERR,
-                  "Export GPIO%s (using %s): %s\n",
-                  port->pathname,
-                  pathname,
-                  strerror(errno));
-        return -RIG_EIO;
-    }
-
-    fprintf(fexp, "%s\n", port->pathname);
-    fclose(fexp);
-    return retval;
+    gpiod_line_close_chip((struct gpiod_line*)port->gpio);
+    return RIG_OK;
 }
-
 
 int gpio_ptt_set(hamlib_port_t *port, ptt_t pttx)
 {
-    char *val;
+    int result = 0;
     port->parm.gpio.value = pttx != RIG_PTT_OFF;
 
-    if ((port->parm.gpio.value && port->parm.gpio.on_value)
-            || (!port->parm.gpio.value && !port->parm.gpio.on_value))
+    if ((port->parm.gpio.value && port->parm.gpio.on_value) ||
+      (!port->parm.gpio.value && !port->parm.gpio.on_value))
     {
-        val = "1\n";
+        result = gpiod_line_set_value((struct gpiod_line*)port->gpio, 1);
     }
     else
     {
-        val = "0\n";
+        result = gpiod_line_set_value((struct gpiod_line*)port->gpio, 0);
     }
 
-    if (write(port->fd, val, strlen(val)) <= 0)
+    if (result)
     {
+        rig_debug(RIG_DEBUG_ERR, "Failed to set the value of GPIO%s: %s\n", port->pathname, strerror(errno));
         return -RIG_EIO;
     }
 
     return RIG_OK;
 }
-
 
 int gpio_ptt_get(hamlib_port_t *port, ptt_t *pttx)
 {
@@ -164,21 +120,15 @@ int gpio_ptt_get(hamlib_port_t *port, ptt_t *pttx)
 
 int gpio_dcd_get(hamlib_port_t *port, dcd_t *dcdx)
 {
-    char val;
-    int port_value;
-
-    lseek(port->fd, 0, SEEK_SET);
-
-    if (read(port->fd, &val, sizeof(val)) <= 0)
+    int val = gpiod_line_get_value((struct gpiod_line*)port->gpio);
+    if (val < 0)
     {
-        return -RIG_EIO;
+        rig_debug(RIG_DEBUG_ERR, "Failed to read the value of GPIO%s: %s\n", port->pathname, strerror(errno));
     }
 
     rig_debug(RIG_DEBUG_VERBOSE, "DCD GPIO pin value: %c\n", val);
 
-    port_value = val - '0';
-
-    if (port_value == port->parm.gpio.on_value)
+    if (val == port->parm.gpio.on_value)
     {
         *dcdx = RIG_DCD_ON;
     }


### PR DESCRIPTION
…eprecated/broken sysfs method.

I've confirmed that this works on my Raspberry Pi 4B.

TODO: I'm not familiar with autoconf to set up linking to libgpiod correctly, so I'd like to ask someone else to do that.
TODO: Should we keep both implementations for the sake of backwards-compatibility?

Fixes #1538

I've included the verbose rigctld output below.

```
â  Hamlib git:(libgpiod) â sudo ./tests/rigctld -P GPIO -p 4 -vvvvv              
rigctld.c(640) Startup: /home/aschuhardt/Hamlib/tests/.libs/rigctld -P GPIO -p 4 -vvvvv
rigctld Hamlib 4.6~git 2024-04-09T22:14:48Z SHA=0ba199 64-bit
Report bugs to <hamlib-developer@lists.sourceforge.net>

Max# of rigctld client services=32
rig_test_2038: enter _TIME_BITS=64, __TIMESIZE=64 testing enabled for GLIBC 2.36
rig_test_2038: time_t 2038 test = 0xf0000000:Mon Aug  5 02:04:00 2097
rig_init: 2038 time test passed
rig_check_rig_caps: p1=0x7f9f298890, p2=0x7f9f29ee18, rig_model=0x7f9f298890, macro_name=0x7f9f29ee18
initrigs4_dummy: _init called
rig_init: rig_model=Hamlib Dummy 20230611.0
rig_init: rig has VFO_A
rig_init: rig has VFO_B
rig_init: rig has VFO_C
rig_init: rig has VFO_SUB_A
rig_init: rig has VFO_SUB_B
rig_init: rig has VFO_MAIN_A
rig_init: rig has VFO_MAIN_B
rig_init: rig has VFO_SUB
rig_init: rig has VFO_MAIN
rig_init: rig has VFO_MEM
***2:dummy.c(223):dummy_init entered
dummy_init called
****3:rig.c(3072):rig_passband_normal entered
rig_passband_normal: return filter#15, width=15000
****3:rig.c(3087):rig_passband_normal returning(15000) 
****3:rig.c(3072):rig_passband_normal entered
rig_passband_normal: return filter#15, width=15000
****3:rig.c(3087):rig_passband_normal returning(15000) 
****3:rig.c(3072):rig_passband_normal entered
rig_passband_normal: return filter#15, width=15000
****3:rig.c(3087):rig_passband_normal returning(15000) 
****3:rig.c(3072):rig_passband_normal entered
rig_passband_normal: return filter#15, width=15000
****3:rig.c(3087):rig_passband_normal returning(15000) 
dummy.c(173) unknown vfo=VFOC
****3:rig.c(3072):rig_passband_normal entered
rig_passband_normal: return filter#15, width=15000
****3:rig.c(3087):rig_passband_normal returning(15000) 
***2:dummy.c(317):dummy_init returning(0) 
main: twiddle=0, uplink=0, twiddle_rit=0
rig.c(945):rig_open entered
rig_settings_get_path: path=/root/.hamlib_settings
rig_settings_load_all: settings_file (/root/.hamlib_settings): No such file or directory
rig_open: cwd=/home/aschuhardt/Hamlib
rig_open: /home/aschuhardt/Hamlib/hamlib_settings No such file or directory
rig_open: async_data_enable=0, async_data_supported=0
***2:rig.c(8288):async_data_handler_start entered
async_data_handler_start: async data support disabled since async_data_enabled=0
***2:rig.c(8295):async_data_handler_start returning(0) 
rig_open: 0x55b81e1fe4 rs->comm_state==1?=1
***2:rig.c(6783):rig_get_powerstat entered
**rig.c(6797) trace
****3:dummy.c(1600):dummy_get_powerstat entered
****3:dummy.c(1603):dummy_get_powerstat returning(0) 
***2:rig.c(6810):rig_get_powerstat returning(0) 
***2:dummy.c(353):dummy_open entered
***2:dummy.c(366):dummy_open returning(0) 
***2:rig.c(3381):rig_get_vfo entered
rig_get_vfo: cache miss age=1000000ms
**rig.c(3415) trace
****3:dummy.c(725):dummy_get_vfo entered
****3:dummy.c(729):dummy_get_vfo returning(0) 
**2:rig_get_vfo: elapsed=20ms
***2:rig.c(3442):rig_get_vfo returning(0) 
***2:rig.c(8332):morse_data_handler_start entered
****3:dummy.c(1262):dummy_get_level entered
rig_setting2idx called
rig_setting2idx: idx=14
dummy_get_level called: KEYSPD
****3:dummy.c(1376):dummy_get_level returning(0) 
morse_data_handler_start(8350): keyspd=0
***2:rig.c(8362):morse_data_handler_start returning(0) 
morse_data_handler: Starting morse data handler thread
***2:rig.c(2384):rig_get_freq entered
rig_get_freq called vfo=VFOA
rig_get_freq(2402) called vfo=VFOA
vfo_fixup:(from rig_get_freq:2409) vfo=VFOA, vfo_curr=VFOA, split=0
vfo_fixup: final vfo=VFOA
rig.c(2411) vfo=VFOA, curr_vfo=VFOA
rig_get_freq: cache miss age=1000000ms, cached_vfo=VFOA, asked_vfo=VFOA, use_cached_freq=0
rig_get_freq(2524): vfo_opt=0, model=1
****3:dummy.c(494):dummy_get_freq entered
dummy_get_freq called: VFOA
dummy_get_freq: freq=145000000
****3:dummy.c(529):dummy_get_freq returning(0) 
rig_get_band called
rig_get_freq: band changing to BAND2M
**2:rig_get_freq: elapsed=22ms
***2:rig.c(2661):rig_get_freq returning(0) 
***2:rig.c(2384):rig_get_freq entered
rig_get_freq called vfo=VFOB
rig_get_freq(2402) called vfo=VFOB
vfo_fixup:(from rig_get_freq:2409) vfo=VFOB, vfo_curr=VFOA, split=0
vfo_fixup: final vfo=VFOB
rig.c(2411) vfo=VFOB, curr_vfo=VFOA
rig_get_freq: cache miss age=1000000ms, cached_vfo=VFOB, asked_vfo=VFOB, use_cached_freq=0
rig_get_freq(2524): vfo_opt=0, model=1
****3:dummy.c(494):dummy_get_freq entered
dummy_get_freq called: VFOB
dummy_get_freq: freq=146000000
****3:dummy.c(529):dummy_get_freq returning(0) 
rig_get_band called
**2:rig_get_freq: elapsed=21ms
***2:rig.c(2661):rig_get_freq returning(0) 
***2:rig.c(5837):rig_get_split_vfo entered
rig_get_split_vfo: cache check age=1000000ms
rig_get_split_vfo: cache miss age=1000000ms
**rig.c(5882) trace
****3:dummy.c(1103):dummy_get_split_vfo entered
dummy_get_split_vfo: split=0, vfo=currVFO, tx_vfo=None
****3:dummy.c(1111):dummy_get_split_vfo returning(0) 
rig_get_split_vfo(5892): cache.split=0
**2:rig_get_split_vfo: elapsed=0ms
***2:rig.c(5897):rig_get_split_vfo returning(0) 
rig_open(1540): Current split=0, tx_vfo=None
***2:rig.c(2915):rig_get_mode entered
vfo_fixup:(from rig_get_mode:2932) vfo=VFOA, vfo_curr=VFOA, split=0
vfo_fixup: final vfo=VFOA
rig_get_mode: VFOA cache check age=44ms
rig_get_mode: cache miss age mode=44ms, width=44ms
**rig.c(2982) trace
****3:dummy.c(625):dummy_get_mode entered
dummy_get_mode called: VFOA
****3:dummy.c(658):dummy_get_mode returning(0) 
rig_get_mode: retcode after get_mode=0
rig_get_mode(3028): debug
****3:cache.c(39):rig_set_cache_mode entered
****3:cache.c(153):rig_set_cache_mode returning(0) 
**2:rig_get_mode: elapsed=21ms
***2:rig.c(3045):rig_get_mode returning(0) 
***2:network.c(1552):network_multicast_publisher_start entered
network.c(1561): multicast publisher address=224.0.0.1, port=4532
network.c(1630) MULTICAST_TRANSCEIVE enabled
network.c(1636) MULTICAST_SPECTRUM enabled
***2:network.c(1688):network_multicast_publisher_start returning(0) 
network.c(988): Starting multicast publisher
***2:network.c(1763):network_multicast_receiver_start entered
network.c(1773): multicast receiver address=224.0.0.2, port=4532
***2:network.c(1856):network_multicast_receiver_start returning(0) 
network.c(1327): Starting multicast receiver
***2:event.c(272):rig_poll_routine_start entered
***2:event.c(312):rig_poll_routine_start returning(0) 
event.c(85): Starting rig poll routine thread
rig_set_cache_timeout_ms: called selection=0, ms=1000
rig.c(296):add_opened_rig entered
rig.c(308):add_opened_rig returning2(0) 
rig.c(1614):rig_open returning2(0) 
Opened rig model 1, 'Dummy'
Backend version: 20230611.0, Status: Stable
main: Using IPV4
main: rigctld listening on port 4532
is_networked: Can use 127.0.0.1
is_networked: Will use 192.168.50.249
multicast_receiver: multicast binding to INADDR_ANY
```