### PR TITLE
Replace state references with macro calls

### DIFF
--- a/rigs/alinco/dx77.c
+++ b/rigs/alinco/dx77.c
@@ -289,7 +289,7 @@ struct rig_caps dx77_caps =
 
 /*
  * dx77_transaction
- * We assume that rig!=NULL, rig->state!= NULL, data!=NULL, data_len!=NULL
+ * We assume that rig!=NULL, RIGPORT(rig)!= NULL, data!=NULL, data_len!=NULL
  * Otherwise, you'll get a nice seg fault. You've been warned!
  * TODO: error case handling
  */

--- a/rigs/alinco/dxsr8.c
+++ b/rigs/alinco/dxsr8.c
@@ -223,7 +223,7 @@ struct rig_caps dxsr8_caps =
 
 /*
  * dxsr8_transaction
- * We assume that rig!=NULL, rig->state!= NULL, data!=NULL, data_len!=NULL
+ * We assume that rig!=NULL, RIGPORT(rig)!= NULL, data!=NULL, data_len!=NULL
  * Otherwise, you'll get a nice seg fault. You've been warned!
  * TODO: error case handling
  */

--- a/rigs/aor/ar3000.c
+++ b/rigs/aor/ar3000.c
@@ -176,7 +176,7 @@ struct rig_caps ar3000a_caps =
 
 /*
  * ar3k_transaction
- * We assume that rig!=NULL, rig->state!= NULL
+ * We assume that rig!=NULL, RIGPORT(rig)!= NULL
  * Otherwise, you'll get a nice seg fault. You've been warned!
  * return value: RIG_OK if everything's fine, negative value otherwise
  * TODO: error case handling

--- a/rigs/aor/ar3030.c
+++ b/rigs/aor/ar3030.c
@@ -208,7 +208,7 @@ struct rig_caps ar3030_caps =
 
 /*
  * ar3030_transaction
- * We assume that rig!=NULL, rig->state!= NULL
+ * We assume that rig!=NULL, RIGPORT(rig)!= NULL
  * Otherwise, you'll get a nice seg fault. You've been warned!
  * return value: RIG_OK if everything's fine, negative value otherwise
  */

--- a/rigs/aor/sr2200.c
+++ b/rigs/aor/sr2200.c
@@ -265,7 +265,7 @@ struct rig_caps sr2200_caps =
 
 /*
  * sr2200_transaction
- * We assume that rig!=NULL, rig->state!= NULL, data!=NULL, data_len!=NULL
+ * We assume that rig!=NULL, RIGPORT(rig)!= NULL, data!=NULL, data_len!=NULL
  * Otherwise, you'll get a nice seg fault. You've been warned!
  * return value: RIG_OK if everything's fine, negative value otherwise
  * TODO: error case handling
@@ -593,7 +593,7 @@ int sr2200_get_vfo(RIG *rig, vfo_t *vfo)
 
 /*
  * sr2200_set_level
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  */
 int sr2200_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
@@ -677,7 +677,7 @@ int sr2200_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
 /*
  * sr2200_get_level
- * Assumes rig!=NULL, rig->state.priv!=NULL, val!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL, val!=NULL
  */
 int sr2200_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {

--- a/rigs/barrett/barrett.c
+++ b/rigs/barrett/barrett.c
@@ -56,10 +56,10 @@ DECLARE_INITRIG_BACKEND(barrett)
 void barrett_flush(RIG *rig)
 {
     hamlib_port_t *rp = RIGPORT(rig);
-    int timesave = rig->state.timeout;
-    rig->state.timeout = 0;
+    int timesave = STATE(rig)->timeout;
+    STATE(rig)->timeout = 0;
     rig_flush(rp);
-    rig->state.timeout = timesave;
+    STATE(rig)->timeout = timesave;
 }
 
 

--- a/rigs/drake/drake.c
+++ b/rigs/drake/drake.c
@@ -53,7 +53,7 @@
 
 /*
  * drake_transaction
- * We assume that rig!=NULL, rig->state!= NULL, data!=NULL, data_len!=NULL
+ * We assume that rig!=NULL, STATE(rig)!= NULL, data!=NULL, data_len!=NULL
  */
 int drake_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
                       int *data_len)

--- a/rigs/dummy/aclog.c
+++ b/rigs/dummy/aclog.c
@@ -321,15 +321,15 @@ static int aclog_init(RIG *rig)
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s version %s\n", __func__, rig->caps->version);
 
-    rig->state.priv  = (struct aclog_priv_data *)calloc(1, sizeof(
+    STATE(rig)->priv  = (struct aclog_priv_data *)calloc(1, sizeof(
                            struct aclog_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         RETURNFUNC(-RIG_ENOMEM);
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     memset(priv, 0, sizeof(struct aclog_priv_data));
     memset(priv->parms, 0, RIG_SETTING_MAX * sizeof(value_t));
@@ -337,7 +337,7 @@ static int aclog_init(RIG *rig)
     /*
      * set arbitrary initial status
      */
-    rig->state.current_vfo = RIG_VFO_A;
+    STATE(rig)->current_vfo = RIG_VFO_A;
     priv->split = 0;
     priv->ptt = 0;
     priv->curr_modeA = -1;
@@ -418,12 +418,12 @@ static rmode_t modeMapGetHamlib(const char *modeACLog)
 
 /*
 * aclog_get_freq
-* Assumes rig!=NULL, rig->state.priv!=NULL, freq!=NULL
+* Assumes rig!=NULL, STATE(rig)->priv!=NULL, freq!=NULL
 */
 static int aclog_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
     char value[MAXARGLEN];
-    struct aclog_priv_data *priv = (struct aclog_priv_data *) rig->state.priv;
+    struct aclog_priv_data *priv = (struct aclog_priv_data *) STATE(rig)->priv;
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s\n", __func__,
@@ -439,7 +439,7 @@ static int aclog_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
     if (vfo == RIG_VFO_CURR)
     {
-        vfo = rig->state.current_vfo;
+        vfo = STATE(rig)->current_vfo;
         rig_debug(RIG_DEBUG_TRACE, "%s: get_freq2 vfo=%s\n",
                   __func__, rig_strvfo(vfo));
     }
@@ -488,14 +488,14 @@ static int aclog_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
 /*
 * aclog_get_mode
-* Assumes rig!=NULL, rig->state.priv!=NULL, mode!=NULL
+* Assumes rig!=NULL, STATE(rig)->priv!=NULL, mode!=NULL
 */
 static int aclog_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
 {
     int retval;
     char value[MAXCMDLEN];
     char *cmdp;
-    struct aclog_priv_data *priv = (struct aclog_priv_data *) rig->state.priv;
+    struct aclog_priv_data *priv = (struct aclog_priv_data *) STATE(rig)->priv;
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s\n", __func__,
@@ -555,7 +555,7 @@ static int aclog_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
 }
 /*
 * aclog_open
-* Assumes rig!=NULL, rig->state.priv!=NULL
+* Assumes rig!=NULL, STATE(rig)->priv!=NULL
 */
 static int aclog_open(RIG *rig)
 {
@@ -563,7 +563,7 @@ static int aclog_open(RIG *rig)
     char value[MAXARGLEN];
     char *p;
 
-    //;struct aclog_priv_data *priv = (struct aclog_priv_data *) rig->state.priv;
+    //;struct aclog_priv_data *priv = (struct aclog_priv_data *) STATE(rig)->priv;
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_VERBOSE, "%s version %s\n", __func__, rig->caps->version);
@@ -618,9 +618,9 @@ static int aclog_open(RIG *rig)
         RETURNFUNC(RIG_EPROTO);
     }
 
-    rig->state.current_vfo = RIG_VFO_A;
+    STATE(rig)->current_vfo = RIG_VFO_A;
     rig_debug(RIG_DEBUG_TRACE, "%s: currvfo=%s value=%s\n", __func__,
-              rig_strvfo(rig->state.current_vfo), value);
+              rig_strvfo(STATE(rig)->current_vfo), value);
 
     RETURNFUNC(retval);
 }
@@ -638,7 +638,7 @@ static int aclog_close(RIG *rig)
 
 /*
 * aclog_cleanup
-* Assumes rig!=NULL, rig->state.priv!=NULL
+* Assumes rig!=NULL, STATE(rig)->priv!=NULL
 */
 static int aclog_cleanup(RIG *rig)
 {
@@ -651,12 +651,12 @@ static int aclog_cleanup(RIG *rig)
         RETURNFUNC2(-RIG_EINVAL);
     }
 
-    priv = (struct aclog_priv_data *)rig->state.priv;
+    priv = (struct aclog_priv_data *)STATE(rig)->priv;
 
     free(priv->ext_parms);
-    free(rig->state.priv);
+    free(STATE(rig)->priv);
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     // we really don't need to free this up as it's only done once
     // was causing problem when cleanup was followed by rig_open
@@ -684,7 +684,7 @@ static int aclog_cleanup(RIG *rig)
 
 /*
 * aclog_set_freq
-* assumes rig!=NULL, rig->state.priv!=NULL
+* assumes rig!=NULL, STATE(rig)->priv!=NULL
 */
 static int aclog_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
@@ -692,7 +692,7 @@ static int aclog_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     char cmd[MAXARGLEN];
     char value[1024];
 
-    //struct aclog_priv_data *priv = (struct aclog_priv_data *) rig->state.priv;
+    //struct aclog_priv_data *priv = (struct aclog_priv_data *) STATE(rig)->priv;
 
     rig_debug(RIG_DEBUG_TRACE, "%s\n", __func__);
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s freq=%.0f\n", __func__,
@@ -709,7 +709,7 @@ static int aclog_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
     if (vfo == RIG_VFO_CURR)
     {
-        vfo = rig->state.current_vfo;
+        vfo = STATE(rig)->current_vfo;
     }
 
 #endif
@@ -740,7 +740,7 @@ static int aclog_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     char *p;
     char *pttmode;
     char *ttmode = NULL;
-    struct aclog_priv_data *priv = (struct aclog_priv_data *) rig->state.priv;
+    struct aclog_priv_data *priv = (struct aclog_priv_data *) STATE(rig)->priv;
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s mode=%s width=%d\n",
@@ -757,7 +757,7 @@ static int aclog_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 
     if (vfo == RIG_VFO_CURR)
     {
-        vfo = rig->state.current_vfo;
+        vfo = STATE(rig)->current_vfo;
     }
 
     if (check_vfo(vfo) == FALSE)
@@ -776,7 +776,7 @@ static int aclog_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     // Switch to VFOB if appropriate since we can't set mode directly
     // MDB
     rig_debug(RIG_DEBUG_TRACE, "%s: curr_vfo = %s\n", __func__,
-              rig_strvfo(rig->state.current_vfo));
+              rig_strvfo(STATE(rig)->current_vfo));
 
     // Set the mode
     if (strstr(modeMapGet(mode), "ERROR") == NULL)
@@ -858,7 +858,7 @@ static int aclog_get_vfo(RIG *rig, vfo_t *vfo)
 */
 static const char *aclog_get_info(RIG *rig)
 {
-    const struct aclog_priv_data *priv = (struct aclog_priv_data *) rig->state.priv;
+    const struct aclog_priv_data *priv = (struct aclog_priv_data *) STATE(rig)->priv;
 
     return (priv->info);
 }
