### PR TITLE
Change Kenwood _send_morse() for TS-890/990

### DIFF
--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -5572,7 +5572,8 @@ int kenwood_send_morse(RIG *rig, vfo_t vfo, const char *msg)
             SNPRINTF(morsebuf, sizeof(morsebuf), "KY %-24s", m2);
 
 #if 0 // Why is this here?? 0x20 == ' '
-            for (int i = strlen(morsebuf) - 1; i > 0 && morsebuf[i] == ' '; --i)
+            int i;
+            for (i = strlen(morsebuf) - 1; i > 0 && morsebuf[i] == ' '; --i)
             {
                 morsebuf[i] = 0x20;
             }

--- a/simulators/simts890.c
+++ b/simulators/simts890.c
@@ -927,6 +927,24 @@ int main(int argc, char *argv[])
         {
             sscanf(buf, "KS%03d", &keyspd);
         }
+        else if (strncmp(buf, "KY", 2) == 0)
+            { // CW Keying
+                if (buf[2] == ';')
+                {
+                     // Checking status - we always have room
+                     OUTPUT("KY0;");
+                }
+            else if (buf[3] == ';')
+            {
+                // Stop sending(?)
+                if (buf[2] != '0') {cmd_err = 1; }
+            }
+            else
+            {
+                // Send the message
+                //printf("CW mesg: %s\n", buf + 2);
+            }
+        }
         else if (strncmp(buf, "OM", 2) == 0)
         {
             // Operating Mode


### PR DESCRIPTION
Use variable length messages for CW keying - drops extra space in output, shortens message by a bunch.

Doesn't help TS-480/590, sorry.

Issue #1634 