### PR TITLE
Balance ENTERFUNC/RETURNFUNC calls

### DIFF
--- a/rigs/dummy/dummy.c
+++ b/rigs/dummy/dummy.c
@@ -435,7 +435,7 @@ static int dummy_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     if (rig == NULL)
     {
         rig_debug(RIG_DEBUG_ERR, "%s: rig is NULL!!!\n", __func__);
-        return -RIG_EINVAL;
+        RETURNFUNC(-RIG_EINVAL);
     }
 
     priv = (struct dummy_priv_data *)STATE(rig)->priv;

--- a/rigs/dummy/netrigctl.c
+++ b/rigs/dummy/netrigctl.c
@@ -2686,7 +2686,7 @@ static int netrigctl_get_trn(RIG *rig, int *trn)
 
     if (ret <= 0)
     {
-        return -RIG_EPROTO;
+        RETURNFUNC(-RIG_EPROTO);
     }
 
     if (strstr(buf, "OFF")) { *trn = RIG_TRN_OFF; }
@@ -2718,7 +2718,7 @@ static int netrigctl_mW2power(RIG *rig, float *power, unsigned int mwpower,
 
     if (ret <= 0)
     {
-        return -RIG_EPROTO;
+        RETURNFUNC(-RIG_EPROTO);
     }
 
     *power = atof(buf);
@@ -2743,7 +2743,7 @@ static int netrigctl_power2mW(RIG *rig, unsigned int *mwpower, float power,
 
     if (ret <= 0)
     {
-        return -RIG_EPROTO;
+        RETURNFUNC(-RIG_EPROTO);
     }
 
     *mwpower = atof(buf);

--- a/rigs/dummy/quisk.c
+++ b/rigs/dummy/quisk.c
@@ -2617,7 +2617,7 @@ static int quisk_get_trn(RIG *rig, int *trn)
 
     if (ret <= 0)
     {
-        return -RIG_EPROTO;
+        RETURNFUNC(-RIG_EPROTO);
     }
 
     if (strstr(buf, "OFF")) { *trn = RIG_TRN_OFF; }
@@ -2649,7 +2649,7 @@ static int quisk_mW2power(RIG *rig, float *power, unsigned int mwpower,
 
     if (ret <= 0)
     {
-        return -RIG_EPROTO;
+        RETURNFUNC(-RIG_EPROTO);
     }
 
     *power = atof(buf);
@@ -2674,7 +2674,7 @@ static int quisk_power2mW(RIG *rig, unsigned int *mwpower, float power,
 
     if (ret <= 0)
     {
-        return -RIG_EPROTO;
+        RETURNFUNC(-RIG_EPROTO);
     }
 
     *mwpower = atof(buf);

--- a/rigs/icom/frame.c
+++ b/rigs/icom/frame.c
@@ -303,7 +303,7 @@ again2:
     if (frm_len <= 0)
     {
         set_transaction_inactive(rig);
-        return frm_len;
+        RETURNFUNC(frm_len);
     }
 
     if (frm_len > 4 && memcmp(buf, sendbuf, frm_len) == 0)

--- a/rigs/icom/ic7300.c
+++ b/rigs/icom/ic7300.c
@@ -2242,7 +2242,7 @@ int ic9700_set_vfo(RIG *rig, vfo_t vfo)
         else
         {
             rig_debug(RIG_DEBUG_ERR, "%s: Invalid VFO %s in satellite mode\n", __func__, rig_strvfo(vfo));
-            return -RIG_EINVAL;
+            RETURNFUNC(-RIG_EINVAL);
         }
     }
 
@@ -2257,7 +2257,7 @@ int ic9700_set_vfo(RIG *rig, vfo_t vfo)
             rig_debug(RIG_DEBUG_WARN, "%s: cannot switch to VFOB when in satmode\n",
                       __func__);
             // we return RIG_OK anyways as this should just be a bad request
-            return RIG_OK;
+            RETURNFUNC(RIG_OK);
         }
 
         retval = icom_transaction(rig, C_SET_VFO, S_VFOB, NULL, 0, ackbuf, &ack_len);
@@ -2269,14 +2269,14 @@ int ic9700_set_vfo(RIG *rig, vfo_t vfo)
         if (retval != RIG_OK)
         {
             rig_debug(RIG_DEBUG_ERR, "%s: %s\n", __func__, rigerror(retval));
-            return retval;
+            RETURNFUNC(retval);
         }
 
         if (cachep->satmode && vfo == RIG_VFO_MAIN_B)
         {
             rig_debug(RIG_DEBUG_WARN, "%s: cannot switch to VFOB when in satmode\n", __func__);
             // we return RIG_OK anyways as this should just be a bad request
-            return RIG_OK;
+            RETURNFUNC(RIG_OK);
         }
 
         if (vfo == RIG_VFO_MAIN_A || vfo == RIG_VFO_MAIN_B)
@@ -2292,14 +2292,14 @@ int ic9700_set_vfo(RIG *rig, vfo_t vfo)
         if (retval != RIG_OK)
         {
             rig_debug(RIG_DEBUG_ERR, "%s: %s\n", __func__, rigerror(retval));
-            return retval;
+            RETURNFUNC(retval);
         }
 
         if (cachep->satmode && vfo == RIG_VFO_SUB_B)
         {
             rig_debug(RIG_DEBUG_WARN, "%s: cannot switch to VFOB when in satmode\n", __func__);
             // we return RIG_OK anyways as this should just be a bad request
-            return RIG_OK;
+            RETURNFUNC(RIG_OK);
         }
 
         if (vfo == RIG_VFO_SUB_A || vfo == RIG_VFO_SUB_B)
@@ -2311,7 +2311,7 @@ int ic9700_set_vfo(RIG *rig, vfo_t vfo)
     }
     else if (vfo == RIG_VFO_MEM)
     {
-        return icom_set_vfo(rig, vfo);
+        RETURNFUNC(icom_set_vfo(rig, vfo));
     }
     else
     {
@@ -2322,7 +2322,7 @@ int ic9700_set_vfo(RIG *rig, vfo_t vfo)
     if (retval != RIG_OK)
     {
         rig_debug(RIG_DEBUG_ERR, "%s: %s\n", __func__, rigerror(retval));
-        return retval;
+        RETURNFUNC(retval);
     }
 
     RETURNFUNC(retval);

--- a/rigs/icom/icom.c
+++ b/rigs/icom/icom.c
@@ -2134,12 +2134,12 @@ int icom_set_dsp_flt(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         if (priv->no_1a_03_cmd == ENUM_1A_03_UNK)
         {
             priv->no_1a_03_cmd = ENUM_1A_03_NO;  /* do not keep asking */
-            return (RIG_OK);
+            RETURNFUNC(RIG_OK);
         }
         else
         {
             rig_debug(RIG_DEBUG_ERR, "%s: 1A 03 %02x failed\n", __func__, flt_ext);
-            return (retval);
+            RETURNFUNC(retval);
         }
     }
 
@@ -5219,7 +5219,7 @@ int icom_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 
     if ((retval = icom_check_ack(ack_len, ackbuf)) != RIG_OK)
     {
-        RETURNFUNC2(retval);
+        RETURNFUNC(retval);
     }
 
     RETURNFUNC(RIG_OK);
@@ -5347,7 +5347,7 @@ int icom_set_rptr_shift(RIG *rig, vfo_t vfo, rptr_shift_t rptr_shift)
 
     if ((retval = icom_check_ack(ack_len, ackbuf)) != RIG_OK)
     {
-        RETURNFUNC2(retval);
+        RETURNFUNC(retval);
     }
 
     RETURNFUNC(RIG_OK);
@@ -5446,7 +5446,7 @@ int icom_set_rptr_offs(RIG *rig, vfo_t vfo, shortfreq_t rptr_offs)
 
     if ((retval = icom_check_ack(ack_len, ackbuf)) != RIG_OK)
     {
-        RETURNFUNC2(retval);
+        RETURNFUNC(retval);
     }
 
     RETURNFUNC(RIG_OK);
@@ -7549,7 +7549,7 @@ int icom_set_ctcss_tone(RIG *rig, vfo_t vfo, tone_t tone)
 
     if ((retval = icom_check_ack(ack_len, ackbuf)) != RIG_OK)
     {
-        RETURNFUNC2(retval);
+        RETURNFUNC(retval);
     }
 
     RETURNFUNC(RIG_OK);
@@ -7740,7 +7740,7 @@ int icom_set_dcs_code(RIG *rig, vfo_t vfo, tone_t code)
 
     if ((retval = icom_check_ack(ack_len, ackbuf)) != RIG_OK)
     {
-        RETURNFUNC2(retval);
+        RETURNFUNC(retval);
     }
 
     RETURNFUNC(RIG_OK);
@@ -7837,7 +7837,7 @@ int icom_set_dcs_sql(RIG *rig, vfo_t vfo, tone_t code)
 
     if ((retval = icom_check_ack(ack_len, ackbuf)) != RIG_OK)
     {
-        RETURNFUNC2(retval);
+        RETURNFUNC(retval);
     }
 
     RETURNFUNC(RIG_OK);
@@ -8248,7 +8248,7 @@ int icom_set_bank(RIG *rig, vfo_t vfo, int bank)
 
     if ((retval = icom_check_ack(ack_len, ackbuf)) != RIG_OK)
     {
-        RETURNFUNC2(retval);
+        RETURNFUNC(retval);
     }
 
     RETURNFUNC(RIG_OK);
@@ -8671,7 +8671,7 @@ int icom_scan(RIG *rig, vfo_t vfo, scan_t scan, int ch)
 
     if ((retval = icom_check_ack(ack_len, ackbuf)) != RIG_OK)
     {
-        RETURNFUNC2(retval);
+        RETURNFUNC(retval);
     }
 
     RETURNFUNC(RIG_OK);
@@ -8719,7 +8719,7 @@ morse_retry:
             }
         }
 
