### PR TITLE
Fix kendwood_priv_data definition

### DIFF
--- a/rigs/kenwood/kenwood.h
+++ b/rigs/kenwood/kenwood.h
@@ -183,7 +183,7 @@ struct kenwood_priv_data
     int save_k2_ext_lvl; // so we can restore to original
     int save_k3_ext_lvl; // so we can restore to original -- for future use if needed
     int voice_bank; /* last voice bank send for use by stop_voice_mem */
-    mode_t last_mode_pc; // last mode memory for PC command
+    rmode_t last_mode_pc; // last mode memory for PC command
     int power_now,power_min,power_max;
 };
 


### PR DESCRIPTION
When compiling Hamlib 4.6 on Alpine Linux, the build fails with the following error message:

    kenwood.h:186:5: error: unknown type name 'mode_t'; did you mean 'rmode_t'?

According to the man page for mode_t (on Debian), the standard C library provides this type and it is an integer type. The struct member last_mode_pc is compared with curr_mode which has type rmode_t so this commit updates the definition to use this type.

With this change, Hamlib 4.6 builds successfully on Alpine Linux 3.21.0.