### PR TITLE
Convert text encoding from ISO-8859-1 to UTF-8

### DIFF
--- a/rigs/aor/README.ar5000
+++ b/rigs/aor/README.ar5000
@@ -24,4 +24,4 @@ Now, it:
 - filter-list mode/bw rearranged.
 - list of tuning steps corrected.
 
-Göran Sandin, SM6PPS
+GÃ¶ran Sandin, SM6PPS

--- a/rigs/kenwood/ts450s.c
+++ b/rigs/kenwood/ts450s.c
@@ -106,7 +106,7 @@ int ts450_open(RIG *rig)
 /*
  * ts450s rig capabilities.
  * Notice that some rigs share the same functions.
- * RIT: Variable Range ±9.99 kHz
+ * RIT: Variable Range Â±9.99 kHz
  *
  * TODO: protocol to be checked with manual (identical to TS690)
  *  - get_channel/set_channel: MR/MW

--- a/rigs/kenwood/ts570.c
+++ b/rigs/kenwood/ts570.c
@@ -893,7 +893,7 @@ int ts570_set_xit(RIG *rig, vfo_t vfo, shortfreq_t rit)
 /*
  * ts570 rig capabilities.
  * Notice that some rigs share the same functions.
- * RIT: Variable Range ±9.99 kHz
+ * RIT: Variable Range Â±9.99 kHz
  *
  * part of infos comes from .http = //www.kenwood.net/
  */
@@ -1079,7 +1079,7 @@ struct rig_caps ts570s_caps =
 /*
  * ts570d rig capabilities, which is basically the ts570s without 6m.
  * Notice that some rigs share the same functions.
- * RIT: Variable Range ±9.99 kHz
+ * RIT: Variable Range Â±9.99 kHz
  *
  * part of infos comes from .http = //www.kenwood.net/
  */

--- a/rigs/kenwood/ts870s.c
+++ b/rigs/kenwood/ts870s.c
@@ -530,7 +530,7 @@ static int ts870s_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 /*
  * ts870s rig capabilities.
  * Notice that some rigs share the same functions.
- * RIT: Variable Range ±9.99 kHz
+ * RIT: Variable Range Â±9.99 kHz
  *
  * part of infos comes from .http = //www.kenwood.net/
  */

--- a/rigs/kit/drt1.c
+++ b/rigs/kit/drt1.c
@@ -290,7 +290,7 @@ int drt1_get_conf(RIG *rig, hamlib_token_t token, char *val)
 The clock multiplier should be set to 8x at start value (possible, that this
 will change to lower clock multiplier).
 
-The charge pump current to 75 µA at start value (possible will change).
+The charge pump current to 75 ÂµA at start value (possible will change).
 
 The VCO gain bit has to be set.
 
@@ -425,7 +425,7 @@ int drt1_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
     /*
      * CFR2:
-     *  clock multiplier set to 8x, charge pump current to 75 µA
+     *  clock multiplier set to 8x, charge pump current to 75 ÂµA
      *  VCO gain bit has to be set
      */
     cfr2 = ((priv->ref_mult << 3) & 0xf8) | 0x4 |

--- a/rigs/kit/elektor304.c
+++ b/rigs/kit/elektor304.c
@@ -71,7 +71,7 @@ static int elektor304_get_conf(RIG *rig, hamlib_token_t token, char *val);
 /*
  * The Elektor DRM Receiver 3/04 COM interface is based on the Visual Basic
  * source code by Burkhard Kainka which can be downloaded from www.b-kainka.de
- * Linux support is based on a code written by Markus März:
+ * Linux support is based on a code written by Markus MÃ¤rz:
  *  http://mitglied.lycos.de/markusmaerz/drm
  * Linux support is available from DRM Dream project.
  *


### PR DESCRIPTION
This PR converts text in comments from ISO-8859-1 to UTF-8 for consistency with other files.
In the diff below, for some reason, github shows the same glyph before/after for ± µ ä but the actual difference is visible when using `git diff` in the terminal.