-        RETURNFUNC2(retval);
+        RETURNFUNC(retval);
     }
 
     RETURNFUNC(RIG_OK);

--- a/rigs/icom/icom.c
+++ b/rigs/icom/icom.c
@@ -989,7 +989,7 @@ static vfo_t icom_current_vfo(RIG *rig)
 
         if (retval != RIG_OK)
         {
-            RETURNFUNC(rs->current_vfo);
+            return rs->current_vfo;
         }
     }
 
@@ -1003,7 +1003,7 @@ static vfo_t icom_current_vfo(RIG *rig)
 
         if (retval != RIG_OK)
         {
-            RETURNFUNC(rs->current_vfo);
+            return rs->current_vfo;
         }
     }
 
@@ -1724,7 +1724,7 @@ int icom_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
                 priv->civ_731_mode = 1;
             }
 
-            RETURNFUNC(retval);
+            return retval;
         }
 
         // Fix VFO if the TX freq command is not available
@@ -1781,7 +1781,7 @@ int icom_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
                 priv->civ_731_mode = 1;
             }
 
-            RETURNFUNC(retval);
+            return retval;
         }
 
         retval = icom_transaction(rig, C_RD_FREQ, -1, NULL, 0, freqbuf, &freq_len);
@@ -1802,7 +1802,7 @@ int icom_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
             priv->civ_731_mode = 1;
         }
 
-        RETURNFUNC(retval);
+        return retval;
     }
 
     /*
@@ -1819,7 +1819,7 @@ int icom_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
         if (vfo == RIG_VFO_MEM && civ_731_mode_save) { priv->civ_731_mode = 1; }
 
-        RETURNFUNC(RIG_OK);
+        return RIG_OK;
     }
 
     if (freq_len == 3 && (ICOM_IS_ID5100 || ICOM_IS_ID4100 || ICOM_IS_ID31
@@ -1843,7 +1843,7 @@ int icom_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
             return -RIG_ETRUNC;
         }
 
-        RETURNFUNC(-RIG_ENAVAIL);
+        return -RIG_ENAVAIL;
     }
 
     if (freq_len != 3 && freq_len != 6 && freq_len != (priv->civ_731_mode ? 4 : 5))
@@ -3965,7 +3965,7 @@ int icom_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
     if ((retval = icom_check_ack(ack_len, ackbuf)) != RIG_OK)
     {
-        RETURNFUNC2(retval);
+        RETURNFUNC(retval);
     }
 
     RETURNFUNC(RIG_OK);
@@ -6028,7 +6028,7 @@ int icom_set_split_mode(RIG *rig, vfo_t vfo, rmode_t tx_mode,
 
         if ((retval = icom_check_ack(ack_len, ackbuf)) != RIG_OK)
         {
-            RETURNFUNC2(retval);
+            RETURNFUNC(retval);
         }
     }
 
@@ -6135,7 +6135,7 @@ int icom_get_split_mode(RIG *rig, vfo_t vfo, rmode_t *tx_mode,
 
         if ((retval = icom_check_ack(ack_len, ackbuf)) != RIG_OK)
         {
-            RETURNFUNC2(retval);
+            RETURNFUNC(retval);
         }
     }
 
@@ -6379,10 +6379,10 @@ int icom_get_split_freq_mode(RIG *rig, vfo_t vfo, freq_t *tx_freq,
 
             if (retval != RIG_OK)
             {
-                RETURNFUNC2(retval);
+                RETURNFUNC(retval);
             }
 
-            RETURNFUNC2(icom_get_mode(rig, vfo, tx_mode, tx_width));
+            RETURNFUNC(icom_get_mode(rig, vfo, tx_mode, tx_width));
         }
     }
 
@@ -6428,7 +6428,7 @@ int icom_get_split_freq_mode(RIG *rig, vfo_t vfo, freq_t *tx_freq,
 
         if ((retval = icom_check_ack(ack_len, ackbuf)) != RIG_OK)
         {
-            RETURNFUNC2(retval);
+            RETURNFUNC(retval);
         }
     }
 
@@ -6766,7 +6766,7 @@ int icom_set_ts(RIG *rig, vfo_t vfo, shortfreq_t ts)
 
     if ((retval = icom_check_ack(ack_len, ackbuf)) != RIG_OK)
     {
-        RETURNFUNC2(retval);
+        RETURNFUNC(retval);
     }
 
     RETURNFUNC(RIG_OK);
@@ -7648,7 +7648,7 @@ int icom_set_ctcss_sql(RIG *rig, vfo_t vfo, tone_t tone)
 
     if ((retval = icom_check_ack(ack_len, ackbuf)) != RIG_OK)
     {
-        RETURNFUNC2(retval);
+        RETURNFUNC(retval);
     }
 
     RETURNFUNC(RIG_OK);
@@ -8170,7 +8170,7 @@ int icom_get_powerstat(RIG *rig, powerstat_t *status)
         // Modify rig_state powerstat directly to reflect power ON/OFF status, but return the result of rig_get_freq,
         // because the error could indicate other connectivity issues too
         STATE(rig)->powerstat = *status;
-        return retval;
+        RETURNFUNC(retval);
     }
     else
     {
@@ -8220,7 +8220,7 @@ int icom_set_mem(RIG *rig, vfo_t vfo, int ch)
 
     if ((retval = icom_check_ack(ack_len, ackbuf)) != RIG_OK)
     {
-        RETURNFUNC2(retval);
+        RETURNFUNC(retval);
     }
 
     RETURNFUNC(RIG_OK);
@@ -8749,7 +8749,7 @@ int icom_stop_morse(RIG *rig, vfo_t vfo)
 
     if ((retval = icom_check_ack(ack_len, ackbuf)) != RIG_OK)
     {
-        RETURNFUNC2(retval);
+        RETURNFUNC(retval);
     }
 
     RETURNFUNC(RIG_OK);
@@ -9169,7 +9169,7 @@ int icom_set_raw(RIG *rig, int cmd, int subcmd, int subcmdbuflen,
 
     if ((retval = icom_check_ack(ack_len, ackbuf)) != RIG_OK)
     {
-        RETURNFUNC2(retval);
+        RETURNFUNC(retval);
     }
 
     RETURNFUNC(RIG_OK);
@@ -9319,7 +9319,7 @@ int icom_send_voice_mem(RIG *rig, vfo_t vfo, int ch)
 
     if ((retval = icom_check_ack(ack_len, ackbuf)) != RIG_OK)
     {
-        RETURNFUNC2(retval);
+        RETURNFUNC(retval);
     }
 
     RETURNFUNC(RIG_OK);

--- a/rigs/icom/id5100.c
+++ b/rigs/icom/id5100.c
@@ -100,7 +100,7 @@ int id5100_set_vfo(RIG *rig, vfo_t vfo)
             if (RIG_OK != (retval = icom_set_func(rig, RIG_VFO_CURR, RIG_FUNC_DUAL_WATCH,
                                                   0)))
             {
-                RETURNFUNC2(retval);
+                RETURNFUNC(retval);
             }
 
             priv->dual_watch = 0;
@@ -116,7 +116,7 @@ int id5100_set_vfo(RIG *rig, vfo_t vfo)
             if (RIG_OK != (retval = icom_set_func(rig, RIG_VFO_CURR, RIG_FUNC_DUAL_WATCH,
                                                   1)))
             {
-                RETURNFUNC2(retval);
+                RETURNFUNC(retval);
             }
 
             priv->dual_watch = 1;
@@ -139,7 +139,7 @@ int id5100_set_vfo(RIG *rig, vfo_t vfo)
     if (RIG_OK != (retval = icom_transaction(rig, C_SET_VFO, myvfo, NULL, 0, ackbuf,
                             &ack_len)))
     {
-        RETURNFUNC2(retval);
+        RETURNFUNC(retval);
     }
 
     RETURNFUNC(retval);

--- a/rigs/kenwood/elecraft.c
+++ b/rigs/kenwood/elecraft.c
@@ -582,13 +582,15 @@ int elecraft_get_vfo_tq(RIG *rig, vfo_t *vfo)
     char cmdbuf[10];
     char splitbuf[12];
 
+    ENTERFUNC2;
+
     memset(splitbuf, 0, sizeof(splitbuf));
     SNPRINTF(cmdbuf, sizeof(cmdbuf), "FR;");
     retval = kenwood_safe_transaction(rig, cmdbuf, splitbuf, 12, 3);
 
     if (retval != RIG_OK)
     {
-        RETURNFUNC(retval);
+        RETURNFUNC2(retval);
     }
 
     if (sscanf(splitbuf, "FR%1d", &fr) != 1)
@@ -601,7 +603,7 @@ int elecraft_get_vfo_tq(RIG *rig, vfo_t *vfo)
 
     if (retval != RIG_OK)
     {
-        RETURNFUNC(retval);
+        RETURNFUNC2(retval);
     }
 
     if (sscanf(splitbuf, "FT%1d", &ft) != 1)
@@ -614,7 +616,7 @@ int elecraft_get_vfo_tq(RIG *rig, vfo_t *vfo)
 
     if (retval != RIG_OK)
     {
-        RETURNFUNC(retval);
+        RETURNFUNC2(retval);
     }
 
     if (sscanf(splitbuf, "TQ%1d", &tq) != 1)

--- a/rigs/kenwood/flex6xxx.c
+++ b/rigs/kenwood/flex6xxx.c
@@ -1294,7 +1294,7 @@ int powersdr_get_parm(RIG *rig, setting_t parm, value_t *val)
     if (n != 1)
     {
         rig_debug(RIG_DEBUG_ERR, "%s: unknown band=%s\n", __func__, buf);
-        return (-RIG_EPROTO);
+        RETURNFUNC(-RIG_EPROTO);
     }
 
     switch (band)

--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -536,7 +536,7 @@ transaction_read:
             {
                 rig_debug(RIG_DEBUG_ERR, "%s: Command rejected by the rig (get): '%s'\n",
                           __func__, cmdstr);
-                RETURNFUNC(-RIG_ERJCTED);
+                RETURNFUNC2(-RIG_ERJCTED);
             }
 
             /* Command not understood by rig or rig busy */
