### PR TITLE
Added multi-stage Docker build and hamlib-runtime image

### DIFF
--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:latest AS hamlib-base-image
 ENV DEBIAN_FRONTEND="noninteractive" TZ="Etc/UTC"
 
 RUN apt-get update \
-	&& apt-get install -y vim git build-essential automake libtool python3.6 \
+	&& apt-get install -y vim git build-essential automake libtool python-is-python3 \
 	&& rm -rf /var/lib/apt/lists/* 
 
 # Builder Image

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,21 +1,27 @@
-# Idea from https://github.com/ok2cqr/cqrlog
+# Base Image
+FROM ubuntu:latest AS hamlib-base-image
 
-FROM ubuntu:latest
+ENV DEBIAN_FRONTEND="noninteractive" TZ="Etc/UTC"
 
-RUN apt-get update && apt-get -y upgrade
+RUN apt-get update && apt-get install -y build-essential automake libtool python3 && rm -rf /var/lib/apt/lists/* 
 
-ENV DEBIAN_FRONTEND="noninteractive" TZ="Europe/London"
+# Builder Image
+FROM hamlib-base-image AS hamlib-builder
 
-RUN apt-get install -y git build-essential automake libtool
+COPY . /tmp/build
 
-RUN mkdir -p /usr/local/hamlib-alpha /home/hamlib/build
+WORKDIR /tmp/build
 
-# Mount point for the git repository:
-VOLUME ["/home/hamlib/build"]
+RUN mkdir -p /tmp/local
 
-# Mount point for the result of the build:
-VOLUME ["/usr/local/hamlib-alpha"]
+RUN ./bootstrap && ./configure --prefix=/tmp/local \
+	&& make clean && make -j && make install
 
-WORKDIR /home/hamlib/build
+# Runtime Image
+FROM ubuntu:latest AS hamlib-runtime
 
-ENTRYPOINT rm -rf build && mkdir -p build && cd build && ../bootstrap && ../configure --prefix=/usr/local/hamlib-alpha && make clean && make && make install
+COPY --from=hamlib-builder /tmp/local/bin /usr/local/bin
+COPY --from=hamlib-builder /tmp/local/lib /usr/local/lib
+COPY --from=hamlib-builder /tmp/local/share /usr/local/share
+
+ENV LD_LIBRARY_PATH="/usr/local/lib"

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -3,25 +3,24 @@ FROM ubuntu:latest AS hamlib-base-image
 
 ENV DEBIAN_FRONTEND="noninteractive" TZ="Etc/UTC"
 
-RUN apt-get update && apt-get install -y build-essential automake libtool python3 && rm -rf /var/lib/apt/lists/* 
+RUN apt-get update \
+	&& apt-get install -y build-essential automake libtool python3.6 \
+	&& rm -rf /var/lib/apt/lists/* 
 
 # Builder Image
+
 FROM hamlib-base-image AS hamlib-builder
 
-COPY . /tmp/build
+COPY . /wip
 
-WORKDIR /tmp/build
+WORKDIR /wip
 
-RUN mkdir -p /tmp/local
-
-RUN ./bootstrap && ./configure --prefix=/tmp/local \
-	&& make clean && make -j && make install
+RUN ./bootstrap && ./configure --prefix=/usr/local \
+	&& make clean && make -j${nproc} && make install
 
 # Runtime Image
 FROM ubuntu:latest AS hamlib-runtime
 
-COPY --from=hamlib-builder /tmp/local/bin /usr/local/bin
-COPY --from=hamlib-builder /tmp/local/lib /usr/local/lib
-COPY --from=hamlib-builder /tmp/local/share /usr/local/share
+COPY --from=hamlib-builder /usr/local /usr/local
 
 ENV LD_LIBRARY_PATH="/usr/local/lib"

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:latest AS hamlib-base-image
 ENV DEBIAN_FRONTEND="noninteractive" TZ="Etc/UTC"
 
 RUN apt-get update \
-	&& apt-get install -y build-essential automake libtool python3.6 \
+	&& apt-get install -y vim git build-essential automake libtool python3.6 \
 	&& rm -rf /var/lib/apt/lists/* 
 
 # Builder Image

--- a/docker-build/README.Docker.md
+++ b/docker-build/README.Docker.md
@@ -1,0 +1,71 @@
+
+# Build the hamlib-runtime from the repository root 
+
+```
+docker buildx build \
+	--platform linux/amd64,linux/arm64 \
+	--target hamlib-runtime \
+	-t hamlib-runtime \
+	-f docker-build/Dockerfile \
+	.
+```
+
+# Interactively, develop with the hamlib-base-image
+
+
+## Support the linux/amd64 and linux/arm64 platforms
+```
+docker buildx build \
+	--platform linux/amd64,linux/arm64 \
+	--target hamlib-base-image \
+	-t hamlib-base-image \
+	-f docker-build/Dockerfile \
+	.
+```
+
+## Develop on the linux/amd64 hamlib-base-image
+
+```
+docker run \
+	-it \
+	--rm \
+	--platform linux/amd64 \
+	-v $(pwd):/wip \
+	-w /wip \
+	-u $(id -u):$(id -g) \
+	hamlib-base-image bash
+```
+
+...or the linux/arm64 hamlib-base-image
+
+```
+docker run \
+	-it \
+	--rm \
+	--platform linux/arm64 \
+	-v $(pwd):/wip \
+	-w /wip \
+	-u $(id -u):$(id -g) \
+	hamlib-base-image bash
+```
+
+# Run the linux/amd64 hamlib-runtime
+
+```
+docker run \
+	-it \
+	--rm \
+	--platform linux/amd64 \
+	hamlib-runtime bash
+```
+
+ ...or the linux/arm64 hamlib-runtime
+
+```
+docker run \
+	-it \
+	--rm \
+	--platform linux/arm64 \
+	hamlib-runtime bash
+```
+

--- a/docker-build/README.docker
+++ b/docker-build/README.docker
@@ -1,7 +1,0 @@
-
-# Build, execute from the repository root 
-`docker buildx build --platform linux/amd64,linux/arm64 -t hamlib-runtime -f docker-build/Dockerfile .`
-
-# Run the hamlib-runtime
-`docker run -it hamlib-runtime bash`
-

--- a/docker-build/README.docker
+++ b/docker-build/README.docker
@@ -1,13 +1,7 @@
-This is all about building hamlib inside docker container - so that you do not need to install dependencies on your local machine.
 
-1. Build docker container
+# Build, execute from the repository root 
+`docker buildx build -t hamlib-runtime -f docker-build/Dockerfile .`
 
-(cd docker-build && docker build --no-cache -t this.registry.is.invalid/hamlib-build .)
+# Run the hamlib-runtime
+`docker run -it hamlib-runtime bash`
 
-2. Build hamlib
-
-docker run -ti -u root -v $(pwd):/home/hamlib/build -v /usr/local/hamlib-alpha:/usr/local/hamlib-alpha this.registry.is.invalid/hamlib-build
-
-3. Execute hamlib
-
-/usr/local/hamlib-alpha/bin/rigctl <your options here>

--- a/docker-build/README.docker
+++ b/docker-build/README.docker
@@ -1,6 +1,6 @@
 
 # Build, execute from the repository root 
-`docker buildx build -t hamlib-runtime -f docker-build/Dockerfile .`
+`docker buildx build --platform linux/amd64,linux/arm64 -t hamlib-runtime -f docker-build/Dockerfile .`
 
 # Run the hamlib-runtime
 `docker run -it hamlib-runtime bash`


### PR DESCRIPTION
I added a multi-stage build to simplify and speed up the build process. The docker-build README provides the user with instructions on how to execute the hamlib-runtime container after the build is complete.