### PR TITLE
Updates to codan_set_ptt command and README.md

### DIFF
--- a/rigs/codan/README.codan
+++ b/rigs/codan/README.codan
@@ -13,4 +13,4 @@ the device which is addressed via the GP port.
 As of SDR firmware V3.51 for Envoy and Sentry radios, the Amatuer option
 allows for Freetune Tx on ham bands only. Freetune Tx is no longer required
 for this rig file to work.
-$${\color{lightblue}VK5MCA}$$
+VK5MCA

--- a/rigs/codan/README.codan
+++ b/rigs/codan/README.codan
@@ -9,3 +9,8 @@ programming.  This is most often the GP (general purpose) port which
 is a 15-pin D-Sub connector on a flying lead on the back of the radio.
 (NGT and Envoy models).  Programming must be set to select "CICS" as
 the device which is addressed via the GP port.
+
+As of SDR firmware V3.51 for Envoy and Sentry radios, the Amatuer option
+allows for Freetune Tx on ham bands only. Freetune Tx is no longer required
+for this rig file to work.
+$${\color{lightblue}VK5MCA}$$

--- a/rigs/codan/codan.c
+++ b/rigs/codan/codan.c
@@ -473,7 +473,6 @@ int codan_get_ptt_2110(RIG *rig, vfo_t vfo, ptt_t *ptt)
  * VK5MCA
  * Changing PTT activation from 'connect tcvr rf ptt %s' to CICS command 'ptt %s voice'.
  * This sets fast ALC and allows audio to pass to the transmitter via the GPIO port.
- * Using the 'rf ptt' command does allow audio to pass through the GPIO port of the Envoy RF Unit or Console.
  */
 int codan_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 {

--- a/rigs/codan/codan.c
+++ b/rigs/codan/codan.c
@@ -469,6 +469,11 @@ int codan_get_ptt_2110(RIG *rig, vfo_t vfo, ptt_t *ptt)
 /*
  * codan_set_ptt
  * Assumes rig!=NULL
+ *
+ * VK5MCA
+ * Changing PTT activation from 'connect tcvr rf ptt %s' to CICS command 'ptt %s voice'.
+ * This sets fast ALC and allows audio to pass to the transmitter via the GPIO port.
+ * Using the 'rf ptt' command does allow audio to pass through the GPIO port of the Envoy RF Unit or Console.
  */
 int codan_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 {
@@ -478,7 +483,7 @@ int codan_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: ptt=%d\n", __func__, ptt);
 
-    SNPRINTF(cmd_buf, sizeof(cmd_buf), "connect tcvr rf ptt %s\rptt",
+    SNPRINTF(cmd_buf, sizeof(cmd_buf), "ptt %s voice\rptt",
              ptt == 0 ? "off" : "on");
     response = NULL;
     retval = codan_transaction(rig, cmd_buf, 0, &response);


### PR DESCRIPTION
Closes: #1702 

Updates to codan_set_ptt command in codan.c to allow for audio from GPIO port to be passed to the transmitter and to set fast ALC.
Updates to the README.md is to notify operators of V3.51 changes to amateur mode.

VK5MCA