@@ -1242,7 +1242,7 @@ int kenwood_set_vfo(RIG *rig, vfo_t vfo)
     if (vfo == RIG_VFO_B &&  priv->is_emulation && priv->curr_mode > 0)
     {
         HAMLIB_TRACE;
-        RETURNFUNC2(RIG_OK);
+        RETURNFUNC(RIG_OK);
     }
 
 #if 0
@@ -1251,7 +1251,7 @@ int kenwood_set_vfo(RIG *rig, vfo_t vfo)
     {
         rig_debug(RIG_DEBUG_VERBOSE, "%s: vfo already is %s...skipping\n", __func__,
                   rig_strvfo(vfo));
-        RETURNFUNC2(RIG_OK);
+        RETURNFUNC(RIG_OK);
     }
 
 #endif
@@ -1284,11 +1284,11 @@ int kenwood_set_vfo(RIG *rig, vfo_t vfo)
     case RIG_VFO_CURR:
         HAMLIB_TRACE;
         STATE(rig)->current_vfo = RIG_VFO_CURR;
-        RETURNFUNC2(RIG_OK);
+        RETURNFUNC(RIG_OK);
 
     default:
         rig_debug(RIG_DEBUG_ERR, "%s: unsupported VFO %s\n", __func__, rig_strvfo(vfo));
-        RETURNFUNC2(-RIG_EINVAL);
+        RETURNFUNC(-RIG_EINVAL);
     }
 
     //if rig=ts2000 then check Satellite mode status
@@ -1302,7 +1302,7 @@ int kenwood_set_vfo(RIG *rig, vfo_t vfo)
 
         if (retval != RIG_OK)
         {
-            RETURNFUNC2(retval);
+            RETURNFUNC(retval);
         }
 
         rig_debug(RIG_DEBUG_VERBOSE, "%s: satellite mode status %s\n", __func__,
@@ -1313,7 +1313,7 @@ int kenwood_set_vfo(RIG *rig, vfo_t vfo)
         {
             //SAT mode doesn't allow FR command (cannot select VFO)
             //selecting VFO is useless in SAT MODE
-            RETURNFUNC2(RIG_OK);
+            RETURNFUNC(RIG_OK);
         }
     }
 
@@ -1344,7 +1344,7 @@ int kenwood_set_vfo(RIG *rig, vfo_t vfo)
 
     if (retval != RIG_OK)
     {
-        RETURNFUNC2(retval);
+        RETURNFUNC(retval);
     }
 
     HAMLIB_TRACE;
@@ -1354,7 +1354,7 @@ int kenwood_set_vfo(RIG *rig, vfo_t vfo)
     /* If split mode on, the don't change TxVFO */
     if ('N' == cmdbuf[1] || priv->split != RIG_SPLIT_OFF)
     {
-        RETURNFUNC2(RIG_OK);
+        RETURNFUNC(RIG_OK);
     }
 
     HAMLIB_TRACE;
@@ -1406,7 +1406,7 @@ int kenwood_set_vfo(RIG *rig, vfo_t vfo)
     cmdbuf[1] = 'T';
     RETURNFUNC(kenwood_transaction(rig, cmdbuf, NULL, 0));
 #else
-    RETURNFUNC2(retval);
+    RETURNFUNC(retval);
 #endif
 }
 
@@ -2262,7 +2262,7 @@ int kenwood_set_xit(RIG *rig, vfo_t vfo, shortfreq_t rit)
 
 int kenwood_scan(RIG *rig, vfo_t vfo, scan_t scan, int ch)
 {
-    rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
+    ENTERFUNC;
 
     if (RIG_IS_TS990S)
     {
@@ -2751,7 +2751,7 @@ static int kenwood_get_filter_width(RIG *rig, rmode_t mode, pbwidth_t *width)
     if (filter_value >= 50) // then it's probably a custom filter width
     {
         *width = filter_value;
-        return (RIG_OK);
+        RETURNFUNC(RIG_OK);
     }
 
     RETURNFUNC(-RIG_EINVAL);
@@ -3788,23 +3788,23 @@ int kenwood_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 
         if (retval != RIG_OK)
         {
-            return retval;
+            RETURNFUNC(retval);
         }
 
         ack_len = strlen(lvlbuf);
 
         if (ack_len != len)
         {
-            return -RIG_EPROTO;
+            RETURNFUNC(-RIG_EPROTO);
         }
 
         if (sscanf(&lvlbuf[len - 3], "%d", &lvl) != 1)
         {
-            return -RIG_EPROTO;
+            RETURNFUNC(-RIG_EPROTO);
         }
 
         val->f = (float) lvl / 255.f;
-        return RIG_OK;
+        RETURNFUNC(RIG_OK);
     }
 
     case RIG_LEVEL_ATT:
@@ -5547,7 +5547,7 @@ int kenwood_send_voice_mem(RIG *rig, vfo_t vfo, int bank)
              || rig->caps->rig_model == RIG_MODEL_TS480))
     {
         rig_debug(RIG_DEBUG_ERR, "%s: TS2000/TS480 channel is from 1 to 3\n", __func__);
-        return -RIG_EINVAL;
+        RETURNFUNC(-RIG_EINVAL);
     }
 
     // some rigs have 5 channels -- newew ones  have 10 channels
@@ -5556,7 +5556,7 @@ int kenwood_send_voice_mem(RIG *rig, vfo_t vfo, int bank)
                 || rig->caps->rig_model == RIG_MODEL_TS590S))
     {
         rig_debug(RIG_DEBUG_ERR, "%s: TS590S/SG channel is from 1 to 5\n", __func__);
-        return -RIG_EINVAL;
+        RETURNFUNC(-RIG_EINVAL);
     }
 
     if (rig->caps->rig_model == RIG_MODEL_TS2000
@@ -6070,7 +6070,7 @@ const char *kenwood_get_info(RIG *rig)
     char firmbuf[10];
     int retval;
 
-    ENTERFUNC;
+    ENTERFUNC2;
 
     if (!rig)
     {

--- a/rigs/kenwood/ts2000.c
+++ b/rigs/kenwood/ts2000.c
@@ -620,7 +620,7 @@ static int ts2000_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         }
 
         val->f = levelint / (float) 255;
-        return RIG_OK;
+        RETURNFUNC(RIG_OK);
 
     case RIG_LEVEL_SQL:
         SNPRINTF(cmdbuf, sizeof(cmdbuf), "SQ%c", vfo_num);

--- a/rigs/kenwood/ts2000.c
+++ b/rigs/kenwood/ts2000.c
@@ -272,7 +272,7 @@ int ts2000_init(RIG *rig)
 
     if (retval != RIG_OK)
     {
-        return retval;
+        RETURNFUNC(retval);
     }
 
     priv = (struct kenwood_priv_data *) STATE(rig)->priv;
@@ -328,12 +328,12 @@ static int ts2000_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
     {
     case RIG_FUNC_MON:
         SNPRINTF(buf, sizeof(buf), "ML00%c", (status == 0) ? '0' : '1');
-        RETURNFUNC(kenwood_transaction(rig, buf, NULL, 0));
+        RETURNFUNC2(kenwood_transaction(rig, buf, NULL, 0));
 
     case RIG_FUNC_LOCK:
         SNPRINTF(buf, sizeof(buf), "LK%c%c", (status == 0) ? '0' : '1',
                  (status == 0) ? '0' : '1');
-        RETURNFUNC(kenwood_transaction(rig, buf, NULL, 0));
+        RETURNFUNC2(kenwood_transaction(rig, buf, NULL, 0));
 
     default:
         return kenwood_set_func(rig, vfo, func, status);
@@ -377,7 +377,7 @@ static int ts2000_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
         break;
 
     default:
-        return kenwood_get_func(rig, vfo, func, status);
+        RETURNFUNC(kenwood_get_func(rig, vfo, func, status));
     }
 
     RETURNFUNC(RIG_OK);
@@ -462,7 +462,7 @@ static int ts2000_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
     case RIG_LEVEL_PREAMP:
         if (val.i != 12 && val.i != 0)
         {
-            RETURNFUNC(-RIG_EINVAL);
+            RETURNFUNC2(-RIG_EINVAL);
         }
 
         SNPRINTF(levelbuf, sizeof(levelbuf), "PA%c", (val.i == 12) ? '1' : '0');
@@ -471,7 +471,7 @@ static int ts2000_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
     case RIG_LEVEL_ATT:
         if (val.i != 12 && val.i != 0)
         {
-            RETURNFUNC(-RIG_EINVAL);
+            RETURNFUNC2(-RIG_EINVAL);
         }
 
         SNPRINTF(levelbuf, sizeof(levelbuf), "RA%02d", (val.i == 12) ? 1 : 0);
@@ -493,7 +493,7 @@ static int ts2000_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
             break;
 
         default:
-            RETURNFUNC(-RIG_EINVAL);
+            RETURNFUNC2(-RIG_EINVAL);
         }
 
         SNPRINTF(levelbuf, sizeof(levelbuf), "RM%d", kenwood_val);
@@ -502,10 +502,10 @@ static int ts2000_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
     case RIG_LEVEL_CWPITCH:
         if (val.i > 1000 || val.i < 400)
         {
-            RETURNFUNC(-RIG_EINVAL);
+            RETURNFUNC2(-RIG_EINVAL);
         }
 
