### PR TITLE
Loads of code for simts890.c

### DIFF
--- a/simulators/simts890.c
+++ b/simulators/simts890.c
@@ -16,6 +16,7 @@ struct ip_mreq
 #include <unistd.h>
 #include <errno.h>
 #include <ctype.h>
+#include <time.h>
 #include <hamlib/rig.h>
 
 #define BUFSIZE 256
@@ -241,10 +242,10 @@ int main(int argc, char *argv[])
         else if (strcmp(buf, "NB1;") == 0)
         {
             hl_usleep(mysleep * 20);
-            sprintf(buf,"NB1%d;", nb1);
+            sprintf(buf, "NB1%d;", nb1);
             OUTPUT(buf);
         }
-        else if (strncmp(buf, "NB1",3) == 0)
+        else if (strncmp(buf, "NB1", 3) == 0)
         {
             puts(buf);
             sscanf(buf, "NB1%d", &nb1);
@@ -252,10 +253,10 @@ int main(int argc, char *argv[])
         else if (strcmp(buf, "NB2;") == 0)
         {
             hl_usleep(mysleep * 20);
-            sprintf(buf,"NB2%d;", nb2);
+            sprintf(buf, "NB2%d;", nb2);
             OUTPUT(buf);
         }
-        else if (strncmp(buf, "NB2",3) == 0)
+        else if (strncmp(buf, "NB2", 3) == 0)
         {
             puts(buf);
             sscanf(buf, "NB2%d", &nb2);
@@ -263,7 +264,7 @@ int main(int argc, char *argv[])
         else if (strcmp(buf, "RA;") == 0)
         {
             hl_usleep(mysleep * 200);
-            sprintf(buf,"RA%d;", ra);
+            sprintf(buf, "RA%d;", ra);
             OUTPUT(buf);
         }
         else if (strncmp(buf, "RA", 2) == 0)
@@ -291,12 +292,12 @@ int main(int argc, char *argv[])
         else if (strcmp(buf, "FV;") == 0)
         {
             hl_usleep(mysleep * 1000);
-            pbuf = "FV1.04;";
+            pbuf = "FV1.05;";
             OUTPUT(pbuf);
         }
         else if (strncmp(buf, "IS;", 3) == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "IS%+04d;", is);
+            snprintf(buf, sizeof(buf), "IS%+04d;", is);
             OUTPUT(buf);
         }
         else if (strncmp(buf, "IS", 2) == 0)
@@ -305,12 +306,12 @@ int main(int argc, char *argv[])
         }
         else if (strncmp(buf, "SM;", 3) == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "SM0035;");
-            OUTPUT(buf);
+            pbuf = "SM0035;";
+            OUTPUT(pbuf);
         }
         else if (strncmp(buf, "PC;", 3) == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "PC%03d;", pc);
+            snprintf(buf, sizeof(buf), "PC%03d;", pc);
             OUTPUT(buf);
         }
         else if (strncmp(buf, "PC", 2) == 0)
@@ -334,7 +335,7 @@ int main(int argc, char *argv[])
         {
             hl_usleep(mysleep * 1000);
             int id = 24;
-            SNPRINTF(buf, sizeof(buf), "ID%03d;", id);
+            snprintf(buf, sizeof(buf), "ID%03d;", id);
             OUTPUT(buf);
         }
 
@@ -471,7 +472,7 @@ int main(int argc, char *argv[])
 #if 0
         else if (strncmp(buf, "DA;", 3) == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "DA%d;", datamode);
+            snprintf(buf, sizeof(buf), "DA%d;", datamode);
             OUTPUT(buf);
         }
         else if (strncmp(buf, "DA", 2) == 0)
@@ -575,7 +576,7 @@ int main(int argc, char *argv[])
 		{
 		  if (meter[i].enabled)
 		    {
-		      SNPRINTF(tbuf, sizeof tbuf, "RM%d%03d;", i + 1, meter[i].value);
+		      snprintf(tbuf, sizeof tbuf, "RM%d%03d;", i + 1, meter[i].value);
 		      pbuf = stpcpy(pbuf, tbuf);
 		    }
 		}
@@ -703,7 +704,7 @@ int main(int argc, char *argv[])
         }
         else if (strncmp(buf, "RL1;", 3) == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "RL%02d;", rl);
+            snprintf(buf, sizeof(buf), "RL%02d;", rl);
             OUTPUT(buf);
         }
         else if (strncmp(buf, "RL1", 2) == 0)
