### PR TITLE
Drop addional unwanted space after message

### DIFF
--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -5551,6 +5551,11 @@ int kenwood_send_morse(RIG *rig, vfo_t vfo, const char *msg)
             SNPRINTF(morsebuf, sizeof(morsebuf), "KY %s", m2);
             break;
 
+        case RIG_MODEL_TS590S:
+            /* the command must consist of 28 bytes right aligned */
+            SNPRINTF(morsebuf, sizeof(morsebuf), "KY %24s", m2);
+	    break;
+
         default:
             /* the command must consist of 28 bytes 0x20 padded */
             SNPRINTF(morsebuf, sizeof(morsebuf), "KY %-24s", m2);


### PR DESCRIPTION
Kenwood_send_morse adds an unwanted space after each transmission on TS-590S model (see issue 1634).

Tests showed that all space before any message gets ignored and all trailing spaces (if any) were compressed to exactly one space.

The patch changes the alignment to the right therefore leaving no trailing unwanted spaces.