-        RETURNFUNC(ts2000_set_ex_menu(rig, 31, 2, (val.i - 400) / 50));
+        RETURNFUNC2(ts2000_set_ex_menu(rig, 31, 2, (val.i - 400) / 50));
 
     default:
         return kenwood_set_level(rig, vfo, level, val);
@@ -597,26 +597,26 @@ static int ts2000_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     switch (level)
     {
     case RIG_LEVEL_AF:
-        return kenwood_get_level(rig, vfo, level, val);
+        RETURNFUNC(kenwood_get_level(rig, vfo, level, val));
 
     case RIG_LEVEL_RF:
         retval = kenwood_transaction(rig, "RG", ackbuf, sizeof(ackbuf));
 
         if (RIG_OK != retval)
         {
-            return retval;
+            RETURNFUNC(retval);
         }
 
         ack_len = strlen(ackbuf);
 
         if (5 != ack_len)
         {
-            return -RIG_EPROTO;
+            RETURNFUNC(-RIG_EPROTO);
         }
 
         if (1 != sscanf(&ackbuf[2], "%d", &levelint))
         {
-            return -RIG_EPROTO;
+            RETURNFUNC(-RIG_EPROTO);
         }
 
         val->f = levelint / (float) 255;
@@ -629,23 +629,23 @@ static int ts2000_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 
         if (retval != RIG_OK)
         {
-            return retval;
+            RETURNFUNC(retval);
         }
 
         ack_len = strlen(ackbuf);
 
         if (ack_len != ack_len_expected)
         {
-            return -RIG_EPROTO;
+            RETURNFUNC(-RIG_EPROTO);
         }
 
         if (sscanf(&ackbuf[ack_len_expected - 3], "%d", &levelint) != 1)
         {
-            return -RIG_EPROTO;
+            RETURNFUNC(-RIG_EPROTO);
         }
 
         val->f = (float) levelint / 255.f;
-        return RIG_OK;
+        RETURNFUNC(RIG_OK);
 
     case RIG_LEVEL_AGC:
         retval = kenwood_transaction(rig, "GT", ackbuf, sizeof(ackbuf));
@@ -653,19 +653,19 @@ static int ts2000_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 
         if (RIG_OK != retval)
         {
-            return retval;
+            RETURNFUNC(retval);
         }
 
         ack_len = strlen(ackbuf);
 
         if (ack_len != ack_len_expected)
         {
-            return -RIG_EPROTO;
+            RETURNFUNC(-RIG_EPROTO);
         }
 
         if (1 != sscanf(&ackbuf[ack_len_expected - 3], "%d", &levelint))
         {
-            return -RIG_EPROTO;
+            RETURNFUNC(-RIG_EPROTO);
         }
 
         if (levelint == 0)
@@ -689,7 +689,7 @@ static int ts2000_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
             val->i = RIG_AGC_SLOW;
         }
 
-        return RIG_OK;
+        RETURNFUNC(RIG_OK);
 
     case RIG_LEVEL_STRENGTH:
         if (CACHE(rig)->ptt != RIG_PTT_OFF)
@@ -698,7 +698,7 @@ static int ts2000_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
             break;
         }
 
-        return kenwood_get_level(rig, vfo, level, val);
+        RETURNFUNC(kenwood_get_level(rig, vfo, level, val));
 
     case RIG_LEVEL_MONITOR_GAIN:
     {
@@ -868,7 +868,7 @@ static int ts2000_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
             break;
 
         default:
-            return -RIG_ENAVAIL;
+            RETURNFUNC(-RIG_ENAVAIL);
         }
 
         break;
@@ -923,7 +923,7 @@ static int ts2000_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     }
 
     default:
-        return kenwood_get_level(rig, vfo, level, val);
+        RETURNFUNC(kenwood_get_level(rig, vfo, level, val));
     }
 
     RETURNFUNC(RIG_OK);

--- a/rigs/kenwood/ts480.c
+++ b/rigs/kenwood/ts480.c
@@ -742,7 +742,7 @@ kenwood_ts480_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     }
 
     default:
-        return kenwood_get_level(rig, vfo, level, val);
+        RETURNFUNC(kenwood_get_level(rig, vfo, level, val));
     }
 
     RETURNFUNC(RIG_OK);

--- a/rigs/kenwood/ts590.c
+++ b/rigs/kenwood/ts590.c
@@ -610,7 +610,7 @@ static int ts590_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
         default:
             rig_debug(RIG_DEBUG_ERR, "%s: unsupported agc value", __func__);
-            return -RIG_EINVAL;
+            RETURNFUNC(-RIG_EINVAL);
         }
 
         SNPRINTF(levelbuf, sizeof(levelbuf), "GT%02d", kenwood_val);
@@ -1004,7 +1004,7 @@ static int ts590_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
             break;
 
         default:
-            return -RIG_ENAVAIL;
+            RETURNFUNC(-RIG_ENAVAIL);
         }
 
         break;

--- a/rigs/kenwood/ts590.c
+++ b/rigs/kenwood/ts590.c
@@ -463,7 +463,7 @@ static int ts590_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
 {
     char buf[20];
 
-    rig_debug(RIG_DEBUG_TRACE, "%s called\n", __func__);
+    ENTERFUNC;
 
     switch (func)
     {
@@ -481,7 +481,7 @@ static int ts590_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
         RETURNFUNC(kenwood_transaction(rig, buf, NULL, 0));
 
     default:
-        return kenwood_set_func(rig, vfo, func, status);
+        RETURNFUNC(kenwood_set_func(rig, vfo, func, status));
     }
 }
 
@@ -547,7 +547,7 @@ static int ts590_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
     int result;
     int cmd;
 
-    rig_debug(RIG_DEBUG_TRACE, "%s called\n", __func__);
+    ENTERFUNC;
 
     switch (level)
     {
@@ -575,7 +575,7 @@ static int ts590_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
         break;
 
     case RIG_LEVEL_AF:
-        return kenwood_set_level(rig, vfo, level, val);
+        RETURNFUNC(kenwood_set_level(rig, vfo, level, val));
 
     case RIG_LEVEL_SQL:
         kenwood_val = val.f * 255;
@@ -758,7 +758,7 @@ static int ts590_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
             val->f = roundl(levelint * 10 / 10.0 + .04) / 10.0;
         }
 
-        return retval;
+        RETURNFUNC(retval);
 
     case RIG_LEVEL_USB_AF_INPUT:
         cmd = 64; // TS-590S
@@ -779,30 +779,30 @@ static int ts590_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         return retval;
 
     case RIG_LEVEL_AF:
-        return kenwood_get_level(rig, vfo, level, val);
+        RETURNFUNC(kenwood_get_level(rig, vfo, level, val));
 
     case RIG_LEVEL_RF:
         retval = kenwood_transaction(rig, "RG", ackbuf, sizeof(ackbuf));
 
         if (RIG_OK != retval)
         {
-            return retval;
+            RETURNFUNC(retval);
         }
 
         ack_len = strlen(ackbuf);
 
         if (5 != ack_len)
         {
-            return -RIG_EPROTO;
+            RETURNFUNC(-RIG_EPROTO);
         }
 
         if (1 != sscanf(&ackbuf[2], "%d", &levelint))
         {
-            return -RIG_EPROTO;
+            RETURNFUNC(-RIG_EPROTO);
         }
 
         val->f = levelint / (float) 255;
-        return RIG_OK;
+        RETURNFUNC(RIG_OK);
 
     case RIG_LEVEL_SQL:
         retval = kenwood_transaction(rig, "SQ0", ackbuf, sizeof(ackbuf));
@@ -810,23 +810,23 @@ static int ts590_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 
         if (RIG_OK != retval)
         {
-            return retval;
+            RETURNFUNC(retval);
         }
 
         ack_len = strlen(ackbuf);
 
         if (ack_len != ack_len_expected)
         {
-            return -RIG_EPROTO;
+            RETURNFUNC(-RIG_EPROTO);
         }
 
         if (1 != sscanf(&ackbuf[ack_len_expected - 3], "%d", &levelint))
         {
-            return -RIG_EPROTO;
+            RETURNFUNC(-RIG_EPROTO);
         }
 
         val->f = (float) levelint / 255.;
-        return RIG_OK;
+        RETURNFUNC(RIG_OK);
 
     case RIG_LEVEL_AGC:
         priv->question_mark_response_means_rejected = 1;
@@ -836,19 +836,19 @@ static int ts590_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 
         if (RIG_OK != retval)
         {
-            return retval;
+            RETURNFUNC(retval);
         }
 
         ack_len = strlen(ackbuf);
 
         if (ack_len != ack_len_expected)
         {
-            return -RIG_EPROTO;
+            RETURNFUNC(-RIG_EPROTO);
         }
 
         if (1 != sscanf(&ackbuf[ack_len_expected - 2], "%d", &levelint))
         {
-            return -RIG_EPROTO;
+            RETURNFUNC(-RIG_EPROTO);
         }
 
         if (levelint == 0)
@@ -872,7 +872,7 @@ static int ts590_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
             val->i = RIG_AGC_SLOW;
         }
 
-        return RIG_OK;
+        RETURNFUNC(RIG_OK);
 
     case RIG_LEVEL_STRENGTH:
         if (CACHE(rig)->ptt != RIG_PTT_OFF)
@@ -881,7 +881,7 @@ static int ts590_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
             break;
         }
 
-        return kenwood_get_level(rig, vfo, level, val);
+        RETURNFUNC(kenwood_get_level(rig, vfo, level, val));
 
     case RIG_LEVEL_MONITOR_GAIN:
     {
@@ -1067,7 +1067,7 @@ static int ts590_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     }
 
     default:
-        return kenwood_get_level(rig, vfo, level, val);
+        RETURNFUNC(kenwood_get_level(rig, vfo, level, val));
     }
 
     RETURNFUNC(RIG_OK);

