### PR TITLE
Normalize some debug/trace output.

### DIFF
--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -33,7 +33,7 @@
 // Our shared secret password 
 #define HAMLIB_SECRET_LENGTH 32
 
-#define HAMLIB_TRACE rig_debug(RIG_DEBUG_TRACE,"%s%s(%d) trace\n",spaces(rig->state.depth-1), __FILE__, __LINE__)
+#define HAMLIB_TRACE rig_debug(RIG_DEBUG_TRACE,"%s%s(%d) trace\n",spaces(rig->state.depth), __FILE__, __LINE__)
 #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 
 #include <stdio.h>
@@ -3738,7 +3738,7 @@ extern HAMLIB_EXPORT_VAR(char) debugmsgsave3[DEBUGMSGSAVE_SIZE];  // last-2 debu
 
 // Measuring elapsed time -- local variable inside function when macro is used
 #define ELAPSED1 struct timespec __begin; elapsed_ms(&__begin, HAMLIB_ELAPSED_SET);
-#define ELAPSED2 rig_debug(RIG_DEBUG_VERBOSE, "%s%d:%s: elapsed=%.0lfms\n", spaces(rig->state.depth-1), rig->state.depth, __func__, elapsed_ms(&__begin, HAMLIB_ELAPSED_GET));
+#define ELAPSED2 rig_debug(RIG_DEBUG_VERBOSE, "%s%d:%s: elapsed=%.0lfms\n", spaces(rig->state.depth), rig->state.depth, __func__, elapsed_ms(&__begin, HAMLIB_ELAPSED_GET));
 
 // use this instead of snprintf for automatic detection of buffer limit
 #define SNPRINTF(s,n,...) { snprintf(s,n,##__VA_ARGS__);if (strlen(s) > n-1) fprintf(stderr,"****** %s(%d): buffer overflow ******\n", __func__, __LINE__); }

--- a/src/misc.c
+++ b/src/misc.c
@@ -2857,26 +2857,21 @@ char *rig_date_strget(char *buf, int buflen, int localtime)
     return date_strget(buf, buflen, localtime);
 }
 
+#define MAX_SPACES 256
 const char *spaces(int len)
 {
-    static char s[256];
-    memset(s, '*', sizeof(s));
+    static const char s[MAX_SPACES + 1] =
+      "****************************************************************"
+      "****************************************************************"
+      "****************************************************************"
+      "****************************************************************";
 
-    if (len > 255)
+    if (len < 0 || len > MAX_SPACES)
     {
         len = 0;
     }
 
-    if (len > 0)
-    {
-        s[len + 1] = 0;
-    }
-    else
-    {
-        s[1] = 0;
-    }
-
-    return s;
+    return &s[MAX_SPACES - len];
 }
 
 // if which==0 rig_band_select str will be returned


### PR DESCRIPTION
Make spaces(len) actually return a string of length 'len', not len + 1. Eliminate static writable memory and a 256 byte write on each debug/trace
 call.
Make the depth stars line up.