@@ -878,7 +879,7 @@ int main(int argc, char *argv[])
         { // TF-SET
 	    if (buf[2] == ';')
             {
-                SNPRINTF(buf, sizeof buf, "TS%d;", tfset);
+                snprintf(buf, sizeof buf, "TS%d;", tfset);
                 OUTPUT(buf);
                 continue;
             }

--- a/simulators/simts890.c
+++ b/simulators/simts890.c
@@ -212,19 +212,6 @@ int main(int argc, char *argv[])
 		    (ptt + ptt_mic + ptt_data + ptt_tune) > 0 ? 1 : 0, vfoLR[0]->mode);
             OUTPUT(ifbuf);
         }
-#if 0
-        else if (strncmp(buf, "RM2", 3) == 0)
-        {
-            pbuf = "RM20020;";
-            OUTPUT(pbuf);
-        }
-        else if (strcmp(buf, "RM5;") == 0)
-        {
-            hl_usleep(mysleep * 1000);
-            pbuf = "RM5100000;";
-            OUTPUT(pbuf);
-        }
-#endif
         else if (strncmp(buf, "AN", 2) == 0)
         {  // Antenna connection handling
             hl_usleep(mysleep * 1000);
@@ -325,19 +312,6 @@ int main(int argc, char *argv[])
         {
             sscanf(buf,"PC%d", &pc);
         }
-#if 0
-        else if (strcmp(buf, "FW1;") == 0)
-        {
-            //usleep(mysleep * 1000);
-            pbuf = "FW10;";
-            OUTPUT(pbuf);
-            hl_usleep(20 * 1000);
-        }
-        else if (strncmp(buf, "FW", 2) == 0)
-        {
-            continue;
-        }
-#endif
         else if (strcmp(buf, "ID;") == 0)
         {
             hl_usleep(mysleep * 1000);
@@ -345,18 +319,6 @@ int main(int argc, char *argv[])
             snprintf(buf, sizeof(buf), "ID%03d;", id);
             OUTPUT(buf);
         }
-
-#if 0
-        else if (strncmp(buf, "AI", 2) == 0)
-        {
-            if (strcmp(buf, "AI;"))
-            {
-                hl_usleep(mysleep * 1000);
-                n = fprintf(fp, "%s", "AI0;");
-            }
-        }
-
-#endif
         else if (strcmp(buf, "EX00011;") == 0)
         {
             pbuf = "EX00011 001;";
@@ -426,18 +388,6 @@ int main(int argc, char *argv[])
 
             printf("modeA=%X, modeB=%X\n", vfoA->mode, vfoB->mode);
         }
-#if 0
-        else if (strncmp(buf, "MD;", 3) == 0)
-        {
-            snprintf(buf, sizeof(buf), "MD%d;",
-                     vfoA->mode); // not worried about modeB yet for simulator
-            OUTPUT(buf);
-        }
-        else if (strncmp(buf, "MD", 2) == 0)
-        {
-            sscanf(buf, "MD%d", &vfoA->mode); // not worried about modeB yet for simulator
-        }
-#endif
         else if (strncmp(buf, "FL", 2) == 0)
         {
             switch (buf[2]) {
@@ -472,17 +422,6 @@ int main(int argc, char *argv[])
                 split = 1;
             }
         }
-#if 0
-        else if (strncmp(buf, "DA;", 3) == 0)
-        {
-            snprintf(buf, sizeof(buf), "DA%d;", datamode);
-            OUTPUT(buf);
-        }
-        else if (strncmp(buf, "DA", 2) == 0)
-        {
-            sscanf(buf, "DA%d", &datamode);
-        }
-#endif
         else if (strncmp(buf, "BD;", 3) == 0)
         {
             continue;
@@ -510,18 +449,6 @@ int main(int argc, char *argv[])
 	      break;
             }
         }
-#if 0
-        else if (strncmp(buf, "CB;", 3) == 0)
-        {
-            printf("No CB command!\n");
-            sprintf(buf, "CB%d;", operatingband);
-            OUTPUT(buf);
-        }
-        else if (strncmp(buf, "CB", 2) == 0)
-        {
-            sscanf(buf, "CB%d", &operatingband);
-        }
-#endif
         else if (strncmp(buf, "TB;", 3) == 0)
         {
             sprintf(buf, "TB%d;", split);


### PR DESCRIPTION
New commands: OM, TS, BD/BU, DN/UP, FC, UD, EC, VV, plus a few placeholders
Reworked: EX, FA/FB, SF, SP, NB, FR, FT, FL

What started out as a simple task (add OM, fix wrong mode after band change) turned into a trip down the rabbit hole that is the TS-890S's VFOs.  Would have been easier if Kenwood had only used one naming convention for them, but trying to reconcile both left/right and A/B with hamlib's notion of A/B was a real hassle.  If only they had stuck with the TS-990S Main/Sub...

Now that the simulator matches more of the real world, I may start on putting some of these into the gaps in ts890.c; but after a break.