--- a/rigs/kenwood/ts590.c
+++ b/rigs/kenwood/ts590.c
@@ -533,7 +533,7 @@ static int ts590_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
         RETURNFUNC(RIG_OK);
 
     default:
-        return kenwood_get_func(rig, vfo, func, status);
+        RETURNFUNC(kenwood_get_func(rig, vfo, func, status));
     }
 
     RETURNFUNC(RIG_OK);
@@ -776,7 +776,7 @@ static int ts590_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
             val->f = roundl(levelint * 10 / 10.0) / 10.0;
         }
 
-        return retval;
+        RETURNFUNC(retval);
 
     case RIG_LEVEL_AF:
         RETURNFUNC(kenwood_get_level(rig, vfo, level, val));

--- a/rigs/kit/funcube.c
+++ b/rigs/kit/funcube.c
@@ -808,7 +808,6 @@ int funcube_hid_cmd(RIG *rig, unsigned char *au8BufOut, unsigned char *au8BufIn,
 
 int funcubepro_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
-    ENTERFUNC;
     int ret;
     unsigned char au8BufOut[64] = { 0 }; // endpoint size
     unsigned char au8BufIn[64] = { 0 };  // endpoint size
@@ -869,7 +868,6 @@ int funcubepro_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 
 int funcubepro_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
-    ENTERFUNC;
     int ret;
     int gain_state;
     unsigned char au8BufOut[64] = { 0 }; // endpoint size

--- a/rigs/motorola/micom.c
+++ b/rigs/motorola/micom.c
@@ -170,7 +170,7 @@ static int micom_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
     write_block(rp, ack, sizeof(ack));
     set_transaction_inactive(rig);
     *freq = (reply[4] << 24) | (reply[5] << 16) | (reply[6] << 8) | reply[7];
-    RETURNFUNC(RIG_OK);
+    RETURNFUNC2(RIG_OK);
 }
 
 static int micom_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)

--- a/rigs/prm80/prm80.c
+++ b/rigs/prm80/prm80.c
@@ -897,7 +897,7 @@ int prm80_set_channel(RIG *rig, vfo_t vfo, const channel_t *chan)
 
         if (ret < 0)
         {
-            RETURNFUNC(ret);
+            return ret;
         }
 
         if (ret == 3 && buf[2] == 'T')
@@ -908,7 +908,7 @@ int prm80_set_channel(RIG *rig, vfo_t vfo, const channel_t *chan)
 
             if (ret < 0)
             {
-                RETURNFUNC(ret);
+                return ret;
             }
 
             // Read extra space
@@ -916,7 +916,7 @@ int prm80_set_channel(RIG *rig, vfo_t vfo, const channel_t *chan)
 
             if (ret < 0)
             {
-                RETURNFUNC(ret);
+                return ret;
             }
 
             // Send confirmation
@@ -924,7 +924,7 @@ int prm80_set_channel(RIG *rig, vfo_t vfo, const channel_t *chan)
 
             if (ret < 0)
             {
-                RETURNFUNC(ret);
+                return ret;
             }
         }
 

--- a/rigs/yaesu/ft1000d.c
+++ b/rigs/yaesu/ft1000d.c
@@ -3827,7 +3827,7 @@ static int ft1000d_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
 
     err = rig_set_split_vfo(rig, vfo, RIG_SPLIT_ON, RIG_VFO_B);
 
-    if (err != RIG_OK) { RETURNFUNC(err); }
+    if (err != RIG_OK) { return err; }
 
 //  priv = (struct ft1000d_priv_data *)STATE(rig)->priv;
 

--- a/rigs/yaesu/ft1000mp.c
+++ b/rigs/yaesu/ft1000mp.c
@@ -1792,6 +1792,7 @@ static int ft1000mp_set_split_mode(RIG *rig, vfo_t vfo, rmode_t tx_mode,
                                    pbwidth_t tx_width)
 {
     int retval;
+    ENTERFUNC;
     retval = rig_set_mode(rig, RIG_VFO_B, tx_mode, tx_width);
     RETURNFUNC(retval);
 }
@@ -1800,6 +1801,7 @@ static int ft1000mp_get_split_mode(RIG *rig, vfo_t vfo, rmode_t *tx_mode,
                                    pbwidth_t *tx_width)
 {
     int retval;
+    ENTERFUNC;
     retval = rig_get_mode(rig, RIG_VFO_B, tx_mode, tx_width);
     RETURNFUNC(retval);
 }
@@ -1808,6 +1810,7 @@ static int ft1000mp_set_split_freq_mode(RIG *rig, vfo_t vfo, freq_t freq,
                                         rmode_t mode, pbwidth_t width)
 {
     int retval;
+    ENTERFUNC;
     retval = rig_set_mode(rig, RIG_VFO_B, mode, width);
 
     if (retval != RIG_OK)
@@ -1832,6 +1835,7 @@ static int ft1000mp_get_split_freq_mode(RIG *rig, vfo_t vfo, freq_t *freq,
                                         rmode_t *mode, pbwidth_t *width)
 {
     int retval;
+    ENTERFUNC;
     retval = rig_get_mode(rig, RIG_VFO_B, mode, width);
 
     if (retval != RIG_OK)

--- a/rigs/yaesu/ft736.c
+++ b/rigs/yaesu/ft736.c
@@ -391,7 +391,7 @@ int ft736_set_split_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
     int retval = rig_set_split_vfo(rig, RIG_VFO_A, RIG_SPLIT_ON, RIG_VFO_B);
 
-    if (retval != RIG_OK) { RETURNFUNC(retval); }
+    if (retval != RIG_OK) { return retval; }
 
     /* store bcd format in cmd (MSB) */
     to_bcd_be(cmd, freq / 10, 8);

--- a/rigs/yaesu/ft767gx.c
+++ b/rigs/yaesu/ft767gx.c
@@ -837,7 +837,7 @@ int ft767_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
 
     retval = rig_set_split_vfo(rig, RIG_VFO_A, RIG_SPLIT_ON, RIG_VFO_B);
 
-    if (retval != RIG_OK) { RETURNFUNC(retval); }
+    if (retval != RIG_OK) { return retval; }
 
     /* This appears to always pass in VFO_CURR as the vfo */
     /* My decision is to only update the xmit VFO if we're in split mode */

--- a/rigs/yaesu/ft857.c
+++ b/rigs/yaesu/ft857.c
@@ -1042,7 +1042,7 @@ int ft857_set_split_freq_mode(RIG *rig, vfo_t vfo, freq_t freq, rmode_t mode,
 
     retcode = rig_set_split_vfo(rig, RIG_VFO_A, RIG_SPLIT_ON, RIG_VFO_B);
 
-    if (retcode != RIG_OK) { RETURNFUNC(retcode); }
+    if (retcode != RIG_OK) { return retcode; }
 
 
     retcode = ft857_send_cmd(rig, FT857_NATIVE_CAT_SET_VFOAB);

--- a/rigs/yaesu/ft920.c
+++ b/rigs/yaesu/ft920.c
@@ -1715,7 +1715,7 @@ static int ft920_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
 
     err = rig_set_split_vfo(rig, RIG_VFO_A, RIG_SPLIT_ON, RIG_VFO_B);
 
-    if (err != RIG_OK) { RETURNFUNC(err); }
+    if (err != RIG_OK) { return err; }
 
     priv = (struct ft920_priv_data *)STATE(rig)->priv;
 

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -1628,7 +1628,7 @@ int newcat_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
     {
         rig_debug(RIG_DEBUG_WARN, "%s: Cannot get from rig when power is off\n",
                   __func__);
-        return RIG_OK; // to prevent repeats
+        RETURNFUNC(RIG_OK); // to prevent repeats
     }
 
     err = newcat_set_vfo_from_alias(rig, &vfo);
@@ -2749,6 +2749,7 @@ int newcat_get_split_mode(RIG *rig, vfo_t vfo, rmode_t *tx_mode,
 int newcat_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
 {
     int err;
+    ENTERFUNC;
     vfo_t rx_vfo = RIG_VFO_NONE;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: entered, rxvfo=%s, txvfo=%s, split=%d\n",
@@ -2767,7 +2768,7 @@ int newcat_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
         rig_debug(RIG_DEBUG_VERBOSE,
                   "%s: force set_split off since we're on 60M exception\n", __func__);
         split = RIG_SPLIT_OFF;
-        //return RIG_OK; // fake the return code to make things happy
+        //RETURNFUNC(RIG_OK); // fake the return code to make things happy
     }
 
     if (is_ft991)
@@ -4310,7 +4311,7 @@ int newcat_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
         {
             rig_debug(RIG_DEBUG_VERBOSE, "%s: rig cannot set MG in CW/RTTY modes\n",
                       __func__);
-            return RIG_OK;
+            RETURNFUNC(RIG_OK);
         }
 
 
@@ -11081,7 +11082,7 @@ int newcat_get_vfo_mode(RIG *rig, vfo_t vfo, vfo_t *vfo_mode)
     {
         rig_debug(RIG_DEBUG_WARN, "%s: Cannot get from rig when power is off\n",
                   __func__);
-        return RIG_OK; // to prevent repeats
+        RETURNFUNC(RIG_OK); // to prevent repeats
     }
 
     /* vfo, mem, P7 ************************** */
@@ -11179,7 +11180,7 @@ int newcat_get_cmd(RIG *rig)
     {
         rig_debug(RIG_DEBUG_WARN, "%s: Cannot get from rig when power is off\n",
                   __func__);
-        return RIG_OK; // to prevent repeats
+        RETURNFUNC(RIG_OK); // to prevent repeats
     }
 
     // try to cache rapid repeats of the IF command
@@ -11599,7 +11600,7 @@ repeat:
         if (strncmp(priv->cmd_str, "FA", 2) == 0
                 || strncmp(priv->cmd_str, "FB", 2) == 0)
         {
-            return RIG_OK;
+            RETURNFUNC(RIG_OK);
         }
 
         if (strncmp(priv->cmd_str, "PC", 2) == 0 && priv->ret_data[0] == '?')
@@ -11961,7 +11962,7 @@ int newcat_send_voice_mem(RIG *rig, vfo_t vfo, int ch)
 
     if (!newcat_valid_command(rig, "PB"))
     {
-        RETURNFUNC(-RIG_ENAVAIL);
+        RETURNFUNC2(-RIG_ENAVAIL);
     }
 
     // we don't do any channel checking -- varies by rig -- could do it but not critical
@@ -12185,7 +12186,7 @@ static int newcat_get_apf_frequency(RIG *rig, vfo_t vfo, int *freq)
 
     if (!newcat_valid_command(rig, "CO"))
     {
-        RETURNFUNC(-RIG_ENAVAIL);
+        RETURNFUNC2(-RIG_ENAVAIL);
     }
 
     if (is_ftdx101d || is_ftdx101mp)
@@ -12203,12 +12204,12 @@ static int newcat_get_apf_frequency(RIG *rig, vfo_t vfo, int *freq)
     }
     else
     {
-        RETURNFUNC(-RIG_ENIMPL);
+        RETURNFUNC2(-RIG_ENIMPL);
     }
 
     if ((err = newcat_get_cmd(rig)) != RIG_OK)
     {
-        RETURNFUNC(err);
+        RETURNFUNC2(err);
     }
 
     ret_data_len = strlen(priv->ret_data);

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -1037,12 +1037,12 @@ int newcat_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
                   __func__, rig_strvfo(vfo), rig_strvfo(rig_s->tx_vfo));
 
         // when in split we can change VFOB but not VFOA
-        if (cachep->split == RIG_SPLIT_ON && target_vfo == '0') { return -RIG_ENTARGET; }
+        if (cachep->split == RIG_SPLIT_ON && target_vfo == '0') { RETURNFUNC(-RIG_ENTARGET); }
 
         // when not in split we can't change VFOA at all
-        if (cachep->split == RIG_SPLIT_OFF && target_vfo == '0') { return -RIG_ENTARGET; }
+        if (cachep->split == RIG_SPLIT_OFF && target_vfo == '0') { RETURNFUNC(-RIG_ENTARGET); }
 
-        if (vfo != rig_s->tx_vfo) { return -RIG_ENTARGET; }
+        if (vfo != rig_s->tx_vfo) { RETURNFUNC(-RIG_ENTARGET); }
     }
 
     if (is_ftdx3000 || is_ftdx3000dm || is_ftdx5000 || is_ftdx1200)
@@ -1069,7 +1069,7 @@ int newcat_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
         }
         while (err == RIG_OK && ptt == RIG_PTT_ON && retry-- > 0);
 
