### PR TITLE
Implement kenwood_get_clock + fixes for TZ offsets 

### DIFF
--- a/rigs/kenwood/kenwood.h
+++ b/rigs/kenwood/kenwood.h
@@ -264,6 +264,8 @@ int kenwood_get_id(RIG *rig, char *buf);
 int kenwood_get_if(RIG *rig);
 int kenwood_send_voice_mem(RIG *rig, vfo_t vfo, int bank);
 int kenwood_stop_voice_mem(RIG *rig, vfo_t vfo);
+int kenwood_get_clock(RIG *rig, int *year, int *month, int *day, int *hour, int *min, int *sec, double *msec, int *utc_offset);
+int kenwood_set_clock(RIG *rig, int year, int month, int day, int hour, int min, int sec, double msec, int utc_offset);
 
 int kenwood_set_trn(RIG *rig, int trn);
 int kenwood_get_trn(RIG *rig, int *trn);

--- a/rigs/kenwood/ts890s.c
+++ b/rigs/kenwood/ts890s.c
@@ -661,5 +661,7 @@ struct rig_caps ts890s_caps =
     .has_set_func = TS890_FUNC_ALL,
     .set_func = ts890_set_func,
     .get_func = ts890_get_func,
+    .get_clock = kenwood_get_clock,
+    .set_clock = kenwood_set_clock,
     .hamlib_check_rig_caps = HAMLIB_CHECK_RIG_CAPS
 };

--- a/rigs/kenwood/ts890s.c
+++ b/rigs/kenwood/ts890s.c
@@ -41,7 +41,7 @@
 
 #define TS890_VFO_OPS (RIG_OP_UP|RIG_OP_DOWN|RIG_OP_BAND_UP|RIG_OP_BAND_DOWN|RIG_OP_CPY|RIG_OP_TUNE)
 
-int kenwood_ts890_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
+static int kenwood_ts890_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
     char levelbuf[16], *command_string;
     int kenwood_val, retval;
@@ -109,7 +109,7 @@ int kenwood_ts890_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
     return kenwood_transaction(rig, levelbuf, NULL, 0);
 }
 
-int kenwood_ts890_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
+static int kenwood_ts890_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
     char ackbuf[50];
     size_t ack_len, ack_len_expected, len;
@@ -403,7 +403,7 @@ int kenwood_ts890_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     return -RIG_EINTERNAL;
 }
 
-int ts890_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
+static int ts890_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
 {
     int mask, retval;
     char current[4];
@@ -434,7 +434,7 @@ int ts890_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
     return kenwood_transaction(rig, current, NULL, 0);
 }
 
-int ts890_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
+static int ts890_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
 {
     int mask, retval;
     char current[4];

--- a/rigs/kenwood/ts990s.c
+++ b/rigs/kenwood/ts990s.c
@@ -373,6 +373,8 @@ struct rig_caps ts990s_caps =
     .set_powerstat =  kenwood_set_powerstat,
     .get_powerstat =  kenwood_get_powerstat,
     .reset =  kenwood_reset,
+    .get_clock = kenwood_get_clock,
+    .set_clock = kenwood_set_clock,
     .hamlib_check_rig_caps = HAMLIB_CHECK_RIG_CAPS
 };
 
@@ -381,7 +383,7 @@ struct rig_caps ts990s_caps =
  */
 
 /*
- * ts2000_get_level
+ * ts990s_get_level
  * Assumes rig!=NULL, val!=NULL
  */
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -2834,7 +2834,7 @@ char *date_strget(char *buf, int buflen, int localtime)
     if (localtime)
     {
         mytm = localtime_r(&t, &result);
-        mytimezone = timezone;
+        mytimezone = - (int)result.tm_gmtoff;
     }
     else
     {

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -5657,7 +5657,7 @@ declare_proto_rig(set_clock)
               __func__, n, year, mon, day, hour, min, sec, msec, utc_offset >= 0 ? "+" : "-",
               (unsigned)abs(utc_offset));
 
-    if (utc_offset < 24) { utc_offset *= 100; } // allow for minutes offset too
+    if (abs(utc_offset) < 24) { utc_offset *= 100; } // allow for minutes offset too
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: utc_offset=%d\n", __func__, utc_offset);
 


### PR DESCRIPTION
Small fixes for computing time zone for setting clocks
Implement rig_get_clock for TS-890S & TS-990S, and enable in simts890.c

rig_set_clock will take some more thought
