### PR TITLE
Fix unbalanced ENTERFUNC/RETURNFUNC pairs in icom.c

### DIFF
--- a/rigs/dummy/aclog.c
+++ b/rigs/dummy/aclog.c
@@ -834,7 +834,7 @@ static int aclog_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     }
 
     rig_debug(RIG_DEBUG_TRACE,
-              "%s: return modeA=%s, widthA=%d\n,modeB=%s, widthB=%d\n", __func__,
+              "%s: Return modeA=%s, widthA=%d\n,modeB=%s, widthB=%d\n", __func__,
               rig_strrmode(priv->curr_modeA), (int)priv->curr_widthA,
               rig_strrmode(priv->curr_modeB), (int)priv->curr_widthB);
     RETURNFUNC(RIG_OK);

--- a/rigs/dummy/flrig.c
+++ b/rigs/dummy/flrig.c
@@ -943,7 +943,7 @@ static int flrig_open(RIG *rig)
 
     if (priv->has_get_bwA)
     {
-        /* see if get_bwB is available FLRig can return empty value too */
+        // see if get_bwB is available FLRig can return empty value too
         retval = flrig_transaction(rig, "rig.get_bwB", NULL, value, sizeof(value));
 
         if (retval == RIG_ENAVAIL || strlen(value) == 0) // must not have it
@@ -1667,7 +1667,7 @@ static int flrig_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     }
 
     rig_debug(RIG_DEBUG_TRACE,
-              "%s: return modeA=%s, widthA=%d\n,modeB=%s, widthB=%d\n", __func__,
+              "%s: Return modeA=%s, widthA=%d\n,modeB=%s, widthB=%d\n", __func__,
               rig_strrmode(priv->curr_modeA), (int)priv->curr_widthA,
               rig_strrmode(priv->curr_modeB), (int)priv->curr_widthB);
     RETURNFUNC(RIG_OK);
@@ -1792,7 +1792,7 @@ static int flrig_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
         if (strlen(value) ==
                 0) // sometimes we get a null reply here -- OK...deal with it
         {
-            rig_debug(RIG_DEBUG_WARN, "%s: empty value return cached bandwidth\n",
+            rig_debug(RIG_DEBUG_WARN, "%s: empty value, returning cached bandwidth\n",
                       __func__);
             *width = CACHE(rig)->widthMainA;
             RETURNFUNC(RIG_OK);
@@ -1819,7 +1819,7 @@ static int flrig_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
 
             if (strlen(value) == 0)
             {
-                rig_debug(RIG_DEBUG_WARN, "%s: empty value return cached bandwidth\n",
+                rig_debug(RIG_DEBUG_WARN, "%s: empty value, returning cached bandwidth\n",
                           __func__);
                 *width = CACHE(rig)->widthMainA;
                 RETURNFUNC(RIG_OK);

--- a/rigs/dummy/netrigctl.c
+++ b/rigs/dummy/netrigctl.c
@@ -280,7 +280,7 @@ static int netrigctl_open(RIG *rig)
     }
     else
     {
-        rig_debug(RIG_DEBUG_ERR, "%s:  unknown return from netrigctl_transaction=%d\n",
+        rig_debug(RIG_DEBUG_ERR, "%s:  unknown value returned from netrigctl_transaction=%d\n",
                   __func__, ret);
     }
 

--- a/rigs/dummy/tci1x.c
+++ b/rigs/dummy/tci1x.c
@@ -1281,7 +1281,7 @@ static int tci1x_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     }
 
     rig_debug(RIG_DEBUG_TRACE,
-              "%s: return modeA=%s, widthA=%d\n,modeB=%s, widthB=%d\n", __func__,
+              "%s: Return modeA=%s, widthA=%d\n,modeB=%s, widthB=%d\n", __func__,
               rig_strrmode(priv->curr_modeA), (int)priv->curr_widthA,
               rig_strrmode(priv->curr_modeB), (int)priv->curr_widthB);
     RETURNFUNC(RIG_OK);

--- a/rigs/icom/frame.c
+++ b/rigs/icom/frame.c
@@ -150,9 +150,8 @@ int icom_one_transaction(RIG *rig, unsigned char cmd, int subcmd,
 
     ctrl_id = priv_caps->serial_full_duplex == 0 ? CTRLID : 0x80;
 
-    /*
-     * should check return code and that write wrote cmd_len chars!
-     */
+    // Should check return code and that write wrote cmd_len chars!
+
     set_transaction_active(rig);
 
 collision_retry:
@@ -204,7 +203,7 @@ again1:
         if (retval < 0)
         {
             set_transaction_inactive(rig);
-            /* Other error, return it */
+            // Other error, return it
             RETURNFUNC(retval);
         }
 
@@ -390,8 +389,8 @@ again2:
                       __func__, priv_caps->re_civ_addr, priv->re_civ_addr);
         }
 
-        /* RIG_TIMEOUT: timeout getting response, return timeout */
-        /* other error: return it */
+        // RIG_TIMEOUT: timeout getting response, return timeout
+        // other error: return it
         RETURNFUNC(frm_len);
     }
 

--- a/rigs/icom/icom.c
+++ b/rigs/icom/icom.c
@@ -1190,7 +1190,7 @@ retry_open:
         rig_debug(RIG_DEBUG_ERR,
                   "%s: Unable to determine Icom echo status -- is rig on and connected?\n",
                   __func__);
-        return retval_echo;
+        RETURNFUNC(retval_echo);
     }
     else
     {
@@ -2687,7 +2687,7 @@ int icom_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     if (width <= 3)
     {
         rig_debug(RIG_DEBUG_TRACE, "%s: setting filter=%d\n", __func__, (int)width);
-        return RIG_OK;
+        RETURNFUNC(RIG_OK);
     }
 
     if (((width != RIG_PASSBAND_NOCHANGE) && (width != current_width))

--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -5518,12 +5518,11 @@ int kenwood_send_morse(RIG *rig, vfo_t vfo, const char *msg)
                 RETURNFUNC(retval);
             }
 
-            /*
-             * If answer is "KY0;", there is space in buffer and we can proceed.
-             * If answer is "KY1;", we have to wait a while
-             * If answer is "KY2;", there is space in buffer and we aren't sending so we can proceed.
-             * If answer is something else, return with error to prevent infinite loops
-             */
+            // If answer is "KY0;", there is space in buffer and we can proceed.
+            // If answer is "KY1;", we have to wait a while
+            // If answer is "KY2;", there is space in buffer and we aren't sending so we can proceed.
+            // If answer is something else, return with error to prevent infinite loops
+
             if (!strncmp(m2, "KY0", 3)) { break; }
 
             if (!strncmp(m2, "KY2", 3)) { break; }

--- a/rigs/yaesu/ft1000mp.c
+++ b/rigs/yaesu/ft1000mp.c
@@ -963,7 +963,7 @@ static int ft1000mp_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
               f,
               vfo);
 