-        if (ptt) { return -RIG_ENTARGET; }
+        if (ptt) { RETURNFUNC(-RIG_ENTARGET); }
     }
 
     if (RIG_MODEL_FT450 == caps->rig_model)
@@ -5129,7 +5129,7 @@ int newcat_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         {
             rig_debug(RIG_DEBUG_VERBOSE, "%s: rig cannot read MG in CW/RTTY modes\n",
                       __func__);
-            return RIG_OK;
+            RETURNFUNC(RIG_OK);
         }
 
         if (is_ft991 || is_ft710 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000
@@ -6961,7 +6961,7 @@ int newcat_set_parm(RIG *rig, setting_t parm, value_t val)
 
         default:
             rig_debug(RIG_DEBUG_ERR, "%s: Unknown band %s=%d\n", __func__, val.s, rigband);
-            return -RIG_EINVAL;
+            RETURNFUNC(-RIG_EINVAL);
         }
 
         SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "BS%02d%c", band, cat_term);
@@ -7646,7 +7646,7 @@ int newcat_scan(RIG *rig, vfo_t vfo, scan_t scan, int ch)
 
     ENTERFUNC;
 
-    if (scan != RIG_SCAN_VFO) { RETURNFUNC2(-RIG_EINVAL); }
+    if (scan != RIG_SCAN_VFO) { RETURNFUNC(-RIG_EINVAL); }
 
     SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "SC%d%c",
              scan == RIG_SCAN_STOP ? 0 : ch, cat_term);
@@ -7655,10 +7655,10 @@ int newcat_scan(RIG *rig, vfo_t vfo, scan_t scan, int ch)
     {
         rig_debug(RIG_DEBUG_VERBOSE, "%s:%d command err = %d\n", __func__, __LINE__,
                   retval);
-        RETURNFUNC2(retval);
+        RETURNFUNC(retval);
     }
 
-    RETURNFUNC2(retval);
+    RETURNFUNC(retval);
 }
 
 

--- a/rigs/yaesu/vx1700.c
+++ b/rigs/yaesu/vx1700.c
@@ -812,7 +812,7 @@ static int vx1700_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
     rig_debug(RIG_DEBUG_TRACE, "%s: freq=%f\n", __func__, tx_freq);
     int err = rig_set_split_vfo(rig, RIG_VFO_A, RIG_SPLIT_ON, RIG_VFO_B);
 
-    if (err != RIG_OK) { RETURNFUNC(err); }
+    if (err != RIG_OK) { return err; }
 
     return vx1700_do_freq_cmd(rig, VX1700_NATIVE_TX_FREQ_SET, tx_freq);
 }

--- a/src/network.c
+++ b/src/network.c
@@ -1601,7 +1601,7 @@ int network_multicast_publisher_start(RIG *rig, const char *multicast_addr,
     {
         rig_debug(RIG_DEBUG_WARN, "%s: No network found...multicast disabled\n",
                   __func__);
-        return RIG_OK;
+        RETURNFUNC(RIG_OK);
     }
 
 #endif
@@ -1610,7 +1610,7 @@ int network_multicast_publisher_start(RIG *rig, const char *multicast_addr,
     {
         rig_debug(RIG_DEBUG_TRACE, "%s(%d): not starting multicast publisher\n",
                   __FILE__, __LINE__);
-        return RIG_OK;
+        RETURNFUNC(RIG_OK);
     }
 
     status = network_init();

--- a/src/register.c
+++ b/src/register.c
@@ -230,7 +230,6 @@ int HAMLIB_API rig_register(struct rig_caps *caps)
     p->next = rig_hash_table[hval];
     rig_hash_table[hval] = p;
 
-    //RETURNFUNC(RIG_OK);
     return RIG_OK;
 }
 //! @endcond

--- a/src/rig.c
+++ b/src/rig.c
@@ -1140,7 +1140,7 @@ int HAMLIB_API rig_open(RIG *rig)
         rig_debug(RIG_DEBUG_VERBOSE, "%s: rs->comm_state==0?=%d\n", __func__,
                   rs->comm_state);
         rs->comm_state = 0;
-        rig->state.comm_status = RIG_COMM_STATUS_ERROR;
+        rs->comm_status = RIG_COMM_STATUS_ERROR;
         RETURNFUNC2(status);
     }
 
@@ -1358,7 +1358,7 @@ int HAMLIB_API rig_open(RIG *rig)
     if (status < 0)
     {
         port_close(rp, rp->type.rig);
-        rig->state.comm_status = RIG_COMM_STATUS_ERROR;
+        rs->comm_status = RIG_COMM_STATUS_ERROR;
         RETURNFUNC2(status);
     }
 
@@ -1371,7 +1371,7 @@ int HAMLIB_API rig_open(RIG *rig)
         if (status < 0)
         {
             port_close(rp, rp->type.rig);
-            rig->state.comm_status = RIG_COMM_STATUS_ERROR;
+            rs->comm_status = RIG_COMM_STATUS_ERROR;
             RETURNFUNC2(status);
         }
     }
@@ -1402,7 +1402,7 @@ int HAMLIB_API rig_open(RIG *rig)
 
             if (status == RIG_OK && (powerflag == RIG_POWER_OFF
                                      || powerflag == RIG_POWER_STANDBY)
-                    && rig->state.auto_power_on == 0)
+                    && rs->auto_power_on == 0)
             {
                 // rig_open() should succeed even if the rig is powered off, so simply log power status
                 rig_debug(RIG_DEBUG_ERR,
@@ -1440,7 +1440,7 @@ int HAMLIB_API rig_open(RIG *rig)
             port_close(rp, rp->type.rig);
             memcpy(&rs->rigport_deprecated, rp, sizeof(hamlib_port_t_deprecated));
             rs->comm_state = 0;
-            rig->state.comm_status = RIG_COMM_STATUS_ERROR;
+            rs->comm_status = RIG_COMM_STATUS_ERROR;
             RETURNFUNC2(status);
         }
     }
@@ -1478,7 +1478,7 @@ int HAMLIB_API rig_open(RIG *rig)
         }
     }
 
-    if (skip_init) { return RIG_OK; }
+    if (skip_init) { RETURNFUNC2(RIG_OK); }
 
 #if defined(HAVE_PTHREAD)
     // Some models don't support CW so don't need morse handler
@@ -1560,10 +1560,10 @@ int HAMLIB_API rig_open(RIG *rig)
     memcpy(&rs->rigport_deprecated, rp, sizeof(hamlib_port_t_deprecated));
     memcpy(&rs->pttport_deprecated, pttp, sizeof(hamlib_port_t_deprecated));
     memcpy(&rs->dcdport_deprecated, dcdp, sizeof(hamlib_port_t_deprecated));
-    int timesave = rig->state.timeout;
-    rig->state.timeout = 0;
+    int timesave = rs->timeout;
+    rs->timeout = 0;
     rig_flush_force(rp, 1);
