### PR TITLE
Fix sscanf() truncating input from thousands separator

### DIFF
--- a/rigs/dummy/aclog.c
+++ b/rigs/dummy/aclog.c
@@ -461,7 +461,7 @@ static int aclog_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
     char *p = strstr(value, "<FREQ>");
     *freq = 0;
 
-    if (p) { sscanf(p, "<FREQ>%lf", freq); }
+    if (p) { sscanf(p, "<FREQ>%'lf", freq); }
 
     *freq *= 1e6; // convert from MHz to Hz
 


### PR DESCRIPTION
Per Github issue #1704, N3FJP logger sends a string with an embedded comma for frequencies above 1 GHz resulting in such frequencies being truncated.  This patch uses the optional apostrophe character in the sscanf() format string to ignore the thousands separator.

A possible bug is when the locale of the system on which libhamlib is executing uses a dot for the thousands separator rather than a comma. It is unclear if the N3FJP software obeys such locales or not.  If this turns out to be an issue then this fix will need to be reconsidered.