### PR TITLE
Prepare for 4.6.1 release

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,7 @@ dnl Please do not use '-' in the version number, as package managers will fail,
 dnl however, the use of '~' should be fine as apt (others?) will treat
 dnl it as an earlier version than the actual release.  TNX KA6MAL
 dnl PACKAGE_NAME + " " + PACKAGE_VERSION must not exceed 20 chars!
-AC_INIT([Hamlib],[4.7~git],[hamlib-developer@lists.sourceforge.net],[hamlib],[http://www.hamlib.org])
+AC_INIT([Hamlib],[4.6.1],[hamlib-developer@lists.sourceforge.net],[hamlib],[http://www.hamlib.org])
 #AC_INIT([PRODUCT_NAME], [Hamlib])
 #AC_DEFINE([Hamlib], [PRODUCT_VERSION_RESOURCE])
 
@@ -76,7 +76,7 @@ dnl See README.release on setting these values
 # Set them here to keep c++/Makefile and src/Makefile in sync.
 ABI_VERSION=4
 ABI_REVISION=6
-ABI_PATCH=0
+ABI_PATCH=1
 ABI_AGE=0
 
 AC_DEFINE_UNQUOTED([ABI_VERSION], [$ABI_VERSION], [Frontend ABI version])


### PR DESCRIPTION
Making this a branch off of the current master as it just has fixes since the 4.6 release.