-    rig->state.timeout = timesave;
+    rs->timeout = timesave;
 
 #if defined(HAVE_PTHREAD)
     enum multicast_item_e items = RIG_MULTICAST_POLL | RIG_MULTICAST_TRANSCEIVE
@@ -1601,7 +1601,7 @@ int HAMLIB_API rig_open(RIG *rig)
 
 #endif
 
-    rig->state.comm_status = RIG_COMM_STATUS_OK;
+    rs->comm_status = RIG_COMM_STATUS_OK;
 
     add_opened_rig(rig);
 
@@ -1916,9 +1916,11 @@ int HAMLIB_API rig_get_twiddle(RIG *rig, int *seconds)
 static int twiddling(RIG *rig)
 {
     const struct rig_caps *caps;
+    struct rig_state *rs = STATE(rig);
 
-    if (rig->state.twiddle_timeout == 0) { return 0; } // don't detect twiddling
+    if (rs->twiddle_timeout == 0) { return 0; } // don't detect twiddling
 
+    ENTERFUNC2;
     caps = rig->caps;
 
     if (caps->get_freq)    // gotta have get_freq of course
@@ -1930,31 +1932,31 @@ static int twiddling(RIG *rig)
         HAMLIB_TRACE;
         retval2 = caps->get_freq(rig, RIG_VFO_CURR, &curr_freq);
 
-        if (retval2 == RIG_OK && rig->state.current_freq != curr_freq)
+        if (retval2 == RIG_OK && rs->current_freq != curr_freq)
         {
             rig_debug(RIG_DEBUG_TRACE,
                       "%s: Somebody twiddling the VFO? last_freq=%.0f, curr_freq=%.0f\n", __func__,
-                      rig->state.current_freq, curr_freq);
+                      rs->current_freq, curr_freq);
 
-            if (rig->state.current_freq == 0)
+            if (rs->current_freq == 0)
             {
-                rig->state.current_freq = curr_freq;
+                rs->current_freq = curr_freq;
                 RETURNFUNC2(0); // not twiddling as first time freq is being set
             }
 
-            rig->state.twiddle_time = time(NULL); // update last twiddle time
-            rig->state.current_freq = curr_freq; // we have a new freq to remember
+            rs->twiddle_time = time(NULL); // update last twiddle time
+            rs->current_freq = curr_freq; // we have a new freq to remember
             rig_set_cache_freq(rig, RIG_VFO_CURR, curr_freq);
         }
 
-        elapsed = time(NULL) - rig->state.twiddle_time;
+        elapsed = time(NULL) - rs->twiddle_time;
 
-        if (elapsed < rig->state.twiddle_timeout)
+        if (elapsed < rs->twiddle_timeout)
         {
             rig_debug(RIG_DEBUG_TRACE, "%s: Twiddle elapsed < %d, elapsed=%d\n", __func__,
-                      rig->state.twiddle_timeout, elapsed);
-            rig->state.twiddle_state = TWIDDLE_ON; // gets turned off in rig_set_freq;
-            RETURNFUNC(1); // would be better as error but other software won't handle it
+                      rs->twiddle_timeout, elapsed);
+            rs->twiddle_state = TWIDDLE_ON; // gets turned off in rig_set_freq;
+            RETURNFUNC2(1); // would be better as error but other software won't handle it
         }
     }
 
@@ -2141,6 +2143,7 @@ int rig_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
     if (skip_freq(rig, vfo))
     {
+        ELAPSED2;
         LOCK(0);
         RETURNFUNC(RIG_OK);
     }
@@ -4443,10 +4446,9 @@ int HAMLIB_API rig_set_rptr_offs(RIG *rig, vfo_t vfo, shortfreq_t rptr_offs)
 
     if (!caps->set_vfo)
     {
+        ELAPSED2;
         RETURNFUNC(-RIG_ENAVAIL);
     }
-
-    ELAPSED2;
 
     curr_vfo = rig->state.current_vfo;
     HAMLIB_TRACE;
@@ -4579,14 +4581,13 @@ int HAMLIB_API rig_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
     vfo_t curr_vfo, tx_vfo = RIG_VFO_CURR;
     freq_t tfreq = 0;
 
-    ENTERFUNC2;
-
     if (CHECK_RIG_ARG(rig))
     {
         rig_debug(RIG_DEBUG_ERR, "%s: rig or rig->caps is null\n", __func__);
         return -RIG_EINVAL;
     }
 
+    ENTERFUNC2;
     ELAPSED1;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called vfo=%s, curr_vfo=%s, tx_freq=%.0f\n",
@@ -4654,7 +4655,7 @@ int HAMLIB_API rig_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
 
             if (retcode != RIG_OK)
             {
-                RETURNFUNC(retcode);
+                RETURNFUNC2(retcode);
             }
 
 #if 0 // this verification seems to be causing bad behavior on some rigs
@@ -5016,7 +5017,7 @@ int HAMLIB_API rig_set_split_mode(RIG *rig,
         RETURNFUNC(retcode);
     }
 
-    curr_vfo = rig->state.current_vfo;
+    curr_vfo = rs->current_vfo;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: curr_vfo=%s, tx_vfo=%s\n", __func__,
               rig_strvfo(curr_vfo), rig_strvfo(tx_vfo));