@@ -866,7 +866,7 @@ static const char *aclog_get_info(RIG *rig)
 static int aclog_power2mW(RIG *rig, unsigned int *mwpower, float power,
                           freq_t freq, rmode_t mode)
 {
-    const struct aclog_priv_data *priv = (struct aclog_priv_data *) rig->state.priv;
+    const struct aclog_priv_data *priv = (struct aclog_priv_data *) STATE(rig)->priv;
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s: passed power = %f\n", __func__, power);
     rig_debug(RIG_DEBUG_TRACE, "%s: passed freq = %"PRIfreq" Hz\n", __func__, freq);
@@ -902,7 +902,7 @@ static int aclog_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 {
     int retval;
     char cmd[MAXCMDLEN];
-    struct aclog_priv_data *priv = (struct aclog_priv_data *) rig->state.priv;
+    struct aclog_priv_data *priv = (struct aclog_priv_data *) STATE(rig)->priv;
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s: ptt=%d\n", __func__, ptt);

--- a/rigs/dummy/amp_dummy.c
+++ b/rigs/dummy/amp_dummy.c
@@ -52,15 +52,15 @@ static int dummy_amp_init(AMP *amp)
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    amp->state.priv = (struct dummy_amp_priv_data *)
+    AMPSTATE(amp)->priv = (struct dummy_amp_priv_data *)
                       calloc(1, sizeof(struct dummy_amp_priv_data));
 
-    if (!amp->state.priv)
+    if (!AMPSTATE(amp)->priv)
     {
         return -RIG_ENOMEM;
     }
 
-    priv = amp->state.priv;
+    priv = AMPSTATE(amp)->priv;
 
     AMPPORT(amp)->type.rig = RIG_PORT_NONE;
 
@@ -73,12 +73,12 @@ static int dummy_amp_cleanup(AMP *amp)
 {
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    if (amp->state.priv)
+    if (AMPSTATE(amp)->priv)
     {
-        free(amp->state.priv);
+        free(AMPSTATE(amp)->priv);
     }
 
-    amp->state.priv = NULL;
+    AMPSTATE(amp)->priv = NULL;
 
     return RIG_OK;
 }
@@ -143,7 +143,7 @@ Also a way to display faults (there are commands)
 static int dummy_amp_get_freq(AMP *amp, freq_t *freq)
 {
     const struct dummy_amp_priv_data *priv = (struct dummy_amp_priv_data *)
-            amp->state.priv;
+            AMPSTATE(amp)->priv;
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
     *freq = priv->freq;
     return RIG_OK;
@@ -152,7 +152,7 @@ static int dummy_amp_get_freq(AMP *amp, freq_t *freq)
 static int dummy_amp_set_freq(AMP *amp, freq_t freq)
 {
     struct dummy_amp_priv_data *priv = (struct dummy_amp_priv_data *)
-                                       amp->state.priv;
+                                       AMPSTATE(amp)->priv;
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
     priv->freq = freq;
     return RIG_OK;
@@ -227,7 +227,7 @@ static int dummy_amp_get_level(AMP *amp, setting_t level, value_t *val)
 static int dummy_amp_set_powerstat(AMP *amp, powerstat_t status)
 {
     struct dummy_amp_priv_data *priv = (struct dummy_amp_priv_data *)
-                                       amp->state.priv;
+                                       AMPSTATE(amp)->priv;
 
     switch (status)
     {
@@ -267,7 +267,7 @@ static int dummy_amp_set_powerstat(AMP *amp, powerstat_t status)
 static int dummy_amp_get_powerstat(AMP *amp, powerstat_t *status)
 {
     const struct dummy_amp_priv_data *priv = (struct dummy_amp_priv_data *)
-            amp->state.priv;
+            AMPSTATE(amp)->priv;
 
     *status = priv->powerstat;
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
@@ -279,7 +279,7 @@ static int dummy_amp_get_powerstat(AMP *amp, powerstat_t *status)
 static int dummy_amp_get_ext_level(AMP *amp, hamlib_token_t token, value_t *val)
 {
     struct dummy_amp_priv_data *priv = (struct dummy_amp_priv_data *)
-                                       amp->state.priv;
+                                       AMPSTATE(amp)->priv;
     const struct confparams *cfp;
     struct ext_list *elp;
 

--- a/rigs/dummy/netampctl.c
+++ b/rigs/dummy/netampctl.c
@@ -62,7 +62,7 @@ static int netampctl_transaction(AMP *amp, char *cmd, int len, char *buf)
 static int netampctl_open(AMP *amp)
 {
     int ret;
-    //struct amp_state *rs = &amp->state;
+    //struct amp_state *rs = AMPSTATE(amp);
     hamlib_port_t *ampp = AMPPORT(amp);
     int pamp_ver;
     char cmd[CMD_MAX];

--- a/rigs/dummy/netrigctl.c
+++ b/rigs/dummy/netrigctl.c
@@ -48,7 +48,7 @@ struct netrigctl_priv_data
 int netrigctl_get_vfo_mode(RIG *rig)
 {
     struct netrigctl_priv_data *priv;
-    priv = (struct netrigctl_priv_data *)rig->state.priv;
+    priv = (struct netrigctl_priv_data *)STATE(rig)->priv;
     return priv->rigctld_vfo_mode;
 }
 
@@ -105,7 +105,7 @@ static int netrigctl_vfostr(RIG *rig, char *vfostr, int len, vfo_t vfo)
 
     vfostr[0] = 0;
 
-    priv = (struct netrigctl_priv_data *)rig->state.priv;
+    priv = (struct netrigctl_priv_data *)STATE(rig)->priv;
 
     if (vfo == RIG_VFO_CURR)
     {
@@ -118,9 +118,9 @@ static int netrigctl_vfostr(RIG *rig, char *vfostr, int len, vfo_t vfo)
     else if (vfo == RIG_VFO_RX) { vfo = priv->rx_vfo; }
     else if (vfo == RIG_VFO_TX) { vfo = priv->tx_vfo; }
 
-    rig_debug(RIG_DEBUG_TRACE, "%s: vfo_opt=%d\n", __func__, rig->state.vfo_opt);
+    rig_debug(RIG_DEBUG_TRACE, "%s: vfo_opt=%d\n", __func__, STATE(rig)->vfo_opt);
 
-    if (rig->state.vfo_opt || priv->rigctld_vfo_mode)
+    if (STATE(rig)->vfo_opt || priv->rigctld_vfo_mode)
     {
         rig_debug(RIG_DEBUG_TRACE, "%s: vfo_opt vfo=%u\n", __func__, vfo);
         char *myvfo;
@@ -164,15 +164,15 @@ static int netrigctl_init(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    rig->state.priv = (struct netrigctl_priv_data *)calloc(1, sizeof(
+    STATE(rig)->priv = (struct netrigctl_priv_data *)calloc(1, sizeof(
                           struct netrigctl_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
     memset(priv, 0, sizeof(struct netrigctl_priv_data));
 
     rig_debug(RIG_DEBUG_TRACE, "%s version %s\n", __func__, rig->caps->version);
@@ -189,9 +189,9 @@ static int netrigctl_init(RIG *rig)
 
 static int netrigctl_cleanup(RIG *rig)
 {
-    if (rig->state.priv) { free(rig->state.priv); }
+    if (STATE(rig)->priv) { free(STATE(rig)->priv); }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
     return RIG_OK;
 }
 
@@ -247,7 +247,7 @@ int parse_array_double(const char *s, const char *delim, double *array,
 static int netrigctl_open(RIG *rig)
 {
     int ret, i;
-    struct rig_state *rs = &rig->state;
+    struct rig_state *rs = STATE(rig);
     hamlib_port_t *rp = RIGPORT(rig);
     int prot_ver;
     char cmd[CMD_MAX];
@@ -257,7 +257,7 @@ static int netrigctl_open(RIG *rig)
 
     ENTERFUNC;
 
-    priv = (struct netrigctl_priv_data *)rig->state.priv;
+    priv = (struct netrigctl_priv_data *)STATE(rig)->priv;
     priv->rx_vfo = RIG_VFO_A;
     priv->tx_vfo = RIG_VFO_B;
 
@@ -266,7 +266,7 @@ static int netrigctl_open(RIG *rig)
 
     if (sscanf(buf, "%d", &priv->rigctld_vfo_mode) == 1)
     {
-        rig->state.vfo_opt = priv->rigctld_vfo_mode;
+        STATE(rig)->vfo_opt = priv->rigctld_vfo_mode;
         rig_debug(RIG_DEBUG_TRACE, "%s: chkvfo=%d\n", __func__, priv->rigctld_vfo_mode);
     }
     else if (ret == 2)
@@ -647,7 +647,7 @@ static int netrigctl_open(RIG *rig)
         {
             if (strcmp(setting, "vfo_ops") == 0)
             {
-                rig->caps->vfo_ops = rig->state.vfo_ops = strtoll(value, NULL, 0);
+                rig->caps->vfo_ops = STATE(rig)->vfo_ops = strtoll(value, NULL, 0);
                 rig_debug(RIG_DEBUG_TRACE, "%s: %s set to %d\n", __func__, setting,
                           rig->caps->vfo_ops);
             }
@@ -665,7 +665,7 @@ static int netrigctl_open(RIG *rig)
                      * locally overridden it
                      */
                     pttp->type.ptt = RIG_PTT_RIG_MICDATA;
-                    rig->caps->ptt_type = rig->state.ptt_type = RIG_PTT_RIG_MICDATA;
+                    rig->caps->ptt_type = STATE(rig)->ptt_type = RIG_PTT_RIG_MICDATA;
                     rig_debug(RIG_DEBUG_TRACE, "%s: %s set to %d\n", __func__, setting,
                               pttp->type.ptt);
                 }
@@ -673,13 +673,13 @@ static int netrigctl_open(RIG *rig)
                 {
                     rig_debug(RIG_DEBUG_VERBOSE, "%s: ptt_type= %d\n", __func__, temp);
                     pttp->type.ptt = temp;
-                    rig->caps->ptt_type = rig->state.ptt_type = temp;
+                    rig->caps->ptt_type = STATE(rig)->ptt_type = temp;
                 }
             }
 
             else if (strcmp(setting, "targetable_vfo") == 0)
             {
-                rig->caps->targetable_vfo = rig->state.targetable_vfo = strtol(value, NULL, 0);
+                rig->caps->targetable_vfo = STATE(rig)->targetable_vfo = strtol(value, NULL, 0);
                 rig_debug(RIG_DEBUG_VERBOSE, "%s: targetable_vfo=0x%2x\n", __func__,
                           rig->caps->targetable_vfo);
             }
@@ -922,7 +922,7 @@ static int netrigctl_open(RIG *rig)
 
 static int netrigctl_close(RIG *rig)
 {
-    const struct rig_state *rs = &rig->state;
+    const struct rig_state *rs = STATE(rig);
     int ret;
     char buf[BUF_MAX];
 
@@ -1105,7 +1105,7 @@ static int netrigctl_set_vfo(RIG *rig, vfo_t vfo)
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    priv = (struct netrigctl_priv_data *)rig->state.priv;
+    priv = (struct netrigctl_priv_data *)STATE(rig)->priv;
 
     SNPRINTF(cmd, sizeof(cmd), "V %s\n", rig_strvfo(vfo));
     rig_debug(RIG_DEBUG_VERBOSE, "%s: cmd='%s'\n", __func__, cmd);
@@ -1117,7 +1117,7 @@ static int netrigctl_set_vfo(RIG *rig, vfo_t vfo)
     }
 
     priv->vfo_curr = vfo; // remember our vfo
-    rig->state.current_vfo = vfo;
+    STATE(rig)->current_vfo = vfo;
     return ret;
 }
 
@@ -1131,7 +1131,7 @@ static int netrigctl_get_vfo(RIG *rig, vfo_t *vfo)
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    priv = (struct netrigctl_priv_data *)rig->state.priv;
+    priv = (struct netrigctl_priv_data *)STATE(rig)->priv;
 
     SNPRINTF(cmd, sizeof(cmd), "v\n");
 
@@ -2651,7 +2651,7 @@ static int netrigctl_set_vfo_opt(RIG *rig, int status)
         return -RIG_EPROTO;
     }
 
-    rig->state.vfo_opt = status;
+    STATE(rig)->vfo_opt = status;
     return RIG_OK;
 }
 

--- a/rigs/dummy/netrotctl.c
+++ b/rigs/dummy/netrotctl.c
@@ -66,7 +66,7 @@ static int netrotctl_transaction(ROT *rot, char *cmd, int len, char *buf)
 static int netrotctl_open(ROT *rot)
 {
     int ret;
-    struct rot_state *rs = &rot->state;
+    struct rot_state *rs = ROTSTATE(rot);
     hamlib_port_t *rotp = ROTPORT(rot);
     int prot_ver;
     char cmd[CMD_MAX];

--- a/rigs/dummy/quisk.c
+++ b/rigs/dummy/quisk.c
@@ -50,7 +50,7 @@ struct quisk_priv_data
 int quisk_get_vfo_mode(RIG *rig)
 {
     struct quisk_priv_data *priv;
-    priv = (struct quisk_priv_data *)rig->state.priv;
+    priv = (struct quisk_priv_data *)STATE(rig)->priv;
     return priv->rigctld_vfo_mode;
 }
 #endif
@@ -109,7 +109,7 @@ static int quisk_vfostr(RIG *rig, char *vfostr, int len, vfo_t vfo)
 
     vfostr[0] = 0;
 
-    priv = (struct quisk_priv_data *)rig->state.priv;
+    priv = (struct quisk_priv_data *)STATE(rig)->priv;
 
     if (vfo == RIG_VFO_CURR)
     {
@@ -122,9 +122,9 @@ static int quisk_vfostr(RIG *rig, char *vfostr, int len, vfo_t vfo)
     else if (vfo == RIG_VFO_RX) { vfo = priv->rx_vfo; }
     else if (vfo == RIG_VFO_TX) { vfo = priv->tx_vfo; }
 
-    rig_debug(RIG_DEBUG_TRACE, "%s: vfo_opt=%d\n", __func__, rig->state.vfo_opt);
+    rig_debug(RIG_DEBUG_TRACE, "%s: vfo_opt=%d\n", __func__, STATE(rig)->vfo_opt);
 
-    if (rig->state.vfo_opt || priv->rigctld_vfo_mode)
+    if (STATE(rig)->vfo_opt || priv->rigctld_vfo_mode)
     {
         rig_debug(RIG_DEBUG_TRACE, "%s: vfo_opt vfo=%u\n", __func__, vfo);
         char *myvfo;
@@ -168,15 +168,15 @@ static int quisk_init(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    rig->state.priv = (struct quisk_priv_data *)calloc(1, sizeof(
+    STATE(rig)->priv = (struct quisk_priv_data *)calloc(1, sizeof(
                           struct quisk_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
     memset(priv, 0, sizeof(struct quisk_priv_data));
 
     rig_debug(RIG_DEBUG_TRACE, "%s version %s\n", __func__, rig->caps->version);
@@ -193,9 +193,9 @@ static int quisk_init(RIG *rig)
 
 static int quisk_cleanup(RIG *rig)
 {
-    if (rig->state.priv) { free(rig->state.priv); }
+    if (STATE(rig)->priv) { free(STATE(rig)->priv); }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
     return RIG_OK;
 }
 
@@ -208,7 +208,7 @@ extern int parse_array_double(const char *s, const char *delim, double *array,
 static int quisk_open(RIG *rig)
 {
     int ret, i;
-    struct rig_state *rs = &rig->state;
+    struct rig_state *rs = STATE(rig);
     int prot_ver;
     char cmd[CMD_MAX];
     char buf[BUF_MAX];
@@ -218,7 +218,7 @@ static int quisk_open(RIG *rig)
 
     ENTERFUNC;
 
-    priv = (struct quisk_priv_data *)rig->state.priv;
+    priv = (struct quisk_priv_data *)rs->priv;
     priv->rx_vfo = RIG_VFO_A;
     priv->tx_vfo = RIG_VFO_A;
 
@@ -850,7 +850,7 @@ static int quisk_open(RIG *rig)
 
 static int quisk_close(RIG *rig)
 {
-    const struct rig_state *rs = &rig->state;
+    const struct rig_state *rs = STATE(rig);
     int ret;
     char buf[BUF_MAX];
 
@@ -1035,7 +1035,7 @@ static int quisk_set_vfo(RIG *rig, vfo_t vfo)
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    priv = (struct quisk_priv_data *)rig->state.priv;
+    priv = (struct quisk_priv_data *)STATE(rig)->priv;
 
     SNPRINTF(cmd, sizeof(cmd), "V%s %s\n", vfostr, rig_strvfo(vfo));
     rig_debug(RIG_DEBUG_VERBOSE, "%s: cmd='%s'\n", __func__, cmd);
@@ -1047,7 +1047,7 @@ static int quisk_set_vfo(RIG *rig, vfo_t vfo)
     }
 
     priv->vfo_curr = vfo; // remember our vfo
-    rig->state.current_vfo = vfo;
+    STATE(rig)->current_vfo = vfo;
     return ret;
 }
 
@@ -1061,7 +1061,7 @@ static int quisk_get_vfo(RIG *rig, vfo_t *vfo)
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    priv = (struct quisk_priv_data *)rig->state.priv;
+    priv = (struct quisk_priv_data *)STATE(rig)->priv;
 
     SNPRINTF(cmd, sizeof(cmd), "v\n");
 
@@ -2582,7 +2582,7 @@ static int quisk_set_vfo_opt(RIG *rig, int status)
         return -RIG_EPROTO;
     }
 
-    rig->state.vfo_opt = status;
+    STATE(rig)->vfo_opt = status;
     return RIG_OK;
 }
 

--- a/rigs/dummy/rot_dummy.c
+++ b/rigs/dummy/rot_dummy.c
@@ -120,15 +120,15 @@ static int dummy_rot_init(ROT *rot)
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    rot->state.priv = (struct dummy_rot_priv_data *)
+    ROTSTATE(rot)->priv = (struct dummy_rot_priv_data *)
                       calloc(1, sizeof(struct dummy_rot_priv_data));
 
-    if (!rot->state.priv)
+    if (!ROTSTATE(rot)->priv)
     {
         return -RIG_ENOMEM;
     }
 
-    priv = rot->state.priv;
+    priv = ROTSTATE(rot)->priv;
 
     priv->ext_funcs = alloc_init_ext(dummy_ext_funcs);
 
@@ -165,7 +165,7 @@ static int dummy_rot_init(ROT *rot)
 static int dummy_rot_cleanup(ROT *rot)
 {
     struct dummy_rot_priv_data *priv = (struct dummy_rot_priv_data *)
-                                       rot->state.priv;
+                                       ROTSTATE(rot)->priv;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
@@ -173,9 +173,9 @@ static int dummy_rot_cleanup(ROT *rot)
     free(priv->ext_levels);
     free(priv->ext_parms);
     free(priv->magic_conf);
-    free(rot->state.priv);
+    free(ROTSTATE(rot)->priv);
 
-    rot->state.priv = NULL;
+    ROTSTATE(rot)->priv = NULL;
 
     return RIG_OK;
 }
@@ -205,7 +205,7 @@ static int dummy_set_conf(ROT *rot, hamlib_token_t token, const char *val)
 {
     struct dummy_rot_priv_data *priv;
 
-    priv = (struct dummy_rot_priv_data *)rot->state.priv;
+    priv = (struct dummy_rot_priv_data *)ROTSTATE(rot)->priv;
 
     switch (token)
     {
@@ -230,7 +230,7 @@ static int dummy_get_conf2(ROT *rot, hamlib_token_t token, char *val, int val_le
 {
     struct dummy_rot_priv_data *priv;
 
-    priv = (struct dummy_rot_priv_data *)rot->state.priv;
+    priv = (struct dummy_rot_priv_data *)ROTSTATE(rot)->priv;
 
     switch (token)
     {
@@ -255,7 +255,7 @@ static int dummy_get_conf(ROT *rot, hamlib_token_t token, char *val)
 static int dummy_rot_set_position(ROT *rot, azimuth_t az, elevation_t el)
 {
     struct dummy_rot_priv_data *priv = (struct dummy_rot_priv_data *)
-                                       rot->state.priv;
+                                       ROTSTATE(rot)->priv;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called: %.2f %.2f\n", __func__,
               az, el);
@@ -279,7 +279,7 @@ static int dummy_rot_set_position(ROT *rot, azimuth_t az, elevation_t el)
 static void dummy_rot_simulate_rotation(ROT *rot)
 {
     struct dummy_rot_priv_data *priv = (struct dummy_rot_priv_data *)
-                                       rot->state.priv;
+                                       ROTSTATE(rot)->priv;
     struct timeval tv;
     unsigned elapsed; /* ms */
 
@@ -354,7 +354,7 @@ static void dummy_rot_simulate_rotation(ROT *rot)
 static int dummy_rot_get_position(ROT *rot, azimuth_t *az, elevation_t *el)
 {
     const struct dummy_rot_priv_data *priv = (struct dummy_rot_priv_data *)
-            rot->state.priv;
+            ROTSTATE(rot)->priv;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
@@ -381,7 +381,7 @@ static int dummy_rot_get_position(ROT *rot, azimuth_t *az, elevation_t *el)
 static int dummy_rot_stop(ROT *rot)
 {
     struct dummy_rot_priv_data *priv = (struct dummy_rot_priv_data *)
-                                       rot->state.priv;
+                                       ROTSTATE(rot)->priv;
     azimuth_t az;
     elevation_t el;
 
@@ -416,7 +416,7 @@ static int dummy_rot_reset(ROT *rot, rot_reset_t reset)
 static int dummy_rot_move(ROT *rot, int direction, int speed)
 {
     const struct dummy_rot_priv_data *priv = (struct dummy_rot_priv_data *)
-            rot->state.priv;
+            ROTSTATE(rot)->priv;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
     rig_debug(RIG_DEBUG_TRACE, "%s: Direction = %d, Speed = %d\n", __func__,
@@ -469,7 +469,7 @@ static const char *dummy_rot_get_info(ROT *rot)
 static int dummy_set_func(ROT *rot, setting_t func, int status)
 {
     struct dummy_rot_priv_data *priv = (struct dummy_rot_priv_data *)
-                                       rot->state.priv;
+                                       ROTSTATE(rot)->priv;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called: %s %d\n", __func__,
               rot_strfunc(func), status);
@@ -490,7 +490,7 @@ static int dummy_set_func(ROT *rot, setting_t func, int status)
 static int dummy_get_func(ROT *rot, setting_t func, int *status)
 {
     const struct dummy_rot_priv_data *priv = (struct dummy_rot_priv_data *)
-            rot->state.priv;
+            ROTSTATE(rot)->priv;
 
     *status = (priv->funcs & func) ? 1 : 0;
 
@@ -504,7 +504,7 @@ static int dummy_get_func(ROT *rot, setting_t func, int *status)
 static int dummy_set_level(ROT *rot, setting_t level, value_t val)
 {
     struct dummy_rot_priv_data *priv = (struct dummy_rot_priv_data *)
-                                       rot->state.priv;
+                                       ROTSTATE(rot)->priv;
     int idx;
     char lstr[32];
 
@@ -536,7 +536,7 @@ static int dummy_set_level(ROT *rot, setting_t level, value_t val)
 static int dummy_get_level(ROT *rot, setting_t level, value_t *val)
 {
     struct dummy_rot_priv_data *priv = (struct dummy_rot_priv_data *)
-                                       rot->state.priv;
+                                       ROTSTATE(rot)->priv;
     int idx;
 
     idx = rig_setting2idx(level);
@@ -557,7 +557,7 @@ static int dummy_get_level(ROT *rot, setting_t level, value_t *val)
 static int dummy_set_ext_level(ROT *rot, hamlib_token_t token, value_t val)
 {
     struct dummy_rot_priv_data *priv = (struct dummy_rot_priv_data *)
-                                       rot->state.priv;
+                                       ROTSTATE(rot)->priv;
     char lstr[64];
     const struct confparams *cfp;
     struct ext_list *elp;
@@ -626,7 +626,7 @@ static int dummy_set_ext_level(ROT *rot, hamlib_token_t token, value_t val)
 static int dummy_get_ext_level(ROT *rot, hamlib_token_t token, value_t *val)
 {
     struct dummy_rot_priv_data *priv = (struct dummy_rot_priv_data *)
-                                       rot->state.priv;
+                                       ROTSTATE(rot)->priv;
     const struct confparams *cfp;
     struct ext_list *elp;
 
@@ -669,7 +669,7 @@ static int dummy_get_ext_level(ROT *rot, hamlib_token_t token, value_t *val)
 static int dummy_set_ext_func(ROT *rot, hamlib_token_t token, int status)
 {
     struct dummy_rot_priv_data *priv = (struct dummy_rot_priv_data *)
-                                       rot->state.priv;
+                                       ROTSTATE(rot)->priv;
     const struct confparams *cfp;
     struct ext_list *elp;
 
@@ -721,7 +721,7 @@ static int dummy_set_ext_func(ROT *rot, hamlib_token_t token, int status)
 static int dummy_get_ext_func(ROT *rot, hamlib_token_t token, int *status)
 {
     struct dummy_rot_priv_data *priv = (struct dummy_rot_priv_data *)
-                                       rot->state.priv;
+                                       ROTSTATE(rot)->priv;
     const struct confparams *cfp;
     struct ext_list *elp;
 
@@ -761,7 +761,7 @@ static int dummy_get_ext_func(ROT *rot, hamlib_token_t token, int *status)
 static int dummy_set_parm(ROT *rot, setting_t parm, value_t val)
 {
     struct dummy_rot_priv_data *priv = (struct dummy_rot_priv_data *)
-                                       rot->state.priv;
+                                       ROTSTATE(rot)->priv;
     int idx;
     char pstr[32];
 
@@ -793,7 +793,7 @@ static int dummy_set_parm(ROT *rot, setting_t parm, value_t val)
 static int dummy_get_parm(ROT *rot, setting_t parm, value_t *val)
 {
     struct dummy_rot_priv_data *priv = (struct dummy_rot_priv_data *)
-                                       rot->state.priv;
+                                       ROTSTATE(rot)->priv;
     int idx;
 
     idx = rig_setting2idx(parm);
@@ -814,7 +814,7 @@ static int dummy_get_parm(ROT *rot, setting_t parm, value_t *val)
 static int dummy_set_ext_parm(ROT *rot, hamlib_token_t token, value_t val)
 {
     struct dummy_rot_priv_data *priv = (struct dummy_rot_priv_data *)
-                                       rot->state.priv;
+                                       ROTSTATE(rot)->priv;
     char lstr[64];
     const struct confparams *cfp;
     struct ext_list *epp;
@@ -880,7 +880,7 @@ static int dummy_set_ext_parm(ROT *rot, hamlib_token_t token, value_t val)
 static int dummy_get_ext_parm(ROT *rot, hamlib_token_t token, value_t *val)
 {
     struct dummy_rot_priv_data *priv = (struct dummy_rot_priv_data *)
-                                       rot->state.priv;
+                                       ROTSTATE(rot)->priv;
     const struct confparams *cfp;
     struct ext_list *epp;
 
@@ -920,7 +920,7 @@ static int dummy_get_ext_parm(ROT *rot, hamlib_token_t token, value_t *val)
 static int dummy_rot_get_status(ROT *rot, rot_status_t *status)
 {
     const struct dummy_rot_priv_data *priv = (struct dummy_rot_priv_data *)
-            rot->state.priv;
+            ROTSTATE(rot)->priv;
 
     if (simulating)
     {

--- a/rigs/dummy/sdrsharp.c
+++ b/rigs/dummy/sdrsharp.c
@@ -274,15 +274,15 @@ static int sdrsharp_init(RIG *rig)
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s version %s\n", __func__, rig->caps->version);
 
-    rig->state.priv  = (struct sdrsharp_priv_data *)calloc(1, sizeof(
+    STATE(rig)->priv  = (struct sdrsharp_priv_data *)calloc(1, sizeof(
                            struct sdrsharp_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         RETURNFUNC(-RIG_ENOMEM);
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     memset(priv, 0, sizeof(struct sdrsharp_priv_data));
     memset(priv->parms, 0, RIG_SETTING_MAX * sizeof(value_t));
@@ -290,7 +290,7 @@ static int sdrsharp_init(RIG *rig)
     /*
      * set arbitrary initial status
      */
-    rig->state.current_vfo = RIG_VFO_A;
+    STATE(rig)->current_vfo = RIG_VFO_A;
     priv->split = 0;
     priv->ptt = 0;
     priv->curr_modeA = -1;
@@ -310,12 +310,12 @@ static int sdrsharp_init(RIG *rig)
 
 /*
 * sdrsharp_get_freq
-* Assumes rig!=NULL, rig->state.priv!=NULL, freq!=NULL
+* Assumes rig!=NULL, STATE(rig)->priv!=NULL, freq!=NULL
 */
 static int sdrsharp_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
     char value[MAXARGLEN];
-    struct sdrsharp_priv_data *priv = (struct sdrsharp_priv_data *) rig->state.priv;
+    struct sdrsharp_priv_data *priv = (struct sdrsharp_priv_data *) STATE(rig)->priv;
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s\n", __func__,
@@ -331,7 +331,7 @@ static int sdrsharp_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
     if (vfo == RIG_VFO_CURR)
     {
-        vfo = rig->state.current_vfo;
+        vfo = STATE(rig)->current_vfo;
         rig_debug(RIG_DEBUG_TRACE, "%s: get_freq2 vfo=%s\n",
                   __func__, rig_strvfo(vfo));
     }
@@ -377,7 +377,7 @@ static int sdrsharp_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
 /*
 * sdrsharp_open
-* Assumes rig!=NULL, rig->state.priv!=NULL
+* Assumes rig!=NULL, STATE(rig)->priv!=NULL
 */
 static int sdrsharp_open(RIG *rig)
 {
@@ -397,9 +397,9 @@ static int sdrsharp_open(RIG *rig)
         RETURNFUNC(RIG_EPROTO);
     }
 
-    rig->state.current_vfo = RIG_VFO_A;
+    STATE(rig)->current_vfo = RIG_VFO_A;
     rig_debug(RIG_DEBUG_TRACE, "%s: currvfo=%s value=%s\n", __func__,
-              rig_strvfo(rig->state.current_vfo), value);
+              rig_strvfo(STATE(rig)->current_vfo), value);
 
     RETURNFUNC(retval);
 }
@@ -417,7 +417,7 @@ static int sdrsharp_close(RIG *rig)
 
 /*
 * sdrsharp_cleanup
-* Assumes rig!=NULL, rig->state.priv!=NULL
+* Assumes rig!=NULL, STATE(rig)->priv!=NULL
 */
 static int sdrsharp_cleanup(RIG *rig)
 {
@@ -430,12 +430,12 @@ static int sdrsharp_cleanup(RIG *rig)
         RETURNFUNC2(-RIG_EINVAL);
     }
 
-    priv = (struct sdrsharp_priv_data *)rig->state.priv;
+    priv = (struct sdrsharp_priv_data *)STATE(rig)->priv;
 
     free(priv->ext_parms);
-    free(rig->state.priv);
+    free(STATE(rig)->priv);
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     // we really don't need to free this up as it's only done once
     // was causing problem when cleanup was followed by rig_open
@@ -463,7 +463,7 @@ static int sdrsharp_cleanup(RIG *rig)
 
 /*
 * sdrsharp_set_freq
-* assumes rig!=NULL, rig->state.priv!=NULL
+* assumes rig!=NULL, STATE(rig)->priv!=NULL
 */
 static int sdrsharp_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
@@ -471,7 +471,7 @@ static int sdrsharp_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     char cmd[MAXARGLEN];
     char value[1024];
 
-    //struct sdrsharp_priv_data *priv = (struct sdrsharp_priv_data *) rig->state.priv;
+    //struct sdrsharp_priv_data *priv = (struct sdrsharp_priv_data *) STATE(rig)->priv;
 
     rig_debug(RIG_DEBUG_TRACE, "%s\n", __func__);
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s freq=%.0f\n", __func__,
@@ -488,7 +488,7 @@ static int sdrsharp_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
     if (vfo == RIG_VFO_CURR)
     {
-        vfo = rig->state.current_vfo;
+        vfo = STATE(rig)->current_vfo;
     }
 
 #endif

--- a/rigs/dummy/tci1x.c
+++ b/rigs/dummy/tci1x.c
@@ -424,15 +424,15 @@ static int tci1x_init(RIG *rig)
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s version %s\n", __func__, rig->caps->version);
 
-    rig->state.priv  = (struct tci1x_priv_data *)calloc(1, sizeof(
+    STATE(rig)->priv  = (struct tci1x_priv_data *)calloc(1, sizeof(
                            struct tci1x_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         RETURNFUNC(-RIG_ENOMEM);
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     memset(priv, 0, sizeof(struct tci1x_priv_data));
     memset(priv->parms, 0, RIG_SETTING_MAX * sizeof(value_t));
@@ -440,7 +440,7 @@ static int tci1x_init(RIG *rig)
     /*
      * set arbitrary initial status
      */
-    rig->state.current_vfo = RIG_VFO_A;
+    STATE(rig)->current_vfo = RIG_VFO_A;
     priv->split = 0;
     priv->ptt = 0;
     priv->curr_modeA = -1;
@@ -583,7 +583,7 @@ static void modeMapAdd(rmode_t *modes, rmode_t mode_hamlib, char *mode_tci1x)
 
 /*
 * tci1x_open
-* Assumes rig!=NULL, rig->state.priv!=NULL
+* Assumes rig!=NULL, STATE(rig)->priv!=NULL
 */
 static int tci1x_open(RIG *rig)
 {
@@ -594,7 +594,7 @@ static int tci1x_open(RIG *rig)
     rmode_t modes;
     char *p;
     char *pr;
-    //struct tci1x_priv_data *priv = (struct tci1x_priv_data *) rig->state.priv;
+    //struct tci1x_priv_data *priv = (struct tci1x_priv_data *) STATE(rig)->priv;
     arg[0] = '?';
     arg[1] = 0;
 
@@ -657,9 +657,9 @@ static int tci1x_open(RIG *rig)
         rig_debug(RIG_DEBUG_ERR, "%s: tci1x_get_freq not working!!\n", __func__);
     }
 
-    rig->state.current_vfo = RIG_VFO_A;
+    STATE(rig)->current_vfo = RIG_VFO_A;
     rig_debug(RIG_DEBUG_TRACE, "%s: currvfo=%s value=%s\n", __func__,
-              rig_strvfo(rig->state.current_vfo), value);
+              rig_strvfo(STATE(rig)->current_vfo), value);
     //tci1x_get_split_vfo(rig, vfo, &priv->split, &vfo_tx);
     RETURNFUNC2(RIG_OK);
 
@@ -784,7 +784,7 @@ static int tci1x_open(RIG *rig)
         else { rig_debug(RIG_DEBUG_ERR, "%s: Unknown mode (new?) for this rig='%s'\n", __func__, p); }
     }
 
-    rig->state.mode_list = modes;
+    STATE(rig)->mode_list = modes;
 
     retval = rig_strrmodes(modes, value, sizeof(value));
 
@@ -811,7 +811,7 @@ static int tci1x_close(RIG *rig)
 
 /*
 * tci1x_cleanup
-* Assumes rig!=NULL, rig->state.priv!=NULL
+* Assumes rig!=NULL, STATE(rig)->priv!=NULL
 */
 static int tci1x_cleanup(RIG *rig)
 {
@@ -819,24 +819,24 @@ static int tci1x_cleanup(RIG *rig)
 
     ENTERFUNC;
 
-    priv = (struct tci1x_priv_data *)rig->state.priv;
+    priv = (struct tci1x_priv_data *)STATE(rig)->priv;
 
     free(priv->ext_parms);
-    free(rig->state.priv);
+    free(STATE(rig)->priv);
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     RETURNFUNC(RIG_OK);
 }
 
 /*
 * tci1x_get_freq
-* Assumes rig!=NULL, rig->state.priv!=NULL, freq!=NULL
+* Assumes rig!=NULL, STATE(rig)->priv!=NULL, freq!=NULL
 */
 static int tci1x_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
     char value[MAXARGLEN];
-    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) rig->state.priv;
+    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) STATE(rig)->priv;
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s\n", __func__,
@@ -852,7 +852,7 @@ static int tci1x_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
     if (vfo == RIG_VFO_CURR)
     {
-        vfo = rig->state.current_vfo;
+        vfo = STATE(rig)->current_vfo;
         rig_debug(RIG_DEBUG_TRACE, "%s: get_freq2 vfo=%s\n",
                   __func__, rig_strvfo(vfo));
     }
@@ -899,14 +899,14 @@ static int tci1x_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
 /*
 * tci1x_set_freq
-* assumes rig!=NULL, rig->state.priv!=NULL
+* assumes rig!=NULL, STATE(rig)->priv!=NULL
 */
 static int tci1x_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
     int retval;
     char cmd_arg[MAXARGLEN];
     char *cmd;
-    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) rig->state.priv;
+    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) STATE(rig)->priv;
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s freq=%.0f\n", __func__,
@@ -921,7 +921,7 @@ static int tci1x_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
     if (vfo == RIG_VFO_CURR)
     {
-        vfo = rig->state.current_vfo;
+        vfo = STATE(rig)->current_vfo;
     }
     else if (vfo == RIG_VFO_TX && priv->split)
     {
@@ -972,7 +972,7 @@ static int tci1x_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 {
     int retval;
     char cmd_arg[MAXARGLEN];
-    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) rig->state.priv;
+    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) STATE(rig)->priv;
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s: ptt=%d\n", __func__, ptt);
@@ -1015,7 +1015,7 @@ static int tci1x_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 static int tci1x_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
 {
     char value[MAXCMDLEN];
-    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) rig->state.priv;
+    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) STATE(rig)->priv;
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s\n", __func__,
@@ -1046,7 +1046,7 @@ static int tci1x_set_split_mode(RIG *rig, vfo_t vfo, rmode_t mode,
                                 pbwidth_t width)
 {
     int retval;
-    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) rig->state.priv;
+    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) STATE(rig)->priv;
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s mode=%s width=%d\n",
@@ -1055,7 +1055,7 @@ static int tci1x_set_split_mode(RIG *rig, vfo_t vfo, rmode_t mode,
     switch (vfo)
     {
     case RIG_VFO_CURR:
-        vfo = rig->state.current_vfo;
+        vfo = STATE(rig)->current_vfo;
         break;
 
     case RIG_VFO_TX:
@@ -1094,7 +1094,7 @@ static int tci1x_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     char *p;
     char *pttmode;
     char *ttmode = NULL;
-    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) rig->state.priv;
+    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) STATE(rig)->priv;
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s mode=%s width=%d\n",
@@ -1111,7 +1111,7 @@ static int tci1x_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 
     if (vfo == RIG_VFO_CURR)
     {
-        vfo = rig->state.current_vfo;
+        vfo = STATE(rig)->current_vfo;
     }
 
     if (check_vfo(vfo) == FALSE)
@@ -1131,11 +1131,11 @@ static int tci1x_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     // MDB
     vfoSwitched = 0;
     rig_debug(RIG_DEBUG_TRACE, "%s: curr_vfo = %s\n", __func__,
-              rig_strvfo(rig->state.current_vfo));
+              rig_strvfo(STATE(rig)->current_vfo));
 
     // If we don't have the get_bwA call we have to switch VFOs ourself
     if (!priv->has_get_bwA && vfo == RIG_VFO_B
-            && rig->state.current_vfo != RIG_VFO_B)
+            && STATE(rig)->current_vfo != RIG_VFO_B)
     {
         vfoSwitched = 1;
         rig_debug(RIG_DEBUG_TRACE, "%s: switch to VFOB = %d\n", __func__,
@@ -1289,7 +1289,7 @@ static int tci1x_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 
 /*
 * tci1x_get_mode
-* Assumes rig!=NULL, rig->state.priv!=NULL, mode!=NULL
+* Assumes rig!=NULL, STATE(rig)->priv!=NULL, mode!=NULL
 */
 static int tci1x_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
 {
@@ -1299,7 +1299,7 @@ static int tci1x_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
     char *cmdp;
     vfo_t curr_vfo;
     rmode_t my_mode;
-    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) rig->state.priv;
+    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) STATE(rig)->priv;
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s\n", __func__,
@@ -1312,11 +1312,11 @@ static int tci1x_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
         RETURNFUNC(-RIG_EINVAL);
     }
 
-    curr_vfo = rig->state.current_vfo;
+    curr_vfo = STATE(rig)->current_vfo;
 
     if (vfo == RIG_VFO_CURR)
     {
-        vfo = rig->state.current_vfo;
+        vfo = STATE(rig)->current_vfo;
     }
 
     rig_debug(RIG_DEBUG_TRACE, "%s: using vfo=%s\n", __func__,
@@ -1454,8 +1454,8 @@ static int tci1x_set_vfo(RIG *rig, vfo_t vfo)
 {
     int retval;
     char cmd_arg[MAXBUFLEN];
-    struct rig_state *rs = &rig->state;
-    const struct tci1x_priv_data *priv = (struct tci1x_priv_data *) rig->state.priv;
+    struct rig_state *rs = STATE(rig);
+    const struct tci1x_priv_data *priv = (struct tci1x_priv_data *) STATE(rig)->priv;
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s\n", __func__,
@@ -1477,7 +1477,7 @@ static int tci1x_set_vfo(RIG *rig, vfo_t vfo)
 
     if (vfo == RIG_VFO_CURR)
     {
-        vfo = rig->state.current_vfo;
+        vfo = STATE(rig)->current_vfo;
     }
 
     SNPRINTF(cmd_arg, sizeof(cmd_arg),
@@ -1492,7 +1492,7 @@ static int tci1x_set_vfo(RIG *rig, vfo_t vfo)
         RETURNFUNC(retval);
     }
 
-    rig->state.current_vfo = vfo;
+    STATE(rig)->current_vfo = vfo;
     rs->tx_vfo = RIG_VFO_B; // always VFOB
 
     /* for some rigs TCI turns off split when VFOA is selected */
@@ -1556,7 +1556,7 @@ static int tci1x_get_vfo(RIG *rig, vfo_t *vfo)
         RETURNFUNC(-RIG_EINVAL);
     }
 
-    rig->state.current_vfo = *vfo;
+    STATE(rig)->current_vfo = *vfo;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s\n", __func__,
               rig_strvfo(*vfo));
@@ -1573,7 +1573,7 @@ static int tci1x_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
     int retval;
     char cmd_arg[MAXBUFLEN];
     freq_t qtx_freq;
-    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) rig->state.priv;
+    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) STATE(rig)->priv;
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s freq=%.1f\n", __func__,
@@ -1615,7 +1615,7 @@ static int tci1x_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
 static int tci1x_get_split_freq(RIG *rig, vfo_t vfo, freq_t *tx_freq)
 {
     int retval;
-    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) rig->state.priv;
+    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) STATE(rig)->priv;
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s\n", __func__,
@@ -1635,7 +1635,7 @@ static int tci1x_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
     int retval;
     vfo_t qtx_vfo;
     split_t qsplit;
-    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) rig->state.priv;
+    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) STATE(rig)->priv;
     char cmd_arg[MAXBUFLEN];
 
     ENTERFUNC;
@@ -1677,7 +1677,7 @@ static int tci1x_get_split_vfo(RIG *rig, vfo_t vfo, split_t *split,
                                vfo_t *tx_vfo)
 {
     char value[MAXCMDLEN];
-    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) rig->state.priv;
+    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) STATE(rig)->priv;
 
     ENTERFUNC;
 
@@ -1707,7 +1707,7 @@ static int tci1x_set_split_freq_mode(RIG *rig, vfo_t vfo, freq_t freq,
     int retval;
     rmode_t qmode;
     pbwidth_t qwidth;
-    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) rig->state.priv;
+    struct tci1x_priv_data *priv = (struct tci1x_priv_data *) STATE(rig)->priv;
 
     ENTERFUNC;
 
@@ -1823,14 +1823,14 @@ static int tci1x_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
 /*
 * tci1x_get_level
-* Assumes rig!=NULL, rig->state.priv!=NULL, val!=NULL
+* Assumes rig!=NULL, STATE(rig)->priv!=NULL, val!=NULL
 */
 static int tci1x_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
     char value[MAXARGLEN];
     char *cmd;
     int retval;
-    const struct tci1x_priv_data *priv = (struct tci1x_priv_data *) rig->state.priv;
+    const struct tci1x_priv_data *priv = (struct tci1x_priv_data *) STATE(rig)->priv;
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s\n", __func__,
@@ -1906,7 +1906,7 @@ static int tci1x_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 */
 static const char *tci1x_get_info(RIG *rig)
 {
-    const struct tci1x_priv_data *priv = (struct tci1x_priv_data *) rig->state.priv;
+    const struct tci1x_priv_data *priv = (struct tci1x_priv_data *) STATE(rig)->priv;
 
     return (priv->info);
 }
@@ -1914,7 +1914,7 @@ static const char *tci1x_get_info(RIG *rig)
 static int tci1x_power2mW(RIG *rig, unsigned int *mwpower, float power,
                           freq_t freq, rmode_t mode)
 {
-    const struct tci1x_priv_data *priv = (struct tci1x_priv_data *) rig->state.priv;
+    const struct tci1x_priv_data *priv = (struct tci1x_priv_data *) STATE(rig)->priv;
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s: passed power = %f\n", __func__, power);
     rig_debug(RIG_DEBUG_TRACE, "%s: passed freq = %"PRIfreq" Hz\n", __func__, freq);
@@ -1945,7 +1945,7 @@ static int tci1x_mW2power(RIG *rig, float *power, unsigned int mwpower,
 #ifdef XXNOTIMPLEMENTED
 static int tci1x_set_ext_parm(RIG *rig, hamlib_token_t token, value_t val)
 {
-    struct tci1x_priv_data *priv = (struct tci1x_priv_data *)rig->state.priv;
+    struct tci1x_priv_data *priv = (struct tci1x_priv_data *)STATE(rig)->priv;
     char lstr[64];
     const struct confparams *cfp;
     struct ext_list *epp;
@@ -2022,7 +2022,7 @@ static int tci1x_set_ext_parm(RIG *rig, hamlib_token_t token, value_t val)
 
 static int tci1x_get_ext_parm(RIG *rig, hamlib_token_t token, value_t *val)
 {
-    struct tci1x_priv_data *priv = (struct tci1x_priv_data *)rig->state.priv;
+    struct tci1x_priv_data *priv = (struct tci1x_priv_data *)STATE(rig)->priv;
     const struct confparams *cfp;
     struct ext_list *epp;
 
@@ -2065,7 +2065,7 @@ static int tci1x_get_ext_parm(RIG *rig, hamlib_token_t token, value_t *val)
 
 static int tci1x_set_ext_parm(RIG *rig, setting_t parm, value_t val)
 {
-    struct tci1x_priv_data *priv = (struct tci1x_priv_data *)rig->state.priv;
+    struct tci1x_priv_data *priv = (struct tci1x_priv_data *)STATE(rig)->priv;
     int idx;
     char pstr[32];
 
@@ -2095,7 +2095,7 @@ static int tci1x_set_ext_parm(RIG *rig, setting_t parm, value_t val)
 
 static int tci1x_get_ext_parm(RIG *rig, setting_t parm, value_t *val)
 {
-    struct tci1x_priv_data *priv = (struct tci1x_priv_data *)rig->state.priv;
+    struct tci1x_priv_data *priv = (struct tci1x_priv_data *)STATE(rig)->priv;
     int idx;
 
     ENTERFUNC;

--- a/rigs/dummy/trxmanager.c
+++ b/rigs/dummy/trxmanager.c
@@ -208,7 +208,7 @@ static int vfo_curr(RIG *rig, vfo_t vfo)
     int retval = 0;
     vfo_t vfocurr;
     struct trxmanager_priv_data *priv = (struct trxmanager_priv_data *)
-                                        rig->state.priv;
+                                        STATE(rig)->priv;
 
     // get the current VFO from trxmanager in case user changed it
     if ((retval = trxmanager_get_vfo(rig, &vfocurr)) != RIG_OK)
@@ -257,15 +257,15 @@ static int trxmanager_init(RIG *rig)
 
     rig_debug(RIG_DEBUG_TRACE, "%s version %s\n", __func__, BACKEND_VER);
 
-    rig->state.priv = (struct trxmanager_priv_data *)calloc(1,
+    STATE(rig)->priv = (struct trxmanager_priv_data *)calloc(1,
                       sizeof(struct trxmanager_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     memset(priv, 0, sizeof(struct trxmanager_priv_data));
 
@@ -287,7 +287,7 @@ static int trxmanager_init(RIG *rig)
 
 /*
  * trxmanager_open
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  */
 static int trxmanager_open(RIG *rig)
 {
@@ -297,7 +297,7 @@ static int trxmanager_open(RIG *rig)
     char response[MAXCMDLEN] = "";
     hamlib_port_t *rp = RIGPORT(rig);
     struct trxmanager_priv_data *priv = (struct trxmanager_priv_data *)
-                                        rig->state.priv;
+                                        STATE(rig)->priv;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s version %s\n", __func__, BACKEND_VER);
 
@@ -377,7 +377,7 @@ static int trxmanager_close(RIG *rig)
 
 /*
  * trxmanager_cleanup
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  */
 static int trxmanager_cleanup(RIG *rig)
 {
@@ -387,15 +387,15 @@ static int trxmanager_cleanup(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    free(rig->state.priv);
-    rig->state.priv = NULL;
+    free(STATE(rig)->priv);
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
 
 /*
  * trxmanager_get_freq
- * Assumes rig!=NULL, rig->state.priv!=NULL, freq!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL, freq!=NULL
  */
 static int trxmanager_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
@@ -405,7 +405,7 @@ static int trxmanager_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
     char cmd[MAXCMDLEN];
     char response[MAXCMDLEN] = "";
     struct trxmanager_priv_data *priv = (struct trxmanager_priv_data *)
-                                        rig->state.priv;
+                                        STATE(rig)->priv;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s\n", __func__,
               rig_strvfo(vfo));
@@ -465,7 +465,7 @@ static int trxmanager_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
 /*
  * trxmanager_set_freq
- * assumes rig!=NULL, rig->state.priv!=NULL
+ * assumes rig!=NULL, STATE(rig)->priv!=NULL
  */
 static int trxmanager_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
@@ -474,7 +474,7 @@ static int trxmanager_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     char cmd[MAXCMDLEN];
     char response[MAXCMDLEN] = "";
     const struct trxmanager_priv_data *priv = (struct trxmanager_priv_data *)
-            rig->state.priv;
+            STATE(rig)->priv;
 
 
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s freq=%.1f\n", __func__,
@@ -725,7 +725,7 @@ static int trxmanager_set_mode(RIG *rig, vfo_t vfo, rmode_t mode,
 
 /*
  * trxmanager_get_mode
- * Assumes rig!=NULL, rig->state.priv!=NULL, mode!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL, mode!=NULL
  */
 static int trxmanager_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode,
                                pbwidth_t *width)
@@ -738,7 +738,7 @@ static int trxmanager_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode,
     char response[MAXCMDLEN] = "";
     hamlib_port_t *rp = RIGPORT(rig);
     struct trxmanager_priv_data *priv = (struct trxmanager_priv_data *)
-                                        rig->state.priv;
+                                        STATE(rig)->priv;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s\n", __func__,
               rig_strvfo(vfo));
@@ -877,9 +877,9 @@ static int trxmanager_set_vfo(RIG *rig, vfo_t vfo)
     int retval;
     char cmd[MAXCMDLEN];
     char response[MAXCMDLEN] = "";
-    struct rig_state *rs = &rig->state;
+    struct rig_state *rs = STATE(rig);
     struct trxmanager_priv_data *priv = (struct trxmanager_priv_data *)
-                                        rig->state.priv;
+                                        rs->priv;
 
 
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo=%s\n", __func__,
@@ -929,7 +929,7 @@ static int trxmanager_get_vfo(RIG *rig, vfo_t *vfo)
     // So we maintain our own internal state during set_vfo
     // This keeps the hamlib interface consistent with other rigs
     struct trxmanager_priv_data *priv = (struct trxmanager_priv_data *)
-                                        rig->state.priv;
+                                        STATE(rig)->priv;
     char vfoab;
 
 
@@ -1092,7 +1092,7 @@ static int trxmanager_get_split_vfo(RIG *rig, vfo_t vfo, split_t *split,
     char cmd[MAXCMDLEN];
     char response[MAXCMDLEN] = "";
     struct trxmanager_priv_data *priv = (struct trxmanager_priv_data *)
-                                        rig->state.priv;
+                                        STATE(rig)->priv;
 
     rig_debug(RIG_DEBUG_TRACE, "%s\n", __func__);
     SNPRINTF(cmd, sizeof(cmd), "SP;");
@@ -1136,7 +1136,7 @@ static int trxmanager_set_split_freq_mode(RIG *rig, vfo_t vfo, freq_t freq,
     char cmd[MAXCMDLEN];
     char response[MAXCMDLEN] = "";
     struct trxmanager_priv_data *priv = (struct trxmanager_priv_data *)
-                                        rig->state.priv;
+                                        STATE(rig)->priv;
 
     rig_debug(RIG_DEBUG_TRACE, "%s\n", __func__);
 
@@ -1205,7 +1205,7 @@ static int trxmanager_get_split_freq_mode(RIG *rig, vfo_t vfo, freq_t *freq,
 static const char *trxmanager_get_info(RIG *rig)
 {
     const struct trxmanager_priv_data *priv = (struct trxmanager_priv_data *)
-            rig->state.priv;
+            STATE(rig)->priv;
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
     return priv->info;

--- a/rigs/gomspace/gs100.c
+++ b/rigs/gomspace/gs100.c
@@ -107,7 +107,7 @@ static int gs100_init(RIG *rig)
         RETURNFUNC(-RIG_ENOMEM);
     }
 
-    rig->state.priv = (void *)priv;
+    STATE(rig)->priv = (void *)priv;
 
 #ifdef _LOCAL_SIMULATION_
     RIGPORT(rig)->type.rig = RIG_PORT_NONE;  // just simulation
@@ -126,12 +126,12 @@ static int gs100_cleanup(RIG *rig)
 {
     ENTERFUNC;
 
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     RETURNFUNC(RIG_OK);
 }
@@ -169,11 +169,11 @@ static int gs100_close(RIG *rig)
 static int gs100_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 {
     __attribute__((unused)) struct gs100_priv_data *priv = (struct gs100_priv_data
-            *)rig->state.priv;
+            *)STATE(rig)->priv;
 
     ENTERFUNC;
 
-    priv = (struct gs100_priv_data *)rig->state.priv;
+    priv = (struct gs100_priv_data *)STATE(rig)->priv;
 
     switch (token)
     {
@@ -195,11 +195,11 @@ static int gs100_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 static int gs100_get_conf(RIG *rig, hamlib_token_t token, char *val)
 {
     __attribute__((unused)) struct gs100_priv_data *priv = (struct gs100_priv_data
-            *)rig->state.priv;
+            *)STATE(rig)->priv;
 
     ENTERFUNC;
 
-    priv = (struct gs100_priv_data *)rig->state.priv;
+    priv = (struct gs100_priv_data *)STATE(rig)->priv;
 
     switch (token)
     {
@@ -220,7 +220,7 @@ static int gs100_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 #ifdef _LOCAL_SIMULATION_
     __attribute__((unused)) const struct gs100_priv_data *priv =
         (struct gs100_priv_data
-         *)rig->state.priv;
+         *)STATE(rig)->priv;
 #endif
     char fstr[20], value[20];
     int retval;
@@ -255,7 +255,7 @@ static int gs100_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 #ifdef _LOCAL_SIMULATION_
     __attribute__((unused)) const struct gs100_priv_data *priv =
         (struct gs100_priv_data
-         *)rig->state.priv;
+         *)STATE(rig)->priv;
 #endif
     char resp[20];
     int retval;
@@ -292,7 +292,7 @@ static int gs100_set_tx_freq(RIG *rig, vfo_t vfo, freq_t freq)
 #ifdef _LOCAL_SIMULATION_
     __attribute__((unused)) const struct gs100_priv_data *priv =
         (struct gs100_priv_data
-         *)rig->state.priv;
+         *)STATE(rig)->priv;
 #endif
     char fstr[20], value[20];
     int retval;
@@ -327,7 +327,7 @@ static int gs100_get_tx_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 #ifdef _LOCAL_SIMULATION_
     __attribute__((unused)) const struct gs100_priv_data *priv =
         (struct gs100_priv_data
-         *)rig->state.priv;
+         *)STATE(rig)->priv;
 #endif
     char resp[20];
     int retval;
@@ -440,7 +440,7 @@ struct rig_caps GS100_caps =
 static int gomx_set(RIG *rig, int table, char *varname, char *varvalue)
 {
     __attribute__((unused)) struct gs100_priv_data *priv = (struct gs100_priv_data
-            *)rig->state.priv;
+            *)STATE(rig)->priv;
     int retval;
     char msg[BUFSZ], resp[BUFSZ];
 
@@ -479,7 +479,7 @@ static int gomx_get(RIG *rig, int table, char *varname, const char *varvalue,
                     int varvalue_len)
 {
     __attribute__((unused)) struct gs100_priv_data *priv = (struct gs100_priv_data
-            *)rig->state.priv;
+            *)STATE(rig)->priv;
     int retval;
     char msg[BUFSZ], resp[BUFSZ], *c;
     char fmt[32];

--- a/rigs/icmarine/icm710.c
+++ b/rigs/icmarine/icm710.c
@@ -267,16 +267,16 @@ int icm710_init(RIG *rig)
 
     priv_caps = (const struct icm710_priv_caps *) caps->priv;
 
-    rig->state.priv = (struct icm710_priv_data *)calloc(1,
+    STATE(rig)->priv = (struct icm710_priv_data *)calloc(1,
                       sizeof(struct icm710_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     priv->remote_id = priv_caps->default_remote_id;
     priv->split = RIG_SPLIT_OFF;
@@ -317,12 +317,12 @@ int icm710_cleanup(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
@@ -331,7 +331,7 @@ int icm710_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 {
     struct icm710_priv_data *priv;
 
-    priv = (struct icm710_priv_data *)rig->state.priv;
+    priv = (struct icm710_priv_data *)STATE(rig)->priv;
 
     switch (token)
     {
@@ -350,7 +350,7 @@ int icm710_get_conf2(RIG *rig, hamlib_token_t token, char *val, int val_len)
 {
     struct icm710_priv_data *priv;
 
-    priv = (struct icm710_priv_data *)rig->state.priv;
+    priv = (struct icm710_priv_data *)STATE(rig)->priv;
 
     switch (token)
     {
@@ -376,7 +376,7 @@ int icm710_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     struct icm710_priv_data *priv;
     int retval;
 
-    priv = (struct icm710_priv_data *)rig->state.priv;
+    priv = (struct icm710_priv_data *)STATE(rig)->priv;
 
     SNPRINTF(freqbuf, sizeof(freqbuf), "%.6f", freq / MHz(1));
 
@@ -412,7 +412,7 @@ int icm710_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
  */
 int icm710_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
-    *freq = ((struct icm710_priv_data *)rig->state.priv)->rxfreq;
+    *freq = ((struct icm710_priv_data *)STATE(rig)->priv)->rxfreq;
 
     return RIG_OK;
 }
@@ -423,7 +423,7 @@ int icm710_set_tx_freq(RIG *rig, vfo_t vfo, freq_t freq)
     int retval;
     struct icm710_priv_data *priv;
 
-    priv = (struct icm710_priv_data *)rig->state.priv;
+    priv = (struct icm710_priv_data *)STATE(rig)->priv;
 
     SNPRINTF(freqbuf, sizeof(freqbuf), "%.6f", freq / MHz(1));
 
@@ -442,7 +442,7 @@ int icm710_get_tx_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
     struct icm710_priv_data *priv;
 
-    priv = (struct icm710_priv_data *)rig->state.priv;
+    priv = (struct icm710_priv_data *)STATE(rig)->priv;
 
     *freq = priv->txfreq;
     return RIG_OK;
@@ -452,7 +452,7 @@ int icm710_set_split_vfo(RIG *rig, vfo_t rx_vfo, split_t split, vfo_t tx_vfo)
 {
     struct icm710_priv_data *priv;
 
-    priv = (struct icm710_priv_data *)rig->state.priv;
+    priv = (struct icm710_priv_data *)STATE(rig)->priv;
 
 
     /* when disabling split mode */
@@ -475,7 +475,7 @@ int icm710_get_split_vfo(RIG *rig, vfo_t rx_vfo, split_t *split, vfo_t *tx_vfo)
 {
     struct icm710_priv_data *priv;
 
-    priv = (struct icm710_priv_data *)rig->state.priv;
+    priv = (struct icm710_priv_data *)STATE(rig)->priv;
 
     *split = priv->split;
     *tx_vfo = rx_vfo;
@@ -522,7 +522,7 @@ int icm710_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 
 int icm710_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
 {
-    *mode = ((struct icm710_priv_data *)rig->state.priv)->mode;
+    *mode = ((struct icm710_priv_data *)STATE(rig)->priv)->mode;
     *width = 2200;
 
     return RIG_OK;
@@ -536,7 +536,7 @@ int icm710_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
     int retval;
     struct icm710_priv_data *priv;
 
-    priv = (struct icm710_priv_data *)rig->state.priv;
+    priv = (struct icm710_priv_data *)STATE(rig)->priv;
     retval = icmarine_transaction(rig, CMD_PTT,
                                   ptt == RIG_PTT_ON ? "TX" : "RX", NULL);
 
@@ -552,7 +552,7 @@ int icm710_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 
 int icm710_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
 {
-    *ptt = ((struct icm710_priv_data *)rig->state.priv)->ptt;
+    *ptt = ((struct icm710_priv_data *)STATE(rig)->priv)->ptt;
 
     return RIG_OK;
 }
@@ -613,7 +613,7 @@ int icm710_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
     unsigned value;
     struct icm710_priv_data *priv;
 
-    priv = (struct icm710_priv_data *)rig->state.priv;
+    priv = (struct icm710_priv_data *)STATE(rig)->priv;
 
 
     switch (level)
@@ -676,7 +676,7 @@ int icm710_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
     struct icm710_priv_data *priv;
 
-    priv = (struct icm710_priv_data *)rig->state.priv;
+    priv = (struct icm710_priv_data *)STATE(rig)->priv;
 
 
     switch (level)

--- a/rigs/icmarine/icmarine.c
+++ b/rigs/icmarine/icmarine.c
@@ -129,16 +129,16 @@ int icmarine_init(RIG *rig)
 
     priv_caps = (const struct icmarine_priv_caps *) caps->priv;
 
-    rig->state.priv = (struct icmarine_priv_data *)calloc(1, sizeof(
+    STATE(rig)->priv = (struct icmarine_priv_data *)calloc(1, sizeof(
                           struct icmarine_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     priv->remote_id = priv_caps->default_remote_id;
     priv->split = RIG_SPLIT_OFF;
@@ -153,12 +153,12 @@ int icmarine_cleanup(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
@@ -187,7 +187,7 @@ int icmarine_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 {
     struct icmarine_priv_data *priv;
 
-    priv = (struct icmarine_priv_data *)rig->state.priv;
+    priv = (struct icmarine_priv_data *)STATE(rig)->priv;
 
     switch (token)
     {
@@ -206,7 +206,7 @@ int icmarine_get_conf2(RIG *rig, hamlib_token_t token, char *val, int val_len)
 {
     struct icmarine_priv_data *priv;
 
-    priv = (struct icmarine_priv_data *)rig->state.priv;
+    priv = (struct icmarine_priv_data *)STATE(rig)->priv;
 
     switch (token)
     {
@@ -229,7 +229,7 @@ int icmarine_get_conf(RIG *rig, hamlib_token_t token, char *val)
 
 /*
  * icmarine_transaction
- * We assume that rig!=NULL, rig->state!= NULL, data!=NULL, data_len!=NULL
+ * We assume that rig!=NULL, STATE(rig)!= NULL, data!=NULL, data_len!=NULL
  *
  * cmd: mandatory
  * param: only 1 optional NMEA parameter, NULL for none (=query)
@@ -252,7 +252,7 @@ int icmarine_transaction(RIG *rig, const char *cmd, const char *param,
     rig_debug(RIG_DEBUG_TRACE, "%s: cmd='%s', param=%s\n", __func__, cmd,
               param == NULL ? "NULL" : param);
 
-    rs = &rig->state;
+    rs = STATE(rig);
     priv = (struct icmarine_priv_data *)rs->priv;
 
     rig_flush(rp);
@@ -362,7 +362,7 @@ int icmarine_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
     rig_debug(RIG_DEBUG_TRACE, "%s:\n", __func__);
 
-    priv = (struct icmarine_priv_data *)rig->state.priv;
+    priv = (struct icmarine_priv_data *)STATE(rig)->priv;
 
     SNPRINTF(freqbuf, sizeof(freqbuf), "%.6f", freq / MHz(1));
 
@@ -461,7 +461,7 @@ int icmarine_set_split_vfo(RIG *rig, vfo_t rx_vfo, split_t split, vfo_t tx_vfo)
 
     rig_debug(RIG_DEBUG_TRACE, "%s:\n", __func__);
 
-    priv = (struct icmarine_priv_data *)rig->state.priv;
+    priv = (struct icmarine_priv_data *)STATE(rig)->priv;
 
     /* when disabling split mode */
     if (RIG_SPLIT_ON == priv->split &&
@@ -487,7 +487,7 @@ int icmarine_get_split_vfo(RIG *rig, vfo_t rx_vfo, split_t *split,
 
     rig_debug(RIG_DEBUG_TRACE, "%s:\n", __func__);
 
-    priv = (struct icmarine_priv_data *)rig->state.priv;
+    priv = (struct icmarine_priv_data *)STATE(rig)->priv;
 
     *split = priv->split;
     *tx_vfo = rx_vfo;

--- a/rigs/jrc/jrc.c
+++ b/rigs/jrc/jrc.c
@@ -59,7 +59,7 @@
 
 /*
  * jrc_transaction
- * We assume that rig!=NULL, rig->state!= NULL, data!=NULL, data_len!=NULL
+ * We assume that rig!=NULL, RIGPORT(rig)!= NULL, data!=NULL, data_len!=NULL
  * Otherwise, you'll get a nice seg fault. You've been warned!
  * TODO: error case handling
  */

--- a/rigs/jrc/jst145.c
+++ b/rigs/jrc/jst145.c
@@ -286,7 +286,7 @@ static int jst145_init(RIG *rig)
         return -RIG_ENOMEM;
     }
 
-    rig->state.priv = (void *)priv;
+    STATE(rig)->priv = (void *)priv;
     return RIG_OK;
 }
 
@@ -296,7 +296,7 @@ static int jst145_open(RIG *rig)
     freq_t freq;
     rmode_t mode;
     pbwidth_t width;
-    struct jst145_priv_data *priv = rig->state.priv;
+    struct jst145_priv_data *priv = STATE(rig)->priv;
 
     retval = write_block(RIGPORT(rig), (unsigned char *) "H1\r", 3);
 
@@ -345,7 +345,7 @@ ptt_retry:
 
     if (ptt)  // can't get vfo while transmitting
     {
-        *vfo = rig->state.current_vfo;
+        *vfo = STATE(rig)->current_vfo;
         return RIG_OK;
     }
 
@@ -371,8 +371,8 @@ static int jst145_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
     char freqbuf[MAX_LEN];
     int retval;
-    struct jst145_priv_data *priv = rig->state.priv;
-    vfo_t save_vfo = rig->state.current_vfo;
+    struct jst145_priv_data *priv = STATE(rig)->priv;
+    vfo_t save_vfo = STATE(rig)->current_vfo;
 
     if (vfo == RIG_VFO_CURR) { vfo = save_vfo; }
 
@@ -414,9 +414,9 @@ static int jst145_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
     int freqbuf_size = sizeof(freqbuf);
     int retval;
     int n;
-    vfo_t save_vfo = rig->state.current_vfo;
+    vfo_t save_vfo = STATE(rig)->current_vfo;
 
-    //struct jst145_priv_data *priv = rig->state.priv;
+    //struct jst145_priv_data *priv = STATE(rig)->priv;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: vfo=%s curr_vfo=%s\n", __func__,
               rig_strvfo(vfo), rig_strvfo(save_vfo));
@@ -455,7 +455,7 @@ static int jst145_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
     int retval;
     char *modestr;
-    struct jst145_priv_data *priv = rig->state.priv;
+    struct jst145_priv_data *priv = STATE(rig)->priv;
 
     switch (mode)
     {
@@ -579,7 +579,7 @@ static int jst145_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op)
 static int jst145_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 {
     char cmd[MAX_LEN];
-    struct jst145_priv_data *priv = rig->state.priv;
+    struct jst145_priv_data *priv = STATE(rig)->priv;
     rig_debug(RIG_DEBUG_TRACE, "%s: entered\n", __func__);
     SNPRINTF(cmd, sizeof(cmd), "X%c\r", ptt ? '1' : '0');
     priv->ptt = ptt;
@@ -592,7 +592,7 @@ static int jst145_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
     char pttstatus[MAX_LEN];
     int pttstatus_size = sizeof(pttstatus);
     int retval;
-    struct jst145_priv_data *priv = rig->state.priv;
+    struct jst145_priv_data *priv = STATE(rig)->priv;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: entered\n", __func__);
 

--- a/rigs/kachina/kachina.c
+++ b/rigs/kachina/kachina.c
@@ -58,7 +58,7 @@
 
 /*
  * kachina_transaction
- * We assume that rig!=NULL, rig->state!= NULL
+ * We assume that rig!=NULL, STATE(rig)!= NULL
  * Otherwise, you'll get a nice seg fault. You've been warned!
  * TODO: error case handling
  */

--- a/rigs/kit/dds60.c
+++ b/rigs/kit/dds60.c
@@ -168,16 +168,16 @@ int dds60_init(RIG *rig)
 {
     struct dds60_priv_data *priv;
 
-    rig->state.priv = (struct dds60_priv_data *)calloc(1, sizeof(
+    STATE(rig)->priv = (struct dds60_priv_data *)calloc(1, sizeof(
                           struct dds60_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     priv->osc_freq = OSCFREQ;
     priv->if_mix_freq = IFMIXFREQ;
@@ -194,26 +194,26 @@ int dds60_cleanup(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
 
 
 /*
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  */
 int dds60_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 {
     struct dds60_priv_data *priv;
     float phase;
 
-    priv = (struct dds60_priv_data *)rig->state.priv;
+    priv = (struct dds60_priv_data *)STATE(rig)->priv;
 
     switch (token)
     {
@@ -243,14 +243,14 @@ int dds60_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 
 /*
  * assumes rig!=NULL,
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  *  and val points to a buffer big enough to hold the conf value.
  */
 int dds60_get_conf2(RIG *rig, hamlib_token_t token, char *val, int val_len)
 {
     struct dds60_priv_data *priv;
 
-    priv = (struct dds60_priv_data *)rig->state.priv;
+    priv = (struct dds60_priv_data *)STATE(rig)->priv;
 
     switch (token)
     {
@@ -351,7 +351,7 @@ int dds60_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     hamlib_port_t *port = RIGPORT(rig);
     freq_t osc_ref;
 
-    priv = (struct dds60_priv_data *)rig->state.priv;
+    priv = (struct dds60_priv_data *)STATE(rig)->priv;
 
     if (priv->multiplier)
     {

--- a/rigs/kit/drt1.c
+++ b/rigs/kit/drt1.c
@@ -168,16 +168,16 @@ int drt1_init(RIG *rig)
 {
     struct drt1_priv_data *priv;
 
-    rig->state.priv = (struct drt1_priv_data *)calloc(1, sizeof(
+    STATE(rig)->priv = (struct drt1_priv_data *)calloc(1, sizeof(
                           struct drt1_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     priv->osc_freq = OSCFREQ;
     priv->ref_mult = REFMULT;
@@ -194,25 +194,25 @@ int drt1_cleanup(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
 
 
 /*
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  */
 int drt1_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 {
     struct drt1_priv_data *priv;
 
-    priv = (struct drt1_priv_data *)rig->state.priv;
+    priv = (struct drt1_priv_data *)STATE(rig)->priv;
 
     switch (token)
     {
@@ -241,14 +241,14 @@ int drt1_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 
 /*
  * assumes rig!=NULL,
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  *  and val points to a buffer big enough to hold the conf value.
  */
 int drt1_get_conf2(RIG *rig, hamlib_token_t token, char *val, int val_len)
 {
     struct drt1_priv_data *priv;
 
-    priv = (struct drt1_priv_data *)rig->state.priv;
+    priv = (struct drt1_priv_data *)STATE(rig)->priv;
 
     switch (token)
     {
@@ -414,7 +414,7 @@ int drt1_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     struct drt1_priv_data *priv;
     hamlib_port_t *port = RIGPORT(rig);
 
-    priv = (struct drt1_priv_data *)rig->state.priv;
+    priv = (struct drt1_priv_data *)STATE(rig)->priv;
 
     rig_flush(port);
 

--- a/rigs/kit/dwt.c
+++ b/rigs/kit/dwt.c
@@ -226,16 +226,16 @@ int dwtdll_init(RIG *rig)
 {
     struct dwtdll_priv_data *priv;
 
-    rig->state.priv = (struct dwtdll_priv_data *)calloc(1, sizeof(
+    STATE(rig)->priv = (struct dwtdll_priv_data *)calloc(1, sizeof(
                           struct dwtdll_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     /* Try to load required dll */
     priv->dll = LoadLibrary(DWTDLL);
@@ -244,7 +244,7 @@ int dwtdll_init(RIG *rig)
     {
         rig_debug(RIG_DEBUG_ERR, "%s: Unable to LoadLibrary %s\n",
                   __func__, DWTDLL);
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
         return -RIG_EIO;    /* huh! */
     }
 
@@ -295,7 +295,7 @@ int dwtdll_init(RIG *rig)
 
 int dwtdll_open(RIG *rig)
 {
-    struct dwtdll_priv_data *priv = (struct dwtdll_priv_data *)rig->state.priv;
+    struct dwtdll_priv_data *priv = (struct dwtdll_priv_data *)STATE(rig)->priv;
     short ret;
 
     /* Open DWT receiver */
@@ -319,7 +319,7 @@ int dwtdll_open(RIG *rig)
 
 int dwtdll_close(RIG *rig)
 {
-    struct dwtdll_priv_data *priv = (struct dwtdll_priv_data *)rig->state.priv;
+    struct dwtdll_priv_data *priv = (struct dwtdll_priv_data *)STATE(rig)->priv;
     short ret;
 
     /* Open DWT receiver */
@@ -335,24 +335,24 @@ int dwtdll_close(RIG *rig)
 
 int dwtdll_cleanup(RIG *rig)
 {
-    struct dwtdll_priv_data *priv = (struct dwtdll_priv_data *)rig->state.priv;
+    struct dwtdll_priv_data *priv = (struct dwtdll_priv_data *)STATE(rig)->priv;
 
     /* Clean up the dll access */
     if (priv) { FreeLibrary(priv->dll); }
 
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
 
 int dwtdll_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-    struct dwtdll_priv_data *priv = (struct dwtdll_priv_data *)rig->state.priv;
+    struct dwtdll_priv_data *priv = (struct dwtdll_priv_data *)STATE(rig)->priv;
     short ret;
 
     ret = priv->FrontendSetFrequency((double) freq);
@@ -362,7 +362,7 @@ int dwtdll_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
 int dwtdll_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
-    struct dwtdll_priv_data *priv = (struct dwtdll_priv_data *)rig->state.priv;
+    struct dwtdll_priv_data *priv = (struct dwtdll_priv_data *)STATE(rig)->priv;
 
     *freq = (freq_t) priv->FrontendGetFrequency();
 
@@ -371,7 +371,7 @@ int dwtdll_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
 int dwtdll_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
-    struct dwtdll_priv_data *priv = (struct dwtdll_priv_data *)rig->state.priv;
+    struct dwtdll_priv_data *priv = (struct dwtdll_priv_data *)STATE(rig)->priv;
     tFrontendMode dwtmode;
     short ret;
 
@@ -394,7 +394,7 @@ int dwtdll_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 
 int dwtdll_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
 {
-    struct dwtdll_priv_data *priv = (struct dwtdll_priv_data *)rig->state.priv;
+    struct dwtdll_priv_data *priv = (struct dwtdll_priv_data *)STATE(rig)->priv;
     tFrontendMode dwtmode;
 
     dwtmode = priv->FrontendGetMode();
@@ -419,7 +419,7 @@ int dwtdll_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
 
 int dwtdll_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
-    struct dwtdll_priv_data *priv = (struct dwtdll_priv_data *)rig->state.priv;
+    struct dwtdll_priv_data *priv = (struct dwtdll_priv_data *)STATE(rig)->priv;
     short ret = 0;
 
     switch (level)
@@ -437,7 +437,7 @@ int dwtdll_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
 int dwtdll_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
-    struct dwtdll_priv_data *priv = (struct dwtdll_priv_data *)rig->state.priv;
+    struct dwtdll_priv_data *priv = (struct dwtdll_priv_data *)STATE(rig)->priv;
     signed short ret = 0;
 
     switch (level)
@@ -489,7 +489,7 @@ int dwtdll_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 
 static const char *dwtdll_get_info(RIG *rig)
 {
-    struct dwtdll_priv_data *priv = (struct dwtdll_priv_data *)rig->state.priv;
+    struct dwtdll_priv_data *priv = (struct dwtdll_priv_data *)STATE(rig)->priv;
     static char info[22];
 
     if (priv->FrontendGetId(info) < 0)

--- a/rigs/kit/elektor304.c
+++ b/rigs/kit/elektor304.c
@@ -160,16 +160,16 @@ int elektor304_init(RIG *rig)
 {
     struct elektor304_priv_data *priv;
 
-    rig->state.priv = (struct elektor304_priv_data *)calloc(1, sizeof(struct
+    STATE(rig)->priv = (struct elektor304_priv_data *)calloc(1, sizeof(struct
                       elektor304_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     priv->osc_freq = OSCFREQ;
     priv->if_mix_freq = IFMIXFREQ;
@@ -184,25 +184,25 @@ int elektor304_cleanup(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
 
 
 /*
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  */
 int elektor304_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 {
     struct elektor304_priv_data *priv;
 
-    priv = (struct elektor304_priv_data *)rig->state.priv;
+    priv = (struct elektor304_priv_data *)STATE(rig)->priv;
 
     switch (token)
     {
@@ -223,14 +223,14 @@ int elektor304_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 
 /*
  * assumes rig!=NULL,
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  *  and val points to a buffer big enough to hold the conf value.
  */
 int elektor304_get_conf2(RIG *rig, hamlib_token_t token, char *val, int val_len)
 {
     struct elektor304_priv_data *priv;
 
-    priv = (struct elektor304_priv_data *)rig->state.priv;
+    priv = (struct elektor304_priv_data *)STATE(rig)->priv;
 
     switch (token)
     {
@@ -344,7 +344,7 @@ int elektor304_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     struct elektor304_priv_data *priv;
     hamlib_port_t *port = RIGPORT(rig);
 
-    priv = (struct elektor304_priv_data *)rig->state.priv;
+    priv = (struct elektor304_priv_data *)STATE(rig)->priv;
 
     rig_flush(port);
 

--- a/rigs/kit/elektor507.c
+++ b/rigs/kit/elektor507.c
@@ -280,7 +280,7 @@ int elektor507_init(RIG *rig)
     extra_priv->FT_Write =
         (FNCFT_Write) GetProcAddress(extra_priv->dll, "FT_Write");
 
-    rig->state.priv = (void *)priv;
+    STATE(rig)->priv = (void *)priv;
 
     return RIG_OK;
 }
@@ -289,7 +289,7 @@ int elektor507_ftdi_write_data(RIG *rig, void *FTOutBuf,
                                unsigned long BufferSize)
 {
     struct elektor507_extra_priv_data *extra_priv =
-        &((struct elektor507_priv_data *)rig->state.priv)->extra_priv;
+        &((struct elektor507_priv_data *)STATE(rig)->priv)->extra_priv;
     FT_Result ret;
     int Result;
 
@@ -338,17 +338,17 @@ int elektor507_ftdi_write_data(RIG *rig, void *FTOutBuf,
 int elektor507_cleanup(RIG *rig)
 {
     struct elektor507_priv_data *priv = (struct elektor507_priv_data *)
-                                        rig->state.priv;
+                                        STATE(rig)->priv;
 
     /* Clean up the dll access */
     if (priv) { FreeLibrary(priv->extra_priv.dll); }
 
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
@@ -376,16 +376,16 @@ int elektor507_init(RIG *rig)
     hamlib_port_t *rp = RIGPORT(rig);
     struct elektor507_priv_data *priv;
 
-    rig->state.priv = (struct elektor507_priv_data *)calloc(sizeof(struct
+    STATE(rig)->priv = (struct elektor507_priv_data *)calloc(sizeof(struct
                       elektor507_priv_data), 1);
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     priv->xtal_cal = XTAL_CAL;
     priv->osc_freq = OSCFREQ;
@@ -412,12 +412,12 @@ int elektor507_cleanup(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
@@ -646,7 +646,7 @@ int elektor507_set_conf(RIG *rig, hamlib_token_t token, const char *val)
     struct elektor507_priv_data *priv;
     freq_t freq;
 
-    priv = (struct elektor507_priv_data *)rig->state.priv;
+    priv = (struct elektor507_priv_data *)STATE(rig)->priv;
 
     switch (token)
     {
@@ -670,7 +670,7 @@ int elektor507_get_conf2(RIG *rig, hamlib_token_t token, char *val, int val_len)
 {
     struct elektor507_priv_data *priv;
 
-    priv = (struct elektor507_priv_data *)rig->state.priv;
+    priv = (struct elektor507_priv_data *)STATE(rig)->priv;
 
     switch (token)
     {
@@ -699,7 +699,7 @@ int elektor507_get_conf(RIG *rig, hamlib_token_t token, char *val)
 int elektor507_open(RIG *rig)
 {
     struct elektor507_priv_data *priv = (struct elektor507_priv_data *)
-                                        rig->state.priv;
+                                        STATE(rig)->priv;
     int ret;
 
     rig_debug(RIG_DEBUG_TRACE, "%s called\n", __func__);
@@ -1022,7 +1022,7 @@ static void find_P_Q_DIV1N(
 int elektor507_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
     struct elektor507_priv_data *priv = (struct elektor507_priv_data *)
-                                        rig->state.priv;
+                                        STATE(rig)->priv;
     freq_t final_freq;
     int ret = 0;
 
@@ -1067,7 +1067,7 @@ int elektor507_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 int elektor507_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
     struct elektor507_priv_data *priv = (struct elektor507_priv_data *)
-                                        rig->state.priv;
+                                        STATE(rig)->priv;
     double VCO;
 
     VCO = ((double)priv->osc_freq * kHz(1)) / priv->Q * priv->P;
@@ -1081,7 +1081,7 @@ int elektor507_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 int elektor507_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
     struct elektor507_priv_data *priv = (struct elektor507_priv_data *)
-                                        rig->state.priv;
+                                        STATE(rig)->priv;
     int ret = 0;
     int att = 0;
 
@@ -1120,7 +1120,7 @@ int elektor507_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 int elektor507_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
     const struct elektor507_priv_data *priv = (struct elektor507_priv_data *)
-            rig->state.priv;
+            STATE(rig)->priv;
     int ret = 0;
 
     switch (level)
@@ -1152,7 +1152,7 @@ int elektor507_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 int elektor507_set_ant(RIG *rig, vfo_t vfo, ant_t ant, value_t option)
 {
     struct elektor507_priv_data *priv = (struct elektor507_priv_data *)
-                                        rig->state.priv;
+                                        STATE(rig)->priv;
     int ret, Mux;
 
     rig_debug(RIG_DEBUG_TRACE, "%s called\n", __func__);
@@ -1197,7 +1197,7 @@ int elektor507_get_ant(RIG *rig, vfo_t vfo, ant_t dummy, value_t *option,
                        ant_t *ant_curr, ant_t *ant_tx, ant_t *ant_rx)
 {
     const struct elektor507_priv_data *priv = (struct elektor507_priv_data *)
-            rig->state.priv;
+            STATE(rig)->priv;
 
     *ant_curr = priv->ant;
 
@@ -1211,7 +1211,7 @@ int elektor507_get_ant(RIG *rig, vfo_t vfo, ant_t dummy, value_t *option,
 static int cy_update_pll(RIG *rig, unsigned char IICadr)
 {
     const struct elektor507_priv_data *priv = (struct elektor507_priv_data *)
-            rig->state.priv;
+            STATE(rig)->priv;
     int P0, R40, R41, R42;
     unsigned char Div1N;
     unsigned char Clk3_src;
@@ -1297,7 +1297,7 @@ static int cy_update_pll(RIG *rig, unsigned char IICadr)
 static void ftdi_SCL(RIG *rig, int d)
 {
     struct elektor507_priv_data *priv = (struct elektor507_priv_data *)
-                                        rig->state.priv;
+                                        STATE(rig)->priv;
 
     if (priv->Buf_adr >= FT_OUT_BUFFER_MAX)
     {
@@ -1323,7 +1323,7 @@ static void ftdi_SCL(RIG *rig, int d)
 static void ftdi_SDA(RIG *rig, int d)
 {
     struct elektor507_priv_data *priv = (struct elektor507_priv_data *)
-                                        rig->state.priv;
+                                        STATE(rig)->priv;
 
     if (priv->Buf_adr >= FT_OUT_BUFFER_MAX)
     {
@@ -1399,7 +1399,7 @@ int i2c_write_regs(RIG *rig, unsigned char IICadr, int reg_count,
                    unsigned char reg_val1, unsigned char reg_val2, unsigned char reg_val3)
 {
     struct elektor507_priv_data *priv = (struct elektor507_priv_data *)
-                                        rig->state.priv;
+                                        STATE(rig)->priv;
     int ret;
 
     /* Start with a new buffer */
@@ -1461,7 +1461,7 @@ static const unsigned char ftdi_code[256] =
 int load_ftdi_code(RIG *rig, unsigned char IICadr, const unsigned char code[])
 {
     struct elektor507_priv_data *priv = (struct elektor507_priv_data *)
-                                        rig->state.priv;
+                                        STATE(rig)->priv;
     int ret;
     int i, j;
 

--- a/rigs/kit/fifisdr.c
+++ b/rigs/kit/fifisdr.c
@@ -329,16 +329,16 @@ int fifisdr_init(RIG *rig)
     hamlib_port_t *rp = RIGPORT(rig);
     struct fifisdr_priv_instance_data *priv;
 
-    rig->state.priv = (struct fifisdr_priv_instance_data *)calloc(sizeof(
+    STATE(rig)->priv = (struct fifisdr_priv_instance_data *)calloc(sizeof(
                           struct fifisdr_priv_instance_data), 1);
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     priv->multiplier = 4;
 
@@ -365,12 +365,12 @@ int fifisdr_cleanup(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
@@ -384,7 +384,7 @@ int fifisdr_open(RIG *rig)
     struct fifisdr_priv_instance_data *priv;
 
 
-    priv = (struct fifisdr_priv_instance_data *)rig->state.priv;
+    priv = (struct fifisdr_priv_instance_data *)STATE(rig)->priv;
 
     /* The VCO is a multiple of the RX frequency. Typically 4 */
     ret = fifisdr_usb_read(rig, REQUEST_FIFISDR_READ, 0,
@@ -426,7 +426,7 @@ int fifisdr_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
     const struct fifisdr_priv_instance_data *priv = (struct
             fifisdr_priv_instance_data *)
-            rig->state.priv;
+            STATE(rig)->priv;
     int ret;
     double mhz;
     uint32_t freq1121;
@@ -453,7 +453,7 @@ int fifisdr_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
     const struct fifisdr_priv_instance_data *priv = (struct
             fifisdr_priv_instance_data *)
-            rig->state.priv;
+            STATE(rig)->priv;
     int ret;
     uint32_t freq1121;
 

--- a/rigs/kit/funcube.c
+++ b/rigs/kit/funcube.c
@@ -228,16 +228,16 @@ int funcube_init(RIG *rig)
     hamlib_port_t *rp = RIGPORT(rig);
     struct funcube_priv_data *priv;
 
-    rig->state.priv = (struct funcube_priv_data *)calloc(sizeof(
+    STATE(rig)->priv = (struct funcube_priv_data *)calloc(sizeof(
                           struct funcube_priv_data), 1);
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     priv->freq = 0;
 
@@ -258,16 +258,16 @@ int funcubeplus_init(RIG *rig)
     hamlib_port_t *rp = RIGPORT(rig);
     struct funcube_priv_data *priv;
 
-    rig->state.priv = (struct funcube_priv_data *)calloc(sizeof(
+    STATE(rig)->priv = (struct funcube_priv_data *)calloc(sizeof(
                           struct funcube_priv_data), 1);
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     priv->freq = 0;
 
@@ -290,12 +290,12 @@ int funcube_cleanup(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
@@ -426,7 +426,7 @@ int set_freq_v1(libusb_device_handle *udh, unsigned int f, int timeout)
 
 int funcube_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-    struct funcube_priv_data *priv = (struct funcube_priv_data *)rig->state.priv;
+    struct funcube_priv_data *priv = (struct funcube_priv_data *)STATE(rig)->priv;
     hamlib_port_t *rp = RIGPORT(rig);
     libusb_device_handle *udh = rp->handle;
 
@@ -450,7 +450,7 @@ int funcube_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 int get_freq_v0(RIG *rig, vfo_t vfo, freq_t *freq)
 {
     const struct funcube_priv_data *priv = (struct funcube_priv_data *)
-                                           rig->state.priv;
+                                           STATE(rig)->priv;
 
     rig_debug(RIG_DEBUG_TRACE,
               "%s: frequency is not read from the device, the value shown is the last successfully set.\n",

--- a/rigs/kit/hiqsdr.c
+++ b/rigs/kit/hiqsdr.c
@@ -189,7 +189,7 @@ struct rig_caps hiqsdr_caps =
 static int send_command(RIG *rig)
 {
     const struct hiqsdr_priv_data *priv = (struct hiqsdr_priv_data *)
-                                          rig->state.priv;
+                                          STATE(rig)->priv;
     int ret;
 
     ret = write_block(RIGPORT(rig), (unsigned char *) priv->control_frame,
@@ -223,14 +223,14 @@ static unsigned compute_sample_rate(const struct hiqsdr_priv_data *priv)
 }
 
 /*
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  */
 int hiqsdr_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 {
     struct hiqsdr_priv_data *priv;
     struct rig_state *rs;
 
-    rs = &rig->state;
+    rs = STATE(rig);
     priv = (struct hiqsdr_priv_data *)rs->priv;
 
     switch (token)
@@ -254,7 +254,7 @@ int hiqsdr_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 
 /*
  * assumes rig!=NULL,
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  *  and val points to a buffer big enough to hold the conf value.
  */
 int hiqsdr_get_conf2(RIG *rig, hamlib_token_t token, char *val, int val_len)
@@ -262,7 +262,7 @@ int hiqsdr_get_conf2(RIG *rig, hamlib_token_t token, char *val, int val_len)
     struct hiqsdr_priv_data *priv;
     struct rig_state *rs;
 
-    rs = &rig->state;
+    rs = STATE(rig);
     priv = (struct hiqsdr_priv_data *)rs->priv;
 
     switch (token)
@@ -293,15 +293,15 @@ int hiqsdr_init(RIG *rig)
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    rig->state.priv = (struct hiqsdr_priv_data *)calloc(1, sizeof(
+    STATE(rig)->priv = (struct hiqsdr_priv_data *)calloc(1, sizeof(
                           struct hiqsdr_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     priv->split = RIG_SPLIT_OFF;
     priv->ref_clock = REFCLOCK;
@@ -314,7 +314,7 @@ int hiqsdr_init(RIG *rig)
 
 int hiqsdr_open(RIG *rig)
 {
-    struct hiqsdr_priv_data *priv = (struct hiqsdr_priv_data *)rig->state.priv;
+    struct hiqsdr_priv_data *priv = (struct hiqsdr_priv_data *)STATE(rig)->priv;
 #if 0
     const char buf_send_to_me[] = { 0x72, 0x72 };
     int ret;
@@ -371,12 +371,12 @@ int hiqsdr_cleanup(RIG *rig)
 {
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
@@ -386,7 +386,7 @@ int hiqsdr_cleanup(RIG *rig)
  */
 int hiqsdr_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-    struct hiqsdr_priv_data *priv = (struct hiqsdr_priv_data *)rig->state.priv;
+    struct hiqsdr_priv_data *priv = (struct hiqsdr_priv_data *)STATE(rig)->priv;
     int ret;
     double rxphase;
     uint32_t rxphase32;
@@ -417,7 +417,7 @@ int hiqsdr_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 static int hiqsdr_set_split_vfo(RIG *rig, vfo_t vfo, split_t split,
                                 vfo_t tx_vfo)
 {
-    struct hiqsdr_priv_data *priv = (struct hiqsdr_priv_data *)rig->state.priv;
+    struct hiqsdr_priv_data *priv = (struct hiqsdr_priv_data *)STATE(rig)->priv;
 
     priv->split = split;
 
@@ -426,7 +426,7 @@ static int hiqsdr_set_split_vfo(RIG *rig, vfo_t vfo, split_t split,
 
 int hiqsdr_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
 {
-    struct hiqsdr_priv_data *priv = (struct hiqsdr_priv_data *)rig->state.priv;
+    struct hiqsdr_priv_data *priv = (struct hiqsdr_priv_data *)STATE(rig)->priv;
     int ret;
     double rxphase;
     uint32_t rxphase32;
@@ -454,7 +454,7 @@ int hiqsdr_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
 int hiqsdr_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
-    struct hiqsdr_priv_data *priv = (struct hiqsdr_priv_data *)rig->state.priv;
+    struct hiqsdr_priv_data *priv = (struct hiqsdr_priv_data *)STATE(rig)->priv;
     int ret = RIG_OK;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called: %s\n",
@@ -477,7 +477,7 @@ int hiqsdr_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 
 int hiqsdr_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 {
-    struct hiqsdr_priv_data *priv = (struct hiqsdr_priv_data *)rig->state.priv;
+    struct hiqsdr_priv_data *priv = (struct hiqsdr_priv_data *)STATE(rig)->priv;
     int ret = RIG_OK;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called: %d\n",
@@ -505,7 +505,7 @@ int hiqsdr_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 
 int hiqsdr_set_ant(RIG *rig, vfo_t vfo, ant_t ant, value_t option)
 {
-    struct hiqsdr_priv_data *priv = (struct hiqsdr_priv_data *)rig->state.priv;
+    struct hiqsdr_priv_data *priv = (struct hiqsdr_priv_data *)STATE(rig)->priv;
     int ret = RIG_OK;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called: %u\n",
@@ -528,7 +528,7 @@ int hiqsdr_set_ant(RIG *rig, vfo_t vfo, ant_t ant, value_t option)
 
 int hiqsdr_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
-    struct hiqsdr_priv_data *priv = (struct hiqsdr_priv_data *)rig->state.priv;
+    struct hiqsdr_priv_data *priv = (struct hiqsdr_priv_data *)STATE(rig)->priv;
     int ret = RIG_OK;
 
     switch (level)

--- a/rigs/kit/si570avrusb.c
+++ b/rigs/kit/si570avrusb.c
@@ -569,16 +569,16 @@ int si570avrusb_init(RIG *rig)
     hamlib_port_t *rp = RIGPORT(rig);
     struct si570xxxusb_priv_data *priv;
 
-    rig->state.priv = (struct si570xxxusb_priv_data *)calloc(sizeof(struct
+    STATE(rig)->priv = (struct si570xxxusb_priv_data *)calloc(sizeof(struct
                       si570xxxusb_priv_data), 1);
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     priv->osc_freq = SI570_NOMINAL_XTALL_FREQ;
     /* QSD/QSE */
@@ -610,16 +610,16 @@ int si570peaberry1_init(RIG *rig)
     hamlib_port_t *rp = RIGPORT(rig);
     struct si570xxxusb_priv_data *priv;
 
-    rig->state.priv = (struct si570xxxusb_priv_data *)calloc(sizeof(struct
+    STATE(rig)->priv = (struct si570xxxusb_priv_data *)calloc(sizeof(struct
                       si570xxxusb_priv_data), 1);
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     priv->osc_freq = SI570_NOMINAL_XTALL_FREQ;
     /* QSD/QSE */
@@ -651,16 +651,16 @@ int si570peaberry2_init(RIG *rig)
     hamlib_port_t *rp = RIGPORT(rig);
     struct si570xxxusb_priv_data *priv;
 
-    rig->state.priv = (struct si570xxxusb_priv_data *)calloc(sizeof(struct
+    STATE(rig)->priv = (struct si570xxxusb_priv_data *)calloc(sizeof(struct
                       si570xxxusb_priv_data), 1);
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     priv->osc_freq = SI570_NOMINAL_XTALL_FREQ;
     /* QSD/QSE */
@@ -692,16 +692,16 @@ int si570picusb_init(RIG *rig)
     hamlib_port_t *rp = RIGPORT(rig);
     struct si570xxxusb_priv_data *priv;
 
-    rig->state.priv = (struct si570xxxusb_priv_data *)calloc(sizeof(struct
+    STATE(rig)->priv = (struct si570xxxusb_priv_data *)calloc(sizeof(struct
                       si570xxxusb_priv_data), 1);
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     priv->osc_freq = SI570_NOMINAL_XTALL_FREQ;
     /* QSD/QSE */
@@ -733,16 +733,16 @@ int fasdr_init(RIG *rig)
     hamlib_port_t *rp = RIGPORT(rig);
     struct si570xxxusb_priv_data *priv;
 
-    rig->state.priv = (struct si570xxxusb_priv_data *)calloc(sizeof(struct
+    STATE(rig)->priv = (struct si570xxxusb_priv_data *)calloc(sizeof(struct
                       si570xxxusb_priv_data), 1);
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     priv->osc_freq = SI570_NOMINAL_XTALL_FREQ;
     /* QSD/QSE */
@@ -770,7 +770,7 @@ int fasdr_init(RIG *rig)
 int fasdr_open(RIG *rig)
 {
     struct si570xxxusb_priv_data *priv = (struct si570xxxusb_priv_data *)
-                                         rig->state.priv;
+                                         STATE(rig)->priv;
     libusb_device_handle *udh = RIGPORT(rig)->handle;
     int ret, i;
     double f;
@@ -852,12 +852,12 @@ int si570xxxusb_cleanup(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
@@ -869,7 +869,7 @@ int si570xxxusb_set_conf(RIG *rig, hamlib_token_t token, const char *val)
     double multiplier;
     unsigned int i2c_addr;
 
-    priv = (struct si570xxxusb_priv_data *)rig->state.priv;
+    priv = (struct si570xxxusb_priv_data *)STATE(rig)->priv;
 
     switch (token)
     {
@@ -928,7 +928,7 @@ int si570xxxusb_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 int si570xxxusb_get_conf2(RIG *rig, hamlib_token_t token, char *val, int val_len)
 {
     struct si570xxxusb_priv_data *priv;
-    priv = (struct si570xxxusb_priv_data *)rig->state.priv;
+    priv = (struct si570xxxusb_priv_data *)STATE(rig)->priv;
 
     switch (token)
     {
@@ -1014,7 +1014,7 @@ static int setBPF(RIG *rig, int enable)
 int si570xxxusb_open(RIG *rig)
 {
     struct si570xxxusb_priv_data *priv = (struct si570xxxusb_priv_data *)
-                                         rig->state.priv;
+                                         STATE(rig)->priv;
     libusb_device_handle *udh = RIGPORT(rig)->handle;
     int ret;
     unsigned char buffer[4];
@@ -1112,7 +1112,7 @@ static const int HS_DIV_MAP[] = {4, 5, 6, 7, -1, 9, -1, 11};
 static int calcDividers(RIG *rig, double f, struct solution *solution)
 {
     const struct si570xxxusb_priv_data *priv = (struct si570xxxusb_priv_data *)
-            rig->state.priv;
+            STATE(rig)->priv;
     struct solution sols[8];
     int i;
     int imin;
@@ -1194,7 +1194,7 @@ static int calcDividers(RIG *rig, double f, struct solution *solution)
 int si570xxxusb_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
     const struct si570xxxusb_priv_data *priv = (struct si570xxxusb_priv_data *)
-            rig->state.priv;
+            STATE(rig)->priv;
     libusb_device_handle *udh = RIGPORT(rig)->handle;
     int ret;
     unsigned char buffer[6];
@@ -1260,7 +1260,7 @@ int si570xxxusb_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 int si570xxxusb_set_freq_by_value(RIG *rig, vfo_t vfo, freq_t freq)
 {
     const struct si570xxxusb_priv_data *priv = (struct si570xxxusb_priv_data *)
-            rig->state.priv;
+            STATE(rig)->priv;
     libusb_device_handle *udh = RIGPORT(rig)->handle;
     int ret;
 
@@ -1299,7 +1299,7 @@ int si570xxxusb_set_freq_by_value(RIG *rig, vfo_t vfo, freq_t freq)
 static double calculateFrequency(RIG *rig, const unsigned char *buffer)
 {
     const struct si570xxxusb_priv_data *priv = (struct si570xxxusb_priv_data *)
-            rig->state.priv;
+            STATE(rig)->priv;
 
     int RFREQ_int = ((buffer[2] & 0xf0) >> 4) + ((buffer[1] & 0x3f) * 16);
     int RFREQ_frac = (256 * 256 * 256 * (buffer[2] & 0xf)) +
@@ -1330,7 +1330,7 @@ static double calculateFrequency(RIG *rig, const unsigned char *buffer)
 int si570xxxusb_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
     struct si570xxxusb_priv_data *priv = (struct si570xxxusb_priv_data *)
-                                         rig->state.priv;
+                                         STATE(rig)->priv;
     libusb_device_handle *udh = RIGPORT(rig)->handle;
     unsigned char buffer[6];
     int ret;
@@ -1362,7 +1362,7 @@ int si570xxxusb_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 int si570xxxusb_get_freq_by_value(RIG *rig, vfo_t vfo, freq_t *freq)
 {
     const struct si570xxxusb_priv_data *priv = (struct si570xxxusb_priv_data *)
-            rig->state.priv;
+            STATE(rig)->priv;
     libusb_device_handle *udh = RIGPORT(rig)->handle;
     int ret;
     unsigned char buffer[4];

--- a/rigs/kit/usrp_impl.cc
+++ b/rigs/kit/usrp_impl.cc
@@ -46,8 +46,8 @@ struct usrp_priv_data {
 int usrp_init(RIG *rig)
 {
     // cppcheck-suppress leakReturnValNotUsed
-	rig->state.priv = static_cast<struct usrp_priv_data*>malloc(sizeof(struct usrp_priv_data));
-	if (!rig->state.priv) {
+	STATE(rig)->priv = static_cast<struct usrp_priv_data*>malloc(sizeof(struct usrp_priv_data));
+	if (!STATE(rig)->priv) {
 		/* whoops! memory shortage! */
 		return -RIG_ENOMEM;
 	}
@@ -60,16 +60,16 @@ int usrp_cleanup(RIG *rig)
 	if (!rig)
 		return -RIG_EINVAL;
 
-	if (rig->state.priv)
-		free(rig->state.priv);
-	rig->state.priv = NULL;
+	if (STATE(rig)->priv)
+		free(STATE(rig)->priv);
+	STATE(rig)->priv = NULL;
 
 	return RIG_OK;
 }
 
 int usrp_open(RIG *rig)
 {
-	struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>rig->state.priv;
+	struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>STATE(rig)->priv;
 
 	int which_board = 0;
 	int decim = 125;
@@ -83,7 +83,7 @@ int usrp_open(RIG *rig)
 
 int usrp_close(RIG *rig)
 {
-	struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>rig->state.priv;
+	struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>STATE(rig)->priv;
 
     if (!priv)
     {
@@ -97,11 +97,11 @@ int usrp_close(RIG *rig)
 }
 
 /*
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  */
 int usrp_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 {
-	struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>rig->state.priv;
+	struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>STATE(rig)->priv;
 
     if (!priv)
     {
@@ -121,12 +121,12 @@ int usrp_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 
 /*
  * assumes rig!=NULL,
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  *  and val points to a buffer big enough to hold the conf value.
  */
 int usrp_get_conf(RIG *rig, hamlib_token_t token, char *val)
 {
-	const struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>rig->state.priv;
+	const struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>STATE(rig)->priv;
 
     if (!priv)
     {
@@ -148,7 +148,7 @@ int usrp_get_conf(RIG *rig, hamlib_token_t token, char *val)
 
 int usrp_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-	const struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>rig->state.priv;
+	const struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>STATE(rig)->priv;
 	int chan = 0;
 
     if (!priv)
@@ -166,7 +166,7 @@ int usrp_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
 int usrp_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
-	const struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>rig->state.priv;
+	const struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>STATE(rig)->priv;
 	int chan = 0;
 
     if (!priv)

--- a/rigs/lowe/lowe.c
+++ b/rigs/lowe/lowe.c
@@ -46,7 +46,7 @@
 
 /*
  * lowe_transaction
- * We assume that rig!=NULL, rig->state!= NULL, data!=NULL, data_len!=NULL
+ * We assume that rig!=NULL, STATE(rig)!= NULL, data!=NULL, data_len!=NULL
  */
 int lowe_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
                      int *data_len)

--- a/rigs/mds/mds.c
+++ b/rigs/mds/mds.c
@@ -51,7 +51,7 @@ int mds_transaction(RIG *rig, char *cmd, int expected, char **result)
     char cmd_buf[MAXCMDLEN];
     int retval;
     hamlib_port_t *rp = RIGPORT(rig);
-    struct mds_priv_data *priv = rig->state.priv;
+    struct mds_priv_data *priv = STATE(rig)->priv;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: cmd=%s\n", __func__, cmd);
 
@@ -101,10 +101,10 @@ int mds_init(RIG *rig)
 {
     rig_debug(RIG_DEBUG_VERBOSE, "%s version %s\n", __func__, rig->caps->version);
     // cppcheck claims leak here but it's freed in cleanup
-    rig->state.priv = (struct mds_priv_data *)calloc(1,
+    STATE(rig)->priv = (struct mds_priv_data *)calloc(1,
                       sizeof(struct mds_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         return -RIG_ENOMEM;
     }
@@ -127,19 +127,19 @@ int mds_cleanup(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
 
 /*
  * mds_get_freq
- * Assumes rig!=NULL, rig->state.priv!=NULL, freq!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL, freq!=NULL
  */
 int mds_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
@@ -171,7 +171,7 @@ int mds_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 // TC command does not work on 4050 -- not implemented as of 2022-01-12
 /*
  * mds_set_freq
- * assumes rig!=NULL, rig->state.priv!=NULL
+ * assumes rig!=NULL, STATE(rig)->priv!=NULL
  */
 int mds_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
@@ -303,7 +303,7 @@ int mds_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     rmode_t tmode;
     pbwidth_t twidth;
 
-    //struct tt588_priv_data *priv = (struct tt588_priv_data *) rig->state.priv;
+    //struct tt588_priv_data *priv = (struct tt588_priv_data *) STATE(rig)->priv;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: vfo=%s mode=%s width=%d\n", __func__,
               rig_strvfo(vfo), rig_strrmode(mode), (int)width);

--- a/rigs/pcr/pcr.c
+++ b/rigs/pcr/pcr.c
@@ -163,7 +163,7 @@ pcr_read_block(RIG *rig, char *rxbuffer, size_t count)
 {
     int read = 0, tries = 4;
 
-    struct rig_state *rs = &rig->state;
+    struct rig_state *rs = STATE(rig);
     hamlib_port_t *rp = RIGPORT(rig);
     const struct pcr_priv_caps *caps = pcr_caps(rig);
     struct pcr_priv_data *priv = (struct pcr_priv_data *) rs->priv;
@@ -235,7 +235,7 @@ pcr_read_block(RIG *rig, char *rxbuffer, size_t count)
 static int
 pcr_parse_answer(RIG *rig, char *buf, int len)
 {
-    struct rig_state *rs = &rig->state;
+    struct rig_state *rs = STATE(rig);
     struct pcr_priv_data *priv = (struct pcr_priv_data *) rs->priv;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: len = %d\n", __func__, len);
@@ -342,7 +342,7 @@ static int
 pcr_send(RIG *rig, const char *cmd)
 {
     int err;
-    struct rig_state *rs = &rig->state;
+    struct rig_state *rs = STATE(rig);
     struct pcr_priv_data *priv = (struct pcr_priv_data *) rs->priv;
 
     int len = strlen(cmd);
@@ -371,7 +371,7 @@ static int
 pcr_transaction(RIG *rig, const char *cmd)
 {
     int err;
-    struct rig_state *rs = &rig->state;
+    struct rig_state *rs = STATE(rig);
     struct pcr_priv_caps *caps = pcr_caps(rig);
     struct pcr_priv_data *priv = (struct pcr_priv_data *) rs->priv;
 
@@ -481,16 +481,16 @@ pcr_init(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    rig->state.priv = (struct pcr_priv_data *) calloc(1,
+    STATE(rig)->priv = (struct pcr_priv_data *) calloc(1,
                       sizeof(struct pcr_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     memset(priv, 0x00, sizeof(struct pcr_priv_data));
 
@@ -532,9 +532,9 @@ pcr_cleanup(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    free(rig->state.priv);
+    free(STATE(rig)->priv);
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
@@ -549,7 +549,7 @@ pcr_cleanup(RIG *rig)
 int
 pcr_open(RIG *rig)
 {
-    struct rig_state *rs = &rig->state;
+    struct rig_state *rs = STATE(rig);
     hamlib_port_t *rp = RIGPORT(rig);
     struct pcr_priv_data *priv = (struct pcr_priv_data *) rs->priv;
 
@@ -633,7 +633,7 @@ pcr_open(RIG *rig)
         return err;
     }
 
-    if ((rig->state.vfo_list & RIG_VFO_SUB) == RIG_VFO_SUB)
+    if ((STATE(rig)->vfo_list & RIG_VFO_SUB) == RIG_VFO_SUB)
     {
         err = pcr_set_squelch(rig, RIG_VFO_SUB, priv->sub_rcvr.squelch);
 
@@ -675,7 +675,7 @@ pcr_open(RIG *rig)
 int
 pcr_close(RIG *rig)
 {
-    struct pcr_priv_data *priv = (struct pcr_priv_data *) rig->state.priv;
+    struct pcr_priv_data *priv = (struct pcr_priv_data *) STATE(rig)->priv;
     /* when the pcr turns itself off sometimes we receive
      * a malformed answer, so don't check for it.
      */
@@ -692,7 +692,7 @@ pcr_close(RIG *rig)
 int
 pcr_set_vfo(RIG *rig, vfo_t vfo)
 {
-    struct pcr_priv_data *priv = (struct pcr_priv_data *) rig->state.priv;
+    struct pcr_priv_data *priv = (struct pcr_priv_data *) STATE(rig)->priv;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: vfo = %s\n",
               __func__, rig_strvfo(vfo));
@@ -715,7 +715,7 @@ pcr_set_vfo(RIG *rig, vfo_t vfo)
 int
 pcr_get_vfo(RIG *rig, vfo_t *vfo)
 {
-    const struct pcr_priv_data *priv = (struct pcr_priv_data *) rig->state.priv;
+    const struct pcr_priv_data *priv = (struct pcr_priv_data *) STATE(rig)->priv;
 
     *vfo = priv->current_vfo;
     return RIG_OK;
@@ -755,7 +755,7 @@ pcr_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     rig_debug(RIG_DEBUG_VERBOSE, "%s: vfo = %s, freq = %.0f\n",
               __func__, rig_strvfo(vfo), freq);
 
-    priv = (struct pcr_priv_data *) rig->state.priv;
+    priv = (struct pcr_priv_data *) STATE(rig)->priv;
     rcvr = is_sub_rcvr(rig, vfo) ? &priv->sub_rcvr : &priv->main_rcvr;
 
     SNPRINTF((char *) buf, sizeof(buf), "K%c%010" PRIll "0%c0%c00",
@@ -783,7 +783,7 @@ pcr_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 int
 pcr_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
-    struct pcr_priv_data *priv = (struct pcr_priv_data *) rig->state.priv;
+    struct pcr_priv_data *priv = (struct pcr_priv_data *) STATE(rig)->priv;
     const struct pcr_rcvr *rcvr = is_sub_rcvr(rig,
                                   vfo) ? &priv->sub_rcvr : &priv->main_rcvr;
 
@@ -800,7 +800,7 @@ pcr_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 int
 pcr_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
-    struct pcr_priv_data *priv = (struct pcr_priv_data *) rig->state.priv;
+    struct pcr_priv_data *priv = (struct pcr_priv_data *) STATE(rig)->priv;
     struct pcr_rcvr *rcvr = is_sub_rcvr(rig,
                                         vfo) ? &priv->sub_rcvr : &priv->main_rcvr;
 
@@ -941,7 +941,7 @@ pcr_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
     struct pcr_priv_data *priv;
     struct pcr_rcvr *rcvr;
 
-    priv = (struct pcr_priv_data *) rig->state.priv;
+    priv = (struct pcr_priv_data *) STATE(rig)->priv;
     rcvr = is_sub_rcvr(rig, vfo) ? &priv->sub_rcvr : &priv->main_rcvr;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s, last_mode = %c, last_filter = %c\n",
@@ -1020,7 +1020,7 @@ pcr_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
 const char *
 pcr_get_info(RIG *rig)
 {
-    struct pcr_priv_data *priv = (struct pcr_priv_data *) rig->state.priv;
+    struct pcr_priv_data *priv = (struct pcr_priv_data *) STATE(rig)->priv;
 
     char *country = NULL;
 
@@ -1169,7 +1169,7 @@ int
 pcr_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
     int err;
-    struct pcr_priv_data *priv = (struct pcr_priv_data *) rig->state.priv;
+    struct pcr_priv_data *priv = (struct pcr_priv_data *) STATE(rig)->priv;
     const struct pcr_rcvr *rcvr = is_sub_rcvr(rig,
                                   vfo) ? &priv->sub_rcvr : &priv->main_rcvr;
 
@@ -1196,7 +1196,7 @@ pcr_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
             }
         }
 
-        val->i = rig_raw2val(rcvr->raw_level, &rig->state.str_cal);
+        val->i = rig_raw2val(rcvr->raw_level, &STATE(rig)->str_cal);
         /*      rig_debug(RIG_DEBUG_TRACE, "%s, raw = %d, converted = %d\n",
                          __func__, rcvr->raw_level, val->i);
         */
@@ -1235,7 +1235,7 @@ pcr_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 
 /*
  * pcr_set_func
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  *
  * This is missing a way to call the set DSP noise reducer, as we don't have a func to call it
  * based on the flags in rig.h -> see also missing a flag for setting the BFO.
@@ -1243,7 +1243,7 @@ pcr_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 int
 pcr_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
 {
-    struct pcr_priv_data *priv = (struct pcr_priv_data *) rig->state.priv;
+    struct pcr_priv_data *priv = (struct pcr_priv_data *) STATE(rig)->priv;
     const struct pcr_rcvr *rcvr = is_sub_rcvr(rig,
                                   vfo) ? &priv->sub_rcvr : &priv->main_rcvr;
 
@@ -1342,7 +1342,7 @@ pcr_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
 
 /*
  * pcr_get_func
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  *
  * This will need similar variables/flags as get_level. The PCR doesn't offer much in the way of
  *  confirmation of current settings (according to the docs).
@@ -1401,7 +1401,7 @@ pcr_check_ok(RIG *rig)
 static int
 is_sub_rcvr(RIG *rig, vfo_t vfo)
 {
-    const struct pcr_priv_data *priv = (struct pcr_priv_data *) rig->state.priv;
+    const struct pcr_priv_data *priv = (struct pcr_priv_data *) STATE(rig)->priv;
 
     return vfo == RIG_VFO_SUB ||
            (vfo == RIG_VFO_CURR && priv->current_vfo == RIG_VFO_SUB);
@@ -1442,7 +1442,7 @@ static int
 pcr_set_volume(RIG *rig, vfo_t vfo, float level)
 {
     int err;
-    struct pcr_priv_data *priv = (struct pcr_priv_data *) rig->state.priv;
+    struct pcr_priv_data *priv = (struct pcr_priv_data *) STATE(rig)->priv;
     struct pcr_rcvr *rcvr = is_sub_rcvr(rig,
                                         vfo) ? &priv->sub_rcvr : &priv->main_rcvr;
 
@@ -1461,7 +1461,7 @@ pcr_set_volume(RIG *rig, vfo_t vfo, float level)
 
 /*
  * pcr_set_squelch
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  *
  * Format is J41xx - where xx is 00 to FF in hex, and specifies 255 squelch levels
  *
@@ -1481,7 +1481,7 @@ static int
 pcr_set_squelch(RIG *rig, vfo_t vfo, float level)
 {
     int err;
-    struct pcr_priv_data *priv = (struct pcr_priv_data *) rig->state.priv;
+    struct pcr_priv_data *priv = (struct pcr_priv_data *) STATE(rig)->priv;
     struct pcr_rcvr *rcvr = is_sub_rcvr(rig,
                                         vfo) ? &priv->sub_rcvr : &priv->main_rcvr;
 
@@ -1501,7 +1501,7 @@ pcr_set_squelch(RIG *rig, vfo_t vfo, float level)
 
 /*
  * pcr_set_if_shift
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  *
  * Sets the IF shift  of the rig to the level specified in the level integer.
  *  IF-SHIFT position (in 256 stages, 80 = centre):
@@ -1517,7 +1517,7 @@ int
 pcr_set_if_shift(RIG *rig, vfo_t vfo, int level)
 {
     int err;
-    struct pcr_priv_data *priv = (struct pcr_priv_data *) rig->state.priv;
+    struct pcr_priv_data *priv = (struct pcr_priv_data *) STATE(rig)->priv;
     struct pcr_rcvr *rcvr = is_sub_rcvr(rig,
                                         vfo) ? &priv->sub_rcvr : &priv->main_rcvr;
 
@@ -1536,7 +1536,7 @@ pcr_set_if_shift(RIG *rig, vfo_t vfo, int level)
 
 /*
  * pcr_set_agc
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  *
  * Sets the AGC on or off based on the level specified in the level integer.
  *  00 = off, 01 (non zero) is on
@@ -1548,7 +1548,7 @@ int
 pcr_set_agc(RIG *rig, vfo_t vfo, int status)
 {
     int err;
-    struct pcr_priv_data *priv = (struct pcr_priv_data *) rig->state.priv;
+    struct pcr_priv_data *priv = (struct pcr_priv_data *) STATE(rig)->priv;
     struct pcr_rcvr *rcvr = is_sub_rcvr(rig,
                                         vfo) ? &priv->sub_rcvr : &priv->main_rcvr;
 
@@ -1567,7 +1567,7 @@ pcr_set_agc(RIG *rig, vfo_t vfo, int status)
 
 /*
  * pcr_set_afc(RIG *rig, vfo_t vfo, int level);
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  *
  * Sets the Tracking Filter on or off based on the status argument.
  *  00 = on, 01 (non zero) is off
@@ -1584,7 +1584,7 @@ pcr_set_afc(RIG *rig, vfo_t vfo, int status)
 
 /*
  * pcr_set_nb(RIG *rig, vfo_t vfo, int level);
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  *
  * Sets the noise blanker on or off based on the level specified in the level integer.
  *  00 = off, 01 (non zero) is on
@@ -1629,7 +1629,7 @@ pcr_set_diversity(RIG *rig, vfo_t vfo, int status)
 
 /*
  * pcr_set_attenuator(RIG *rig, vfo_t vfo, int level);
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  *
  * Sets the attenuator on or off based on the level specified in the level integer.
  *  00 = off, 01 (non zero) is on
@@ -1643,7 +1643,7 @@ int
 pcr_set_attenuator(RIG *rig, vfo_t vfo, int status)
 {
     int err;
-    struct pcr_priv_data *priv = (struct pcr_priv_data *) rig->state.priv;
+    struct pcr_priv_data *priv = (struct pcr_priv_data *) STATE(rig)->priv;
     struct pcr_rcvr *rcvr = is_sub_rcvr(rig,
                                         vfo) ? &priv->sub_rcvr : &priv->main_rcvr;
 
@@ -1662,7 +1662,7 @@ pcr_set_attenuator(RIG *rig, vfo_t vfo, int status)
 
 /*
  * pcr_set_bfo_shift
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  *
  * Sets the BFO of the rig to the level specified in the level integer.
  *  BFO-SHIFT position (in 256 stages, 80 = centre):
@@ -1684,7 +1684,7 @@ pcr_set_bfo_shift(RIG *rig, vfo_t vfo, int level)
 
 /*
  * pcr_set_dsp(RIG *rig, vfo_t vfo, int level);
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  *
  * Sets the DSP to UT106 (01) or off (non 01)
  *
@@ -1704,7 +1704,7 @@ pcr_set_dsp(RIG *rig, vfo_t vfo, int level)
 
 /*
  * pcr_set_dsp_state(RIG *rig, vfo_t vfo, int level);
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  *
  * Sets the DSP on or off (> 0 = on, 0 = off)
  *
@@ -1725,7 +1725,7 @@ pcr_set_dsp_state(RIG *rig, vfo_t vfo, int level)
 
 /*
  * pcr_set_dsp_noise_reducer(RIG *rig, vfo_t vfo, int level);
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  *
  * Sets the DSP noise reducer on or off (0x01 = on, 0x00 = off)
  *  the level of NR set by values 0x01 to 0x10 (1 to 16 inclusive)
@@ -1748,7 +1748,7 @@ pcr_set_dsp_noise_reducer(RIG *rig, vfo_t vfo, int level)
 
 /*
  * pcr_set_dsp_auto_notch(RIG *rig, vfo_t vfo, int level);
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  *
  * Sets the auto notch on or off (1 = on, 0 = off)
  */
@@ -1777,7 +1777,7 @@ pcr_set_vsc(RIG *rig, vfo_t vfo, int status)  // J50xx
 
 int pcr_get_ctcss_sql(RIG *rig, vfo_t vfo, tone_t *tone)
 {
-    struct pcr_priv_data *priv = (struct pcr_priv_data *) rig->state.priv;
+    struct pcr_priv_data *priv = (struct pcr_priv_data *) STATE(rig)->priv;
     const struct pcr_rcvr *rcvr = is_sub_rcvr(rig,
                                   vfo) ? &priv->sub_rcvr : &priv->main_rcvr;
 
@@ -1788,7 +1788,7 @@ int pcr_get_ctcss_sql(RIG *rig, vfo_t vfo, tone_t *tone)
 int pcr_set_ctcss_sql(RIG *rig, vfo_t vfo, tone_t tone)
 {
     int i, err;
-    struct pcr_priv_data *priv = (struct pcr_priv_data *) rig->state.priv;
+    struct pcr_priv_data *priv = (struct pcr_priv_data *) STATE(rig)->priv;
     struct pcr_rcvr *rcvr = is_sub_rcvr(rig,
                                         vfo) ? &priv->sub_rcvr : &priv->main_rcvr;
 
@@ -1827,7 +1827,7 @@ int pcr_set_ctcss_sql(RIG *rig, vfo_t vfo, tone_t tone)
 
 int pcr_get_dcs_sql(RIG *rig, vfo_t vfo, tone_t *tone)
 {
-    struct pcr_priv_data *priv = (struct pcr_priv_data *) rig->state.priv;
+    struct pcr_priv_data *priv = (struct pcr_priv_data *) STATE(rig)->priv;
     const struct pcr_rcvr *rcvr = is_sub_rcvr(rig,
                                   vfo) ? &priv->sub_rcvr : &priv->main_rcvr;
 
@@ -1838,7 +1838,7 @@ int pcr_get_dcs_sql(RIG *rig, vfo_t vfo, tone_t *tone)
 int pcr_set_dcs_sql(RIG *rig, vfo_t vfo, tone_t tone)
 {
     int i, err;
-    struct pcr_priv_data *priv = (struct pcr_priv_data *) rig->state.priv;
+    struct pcr_priv_data *priv = (struct pcr_priv_data *) STATE(rig)->priv;
     struct pcr_rcvr *rcvr = is_sub_rcvr(rig,
                                         vfo) ? &priv->sub_rcvr : &priv->main_rcvr;
 
@@ -1877,7 +1877,7 @@ int pcr_set_dcs_sql(RIG *rig, vfo_t vfo, tone_t tone)
 
 int pcr_set_trn(RIG *rig, int trn)
 {
-    struct pcr_priv_data *priv = (struct pcr_priv_data *) rig->state.priv;
+    struct pcr_priv_data *priv = (struct pcr_priv_data *) STATE(rig)->priv;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: trn = %d\n", __func__, trn);
 
@@ -1915,7 +1915,7 @@ int pcr_decode_event(RIG *rig)
 
 int pcr_set_powerstat(RIG *rig, powerstat_t status)
 {
-    const struct pcr_priv_data *priv = (struct pcr_priv_data *) rig->state.priv;
+    const struct pcr_priv_data *priv = (struct pcr_priv_data *) STATE(rig)->priv;
 
     if (status == priv->power)
     {
@@ -1936,7 +1936,7 @@ int pcr_set_powerstat(RIG *rig, powerstat_t status)
 
 int pcr_get_powerstat(RIG *rig, powerstat_t *status)
 {
-    struct pcr_priv_data *priv = (struct pcr_priv_data *) rig->state.priv;
+    struct pcr_priv_data *priv = (struct pcr_priv_data *) STATE(rig)->priv;
     int err;
 
     /* return RIG_ERJCTED if power is off */
@@ -1956,7 +1956,7 @@ int pcr_get_powerstat(RIG *rig, powerstat_t *status)
 
 int pcr_get_dcd(RIG *rig, vfo_t vfo, dcd_t *dcd)
 {
-    struct pcr_priv_data *priv = (struct pcr_priv_data *) rig->state.priv;
+    struct pcr_priv_data *priv = (struct pcr_priv_data *) STATE(rig)->priv;
     const struct pcr_rcvr *rcvr = is_sub_rcvr(rig,
                                   vfo) ? &priv->sub_rcvr : &priv->main_rcvr;
 

--- a/rigs/prm80/prm80.c
+++ b/rigs/prm80/prm80.c
@@ -140,7 +140,7 @@ MessageAide:  DB   "H",0Dh,0Ah
 
 static void prm80_force_cache_timeout(RIG *rig)
 {
-    struct prm80_priv_data *priv = (struct prm80_priv_data *)rig->state.priv;
+    struct prm80_priv_data *priv = (struct prm80_priv_data *)STATE(rig)->priv;
 
     rig_force_cache_timeout(&priv->status_tv);
 }
@@ -283,9 +283,9 @@ int prm80_init(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    rig->state.priv = (void *)calloc(1, sizeof(struct prm80_priv_data));
+    STATE(rig)->priv = (void *)calloc(1, sizeof(struct prm80_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
@@ -301,8 +301,8 @@ int prm80_cleanup(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    free(rig->state.priv);
-    rig->state.priv = NULL;
+    free(STATE(rig)->priv);
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
@@ -418,7 +418,7 @@ int prm80_set_rx_tx_freq(RIG *rig, freq_t rx_freq, freq_t tx_freq)
  */
 int prm80_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-    struct prm80_priv_data *priv = (struct prm80_priv_data *)rig->state.priv;
+    struct prm80_priv_data *priv = (struct prm80_priv_data *)STATE(rig)->priv;
     freq_t tx_freq;
     int rc;
 
@@ -448,7 +448,7 @@ int prm80_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
  */
 int prm80_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
 {
-    struct prm80_priv_data *priv = (struct prm80_priv_data *)rig->state.priv;
+    struct prm80_priv_data *priv = (struct prm80_priv_data *)STATE(rig)->priv;
     freq_t rx_freq;
     int rc;
 
@@ -471,7 +471,7 @@ int prm80_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
  */
 int prm80_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
-    struct prm80_priv_data *priv = (struct prm80_priv_data *)rig->state.priv;
+    struct prm80_priv_data *priv = (struct prm80_priv_data *)STATE(rig)->priv;
     int ret;
     channel_t chan;
 
@@ -498,7 +498,7 @@ int prm80_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
  */
 int prm80_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
 {
-    struct prm80_priv_data *priv = (struct prm80_priv_data *)rig->state.priv;
+    struct prm80_priv_data *priv = (struct prm80_priv_data *)STATE(rig)->priv;
 
     priv->split = split;
 
@@ -510,7 +510,7 @@ int prm80_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
  */
 int prm80_get_split_vfo(RIG *rig, vfo_t vfo, split_t *split, vfo_t *tx_vfo)
 {
-    const struct prm80_priv_data *priv = (struct prm80_priv_data *)rig->state.priv;
+    const struct prm80_priv_data *priv = (struct prm80_priv_data *)STATE(rig)->priv;
 
     *split = priv->split;
     *tx_vfo = RIG_VFO_CURR;
@@ -523,7 +523,7 @@ int prm80_get_split_vfo(RIG *rig, vfo_t vfo, split_t *split, vfo_t *tx_vfo)
  */
 int prm80_get_split_freq(RIG *rig, vfo_t vfo, freq_t *tx_freq)
 {
-    struct prm80_priv_data *priv = (struct prm80_priv_data *)rig->state.priv;
+    struct prm80_priv_data *priv = (struct prm80_priv_data *)STATE(rig)->priv;
     int ret;
     channel_t chan;
 
@@ -694,7 +694,7 @@ static int prm80_do_read_system_state(hamlib_port_t *rigport, char *statebuf)
  */
 static int prm80_read_system_state(RIG *rig, char *statebuf)
 {
-    struct prm80_priv_data *priv = (struct prm80_priv_data *)rig->state.priv;
+    struct prm80_priv_data *priv = (struct prm80_priv_data *)STATE(rig)->priv;
     int ret = RIG_OK;
 
     if (rig_check_cache_timeout(&priv->status_tv, PRM80_CACHE_TIMEOUT))
@@ -723,7 +723,7 @@ static int prm80_read_system_state(RIG *rig, char *statebuf)
  */
 int prm80_get_channel(RIG *rig, vfo_t vfo, channel_t *chan, int read_only)
 {
-    const struct prm80_priv_data *priv = (struct prm80_priv_data *)rig->state.priv;
+    const struct prm80_priv_data *priv = (struct prm80_priv_data *)STATE(rig)->priv;
     char statebuf[BUFSZ];
     int ret, chanstate, mode_byte, lock_byte;
 
@@ -821,7 +821,7 @@ int prm80_get_channel(RIG *rig, vfo_t vfo, channel_t *chan, int read_only)
  */
 int prm80_set_channel(RIG *rig, vfo_t vfo, const channel_t *chan)
 {
-    struct prm80_priv_data *priv = (struct prm80_priv_data *)rig->state.priv;
+    struct prm80_priv_data *priv = (struct prm80_priv_data *)STATE(rig)->priv;
     hamlib_port_t *rp = RIGPORT(rig);
     char buf[BUFSZ];
     int ret, chanstate;
@@ -1107,7 +1107,7 @@ int prm80_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 static int prm80_get_rawstr_RAM(RIG *rig, value_t *val)
 {
     char buf[BUFSZ];
-    struct rig_state *rs = &rig->state;
+    struct rig_state *rs = STATE(rig);
     hamlib_port_t *rp = RIGPORT(rig);
     int ret, i;
 

--- a/rigs/racal/ra37xx.c
+++ b/rigs/racal/ra37xx.c
@@ -69,7 +69,7 @@ static int ra37xx_one_transaction(RIG *rig, const char *cmd, char *data,
                                   int *data_len)
 {
     const struct ra37xx_priv_data *priv = (struct ra37xx_priv_data *)
-                                          rig->state.priv;
+                                          STATE(rig)->priv;
     hamlib_port_t *rp = RIGPORT(rig);
     char cmdbuf[BUFSZ];
     char respbuf[BUFSZ];
@@ -215,16 +215,16 @@ int ra37xx_init(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    rig->state.priv = (struct ra37xx_priv_data *)calloc(1, sizeof(
+    STATE(rig)->priv = (struct ra37xx_priv_data *)calloc(1, sizeof(
                           struct ra37xx_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     priv->receiver_id = -1;
 
@@ -240,22 +240,22 @@ int ra37xx_cleanup(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
 
 /*
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  */
 int ra37xx_set_conf2(RIG *rig, hamlib_token_t token, const char *val, int val_len)
 {
-    struct ra37xx_priv_data *priv = (struct ra37xx_priv_data *)rig->state.priv;
+    struct ra37xx_priv_data *priv = (struct ra37xx_priv_data *)STATE(rig)->priv;
     int receiver_id;
 
     switch (token)
@@ -285,13 +285,13 @@ int ra37xx_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 
 /*
  * assumes rig!=NULL,
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  *  and val points to a buffer big enough to hold the conf value.
  */
 int ra37xx_get_conf2(RIG *rig, hamlib_token_t token, char *val, int val_len)
 {
     const struct ra37xx_priv_data *priv = (struct ra37xx_priv_data *)
-                                          rig->state.priv;
+                                          STATE(rig)->priv;
 
     switch (token)
     {
@@ -371,7 +371,7 @@ int ra37xx_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
  */
 int ra37xx_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
-    //struct ra37xx_priv_data *priv = (struct ra37xx_priv_data*)rig->state.priv;
+    //struct ra37xx_priv_data *priv = (struct ra37xx_priv_data*)STATE(rig)->priv;
     int ra_mode, widthtype, widthnum = 0;
     char buf[BUFSZ];
 
@@ -631,7 +631,7 @@ int ra37xx_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         }
 
         sscanf(resbuf + 5, "%d", &i);
-        val->i = i ? rig->state.preamp[0] : 0;
+        val->i = i ? STATE(rig)->preamp[0] : 0;
         break;
 
     case RIG_LEVEL_RAWSTR:

--- a/rigs/racal/racal.c
+++ b/rigs/racal/racal.c
@@ -61,14 +61,14 @@ const struct confparams racal_cfg_params[] =
 
 /*
  * racal_transaction
- * We assume that rig!=NULL, rig->state!= NULL
+ * We assume that rig!=NULL, RIGPORT(rig)!= NULL
  *
  * TODO: Status Response handling with G/T commands
  */
 static int racal_transaction(RIG *rig, const char *cmd, char *data,
                              int *data_len)
 {
-    const struct racal_priv_data *priv = (struct racal_priv_data *)rig->state.priv;
+    const struct racal_priv_data *priv = (struct racal_priv_data *)STATE(rig)->priv;
     hamlib_port_t *rp = RIGPORT(rig);
     char cmdbuf[BUFSZ + 1];
     int retval;
@@ -120,16 +120,16 @@ int racal_init(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    rig->state.priv = (struct racal_priv_data *)calloc(1, sizeof(
+    STATE(rig)->priv = (struct racal_priv_data *)calloc(1, sizeof(
                           struct racal_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     priv->receiver_id = 0;
     priv->bfo = 0;
@@ -147,12 +147,12 @@ int racal_cleanup(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
@@ -160,11 +160,11 @@ int racal_cleanup(RIG *rig)
 
 
 /*
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  */
 int racal_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 {
-    struct racal_priv_data *priv = (struct racal_priv_data *)rig->state.priv;
+    struct racal_priv_data *priv = (struct racal_priv_data *)STATE(rig)->priv;
 
     switch (token)
     {
@@ -181,12 +181,12 @@ int racal_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 
 /*
  * assumes rig!=NULL,
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  *  and val points to a buffer big enough to hold the conf value.
  */
 int racal_get_conf2(RIG *rig, hamlib_token_t token, char *val, int val_len)
 {
-    const struct racal_priv_data *priv = (struct racal_priv_data *)rig->state.priv;
+    const struct racal_priv_data *priv = (struct racal_priv_data *)STATE(rig)->priv;
 
     switch (token)
     {
@@ -275,7 +275,7 @@ int racal_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
  */
 int racal_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
-    const struct racal_priv_data *priv = (struct racal_priv_data *)rig->state.priv;
+    const struct racal_priv_data *priv = (struct racal_priv_data *)STATE(rig)->priv;
     int ra_mode;
     char buf[BUFSZ];
 
@@ -371,7 +371,7 @@ int racal_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
  */
 int racal_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
-    struct racal_priv_data *priv = (struct racal_priv_data *)rig->state.priv;
+    struct racal_priv_data *priv = (struct racal_priv_data *)STATE(rig)->priv;
     char cmdbuf[BUFSZ];
     int agc;
 
@@ -427,7 +427,7 @@ int racal_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
  */
 int racal_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
-    struct racal_priv_data *priv = (struct racal_priv_data *)rig->state.priv;
+    struct racal_priv_data *priv = (struct racal_priv_data *)STATE(rig)->priv;
     char resbuf[BUFSZ];
     int retval, len, att;
     double f;
@@ -510,7 +510,7 @@ int racal_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 }
 
 /*
- * Assumes rig!=NULL, rig->state.priv!=NULL
+ * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  */
 int racal_reset(RIG *rig, reset_t reset)
 {

--- a/rigs/rft/rft.c
+++ b/rigs/rft/rft.c
@@ -36,7 +36,7 @@
 
 /*
  * rft_transaction
- * We assume that rig!=NULL, rig->state!= NULL, data!=NULL, data_len!=NULL
+ * We assume that rig!=NULL, RIGPORT(rig)!= NULL, data!=NULL, data_len!=NULL
  */
 int rft_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
                     int *data_len)

--- a/rigs/rs/ek89x.c
+++ b/rigs/rs/ek89x.c
@@ -47,7 +47,7 @@
 
 /*
  * ek89x
- * We assume that rig!=NULL, rig->state!= NULL, data!=NULL, data_len!=NULL
+ * We assume that rig!=NULL, STATE(rig)!= NULL, data!=NULL, data_len!=NULL
  */
 int
 ek89x_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,

--- a/rigs/rs/gp2000.c
+++ b/rigs/rs/gp2000.c
@@ -52,7 +52,7 @@
 
 /*
  * gp2000
- * We assume that rig!=NULL, rig->state!= NULL, data!=NULL, data_len!=NULL
+ * We assume that rig!=NULL, STATE(rig)!= NULL, data!=NULL, data_len!=NULL
  */
 int
 gp2000_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,

--- a/rigs/rs/rs.c
+++ b/rigs/rs/rs.c
@@ -50,7 +50,7 @@
 
 /*
  * rs_transaction
- * We assume that rig!=NULL, rig->state!= NULL, data!=NULL, data_len!=NULL
+ * We assume that rig!=NULL, STATE(rig)!= NULL, data!=NULL, data_len!=NULL
  */
 int rs_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
                    int *data_len)
@@ -334,7 +334,7 @@ int rs_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 
     case RIG_LEVEL_ATT:
         val->i = (!memcmp(buf, "ON", 2)
-                  || !memcmp(buf, "1", 1)) ? rig->state.attenuator[0] : 0;
+                  || !memcmp(buf, "1", 1)) ? STATE(rig)->attenuator[0] : 0;
         break;
 
     case RIG_LEVEL_AF:

--- a/rigs/skanti/skanti.c
+++ b/rigs/skanti/skanti.c
@@ -51,7 +51,7 @@
 
 /*
  * skanti_transaction
- * We assume that rig!=NULL, rig->state!= NULL, data!=NULL, data_len!=NULL
+ * We assume that rig!=NULL, STATE(rig)!= NULL, data!=NULL, data_len!=NULL
  * Otherwise, you'll get a nice seg fault. You've been warned!
  * TODO: error case handling
  */

--- a/rigs/skanti/trp8255.c
+++ b/rigs/skanti/trp8255.c
@@ -215,14 +215,14 @@ static int cu_open(RIG *rig)
 
     rig_debug(RIG_DEBUG_TRACE, "%s called\n", __func__);
 
-    rig->state.priv = calloc(1, sizeof(struct cu_priv_data));
+    STATE(rig)->priv = calloc(1, sizeof(struct cu_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         return -RIG_ENOMEM;
     }
 
-    priv = (struct cu_priv_data *)rig->state.priv;
+    priv = (struct cu_priv_data *)STATE(rig)->priv;
 
     memset(priv, 0, sizeof(struct cu_priv_data));
     priv->split = RIG_SPLIT_OFF;
@@ -234,7 +234,7 @@ static int cu_open(RIG *rig)
 static int cu_close(RIG *rig)
 {
     const char cmd[] = { 0x16 }; /* DLE */
-    struct cu_priv_data *priv = (struct cu_priv_data *)rig->state.priv;
+    struct cu_priv_data *priv = (struct cu_priv_data *)STATE(rig)->priv;
 
     free(priv);
 
@@ -243,7 +243,7 @@ static int cu_close(RIG *rig)
 
 int cu_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-    const struct cu_priv_data *priv = (struct cu_priv_data *)rig->state.priv;
+    const struct cu_priv_data *priv = (struct cu_priv_data *)STATE(rig)->priv;
     char cmdbuf[16];
     int ret;
 
@@ -272,7 +272,7 @@ int cu_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
 static int cu_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
 {
-    struct cu_priv_data *priv = (struct cu_priv_data *)rig->state.priv;
+    struct cu_priv_data *priv = (struct cu_priv_data *)STATE(rig)->priv;
 
     priv->split = split;
 
@@ -478,7 +478,7 @@ int cu_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 
 static int cu_set_mem(RIG *rig, vfo_t vfo, int ch)
 {
-    struct cu_priv_data *priv = (struct cu_priv_data *)rig->state.priv;
+    struct cu_priv_data *priv = (struct cu_priv_data *)STATE(rig)->priv;
 
     /* memorize channel for RIG_OP_TO_VFO & RIG_OP_FROM_VFO */
     priv->ch = ch;
@@ -489,7 +489,7 @@ static int cu_set_mem(RIG *rig, vfo_t vfo, int ch)
 
 int cu_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op)
 {
-    const struct cu_priv_data *priv = (struct cu_priv_data *)rig->state.priv;
+    const struct cu_priv_data *priv = (struct cu_priv_data *)STATE(rig)->priv;
     char cmdbuf[16];
 
     switch (op)

--- a/rigs/tapr/tapr.c
+++ b/rigs/tapr/tapr.c
@@ -37,7 +37,7 @@
 
 /*
  * tapr_cmd
- * We assume that rig!=NULL, rig->state!= NULL, data!=NULL
+ * We assume that rig!=NULL, STATE(rig)!= NULL, data!=NULL
  * Otherwise, you'll get a nice seg fault. You've been warned!
  * TODO: error case handling
  */

--- a/rigs/tentec/jupiter.c
+++ b/rigs/tentec/jupiter.c
@@ -291,16 +291,16 @@ int tt538_init(RIG *rig)
 {
     struct tt538_priv_data *priv;
 
-    rig->state.priv = (struct tt538_priv_data *) calloc(1, sizeof(
+    STATE(rig)->priv = (struct tt538_priv_data *) calloc(1, sizeof(
                           struct tt538_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     memset(priv, 0, sizeof(struct tt538_priv_data));
 
@@ -315,7 +315,7 @@ int tt538_init(RIG *rig)
 
 static char which_vfo(const RIG *rig, vfo_t vfo)
 {
-    const struct tt538_priv_data *priv = (struct tt538_priv_data *)rig->state.priv;
+    const struct tt538_priv_data *priv = (struct tt538_priv_data *)STATE(rig)->priv;
 
     if (vfo == RIG_VFO_CURR)
     {
@@ -340,7 +340,7 @@ static char which_vfo(const RIG *rig, vfo_t vfo)
 int tt538_get_vfo(RIG *rig, vfo_t *vfo)
 {
 
-    const struct tt538_priv_data *priv = (struct tt538_priv_data *) rig->state.priv;
+    const struct tt538_priv_data *priv = (struct tt538_priv_data *) STATE(rig)->priv;
     *vfo = priv->vfo_curr;
     return RIG_OK;
 }
@@ -351,7 +351,7 @@ int tt538_get_vfo(RIG *rig, vfo_t *vfo)
  */
 int tt538_set_vfo(RIG *rig, vfo_t vfo)
 {
-    struct tt538_priv_data *priv = (struct tt538_priv_data *)rig->state.priv;
+    struct tt538_priv_data *priv = (struct tt538_priv_data *)STATE(rig)->priv;
 
     if (vfo == RIG_VFO_CURR)
     {
@@ -436,7 +436,7 @@ int tt538_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
 /*
  * tt538_set_freq
- * assumes rig!=NULL, rig->state.priv!=NULL
+ * assumes rig!=NULL, STATE(rig)->priv!=NULL
  * assumes priv->mode in AM,CW,LSB or USB.
  */
 
@@ -634,7 +634,7 @@ int tt538_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     unsigned char cmdbuf[32], respbuf[32], ttmode;
     int resp_len, retval;
 
-    const struct tt538_priv_data *priv = (struct tt538_priv_data *) rig->state.priv;
+    const struct tt538_priv_data *priv = (struct tt538_priv_data *) STATE(rig)->priv;
 
     /* Query mode for both VFOs. */
     SNPRINTF((char *) cmdbuf, sizeof(cmdbuf), "?M" EOM);

--- a/rigs/tentec/omnivii.c
+++ b/rigs/tentec/omnivii.c
@@ -330,16 +330,16 @@ int tt588_init(RIG *rig)
     struct tt588_priv_data *priv;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s:\n", __func__);
-    rig->state.priv = (struct tt588_priv_data *) calloc(1, sizeof(
+    STATE(rig)->priv = (struct tt588_priv_data *) calloc(1, sizeof(
                           struct tt588_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     memset(priv, 0, sizeof(struct tt588_priv_data));
 
@@ -380,7 +380,7 @@ static char which_vfo(const RIG *rig, vfo_t vfo)
 int tt588_get_vfo(RIG *rig, vfo_t *vfo)
 {
     static int getinfo = TRUE;
-    const struct tt588_priv_data *priv = (struct tt588_priv_data *) rig->state.priv;
+    const struct tt588_priv_data *priv = (struct tt588_priv_data *) STATE(rig)->priv;
 
     if (getinfo)   // this is the first call to this package so we do this here
     {
@@ -407,7 +407,7 @@ int tt588_get_vfo(RIG *rig, vfo_t *vfo)
  */
 int tt588_set_vfo(RIG *rig, vfo_t vfo)
 {
-    struct tt588_priv_data *priv = (struct tt588_priv_data *)rig->state.priv;
+    struct tt588_priv_data *priv = (struct tt588_priv_data *)STATE(rig)->priv;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: vfo=%s\n", __func__, rig_strvfo(vfo));
 
@@ -461,7 +461,7 @@ int tt588_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
     int resp_len, retval;
     unsigned char cmdbuf[16], respbuf[32];
-    const struct tt588_priv_data *priv = (struct tt588_priv_data *) rig->state.priv;
+    const struct tt588_priv_data *priv = (struct tt588_priv_data *) STATE(rig)->priv;
 
     if (vfo == RIG_VFO_CURR)
     {
@@ -504,7 +504,7 @@ int tt588_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
 /*
  * tt588_set_freq
- * assumes rig!=NULL, rig->state.priv!=NULL
+ * assumes rig!=NULL, STATE(rig)->priv!=NULL
  */
 int tt588_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
@@ -597,7 +597,7 @@ int tt588_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
     int resp_len, retval;
     unsigned char cmdbuf[16], respbuf[32];
     char ttmode;
-    const struct tt588_priv_data *priv = (struct tt588_priv_data *) rig->state.priv;
+    const struct tt588_priv_data *priv = (struct tt588_priv_data *) STATE(rig)->priv;
 
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: vfo=%s\n", __func__, rig_strvfo(vfo));
@@ -798,7 +798,7 @@ int tt588_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     unsigned char cmdbuf[32], respbuf[32], ttmode;
     int resp_len, retval;
 
-    const struct tt588_priv_data *priv = (struct tt588_priv_data *) rig->state.priv;
+    const struct tt588_priv_data *priv = (struct tt588_priv_data *) STATE(rig)->priv;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: vfo=%s mode=%s width=%d\n", __func__,
               rig_strvfo(vfo), rig_strrmode(mode), (int)width);

--- a/rigs/tentec/orion.c
+++ b/rigs/tentec/orion.c
@@ -941,7 +941,7 @@ int tt565_get_xit(RIG *rig, vfo_t vfo, shortfreq_t *xit)
  */
 int tt565_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 {
-    struct tt565_priv_data *priv = (struct tt565_priv_data *)rig->state.priv;
+    struct tt565_priv_data *priv = (struct tt565_priv_data *)STATE(rig)->priv;
     int retval = write_block(RIGPORT(rig),
                        (unsigned char *)(ptt == RIG_PTT_ON ? "*TK" EOM : "*TU" EOM), 4);
     if (retval == RIG_OK)
@@ -958,7 +958,7 @@ int tt565_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
  */
 int tt565_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
 {
-    struct tt565_priv_data *priv = (struct tt565_priv_data *)rig->state.priv;
+    struct tt565_priv_data *priv = (struct tt565_priv_data *)STATE(rig)->priv;
 
     *ptt = priv->ptt;
 

--- a/rigs/tentec/orion.c
+++ b/rigs/tentec/orion.c
@@ -101,7 +101,7 @@ double tt565_timenow()  /* returns current time in secs+microsecs */
  *
  * This is the basic I/O transaction to/from the Orion.
  * \n Read variable number of bytes, up to buffer size, if data & data_len != NULL.
- * \n We assume that rig!=NULL, rig->state!= NULL.
+ * \n We assume that rig!=NULL, STATE(rig)!= NULL.
  * Otherwise, you'll get a nice seg fault. You've been warned!
  */
 
@@ -221,12 +221,12 @@ static int tt565_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
 int tt565_init(RIG *rig)
 {
     struct tt565_priv_data *priv;
-    rig->state.priv = (struct tt565_priv_data *)calloc(1, sizeof(
+    STATE(rig)->priv = (struct tt565_priv_data *)calloc(1, sizeof(
                           struct tt565_priv_data));
 
-    if (!rig->state.priv) { return -RIG_ENOMEM; } /* no memory available */
+    if (!STATE(rig)->priv) { return -RIG_ENOMEM; } /* no memory available */
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     memset(priv, 0, sizeof(struct tt565_priv_data));
     priv->ch = 0; /* set arbitrary initial status */
@@ -242,12 +242,12 @@ int tt565_init(RIG *rig)
  */
 int tt565_cleanup(RIG *rig)
 {
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
@@ -274,11 +274,11 @@ int tt565_open(RIG *rig)
     if (!strstr(buf, "1."))
     {
         /* Not v1 means probably v2 */
-        memcpy(&rig->state.str_cal, &cal2, sizeof(cal_table_t));
+        memcpy(&STATE(rig)->str_cal, &cal2, sizeof(cal_table_t));
     }
     else
     {
-        memcpy(&rig->state.str_cal, &cal1, sizeof(cal_table_t));
+        memcpy(&STATE(rig)->str_cal, &cal1, sizeof(cal_table_t));
     }
 
     return RIG_OK;
@@ -296,7 +296,7 @@ int tt565_open(RIG *rig)
  */
 static char which_receiver(const RIG *rig, vfo_t vfo)
 {
-    const struct tt565_priv_data *priv = (struct tt565_priv_data *)rig->state.priv;
+    const struct tt565_priv_data *priv = (struct tt565_priv_data *)STATE(rig)->priv;
 
     if (vfo == RIG_VFO_CURR)
     {
@@ -325,7 +325,7 @@ static char which_receiver(const RIG *rig, vfo_t vfo)
  */
 static char which_vfo(const RIG *rig, vfo_t vfo)
 {
-    const struct tt565_priv_data *priv = (struct tt565_priv_data *)rig->state.priv;
+    const struct tt565_priv_data *priv = (struct tt565_priv_data *)STATE(rig)->priv;
 
     if (vfo == RIG_VFO_CURR)
     {
@@ -353,7 +353,7 @@ static char which_vfo(const RIG *rig, vfo_t vfo)
  * \param freq
  * \brief Set a frequence into the specified VFO
  *
- * assumes rig->state.priv!=NULL
+ * assumes STATE(rig)->priv!=NULL
  * \n assumes priv->mode in AM,CW,LSB or USB.
  */
 
@@ -373,7 +373,7 @@ int tt565_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
     for (i = 0; i < HAMLIB_FRQRANGESIZ; i++)
     {
-        this_range = rig->state.rx_range_list[i];
+        this_range = STATE(rig)->rx_range_list[i];
 
         if (this_range.startf == 0 && this_range.endf == 0)
         {
@@ -382,7 +382,7 @@ int tt565_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
         /* We don't care about mode setting, but vfo must match. */
         if (freq >= this_range.startf && freq <= this_range.endf &&
-                (this_range.vfo == rig->state.current_vfo))
+                (this_range.vfo == STATE(rig)->current_vfo))
         {
             in_range = TRUE;
             break;
@@ -481,7 +481,7 @@ int tt565_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
  */
 int tt565_set_vfo(RIG *rig, vfo_t vfo)
 {
-    struct tt565_priv_data *priv = (struct tt565_priv_data *)rig->state.priv;
+    struct tt565_priv_data *priv = (struct tt565_priv_data *)STATE(rig)->priv;
 
     if (vfo == RIG_VFO_CURR)
     {
@@ -510,7 +510,7 @@ int tt565_set_vfo(RIG *rig, vfo_t vfo)
  */
 int tt565_get_vfo(RIG *rig, vfo_t *vfo)
 {
-    const struct tt565_priv_data *priv = (struct tt565_priv_data *)rig->state.priv;
+    const struct tt565_priv_data *priv = (struct tt565_priv_data *)STATE(rig)->priv;
 
     *vfo = priv->vfo_curr;
 
@@ -1783,7 +1783,7 @@ int tt565_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
  */
 int tt565_set_mem(RIG *rig, vfo_t vfo, int ch)
 {
-    struct tt565_priv_data *priv = (struct tt565_priv_data *)rig->state.priv;
+    struct tt565_priv_data *priv = (struct tt565_priv_data *)STATE(rig)->priv;
 
     priv->ch = ch;  /* See RIG_OP_TO/FROM_VFO */
     return RIG_OK;
@@ -1798,7 +1798,7 @@ int tt565_set_mem(RIG *rig, vfo_t vfo, int ch)
  */
 int tt565_get_mem(RIG *rig, vfo_t vfo, int *ch)
 {
-    const struct tt565_priv_data *priv = (struct tt565_priv_data *)rig->state.priv;
+    const struct tt565_priv_data *priv = (struct tt565_priv_data *)STATE(rig)->priv;
 
     *ch = priv->ch;
     return RIG_OK;
@@ -1820,7 +1820,7 @@ int tt565_get_mem(RIG *rig, vfo_t vfo, int *ch)
  */
 int tt565_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op)
 {
-    const struct tt565_priv_data *priv = (struct tt565_priv_data *)rig->state.priv;
+    const struct tt565_priv_data *priv = (struct tt565_priv_data *)STATE(rig)->priv;
     char cmdbuf[TT565_BUFSIZE];
     int retval;
 

--- a/rigs/tentec/paragon.c
+++ b/rigs/tentec/paragon.c
@@ -209,16 +209,16 @@ int tt585_init(RIG *rig)
 {
     struct tt585_priv_data *priv;
 
-    rig->state.priv = (struct tt585_priv_data *) calloc(1, sizeof(
+    STATE(rig)->priv = (struct tt585_priv_data *) calloc(1, sizeof(
                           struct tt585_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     memset(priv, 0, sizeof(struct tt585_priv_data));
 
@@ -227,10 +227,10 @@ int tt585_init(RIG *rig)
 
 int tt585_cleanup(RIG *rig)
 {
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
-        rig->state.priv = NULL;
+        free(STATE(rig)->priv);
+        STATE(rig)->priv = NULL;
     }
 
     return RIG_OK;
@@ -238,7 +238,7 @@ int tt585_cleanup(RIG *rig)
 
 int tt585_get_vfo(RIG *rig, vfo_t *vfo)
 {
-    struct tt585_priv_data *priv = (struct tt585_priv_data *) rig->state.priv;
+    struct tt585_priv_data *priv = (struct tt585_priv_data *) STATE(rig)->priv;
     int ret;
 
     ret = tt585_get_status_data(rig);
@@ -302,7 +302,7 @@ int tt585_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t txvfo)
 
 int tt585_get_split_vfo(RIG *rig, vfo_t vfo, split_t *split, vfo_t *txvfo)
 {
-    struct tt585_priv_data *priv = (struct tt585_priv_data *)rig->state.priv;
+    struct tt585_priv_data *priv = (struct tt585_priv_data *)STATE(rig)->priv;
     int ret;
 
     ret = tt585_get_status_data(rig);
@@ -325,7 +325,7 @@ int tt585_get_split_vfo(RIG *rig, vfo_t vfo, split_t *split, vfo_t *txvfo)
  */
 int tt585_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
-    struct tt585_priv_data *priv = (struct tt585_priv_data *)rig->state.priv;
+    struct tt585_priv_data *priv = (struct tt585_priv_data *)STATE(rig)->priv;
     int ret;
     unsigned char *p;
 
@@ -351,13 +351,13 @@ int tt585_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
 /*
  * tt585_set_freq
- * assumes rig!=NULL, rig->state.priv!=NULL
+ * assumes rig!=NULL, STATE(rig)->priv!=NULL
  * assumes priv->mode in AM,CW,LSB or USB.
  */
 
 int tt585_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-    struct tt585_priv_data *priv = (struct tt585_priv_data *)rig->state.priv;
+    struct tt585_priv_data *priv = (struct tt585_priv_data *)STATE(rig)->priv;
 #define FREQBUFSZ 16
     char buf[FREQBUFSZ], *p;
 
@@ -379,7 +379,7 @@ int tt585_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
  */
 int tt585_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
 {
-    const struct tt585_priv_data *priv = (struct tt585_priv_data *)rig->state.priv;
+    const struct tt585_priv_data *priv = (struct tt585_priv_data *)STATE(rig)->priv;
     int ret;
 
     ret = tt585_get_status_data(rig);
@@ -452,7 +452,7 @@ int tt585_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
  */
 int tt585_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
-    struct tt585_priv_data *priv = (struct tt585_priv_data *)rig->state.priv;
+    struct tt585_priv_data *priv = (struct tt585_priv_data *)STATE(rig)->priv;
     const char *mcmd, *wcmd;
     int ret;
     hamlib_port_t *rp = RIGPORT(rig);
@@ -517,7 +517,7 @@ int tt585_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 
 int tt585_set_mem(RIG *rig, vfo_t vfo, int ch)
 {
-    struct tt585_priv_data *priv = (struct tt585_priv_data *)rig->state.priv;
+    struct tt585_priv_data *priv = (struct tt585_priv_data *)STATE(rig)->priv;
     char buf[16];
 
     if (ch < 0 || ch > 61)
@@ -535,7 +535,7 @@ int tt585_set_mem(RIG *rig, vfo_t vfo, int ch)
 
 int tt585_get_mem(RIG *rig, vfo_t vfo, int *ch)
 {
-    struct tt585_priv_data *priv = (struct tt585_priv_data *) rig->state.priv;
+    struct tt585_priv_data *priv = (struct tt585_priv_data *) STATE(rig)->priv;
     int ret;
 
     ret = tt585_get_status_data(rig);
@@ -565,7 +565,7 @@ int tt585_get_mem(RIG *rig, vfo_t vfo, int *ch)
  */
 int tt585_get_status_data(RIG *rig)
 {
-    struct tt585_priv_data *priv = (struct tt585_priv_data *)rig->state.priv;
+    struct tt585_priv_data *priv = (struct tt585_priv_data *)STATE(rig)->priv;
     hamlib_port_t *rigport;
     int ret;
 
@@ -637,7 +637,7 @@ int tt585_set_parm(RIG *rig, setting_t parm, value_t val)
  */
 int tt585_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op)
 {
-    struct tt585_priv_data *priv = (struct tt585_priv_data *)rig->state.priv;
+    struct tt585_priv_data *priv = (struct tt585_priv_data *)STATE(rig)->priv;
     const char *cmd;
     char buf[16];
 

--- a/rigs/tentec/rx331.c
+++ b/rigs/tentec/rx331.c
@@ -232,7 +232,7 @@ struct rig_caps rx331_caps =
 /*
  * rx331_transaction
  * read exactly data_len bytes
- * We assume that rig!=NULL, rig->state!= NULL, data!=NULL, data_len!=NULL
+ * We assume that rig!=NULL, STATE(rig)!= NULL, data!=NULL, data_len!=NULL
  * Otherwise, you'll get a nice seg fault. You've been warned!
  */
 static int rx331_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
@@ -243,7 +243,7 @@ static int rx331_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
     char str[BUFSZ];
     char fmt[16];
     hamlib_port_t *rp = RIGPORT(rig);
-    const struct rx331_priv_data *priv = (struct rx331_priv_data *)rig->state.priv;
+    const struct rx331_priv_data *priv = (struct rx331_priv_data *)STATE(rig)->priv;
 
     rig_flush(rp);
 
@@ -289,16 +289,16 @@ int rx331_init(RIG *rig)
 {
     struct rx331_priv_data *priv;
 
-    rig->state.priv = (struct rx331_priv_data *)calloc(1, sizeof(
+    STATE(rig)->priv = (struct rx331_priv_data *)calloc(1, sizeof(
                           struct rx331_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     memset(priv, 0, sizeof(struct rx331_priv_data));
 
@@ -311,19 +311,19 @@ int rx331_init(RIG *rig)
  */
 int rx331_cleanup(RIG *rig)
 {
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
 
 int rx331_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 {
-    struct rx331_priv_data *priv = (struct rx331_priv_data *)rig->state.priv;
+    struct rx331_priv_data *priv = (struct rx331_priv_data *)STATE(rig)->priv;
 
     switch (token)
     {
@@ -340,7 +340,7 @@ int rx331_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 
 int rx331_get_conf2(RIG *rig, hamlib_token_t token, char *val, int val_len)
 {
-    const struct rx331_priv_data *priv = (struct rx331_priv_data *)rig->state.priv;
+    const struct rx331_priv_data *priv = (struct rx331_priv_data *)STATE(rig)->priv;
 
     switch (token)
     {
@@ -391,7 +391,7 @@ int rx331_close(RIG *rig)
 
 int rx331_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-    const struct rx331_priv_data *priv = (struct rx331_priv_data *)rig->state.priv;
+    const struct rx331_priv_data *priv = (struct rx331_priv_data *)STATE(rig)->priv;
 
     int freq_len, retval;
     char freqbuf[16];
@@ -439,7 +439,7 @@ int rx331_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
  */
 int rx331_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
-    const struct rx331_priv_data *priv = (struct rx331_priv_data *)rig->state.priv;
+    const struct rx331_priv_data *priv = (struct rx331_priv_data *)STATE(rig)->priv;
     char dmode;
     int mdbuf_len, retval;
     char mdbuf[32];
@@ -560,7 +560,7 @@ int rx331_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
  */
 int rx331_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
-    const struct rx331_priv_data *priv = (struct rx331_priv_data *)rig->state.priv;
+    const struct rx331_priv_data *priv = (struct rx331_priv_data *)STATE(rig)->priv;
     int retval = RIG_OK;
     char cmdbuf[32];
 

--- a/rigs/tentec/rx340.c
+++ b/rigs/tentec/rx340.c
@@ -187,7 +187,7 @@ struct rig_caps rx340_caps =
 /*
  * rx340_transaction
  * read exactly data_len bytes
- * We assume that rig!=NULL, rig->state!= NULL, data!=NULL, data_len!=NULL
+ * We assume that rig!=NULL, STATE(rig)!= NULL, data!=NULL, data_len!=NULL
  * Otherwise, you'll get a nice seg fault. You've been warned!
  */
 static int rx340_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
@@ -247,7 +247,7 @@ int rx340_init(RIG *rig)
      * set arbitrary initial status
      */
 
-    rig->state.priv = (rig_ptr_t)priv;
+    STATE(rig)->priv = (rig_ptr_t)priv;
 
     return RIG_OK;
 }
@@ -258,12 +258,12 @@ int rx340_init(RIG *rig)
  */
 int rx340_cleanup(RIG *rig)
 {
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }

--- a/rigs/tentec/tentec.c
+++ b/rigs/tentec/tentec.c
@@ -52,7 +52,7 @@ static int tentec_filters[] =
 /*
  * tentec_transaction
  * read exactly data_len bytes
- * We assume that rig!=NULL, rig->state!= NULL, data!=NULL, data_len!=NULL
+ * We assume that rig!=NULL, STATE(rig)!= NULL, data!=NULL, data_len!=NULL
  * Otherwise, you'll get a nice seg fault. You've been warned!
  */
 int tentec_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
@@ -103,16 +103,16 @@ int tentec_init(RIG *rig)
 {
     struct tentec_priv_data *priv;
 
-    rig->state.priv = (struct tentec_priv_data *)calloc(1, sizeof(
+    STATE(rig)->priv = (struct tentec_priv_data *)calloc(1, sizeof(
                           struct tentec_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     memset(priv, 0, sizeof(struct tentec_priv_data));
 
@@ -127,7 +127,7 @@ int tentec_init(RIG *rig)
     priv->agc = RIG_AGC_MEDIUM; /* medium */
     priv->lnvol = priv->spkvol = 0.0;   /* mute */
 
-    /* tentec_tuning_factor_calc needs rig->state.priv */
+    /* tentec_tuning_factor_calc needs STATE(rig)->priv */
     tentec_tuning_factor_calc(rig);
 
     return RIG_OK;
@@ -139,12 +139,12 @@ int tentec_init(RIG *rig)
  */
 int tentec_cleanup(RIG *rig)
 {
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
@@ -174,7 +174,7 @@ int tentec_trx_open(RIG *rig)
 
 /*
  * Tuning Factor Calculations
- * assumes rig!=NULL, rig->state.priv!=NULL
+ * assumes rig!=NULL, STATE(rig)->priv!=NULL
  * assumes priv->mode in supported modes.
  */
 static void tentec_tuning_factor_calc(RIG *rig)
@@ -183,7 +183,7 @@ static void tentec_tuning_factor_calc(RIG *rig)
     freq_t tfreq;
     int adjtfreq, mcor, fcor, cwbfo;
 
-    priv = (struct tentec_priv_data *)rig->state.priv;
+    priv = (struct tentec_priv_data *)STATE(rig)->priv;
     cwbfo = 0;
 
     /* computed fcor only used if mode is not CW */
@@ -221,7 +221,7 @@ static void tentec_tuning_factor_calc(RIG *rig)
 
 /*
  * tentec_set_freq
- * assumes rig!=NULL, rig->state.priv!=NULL
+ * assumes rig!=NULL, STATE(rig)->priv!=NULL
  * assumes priv->mode in AM,CW,LSB or USB.
  */
 int tentec_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
@@ -231,7 +231,7 @@ int tentec_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     char freqbuf[16];
     freq_t old_freq;
 
-    priv = (struct tentec_priv_data *)rig->state.priv;
+    priv = (struct tentec_priv_data *)STATE(rig)->priv;
 
     old_freq = priv->freq;
     priv->freq = freq;
@@ -260,7 +260,7 @@ int tentec_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 int tentec_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
     const struct tentec_priv_data *priv = (struct tentec_priv_data *)
-                                          rig->state.priv;
+                                          STATE(rig)->priv;
 
     *freq = priv->freq;
 
@@ -273,7 +273,7 @@ int tentec_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
  */
 int tentec_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
-    struct tentec_priv_data *priv = (struct tentec_priv_data *)rig->state.priv;
+    struct tentec_priv_data *priv = (struct tentec_priv_data *)STATE(rig)->priv;
     hamlib_port_t *rp = RIGPORT(rig);
     char ttmode;
     rmode_t saved_mode;
@@ -381,7 +381,7 @@ int tentec_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 int tentec_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
 {
     const struct tentec_priv_data *priv = (struct tentec_priv_data *)
-                                          rig->state.priv;
+                                          STATE(rig)->priv;
 
     *mode = priv->mode;
     *width = priv->width;
@@ -397,7 +397,7 @@ int tentec_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
  */
 int tentec_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
-    struct tentec_priv_data *priv = (struct tentec_priv_data *)rig->state.priv;
+    struct tentec_priv_data *priv = (struct tentec_priv_data *)STATE(rig)->priv;
     hamlib_port_t *rp = RIGPORT(rig);
     int retval = RIG_OK;
     char cmdbuf[32];
@@ -467,7 +467,7 @@ int tentec_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 int tentec_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
     const struct tentec_priv_data *priv = (struct tentec_priv_data *)
-                                          rig->state.priv;
+                                          STATE(rig)->priv;
     int retval, lvl_len;
     unsigned char lvlbuf[32];
 

--- a/rigs/tentec/tentec2.c
+++ b/rigs/tentec/tentec2.c
@@ -78,7 +78,7 @@
 
 /*
  * tentec_set_freq
- * assumes rig!=NULL, rig->state.priv!=NULL
+ * assumes rig!=NULL, STATE(rig)->priv!=NULL
  * assumes priv->mode in AM,CW,LSB or USB.
  */
 int tentec2_set_freq(RIG *rig, vfo_t vfo, freq_t freq)

--- a/rigs/tentec/tt550.c
+++ b/rigs/tentec/tt550.c
@@ -58,7 +58,7 @@ static int tt550_tx_filters[] =
 /*
  * tt550_transaction
  * read exactly data_len bytes
- * We assume that rig!=NULL, rig->state!= NULL, data!=NULL, data_len!=NULL
+ * We assume that rig!=NULL, STATE(rig)!= NULL, data!=NULL, data_len!=NULL
  * Otherwise, you'll get a nice seg fault. You've been warned!
  */
 int
@@ -201,7 +201,7 @@ tt550_tuning_factor_calc(RIG *rig, int tx)
     int FilterBw;         // Filter Bandwidth determined from table
     int Mode, PbtAdj, RitAdj, XitAdj;
 
-    priv = (struct tt550_priv_data *) rig->state.priv;
+    priv = (struct tt550_priv_data *) STATE(rig)->priv;
 
     Mode = (tx ? priv->tx_mode : priv->rx_mode);
     radio_freq = ((tx ? priv->tx_freq : priv->rx_freq)) / (double) MHz(1);
@@ -352,10 +352,10 @@ tt550_init(RIG *rig)
 {
     struct tt550_priv_data *priv;
 
-    rig->state.priv = (struct tt550_priv_data *) calloc(1, sizeof(
+    STATE(rig)->priv = (struct tt550_priv_data *) calloc(1, sizeof(
                           struct tt550_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /*
          * whoops! memory shortage!
@@ -363,7 +363,7 @@ tt550_init(RIG *rig)
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     memset(priv, 0, sizeof(struct tt550_priv_data));
 
@@ -393,12 +393,12 @@ tt550_init(RIG *rig)
 int
 tt550_cleanup(RIG *rig)
 {
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
@@ -454,7 +454,7 @@ tt550_trx_open(RIG *rig)
 
     struct tt550_priv_data *priv;
 
-    priv = (struct tt550_priv_data *) rig->state.priv;
+    priv = (struct tt550_priv_data *) STATE(rig)->priv;
 
     /*
      * Reset the radio and start its program running
@@ -510,7 +510,7 @@ int
 tt550_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
     int retval;
-    const struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
+    const struct tt550_priv_data *priv = (struct tt550_priv_data *) STATE(rig)->priv;
 
     retval = tt550_set_rx_freq(rig, vfo, freq);
 
@@ -535,7 +535,7 @@ tt550_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 int
 tt550_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
-    struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
+    struct tt550_priv_data *priv = (struct tt550_priv_data *) STATE(rig)->priv;
 
     *freq = priv->rx_freq;
 
@@ -552,7 +552,7 @@ int
 tt550_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
     int retval;
-    struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
+    struct tt550_priv_data *priv = (struct tt550_priv_data *) STATE(rig)->priv;
 
     retval = tt550_set_rx_mode(rig, vfo, mode, width);
 
@@ -577,7 +577,7 @@ tt550_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 int
 tt550_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
 {
-    struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
+    struct tt550_priv_data *priv = (struct tt550_priv_data *) STATE(rig)->priv;
 
     *mode = priv->rx_mode;
     *width = priv->width;
@@ -598,7 +598,7 @@ tt550_set_rx_freq(RIG *rig, vfo_t vfo, freq_t freq)
     int retval;
     char freqbuf[16];
 
-    priv = (struct tt550_priv_data *) rig->state.priv;
+    priv = (struct tt550_priv_data *) STATE(rig)->priv;
 
     priv->rx_freq = freq;
 
@@ -631,7 +631,7 @@ tt550_set_tx_freq(RIG *rig, vfo_t vfo, freq_t freq)
     int retval;
     char freqbuf[16];
 
-    priv = (struct tt550_priv_data *) rig->state.priv;
+    priv = (struct tt550_priv_data *) STATE(rig)->priv;
 
     priv->tx_freq = freq;
 
@@ -660,7 +660,7 @@ tt550_set_tx_freq(RIG *rig, vfo_t vfo, freq_t freq)
 int
 tt550_get_tx_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
-    const struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
+    const struct tt550_priv_data *priv = (struct tt550_priv_data *) STATE(rig)->priv;
 
     *freq = priv->tx_freq;
 
@@ -675,7 +675,7 @@ tt550_get_tx_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 int
 tt550_set_rx_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
-    struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
+    struct tt550_priv_data *priv = (struct tt550_priv_data *) STATE(rig)->priv;
     hamlib_port_t *rp = RIGPORT(rig);
     char ttmode;
     rmode_t saved_mode;
@@ -790,7 +790,7 @@ tt550_set_rx_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 int
 tt550_set_tx_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
-    struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
+    struct tt550_priv_data *priv = (struct tt550_priv_data *) STATE(rig)->priv;
     hamlib_port_t *rp = RIGPORT(rig);
     char ttmode;
     rmode_t saved_mode;
@@ -919,7 +919,7 @@ tt550_set_tx_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 int
 tt550_get_tx_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
 {
-    const struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
+    const struct tt550_priv_data *priv = (struct tt550_priv_data *) STATE(rig)->priv;
 
     *mode = priv->tx_mode;
     *width = priv->tx_width;
@@ -933,7 +933,7 @@ tt550_get_tx_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
 int
 tt550_set_rit(RIG *rig, vfo_t vfo, shortfreq_t rit)
 {
-    struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
+    struct tt550_priv_data *priv = (struct tt550_priv_data *) STATE(rig)->priv;
 
     priv->rit = rit;
     tt550_set_rx_freq(rig, vfo, priv->rx_freq);
@@ -947,7 +947,7 @@ tt550_set_rit(RIG *rig, vfo_t vfo, shortfreq_t rit)
 int
 tt550_get_rit(RIG *rig, vfo_t vfo, shortfreq_t *rit)
 {
-    const struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
+    const struct tt550_priv_data *priv = (struct tt550_priv_data *) STATE(rig)->priv;
 
     *rit = priv->rit;
 
@@ -960,7 +960,7 @@ tt550_get_rit(RIG *rig, vfo_t vfo, shortfreq_t *rit)
 int
 tt550_set_xit(RIG *rig, vfo_t vfo, shortfreq_t xit)
 {
-    struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
+    struct tt550_priv_data *priv = (struct tt550_priv_data *) STATE(rig)->priv;
 
     priv->xit = xit;
     tt550_set_tx_freq(rig, vfo, priv->tx_freq);
@@ -974,7 +974,7 @@ tt550_set_xit(RIG *rig, vfo_t vfo, shortfreq_t xit)
 int
 tt550_get_xit(RIG *rig, vfo_t vfo, shortfreq_t *xit)
 {
-    const struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
+    const struct tt550_priv_data *priv = (struct tt550_priv_data *) STATE(rig)->priv;
 
     *xit = priv->xit;
 
@@ -988,7 +988,7 @@ tt550_get_xit(RIG *rig, vfo_t vfo, shortfreq_t *xit)
 int
 tt550_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
-    struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
+    struct tt550_priv_data *priv = (struct tt550_priv_data *) STATE(rig)->priv;
     hamlib_port_t *rp = RIGPORT(rig);
     int retval, ditfactor, dahfactor, spcfactor;
     char cmdbuf[32];
@@ -1195,7 +1195,7 @@ tt550_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 int
 tt550_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
-    const struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
+    const struct tt550_priv_data *priv = (struct tt550_priv_data *) STATE(rig)->priv;
     int retval, lvl_len;
     char lvlbuf[32];
 
@@ -1409,7 +1409,7 @@ tt550_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
 int
 tt550_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
 {
-    struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
+    struct tt550_priv_data *priv = (struct tt550_priv_data *) STATE(rig)->priv;
 
     priv->split = split;
 
@@ -1423,7 +1423,7 @@ tt550_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
 int
 tt550_get_split_vfo(RIG *rig, vfo_t vfo, split_t *split, vfo_t *tx_vfo)
 {
-    const struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
+    const struct tt550_priv_data *priv = (struct tt550_priv_data *) STATE(rig)->priv;
 
     *split = priv->split;
 
@@ -1435,7 +1435,7 @@ int
 tt550_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
 {
     unsigned char fctbuf[16];
-    struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
+    struct tt550_priv_data *priv = (struct tt550_priv_data *) STATE(rig)->priv;
     hamlib_port_t *rp = RIGPORT(rig);
 
     /* Optimize:
@@ -1484,7 +1484,7 @@ tt550_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
 int
 tt550_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
 {
-    const struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
+    const struct tt550_priv_data *priv = (struct tt550_priv_data *) STATE(rig)->priv;
 
     /* Optimize:
      *   sort the switch cases with the most frequent first
@@ -1526,7 +1526,7 @@ tt550_set_tuning_step(RIG *rig, vfo_t vfo, shortfreq_t stepsize)
     struct tt550_priv_data *priv;
     struct rig_state *rs;
 
-    rs = &rig->state;
+    rs = STATE(rig);
     priv = (struct tt550_priv_data *) rs->priv;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: tt550_set_tuning_step - %d\n",
@@ -1547,7 +1547,7 @@ tt550_get_tuning_step(RIG *rig, vfo_t vfo, shortfreq_t *stepsize)
     struct tt550_priv_data *priv;
     struct rig_state *rs;
 
-    rs = &rig->state;
+    rs = STATE(rig);
     priv = (struct tt550_priv_data *) rs->priv;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: tt550_get_tuning_step - %d\n",
@@ -1568,7 +1568,7 @@ tt550_tune(RIG *rig)
     value_t current_power;
     rmode_t current_mode;
     value_t lowpower;
-    const struct tt550_priv_data *priv = (struct tt550_priv_data *) rig->state.priv;
+    const struct tt550_priv_data *priv = (struct tt550_priv_data *) STATE(rig)->priv;
 
     /* Set our lowpower level to about 10 Watts */
     lowpower.f = 0.12;
@@ -1672,7 +1672,7 @@ tt550_decode_event(RIG *rig)
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s/tt: tt550_decode_event called\n", __func__);
 
-    rs = &rig->state;
+    rs = STATE(rig);
     priv = (struct tt550_priv_data *) rs->priv;
 
     data_len = read_string(RIGPORT(rig), buf, MAXFRAMELEN, "\n\r", 2, 0,

--- a/rigs/tuner/v4l.c
+++ b/rigs/tuner/v4l.c
@@ -161,7 +161,7 @@ int v4l_open(RIG *rig)
 {
     int i;
     struct video_tuner vt;
-    struct rig_state *rs = &rig->state;
+    struct rig_state *rs = STATE(rig);
 
     for (i = 0; i < 8; i++)
     {
@@ -190,7 +190,7 @@ int v4l_open(RIG *rig)
 
 int v4l_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-    const struct rig_state *rs = &rig->state;
+    const struct rig_state *rs = STATE(rig);
     hamlib_port_t *rp = RIGPORT(rig);
     struct      video_tuner vt;
     const freq_range_t *range;
@@ -237,7 +237,7 @@ int v4l_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
 int v4l_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
-    const struct rig_state *rs = &rig->state;
+    const struct rig_state *rs = STATE(rig);
     const freq_range_t *range;
     unsigned long f;
     double fact;

--- a/rigs/tuner/v4l2.c
+++ b/rigs/tuner/v4l2.c
@@ -161,7 +161,7 @@ int v4l2_open(RIG *rig)
 {
     int i;
     struct v4l2_tuner vt;
-    struct rig_state *rs = &rig->state;
+    struct rig_state *rs = STATE(rig);
 
     for (i = 0; i < 8; i++)
     {
@@ -190,7 +190,7 @@ int v4l2_open(RIG *rig)
 
 int v4l2_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-    const struct rig_state *rs = &rig->state;
+    const struct rig_state *rs = STATE(rig);
     hamlib_port_t *rp = RIGPORT(rig);
     struct      v4l2_tuner vt;
     const freq_range_t *range;
@@ -237,7 +237,7 @@ int v4l2_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
 int v4l2_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
-    const struct rig_state *rs = &rig->state;
+    const struct rig_state *rs = STATE(rig);
     const freq_range_t *range;
     unsigned long f;
     double fact;

--- a/rigs/uniden/uniden.c
+++ b/rigs/uniden/uniden.c
@@ -91,7 +91,7 @@ tone_t uniden_dcs_list[] =
 
 /**
  * uniden_transaction
- * Assumes rig!=NULL rig->state!=NULL rig->caps!=NULL
+ * Assumes rig!=NULL STATE(rig)!=NULL rig->caps!=NULL
  *
  * cmdstr - Command to be sent to the rig. Cmdstr can also be NULL, indicating
  *          that only a reply is needed (nothing will be send).
@@ -122,7 +122,7 @@ uniden_transaction(RIG *rig, const char *cmdstr, int cmd_len,
     char replybuf[BUFSZ];
     size_t reply_len = BUFSZ;
 
-    rs = &rig->state;
+    rs = STATE(rig);
     rs->transaction_active = 1;
 
 transaction_write:
@@ -429,7 +429,7 @@ int uniden_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
     switch (level)
     {
     case RIG_LEVEL_ATT:
-        if (rig->state.attenuator[0] == 0)
+      if (STATE(rig)->attenuator[0] == 0)
         {
             return -RIG_EINVAL;
         }
@@ -500,7 +500,7 @@ int uniden_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
             return -RIG_ERJCTED;
         }
 
-        val->i = lvlbuf[2] == 'N' ? rig->state.attenuator[0] : 0;
+        val->i = lvlbuf[2] == 'N' ? STATE(rig)->attenuator[0] : 0;
         break;
 
     default:
@@ -630,7 +630,7 @@ int uniden_get_channel(RIG *rig, vfo_t vfo, channel_t *chan, int read_only)
     /* TODO: Trunk, Delay, Recording */
 
     chan->flags = (membuf[22] == 'N') ? RIG_CHFLAG_SKIP : 0;
-    chan->levels[LVL_ATT].i = (membuf[25] == 'N') ? rig->state.attenuator[0] : 0;
+    chan->levels[LVL_ATT].i = (membuf[25] == 'N') ? STATE(rig)->attenuator[0] : 0;
     sscanf(membuf + 41, "%d", &tone);
 
     if (tone >= 1 && tone <= 38)

--- a/rigs/uniden/uniden_digital.c
+++ b/rigs/uniden/uniden_digital.c
@@ -72,7 +72,7 @@ uniden_id_string_list[] =
 /**
  * uniden_transaction
  * uniden_digital_transaction
- * Assumes rig!=NULL rig->state!=NULL rig->caps!=NULL
+ * Assumes rig!=NULL STATE(rig)!=NULL rig->caps!=NULL
  *
  * cmdstr - Command to be sent to the rig. Cmdstr can also be NULL, indicating
  *          that only a reply is needed (nothing will be send).
@@ -103,7 +103,7 @@ uniden_digital_transaction(RIG *rig, const char *cmdstr, int cmd_len,
     char replybuf[BUFSZ];
     size_t reply_len = BUFSZ;
 
-    rs = &rig->state;
+    rs = STATE(rig);
     rs->transaction_active = 1;
 
 transaction_write:

--- a/rigs/winradio/g303.c
+++ b/rigs/winradio/g303.c
@@ -191,15 +191,15 @@ int g3_init(RIG *rig)
 {
     struct g3_priv_data *priv;
 
-    rig->state.priv = (struct g3_priv_data *)calloc(1, sizeof(struct g3_priv_data));
+    STATE(rig)->priv = (struct g3_priv_data *)calloc(1, sizeof(struct g3_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     /* Try to load required dll */
     priv->dll = LoadLibrary(WRG3DLL);
@@ -240,7 +240,7 @@ int g3_init(RIG *rig)
 
 int g3_open(RIG *rig)
 {
-    struct g3_priv_data *priv = (struct g3_priv_data *)rig->state.priv;
+    struct g3_priv_data *priv = (struct g3_priv_data *)STATE(rig)->priv;
     int device_num;
 
     device_num = atoi(RIGPORT(rig)->pathname);
@@ -261,7 +261,7 @@ int g3_open(RIG *rig)
 
 int g3_close(RIG *rig)
 {
-    struct g3_priv_data *priv = (struct g3_priv_data *)rig->state.priv;
+    struct g3_priv_data *priv = (struct g3_priv_data *)STATE(rig)->priv;
 
     priv->CloseRadioDevice(priv->hRadio);
 
@@ -270,24 +270,24 @@ int g3_close(RIG *rig)
 
 int g3_cleanup(RIG *rig)
 {
-    struct g3_priv_data *priv = (struct g3_priv_data *)rig->state.priv;
+    struct g3_priv_data *priv = (struct g3_priv_data *)STATE(rig)->priv;
 
     /* Clean up the dll access */
     if (priv) { FreeLibrary(priv->dll); }
 
-    if (rig->state.priv)
+    if (STATE(rig)->priv)
     {
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
 
 int g3_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-    struct g3_priv_data *priv = (struct g3_priv_data *)rig->state.priv;
+    struct g3_priv_data *priv = (struct g3_priv_data *)STATE(rig)->priv;
     int ret;
 
     ret = priv->G3SetFrequency(priv->hRadio, (DWORD)(freq));
@@ -298,7 +298,7 @@ int g3_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
 int g3_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
-    struct g3_priv_data *priv = (struct g3_priv_data *)rig->state.priv;
+    struct g3_priv_data *priv = (struct g3_priv_data *)STATE(rig)->priv;
 
     *freq = (freq_t) priv->G3GetFrequency(priv->hRadio);
 
@@ -307,7 +307,7 @@ int g3_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
 int g3_set_powerstat(RIG *rig, powerstat_t status)
 {
-    struct g3_priv_data *priv = (struct g3_priv_data *)rig->state.priv;
+    struct g3_priv_data *priv = (struct g3_priv_data *)STATE(rig)->priv;
     int ret;
 
     ret = priv->SetPower(priv->hRadio, status == RIG_POWER_ON ? TRUE : FALSE);
@@ -318,7 +318,7 @@ int g3_set_powerstat(RIG *rig, powerstat_t status)
 
 int g3_get_powerstat(RIG *rig, powerstat_t *status)
 {
-    struct g3_priv_data *priv = (struct g3_priv_data *)rig->state.priv;
+    struct g3_priv_data *priv = (struct g3_priv_data *)STATE(rig)->priv;
     int ret;
 
     ret = priv->GetPower(priv->hRadio);
@@ -329,7 +329,7 @@ int g3_get_powerstat(RIG *rig, powerstat_t *status)
 
 int g3_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
-    struct g3_priv_data *priv = (struct g3_priv_data *)rig->state.priv;
+    struct g3_priv_data *priv = (struct g3_priv_data *)STATE(rig)->priv;
     int ret, agc;
 
     switch (level)
@@ -370,7 +370,7 @@ int g3_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
 int g3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
-    struct g3_priv_data *priv = (struct g3_priv_data *)rig->state.priv;
+    struct g3_priv_data *priv = (struct g3_priv_data *)STATE(rig)->priv;
     int ret;
 
     ret = RIG_OK;
@@ -418,7 +418,7 @@ int g3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 
 static const char *g3_get_info(RIG *rig)
 {
-    struct g3_priv_data *priv = (struct g3_priv_data *)rig->state.priv;
+    struct g3_priv_data *priv = (struct g3_priv_data *)STATE(rig)->priv;
     static RADIO_INFO info;
 
     info.bLength = sizeof(RADIO_INFO);

--- a/rigs/winradio/g305.c
+++ b/rigs/winradio/g305.c
@@ -192,15 +192,15 @@ int g3_init(RIG *rig)
 {
     struct g3_priv_data *priv;
 
-    rig->state.priv = (struct g3_priv_data *)calloc(1, sizeof(struct g3_priv_data));
+    STATE(rig)->priv = (struct g3_priv_data *)calloc(1, sizeof(struct g3_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     /* Try to load required dll */
     priv->dll = LoadLibrary(WRG3DLL);
@@ -241,7 +241,7 @@ int g3_init(RIG *rig)
 
 int g3_open(RIG *rig)
 {
-    struct g3_priv_data *priv = (struct g3_priv_data *)rig->state.priv;
+    struct g3_priv_data *priv = (struct g3_priv_data *)STATE(rig)->priv;
     int device_num;
 
     device_num = atoi(RIGPORT(rig)->pathname);
@@ -262,7 +262,7 @@ int g3_open(RIG *rig)
 
 int g3_close(RIG *rig)
 {
-    struct g3_priv_data *priv = (struct g3_priv_data *)rig->state.priv;
+    struct g3_priv_data *priv = (struct g3_priv_data *)STATE(rig)->priv;
 
     priv->CloseRadioDevice(priv->hRadio);
 
@@ -271,23 +271,23 @@ int g3_close(RIG *rig)
 
 int g3_cleanup(RIG *rig)
 {
-    struct g3_priv_data *priv = (struct g3_priv_data *)rig->state.priv;
+    struct g3_priv_data *priv = (struct g3_priv_data *)STATE(rig)->priv;
 
     if (priv)
     {
         /* Clean up the dll access */
         FreeLibrary(priv->dll);
-        free(rig->state.priv);
+        free(STATE(rig)->priv);
     }
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
 
 int g3_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-    struct g3_priv_data *priv = (struct g3_priv_data *)rig->state.priv;
+    struct g3_priv_data *priv = (struct g3_priv_data *)STATE(rig)->priv;
     int ret;
 
     ret = priv->G3SetFrequency(priv->hRadio, (DWORD)(freq));
@@ -298,7 +298,7 @@ int g3_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
 int g3_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
-    struct g3_priv_data *priv = (struct g3_priv_data *)rig->state.priv;
+    struct g3_priv_data *priv = (struct g3_priv_data *)STATE(rig)->priv;
 
     *freq = (freq_t) priv->G3GetFrequency(priv->hRadio);
 
@@ -307,7 +307,7 @@ int g3_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
 int g3_set_powerstat(RIG *rig, powerstat_t status)
 {
-    struct g3_priv_data *priv = (struct g3_priv_data *)rig->state.priv;
+    struct g3_priv_data *priv = (struct g3_priv_data *)STATE(rig)->priv;
     int ret;
 
     ret = priv->SetPower(priv->hRadio, status == RIG_POWER_ON ? TRUE : FALSE);
@@ -318,7 +318,7 @@ int g3_set_powerstat(RIG *rig, powerstat_t status)
 
 int g3_get_powerstat(RIG *rig, powerstat_t *status)
 {
-    struct g3_priv_data *priv = (struct g3_priv_data *)rig->state.priv;
+    struct g3_priv_data *priv = (struct g3_priv_data *)STATE(rig)->priv;
     int ret;
 
     ret = priv->GetPower(priv->hRadio);
@@ -329,7 +329,7 @@ int g3_get_powerstat(RIG *rig, powerstat_t *status)
 
 int g3_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
-    struct g3_priv_data *priv = (struct g3_priv_data *)rig->state.priv;
+    struct g3_priv_data *priv = (struct g3_priv_data *)STATE(rig)->priv;
     int ret, agc;
 
     switch (level)
@@ -370,7 +370,7 @@ int g3_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
 int g3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
-    struct g3_priv_data *priv = (struct g3_priv_data *)rig->state.priv;
+    struct g3_priv_data *priv = (struct g3_priv_data *)STATE(rig)->priv;
     int ret;
 
     ret = RIG_OK;
@@ -418,7 +418,7 @@ int g3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 
 static const char *g3_get_info(RIG *rig)
 {
-    struct g3_priv_data *priv = (struct g3_priv_data *)rig->state.priv;
+    struct g3_priv_data *priv = (struct g3_priv_data *)STATE(rig)->priv;
     static RADIO_INFO info;
 
     info.bLength = sizeof(RADIO_INFO);

--- a/rigs/winradio/g313-posix.c
+++ b/rigs/winradio/g313-posix.c
@@ -131,7 +131,7 @@ int g313_init(RIG *rig)
 
     /* otherwise try again when open rig */
 
-    rig->state.priv = (void *)priv;
+    STATE(rig)->priv = (void *)priv;
 
     return RIG_OK;
 }
@@ -139,7 +139,7 @@ int g313_init(RIG *rig)
 int g313_open(RIG *rig)
 {
     int ret;
-    struct g313_priv_data *priv = (struct g313_priv_data *)rig->state.priv;
+    struct g313_priv_data *priv = (struct g313_priv_data *)STATE(rig)->priv;
     RADIO_DESC *List;
     int Count;
 
@@ -247,7 +247,7 @@ int g313_open(RIG *rig)
 
 int g313_close(RIG *rig)
 {
-    struct g313_priv_data *priv = (struct g313_priv_data *)rig->state.priv;
+    struct g313_priv_data *priv = (struct g313_priv_data *)STATE(rig)->priv;
 
     if (!priv->Opened)
     {
@@ -279,7 +279,7 @@ int g313_cleanup(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    priv = (struct g313_priv_data *)rig->state.priv;
+    priv = (struct g313_priv_data *)STATE(rig)->priv;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: close fifos\n", __func__);
 
@@ -305,15 +305,15 @@ int g313_cleanup(RIG *rig)
         dlclose(priv->hWRAPI);
     }
 
-    free(rig->state.priv);
+    free(STATE(rig)->priv);
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
     return RIG_OK;
 }
 
 int g313_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-    struct g313_priv_data *priv = (struct g313_priv_data *)rig->state.priv;
+    struct g313_priv_data *priv = (struct g313_priv_data *)STATE(rig)->priv;
     int ret;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: %u\n", __func__, (unsigned int)freq);
@@ -325,7 +325,7 @@ int g313_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
 int g313_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
-    struct g313_priv_data *priv = (struct g313_priv_data *)rig->state.priv;
+    struct g313_priv_data *priv = (struct g313_priv_data *)STATE(rig)->priv;
 
     unsigned int f;
     int ret = GetFrequency(priv->hRadio, &f);
@@ -342,7 +342,7 @@ int g313_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
 int g313_set_powerstat(RIG *rig, powerstat_t status)
 {
-    struct g313_priv_data *priv = (struct g313_priv_data *)rig->state.priv;
+    struct g313_priv_data *priv = (struct g313_priv_data *)STATE(rig)->priv;
 
     int p = status == RIG_POWER_ON ? 1 : 0;
     int ret = SetPower(priv->hRadio, p);
@@ -353,7 +353,7 @@ int g313_set_powerstat(RIG *rig, powerstat_t status)
 
 int g313_get_powerstat(RIG *rig, powerstat_t *status)
 {
-    struct g313_priv_data *priv = (struct g313_priv_data *)rig->state.priv;
+    struct g313_priv_data *priv = (struct g313_priv_data *)STATE(rig)->priv;
 
     int p;
     int ret = GetPower(priv->hRadio, &p);
@@ -371,7 +371,7 @@ int g313_get_powerstat(RIG *rig, powerstat_t *status)
 
 int g313_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
-    struct g313_priv_data *priv = (struct g313_priv_data *)rig->state.priv;
+    struct g313_priv_data *priv = (struct g313_priv_data *)STATE(rig)->priv;
     int ret, agc;
 
     switch (level)
@@ -423,7 +423,7 @@ int g313_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
 int g313_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
-    struct g313_priv_data *priv = (struct g313_priv_data *)rig->state.priv;
+    struct g313_priv_data *priv = (struct g313_priv_data *)STATE(rig)->priv;
     int ret;
     int value;
     unsigned int uvalue;
@@ -524,7 +524,7 @@ int g313_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 
 static const char *g313_get_info(RIG *rig)
 {
-    struct g313_priv_data *priv = (struct g313_priv_data *)rig->state.priv;
+    struct g313_priv_data *priv = (struct g313_priv_data *)STATE(rig)->priv;
     static RADIO_INFO info;
     int ret;
 
@@ -544,7 +544,7 @@ static const char *g313_get_info(RIG *rig)
 
 int g313_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 {
-    struct g313_priv_data *priv = (struct g313_priv_data *)rig->state.priv;
+    struct g313_priv_data *priv = (struct g313_priv_data *)STATE(rig)->priv;
 
     size_t len = strlen(val);
 
@@ -595,7 +595,7 @@ int g313_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 
 int g313_get_conf(RIG *rig, hamlib_token_t token, char *val)
 {
-    struct g313_priv_data *priv = (struct g313_priv_data *)rig->state.priv;
+    struct g313_priv_data *priv = (struct g313_priv_data *)STATE(rig)->priv;
 
     switch (token)
     {

--- a/rigs/winradio/g313-win.c
+++ b/rigs/winradio/g313-win.c
@@ -232,16 +232,16 @@ int g313_init(RIG *rig)
 {
     struct g313_priv_data *priv;
 
-    rig->state.priv = (struct g313_priv_data *)calloc(1, sizeof(
+    STATE(rig)->priv = (struct g313_priv_data *)calloc(1, sizeof(
                           struct g313_priv_data));
 
-    if (!rig->state.priv)
+    if (!STATE(rig)->priv)
     {
         /* whoops! memory shortage! */
         return -RIG_ENOMEM;
     }
 
-    priv = rig->state.priv;
+    priv = STATE(rig)->priv;
 
     priv->WaveOutDeviceID = -1;
 
@@ -374,7 +374,7 @@ int g313_findVSC(struct g313_priv_data *priv)
 
 int g313_open(RIG *rig)
 {
-    struct g313_priv_data *priv = (struct g313_priv_data *)rig->state.priv;
+    struct g313_priv_data *priv = (struct g313_priv_data *)STATE(rig)->priv;
     int device_num;
     int Count;
     int id;
@@ -432,7 +432,7 @@ int g313_open(RIG *rig)
 
 int g313_close(RIG *rig)
 {
-    struct g313_priv_data *priv = (struct g313_priv_data *)rig->state.priv;
+    struct g313_priv_data *priv = (struct g313_priv_data *)STATE(rig)->priv;
 
 
     if (!priv->Opened)
@@ -461,23 +461,23 @@ int g313_cleanup(RIG *rig)
         return -RIG_EINVAL;
     }
 
-    priv = (struct g313_priv_data *)rig->state.priv;
+    priv = (struct g313_priv_data *)STATE(rig)->priv;
 
     /* Clean up the dll access */
     FreeLibrary(priv->dll);
     FreeLibrary(priv->WinMM);
     FreeLibrary(priv->hWRG313WO);
 
-    free(rig->state.priv);
+    free(STATE(rig)->priv);
 
-    rig->state.priv = NULL;
+    STATE(rig)->priv = NULL;
 
     return RIG_OK;
 }
 
 int g313_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-    struct g313_priv_data *priv = (struct g313_priv_data *)rig->state.priv;
+    struct g313_priv_data *priv = (struct g313_priv_data *)STATE(rig)->priv;
     int ret;
 
     ret = priv->G3SetFrequency(priv->hRadio, (DWORD)(freq));
@@ -488,7 +488,7 @@ int g313_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
 int g313_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
-    struct g313_priv_data *priv = (struct g313_priv_data *)rig->state.priv;
+    struct g313_priv_data *priv = (struct g313_priv_data *)STATE(rig)->priv;
 
     *freq = (freq_t) priv->G3GetFrequency(priv->hRadio);
 
@@ -497,7 +497,7 @@ int g313_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
 int g313_set_powerstat(RIG *rig, powerstat_t status)
 {
-    struct g313_priv_data *priv = (struct g313_priv_data *)rig->state.priv;
+    struct g313_priv_data *priv = (struct g313_priv_data *)STATE(rig)->priv;
     int ret;
 
     ret = priv->SetPower(priv->hRadio, status == RIG_POWER_ON ? TRUE : FALSE);
@@ -508,7 +508,7 @@ int g313_set_powerstat(RIG *rig, powerstat_t status)
 
 int g313_get_powerstat(RIG *rig, powerstat_t *status)
 {
-    struct g313_priv_data *priv = (struct g313_priv_data *)rig->state.priv;
+    struct g313_priv_data *priv = (struct g313_priv_data *)STATE(rig)->priv;
     int ret;
 
     ret = priv->GetPower(priv->hRadio);
@@ -519,7 +519,7 @@ int g313_get_powerstat(RIG *rig, powerstat_t *status)
 
 int g313_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
-    struct g313_priv_data *priv = (struct g313_priv_data *)rig->state.priv;
+    struct g313_priv_data *priv = (struct g313_priv_data *)STATE(rig)->priv;
     int ret, agc;
 
     switch (level)
@@ -568,7 +568,7 @@ int g313_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
 int g313_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
-    struct g313_priv_data *priv = (struct g313_priv_data *)rig->state.priv;
+    struct g313_priv_data *priv = (struct g313_priv_data *)STATE(rig)->priv;
     int ret;
 
     ret = RIG_OK;
@@ -626,7 +626,7 @@ int g313_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 
 static const char *g313_get_info(RIG *rig)
 {
-    struct g313_priv_data *priv = (struct g313_priv_data *)rig->state.priv;
+    struct g313_priv_data *priv = (struct g313_priv_data *)STATE(rig)->priv;
     static RADIO_INFO info;
 
     info.bLength = sizeof(RADIO_INFO);
@@ -642,7 +642,7 @@ static const char *g313_get_info(RIG *rig)
 
 int g313_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 {
-    struct g313_priv_data *priv = (struct g313_priv_data *)rig->state.priv;
+    struct g313_priv_data *priv = (struct g313_priv_data *)STATE(rig)->priv;
     int id;
 
     switch (token)
@@ -697,7 +697,7 @@ int g313_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 
 int g313_get_conf2(RIG *rig, hamlib_token_t token, char *val, int val_len)
 {
-    const struct g313_priv_data *priv = (struct g313_priv_data *)rig->state.priv;
+    const struct g313_priv_data *priv = (struct g313_priv_data *)STATE(rig)->priv;
 
     switch (token)
     {

--- a/rigs/winradio/winradio.c
+++ b/rigs/winradio/winradio.c
@@ -284,7 +284,7 @@ int wr_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 
         if (ioctl(rp->fd, RADIO_GET_VOL, &v)) { return -RIG_EINVAL; }
 
-        val->i = v ? rig->state.attenuator[0] : 0;
+        val->i = v ? STATE(rig)->attenuator[0] : 0;
         return RIG_OK;
     }
 

--- a/tests/README
+++ b/tests/README
@@ -17,7 +17,7 @@ If you don't know the number, listrigs can give it to you,
 
 In any case, you are encouraged to check for correct initialization
 by reading the source code, at the beginning of the main().  Check also
-that the program is setup for your rig path strncpy(HAMLIB_STATE(my_rig)->rig_path...
+that the program is setup for your rig path strncpy(HAMLIB_RIGPORT(my_rig)->pathname...
 
 dumpcaps  - Output the caps contents of a rig
 dumpmem   - Dump the memory contents of the rig


### PR DESCRIPTION
This does all of rigs/* except for rigs/icom and rigs/yaesu.
These last two will probably each be a PR.