### PR TITLE
Update skywatcher.c

### DIFF
--- a/rotators/skywatcher/skywatcher.c
+++ b/rotators/skywatcher/skywatcher.c
@@ -67,15 +67,6 @@ static int skywatcher_cmd(ROT *rot, const char *cmd, char *response,
         return -code;
     }
 
-    // the actual response
-    code = read_string(port, (unsigned char *) response, response_len, "\r", 1, 0,
-                       1);
-
-    if (code < 0)
-    {
-        return -code;
-    }
-
     // nullify last \r
     response[strlen(response) - 1] = '\0';
 


### PR DESCRIPTION
Probably by mistake the call to read data from the serial port was left twice. Therefore, controlling Skywatcher mounts does not work and ends with a timeout. Otherwise, excellent work - since all Skywatcher mounts use the same motor controller firmware, it is possible to control not only Allview but all mounts from this manufacturer.