@@ -5600,7 +5601,7 @@ int HAMLIB_API rig_set_split_vfo(RIG *rig,
     {
         rig_debug(RIG_DEBUG_WARN, "%s: cannot execute when PTT is on\n", __func__);
         ELAPSED2;
-        return RIG_OK;
+        RETURNFUNC(RIG_OK);
     }
 
     if (rx_vfo == RIG_VFO_NONE || tx_vfo == RIG_VFO_NONE)
@@ -6623,8 +6624,10 @@ int HAMLIB_API rig_mW2power(RIG *rig,
 
     if (!rig || !rig->caps || !power || mwpower == 0)
     {
-        RETURNFUNC2(-RIG_EINVAL);
+        return -RIG_EINVAL;
     }
+
+    ENTERFUNC2;
 
     if (rig->caps->mW2power != NULL)
     {
@@ -7832,6 +7835,7 @@ int HAMLIB_API rig_get_rig_info(RIG *rig, char *response, int max_response_len)
 
     response[0] = 0;
     ELAPSED1;
+    ENTERFUNC2;
 
     vfoA = vfo_fixup(rig, RIG_VFO_A, cachep->split);
     vfoB = vfo_fixup(rig, RIG_VFO_B, cachep->split);
@@ -8015,6 +8019,7 @@ int HAMLIB_API rig_get_vfo_list(RIG *rig, char *buf, int buflen)
 int HAMLIB_API rig_set_clock(RIG *rig, int year, int month, int day, int hour,
                              int min, int sec, double msec, int utc_offset)
 {
+    ENTERFUNC2;
     if (rig->caps->set_clock == NULL)
     {
         return -RIG_ENIMPL;
@@ -8039,6 +8044,7 @@ int HAMLIB_API rig_get_clock(RIG *rig, int *year, int *month, int *day,
         return -RIG_ENIMPL;
     }
 
+    ENTERFUNC2;
     retval = rig->caps->get_clock(rig, year, month, day, hour, min, sec,
                                   msec, utc_offset);
     RETURNFUNC2(retval);
@@ -8735,7 +8741,8 @@ HAMLIB_EXPORT(int) rig_send_raw(RIG *rig, const unsigned char *send,
                   __func__, rig->caps->model_name);
         memcpy(reply, send, send_len);
         retval = send_len;
-        return retval;
+        ELAPSED2;
+        RETURNFUNC(retval);
     }
     else
     {
@@ -8784,6 +8791,7 @@ HAMLIB_EXPORT(int) rig_send_raw(RIG *rig, const unsigned char *send,
                 rig_debug(RIG_DEBUG_ERR, "%s: read_string, result=%d\n", __func__, retval);
                 rig_flush_force(rp, 1);
                 set_transaction_inactive(rig);
+                ELAPSED2;
                 RETURNFUNC(retval);
             }
 
@@ -8795,7 +8803,8 @@ HAMLIB_EXPORT(int) rig_send_raw(RIG *rig, const unsigned char *send,
                           __func__, reply_len, nbytes);
                 rig_flush_force(rp, 1);
                 set_transaction_inactive(rig);
-                return -RIG_EINVAL;
+                ELAPSED2;
+                RETURNFUNC(-RIG_EINVAL);
             }
         }
 
@@ -8805,6 +8814,7 @@ HAMLIB_EXPORT(int) rig_send_raw(RIG *rig, const unsigned char *send,
     {
         rig_flush_force(rp, 1);
         set_transaction_inactive(rig);
+        ELAPSED2;
         RETURNFUNC(retval);
     }
 

--- a/src/rig.c
+++ b/src/rig.c
@@ -2609,7 +2609,7 @@ int HAMLIB_API rig_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
             rig_cache_show(rig, __func__, __LINE__);
             rig_set_cache_freq(rig, vfo, *freq);
             rig_cache_show(rig, __func__, __LINE__);
-            /* return the first error code */
+            /* Return the first error code */
             retcode = rc2;
         }
     }
@@ -2850,7 +2850,7 @@ int HAMLIB_API rig_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         /* try and revert even if we had an error above */
         rc2 = caps->set_vfo(rig, curr_vfo);
 
-        /* return the first error code */
+        /* Return the first error code */
         if (retcode == RIG_OK)
         {
             retcode = rc2;
@@ -3019,7 +3019,7 @@ int HAMLIB_API rig_get_mode(RIG *rig,
 
         if (RIG_OK == retcode)
         {
-            /* return the first error code */
+            /* Return the first error code */
             retcode = rc2;
         }
     }
@@ -3613,7 +3613,7 @@ int HAMLIB_API rig_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
                     rc2 = caps->set_vfo(rig, curr_vfo);
                 }
 
-                /* return the first error code */
+                /* Return the first error code */
                 if (RIG_OK == retcode)
                 {
                     retcode = rc2;
@@ -3908,7 +3908,7 @@ int HAMLIB_API rig_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
 
             if (RIG_OK == retcode)
             {
-                /* return the first error code */
+                /* Return the first error code */
                 retcode = rc2;
                 cachep->ptt = *ptt;
                 elapsed_ms(&cachep->time_ptt, HAMLIB_ELAPSED_SET);
@@ -4173,7 +4173,7 @@ int HAMLIB_API rig_get_dcd(RIG *rig, vfo_t vfo, dcd_t *dcd)
 
         if (RIG_OK == retcode)
         {
-            /* return the first error code */
+            /* Return the first error code */
             retcode = rc2;
         }
 
@@ -4305,7 +4305,7 @@ int HAMLIB_API rig_set_rptr_shift(RIG *rig, vfo_t vfo, rptr_shift_t rptr_shift)
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -4389,7 +4389,7 @@ int HAMLIB_API rig_get_rptr_shift(RIG *rig, vfo_t vfo, rptr_shift_t *rptr_shift)
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -4466,7 +4466,7 @@ int HAMLIB_API rig_set_rptr_offs(RIG *rig, vfo_t vfo, shortfreq_t rptr_offs)
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -4549,7 +4549,7 @@ int HAMLIB_API rig_get_rptr_offs(RIG *rig, vfo_t vfo, shortfreq_t *rptr_offs)
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -4738,7 +4738,7 @@ int HAMLIB_API rig_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -4908,7 +4908,7 @@ int HAMLIB_API rig_get_split_freq(RIG *rig, vfo_t vfo, freq_t *tx_freq)
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -5144,7 +5144,7 @@ int HAMLIB_API rig_set_split_mode(RIG *rig,
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -5299,7 +5299,7 @@ int HAMLIB_API rig_get_split_mode(RIG *rig, vfo_t vfo, rmode_t *tx_mode,
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -5761,7 +5761,7 @@ int HAMLIB_API rig_set_split_vfo(RIG *rig,
 
         if (RIG_OK == retcode)
         {
-            /* return the first error code */
+            /* Return the first error code */
             retcode = rc2;
         }
     }
@@ -5962,7 +5962,7 @@ int HAMLIB_API rig_set_rit(RIG *rig, vfo_t vfo, shortfreq_t rit)
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -6040,7 +6040,7 @@ int HAMLIB_API rig_get_rit(RIG *rig, vfo_t vfo, shortfreq_t *rit)
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -6112,7 +6112,7 @@ int HAMLIB_API rig_set_xit(RIG *rig, vfo_t vfo, shortfreq_t xit)
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -6190,7 +6190,7 @@ int HAMLIB_API rig_get_xit(RIG *rig, vfo_t vfo, shortfreq_t *xit)
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -6262,7 +6262,7 @@ int HAMLIB_API rig_set_ts(RIG *rig, vfo_t vfo, shortfreq_t ts)
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -6339,7 +6339,7 @@ int HAMLIB_API rig_get_ts(RIG *rig, vfo_t vfo, shortfreq_t *ts)
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -6417,7 +6417,7 @@ int HAMLIB_API rig_set_ant(RIG *rig, vfo_t vfo, ant_t ant, value_t option)
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -6511,7 +6511,7 @@ int HAMLIB_API rig_get_ant(RIG *rig, vfo_t vfo, ant_t ant, value_t *option,
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -7018,7 +7018,7 @@ int HAMLIB_API rig_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op)
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -7126,7 +7126,7 @@ int HAMLIB_API rig_scan(RIG *rig, vfo_t vfo, scan_t scan, int ch)
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -7202,7 +7202,7 @@ int HAMLIB_API rig_send_dtmf(RIG *rig, vfo_t vfo, const char *digits)
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -7279,7 +7279,7 @@ int HAMLIB_API rig_recv_dtmf(RIG *rig, vfo_t vfo, char *digits, int *length)
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -7376,7 +7376,7 @@ int HAMLIB_API rig_send_morse(RIG *rig, vfo_t vfo, const char *msg)
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -7445,7 +7445,7 @@ int HAMLIB_API rig_stop_morse(RIG *rig, vfo_t vfo)
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -7545,7 +7545,7 @@ int HAMLIB_API rig_wait_morse(RIG *rig, vfo_t vfo)
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 
@@ -7616,7 +7616,7 @@ int HAMLIB_API rig_send_voice_mem(RIG *rig, vfo_t vfo, int ch)
 
     if (RIG_OK == retcode)
     {
-        /* return the first error code */
+        /* Return the first error code */
         retcode = rc2;
     }
 

--- a/tests/func_chk.c
+++ b/tests/func_chk.c
@@ -1,48 +1,93 @@
-/* this can change for balanced ENTERFUNC/RETURNFUNC statements */
+/* This can check for balanced ENTERFUNC/RETURNFUNC statements */
 /* RETURNFUNC2 is used when ENTERFUNC is not used in a function */
+//
+// Still may give false positives for /* */ comments or string literals
+// Have to live with them until we can "borrow" a C parser/tokenizer
+//  that doesn't bloat the build requirements.
+//
+// Note that this is very dependent on the Hamlib coding style
 #include <stdio.h>
 #include <string.h>
 
 int main(int argc, const char *argv[])
 {
     char buf[4096];
-    char buf2[4096];
-    FILE *fp = fopen(argv[1], "r");
-    int linenum = 0;
-    int enterfunc = 0;
+    const char *fname;
+    char *s;
+    FILE *fp;
+    int idx, inafunc;
+    int linenum;
+    int enterfunc;
     int retval = 0;
-    retval = 0;
 
-    while (fgets(buf, sizeof(buf), fp))
-    {
-        ++linenum;
-        buf[16] = 0;
+    for (idx = 1; idx < argc; idx++)
+      {
+	fp = fopen(argv[idx], "r");
+	if (fp == NULL) { fprintf(stderr, "Can't open %s\n", argv[idx]); continue;}
+#if 0
+	if (!(fname = strrchr(argv[idx], '/')))
+	  {
+	    fname = argv[idx];
+	  }
+	else
+	  {
+	    fname++;
+	  }
+#else
+	fname = argv[idx];
+#endif
+	linenum = enterfunc = inafunc = 0;
 
-        if (strstr(buf, "ENTERFUNC;")) { enterfunc = 1; }
+	while (fgets(buf, sizeof(buf), fp))
+	  {
+	    ++linenum;
 
-        if (enterfunc && strstr(buf, "RETURNFUNC2"))
-        {
-            printf("Line#%d need RETURNFUNC %s\n", linenum, argv[1]);
-            retval = 1;
-        }
+	    if (buf[0] == '{')
+	      {  //start of a function definition
+		inafunc = 1;
+		enterfunc = 0;
+		continue;
+	      }
+	    else if (buf[0] == '}')
+	      {  // end of function definition; back to comments
+		inafunc = 0;
+	      }
 
-        strcpy(buf2, buf);
-        buf2[15] = 0; // truncate the string
+	    if (!inafunc)
+	      {  // Not in a function, ignore everything
+		continue;
+	      }
 
-        if (!enterfunc && strstr(buf2, "RETURNFUNC("))
-        {
-            printf("Line#%d need RETURNFUNC2 %s\n", linenum, argv[1]);
-            retval = 1;
-        }
+	    // Take care of // comments
+	    if ((s = strstr(buf, "//")))
+	      {
+		*s = '\0';
+	      }
 
-        if (strstr(buf2, "RETURNFUNC("))
-        {
-            if (enterfunc == 0) { printf("Line#%d no matching ENTERFUNC %s\n", linenum, argv[1]); }
+	    if (strstr(buf, "ENTERFUNC;")) { enterfunc = 1; }
 
-            enterfunc = 0;
-        }
-    }
+	    if (enterfunc && (strstr(buf, "RETURNFUNC2") || strstr(buf, "return ")
+			      || strstr(buf, "return;")))
+	      {
+		printf("%s:%d need RETURNFUNC\n", fname, linenum);
+		retval = 1;
+	      }
 
-    fclose(fp);
+	    //TODO: Fix next to make a better guess at what's missing
+	    if (!enterfunc && strstr(buf, "RETURNFUNC("))
+	      {
+		printf("%s:%d need RETURNFUNC2\n", fname, linenum);
+		retval = 1;
+	      }
+
+	    if (strstr(buf, "RETURNFUNC("))
+	      {
+		if (enterfunc == 0) { printf("%s:%d no matching ENTERFUNC\n", fname, linenum); }
+	      }
+	  }
+
+	//printf("%s:%d Done\n", fname, linenum);
+	fclose(fp);
+      }
     return retval;
 }

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -3521,7 +3521,7 @@ declare_proto_rig(get_level)
             RETURNFUNC2(-RIG_EINVAL);
         }
 
-        RETURNFUNC(RIG_OK);
+        RETURNFUNC2(RIG_OK);
     }
 
 
@@ -5095,7 +5095,7 @@ declare_proto_rig(send_cmd)
         flrig_cat_string2(rig, arg1, (char*)buf, sizeof(buf));
         fwrite(cmd->arg2, 1, strlen(cmd->arg2), fout); /* i.e. "Frequency" */
         fprintf(fout, ": %s\n", buf);
-        RETURNFUNC(RIG_OK);
+        RETURNFUNC2(RIG_OK);
     }
 
     // need to move the eom_buf to rig-specifc backends


### PR DESCRIPTION
Balance calls to the various debug/trace macros.  Keep the depth count as well as can be expected.

Make func_chk do more useful things.  It's not bullet-proof; keywords/tokens in comments can still confuse it, but it is better than it was.
