### PR TITLE
Fix rotorez.c to accept config parameters before rig open.

### DIFF
--- a/rotators/rotorez/rotorez.h
+++ b/rotators/rotorez/rotorez.h
@@ -50,6 +50,10 @@ extern const struct rot_caps yrc1_rot_caps;
 #define TOK_JAM     TOKEN_BACKEND(2)
 #define TOK_OVRSHT  TOKEN_BACKEND(3)
 #define TOK_UNSTICK TOKEN_BACKEND(4)
+/*
+ * Maximum number of configuration changes allowed between rot_init and _open
+ */
+#define ROTOREZ_CONF_CHARS 8
 
 #endif  /* _ROT_ROTOREZ_H */
 

--- a/tests/rotctl.c
+++ b/tests/rotctl.c
@@ -341,8 +341,7 @@ int main(int argc, char *argv[])
 
     char *token = strtok(conf_parms, ",");
 
-    // ROTOREZ set_conf needs to be done after rot_open
-    while (token && my_rot->caps->rot_model != ROT_MODEL_ROTOREZ)
+    while (token)
     {
         char mytoken[100], myvalue[100];
         hamlib_token_t lookup;
@@ -405,34 +404,6 @@ int main(int argc, char *argv[])
     {
         fprintf(stderr, "rot_open: error = %s \n", rigerror(retcode));
         exit(2);
-    }
-
-    // ROTOREZ set_conf needs to be done after rot_open
-    while (token && my_rot->caps->rot_model == ROT_MODEL_ROTOREZ)
-    {
-        char mytoken[100], myvalue[100];
-        hamlib_token_t lookup;
-        sscanf(token, "%99[^=]=%99s", mytoken, myvalue);
-        //printf("mytoken=%s,myvalue=%s\n",mytoken, myvalue);
-        lookup = rot_token_lookup(my_rot, mytoken);
-
-        if (lookup == 0)
-        {
-            rig_debug(RIG_DEBUG_ERR, "%s: no such token as '%s', use -L switch to see\n",
-                      __func__, mytoken);
-            token = strtok(NULL, ",");
-            continue;
-        }
-
-        retcode = rot_set_conf(my_rot, rot_token_lookup(my_rot, mytoken), myvalue);
-
-        if (retcode != RIG_OK)
-        {
-            fprintf(stderr, "Config parameter error: %s\n", rigerror(retcode));
-            exit(2);
-        }
-
-        token = strtok(NULL, ",");
     }
 
     /*

--- a/tests/rotctld.c
+++ b/tests/rotctld.c
@@ -347,8 +347,7 @@ int main(int argc, char *argv[])
 
     char *token = strtok(conf_parms, ",");
 
-    // ROTOREZ set_conf needs to be done after rot_open
-    while (token && my_rot->caps->rot_model != ROT_MODEL_ROTOREZ)
+    while (token)
     {
         char mytoken[100], myvalue[100];
         hamlib_token_t lookup;
@@ -417,35 +416,6 @@ int main(int argc, char *argv[])
         fprintf(stderr, "rot_open: error = %s \n", rigerror(retcode));
         exit(2);
     }
-
-    // ROTOREZ set_conf needs to be done after rot_open
-    while (token && my_rot->caps->rot_model == ROT_MODEL_ROTOREZ)
-    {
-        char mytoken[100], myvalue[100];
-        hamlib_token_t lookup;
-        sscanf(token, "%99[^=]=%99s", mytoken, myvalue);
-        //printf("mytoken=%s,myvalue=%s\n",mytoken, myvalue);
-        lookup = rot_token_lookup(my_rot, mytoken);
-
-        if (lookup == 0)
-        {
-            rig_debug(RIG_DEBUG_ERR, "%s: no such token as '%s', use -L switch to see\n",
-                      __func__, mytoken);
-            token = strtok(NULL, ",");
-            continue;
-        }
-
-        retcode = rot_set_conf(my_rot, rot_token_lookup(my_rot, mytoken), myvalue);
-
-        if (retcode != RIG_OK)
-        {
-            fprintf(stderr, "Config parameter error: %s\n", rigerror(retcode));
-            exit(2);
-        }
-
-        token = strtok(NULL, ",");
-    }
-
 
     my_rot->state.az_offset = az_offset;
     my_rot->state.el_offset = el_offset;


### PR DESCRIPTION
Fix the non-conformant handling of config parameters between rot_init and rot_open.  Fixes general application use of this rotator, and eliminates any need for special-casing.