-    *freq = f;                    /* return displayed frequency */
+    *freq = f;                    // return displayed frequency
 
     RETURNFUNC(RIG_OK);
 }
@@ -1542,7 +1542,7 @@ static int ft1000mp_get_rxit(RIG *rig, vfo_t vfo, shortfreq_t *rit)
     rig_debug(RIG_DEBUG_TRACE, "%s: freq = %d Hz for VFO [%s]\n", __func__, (int)f,
               rig_strvfo(vfo));
 
-    *rit = f;     /* return displayed frequency */
+    *rit = f;     // return displayed frequency
 
     RETURNFUNC(RIG_OK);
 }

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -11342,7 +11342,7 @@ int newcat_get_cmd(RIG *rig)
                 RETURNFUNC(-RIG_ENAVAIL);
 
             case 'O':
-                /* Too many characters sent without a carriage return */
+                // Too many characters sent without a carriage return
                 rig_debug(RIG_DEBUG_VERBOSE, "%s: Overflow for '%s'\n", __func__,
                           priv->cmd_str);
                 rc = -RIG_EPROTO;
@@ -11776,7 +11776,7 @@ int newcat_set_cmd(RIG *rig)
                 RETURNFUNC(-RIG_ENAVAIL);
 
             case 'O':
-                /* Too many characters sent without a carriage return */
+                // Too many characters sent without a carriage return
                 rig_debug(RIG_DEBUG_VERBOSE, "%s: Overflow for '%s'\n", __func__,
                           priv->cmd_str);
                 rc = -RIG_EPROTO;

--- a/src/rig.c
+++ b/src/rig.c
@@ -1697,10 +1697,8 @@ int HAMLIB_API rig_close(RIG *rig)
 
 #endif
 
-    /*
-     * Let the backend say 73s to the rig.
-     * and ignore the return code.
-     */
+    // Let the backend say 73 to the rig.
+    // and ignore the return code.
     if (caps->rig_close)
     {
         caps->rig_close(rig);
@@ -3145,14 +3143,14 @@ pbwidth_t HAMLIB_API rig_passband_normal(RIG *rig, rmode_t mode)
     {
         if (rs->filters[i].modes & mode)
         {
-            rig_debug(RIG_DEBUG_VERBOSE, "%s: return filter#%d, width=%d\n", __func__, i,
+            rig_debug(RIG_DEBUG_VERBOSE, "%s: Return filter#%d, width=%d\n", __func__, i,
                       (int)rs->filters[i].width);
             RETURNFUNC(rs->filters[i].width);
         }
     }
 
     rig_debug(RIG_DEBUG_VERBOSE,
-              "%s: filter not found...return %d\n", __func__,
+              "%s: filter not found...returning %d\n", __func__,
               0);
     RETURNFUNC(0);
 }
@@ -3407,7 +3405,7 @@ int HAMLIB_API rig_set_vfo(RIG *rig, vfo_t vfo)
         rig_set_cache_freq(rig, RIG_VFO_ALL, 0);
     }
 
-    rig_debug(RIG_DEBUG_TRACE, "%s: return %d, vfo=%s, curr_vfo=%s\n", __func__,
+    rig_debug(RIG_DEBUG_TRACE, "%s: returning %d, vfo=%s, curr_vfo=%s\n", __func__,
               retcode,
               rig_strvfo(vfo), rig_strvfo(rs->current_vfo));
     ELAPSED2;
@@ -3838,7 +3836,7 @@ int HAMLIB_API rig_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
     cachep->ptt = ptt;
     elapsed_ms(&cachep->time_ptt, HAMLIB_ELAPSED_SET);
 
-    if (retcode != RIG_OK) { rig_debug(RIG_DEBUG_ERR, "%s: return code=%d\n", __func__, retcode); }
+    if (retcode != RIG_OK) { rig_debug(RIG_DEBUG_ERR, "%s: Return code=%d\n", __func__, retcode); }
 
     memcpy(&rs->pttport_deprecated, pttp,
            sizeof(rs->pttport_deprecated));


### PR DESCRIPTION
Also tweak comments/formats to eliminate false positives in code base
   (except for the Catch-22 ones in tests/func_chk.c itself)