### PR TITLE
Fix/typos

### DIFF
--- a/bindings/ignore.swg
+++ b/bindings/ignore.swg
@@ -141,7 +141,6 @@
 %ignore rig_mW2power;
 %ignore rig_get_resolution;
 %ignore rig_set_level;
-%ignore rig_set_ext_level;
 %ignore rig_get_level;
 %ignore rig_set_parm;
 %ignore rig_get_parm;

--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -861,11 +861,10 @@ typedef enum {
 typedef long hamlib_token_t;
 #define token_t hamlib_token_t
 
-
-//! @cond Doxygen_Suppress
+/**
+ * \brief configuration token not found
+ */
 #define RIG_CONF_END 0
-//! @endcond
-
 
 /**
  * \brief parameter types

--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -744,7 +744,7 @@ typedef enum {
  * NOTE: the vfo argument for some vfo operation may be irrelevant,
  * and thus will be ignored.
  *
- * The VFO/MEM "mode" is set by rig_set_vfo.\n
+ * The VFO/MEM "mode" is set by #rig_set_vfo.\n
  * \c STRING used in rigctl
  *
  * \sa rig_parse_vfo_op(), rig_strvfop()
@@ -1065,10 +1065,10 @@ typedef uint64_t rig_level_e;
 #define RIG_LEVEL_KEYSPD     CONSTANT_64BIT_FLAG(14)      /*!< \c KEYSPD -- Key Speed, arg int (WPM) */
 #define RIG_LEVEL_NOTCHF     CONSTANT_64BIT_FLAG(15)      /*!< \c NOTCHF -- Notch Freq., arg int (Hz) */
 #define RIG_LEVEL_COMP       CONSTANT_64BIT_FLAG(16)      /*!< \c COMP -- Compressor, arg float [0.0 ... 1.0] */
-#define RIG_LEVEL_AGC        CONSTANT_64BIT_FLAG(17)      /*!< \c AGC -- AGC, arg int (see enum agc_level_e) */
+#define RIG_LEVEL_AGC        CONSTANT_64BIT_FLAG(17)      /*!< \c AGC -- AGC, arg int (see enum #agc_level_e) */
 #define RIG_LEVEL_BKINDL     CONSTANT_64BIT_FLAG(18)      /*!< \c BKINDL -- BKin Delay, arg int (tenth of dots) */
 #define RIG_LEVEL_BALANCE    CONSTANT_64BIT_FLAG(19)      /*!< \c BAL -- Balance (Dual Watch) arg float [0.0 ... 1.0] */
-#define RIG_LEVEL_METER      CONSTANT_64BIT_FLAG(20)      /*!< \c METER -- Display meter, arg int (see enum meter_level_e) */
+#define RIG_LEVEL_METER      CONSTANT_64BIT_FLAG(20)      /*!< \c METER -- Display meter, arg int (see enum #meter_level_e) */
 #define RIG_LEVEL_VOXGAIN    CONSTANT_64BIT_FLAG(21)      /*!< \c VOXGAIN -- VOX gain level, arg float [0.0 ... 1.0] */
 #define RIG_LEVEL_ANTIVOX    CONSTANT_64BIT_FLAG(22)      /*!< \c ANTIVOX -- anti-VOX level, arg float [0.0 ... 1.0] */
 #define RIG_LEVEL_SLOPE_LOW  CONSTANT_64BIT_FLAG(23)      /*!< \c SLOPE_LOW -- Slope tune, low frequency cut, arg int (Hz) */
@@ -1091,7 +1091,7 @@ typedef uint64_t rig_level_e;
 #define RIG_LEVEL_MONITOR_GAIN CONSTANT_64BIT_FLAG(37)      /*!< \c MONITOR_GAIN -- Monitor gain (level for monitoring of transmitted audio) arg float [0.0 ... 1.0] */
 #define RIG_LEVEL_NB           CONSTANT_64BIT_FLAG(38)      /*!< \c NB -- Noise Blanker level, arg float [0.0 ... 1.0] */
 #define RIG_LEVEL_RFPOWER_METER_WATTS  CONSTANT_64BIT_FLAG(39)      /*!< \c RFPOWER_METER_WATTS -- RF power output meter, arg float [0.0 ... MAX] (output power in watts) */
-#define RIG_LEVEL_SPECTRUM_MODE        CONSTANT_64BIT_FLAG(40)      /*!< \c SPECTRUM_MODE -- Spectrum scope mode, arg int (see enum rig_spectrum_mode_e). Supported modes defined in rig caps. */
+#define RIG_LEVEL_SPECTRUM_MODE        CONSTANT_64BIT_FLAG(40)      /*!< \c SPECTRUM_MODE -- Spectrum scope mode, arg int (see enum #rig_spectrum_mode_e). Supported modes defined in rig caps. */
 #define RIG_LEVEL_SPECTRUM_SPAN        CONSTANT_64BIT_FLAG(41)      /*!< \c SPECTRUM_SPAN -- Spectrum scope span in center mode, arg int (Hz). Supported spans defined in rig caps. */
 #define RIG_LEVEL_SPECTRUM_EDGE_LOW    CONSTANT_64BIT_FLAG(42)      /*!< \c SPECTRUM_EDGE_LOW -- Spectrum scope low edge in fixed mode, arg int (Hz) */
 #define RIG_LEVEL_SPECTRUM_EDGE_HIGH   CONSTANT_64BIT_FLAG(43)      /*!< \c SPECTRUM_EDGE_HIGH -- Spectrum scope high edge in fixed mode, arg int (Hz) */
@@ -1136,7 +1136,7 @@ typedef uint64_t rig_level_e;
  */
 enum rig_parm_e {
     RIG_PARM_NONE =         0,          /*!< '' -- No Parm */
-    RIG_PARM_ANN =          (1 << 0),   /*!< \c ANN -- "Announce" level, see ann_t */
+    RIG_PARM_ANN =          (1 << 0),   /*!< \c ANN -- "Announce" level, see #ann_t */
     RIG_PARM_APO =          (1 << 1),   /*!< \c APO -- Auto power off, int in minute */
     RIG_PARM_BACKLIGHT =    (1 << 2),   /*!< \c BACKLIGHT -- LCD light, float [0.0 ... 1.0] */
     RIG_PARM_BEEP =         (1 << 4),   /*!< \c BEEP -- Beep on keypressed, int (0,1) */
@@ -1696,7 +1696,7 @@ typedef enum {
 struct chan_list {
     int startc;              /*!< Starting memory channel \b number */
     int endc;                /*!< Ending memory channel \b number */
-    chan_type_t type;        /*!< Memory type. see chan_type_t */
+    chan_type_t type;        /*!< Memory type. See #chan_type_t */
     channel_cap_t mem_caps;  /*!< Definition of attributes that can be stored/retrieved */
 };
 

--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -299,9 +299,9 @@ typedef struct s_rig RIG;
  *
  * Digitally-Coded Squelch codes are simple direct integers.
  */
+typedef unsigned int tone_t;
 #define CTCSS_LIST_SIZE 60
 #define DCS_LIST_SIZE 128
-typedef unsigned int tone_t;
 
 
 /**

--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -451,7 +451,7 @@ typedef enum {
 
 
 /**
- * \brief Frequency type,
+ * \brief Frequency type
  *
  * Frequency type unit in Hz, able to hold SHF frequencies.
  */
@@ -2701,7 +2701,7 @@ typedef unsigned int rig_comm_status_t;
  * This struct contains live data, as well as a copy of capability fields
  * that may be updated (ie. customized)
  *
- * It is NOT fine to move fields around as it can break share library offset
+ * It is NOT fine to move fields around as it can break shared library offset
  * As of 2024-03-03  freq_event_elapsed is the last known item being reference externally
  * So any additions or changes to this structure must be at the end of the structure
  */
@@ -2739,7 +2739,7 @@ struct rig_state {
     ann_t announces;            /*!< Announces bit field list */
 
     int preamp[HAMLIB_MAXDBLSTSIZ];    /*!< Preamp list in dB, 0 terminated */
-    int attenuator[HAMLIB_MAXDBLSTSIZ];    /*!< Preamp list in dB, 0 terminated */
+    int attenuator[HAMLIB_MAXDBLSTSIZ];    /*!< Attenuator list in dB, 0 terminated */
 
     setting_t has_get_func;     /*!< List of get functions */
     setting_t has_set_func;     /*!< List of set functions */
@@ -2939,7 +2939,7 @@ struct rig_state_deprecated {
     ann_t announces;            /*!< Announces bit field list */
 
     int preamp[HAMLIB_MAXDBLSTSIZ];    /*!< Preamp list in dB, 0 terminated */
-    int attenuator[HAMLIB_MAXDBLSTSIZ];    /*!< Preamp list in dB, 0 terminated */
+    int attenuator[HAMLIB_MAXDBLSTSIZ];    /*!< Attenuator list in dB, 0 terminated */
 
     setting_t has_get_func;     /*!< List of get functions */
     setting_t has_set_func;     /*!< List of set functions */

--- a/simulators/simatd578.c
+++ b/simulators/simatd578.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simatd578 simatd578.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simatd578.c
+++ b/simulators/simatd578.c
@@ -82,7 +82,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simeasycomm.c
+++ b/simulators/simeasycomm.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simspid simspid.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simeasycomm.c
+++ b/simulators/simeasycomm.c
@@ -67,7 +67,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simelecraft.c
+++ b/simulators/simelecraft.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simyaesu simyaesu.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if  0

--- a/simulators/simelecraft.c
+++ b/simulators/simelecraft.c
@@ -101,7 +101,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simelecraftk4.c
+++ b/simulators/simelecraftk4.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simyaesu simyaesu.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if  0

--- a/simulators/simelecraftk4.c
+++ b/simulators/simelecraftk4.c
@@ -102,7 +102,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simft1000.c
+++ b/simulators/simft1000.c
@@ -69,7 +69,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simft1000.c
+++ b/simulators/simft1000.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simft1000 simft1000.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simft450.c
+++ b/simulators/simft450.c
@@ -115,7 +115,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simft450.c
+++ b/simulators/simft450.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simyaesu simyaesu.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simft710.c
+++ b/simulators/simft710.c
@@ -117,7 +117,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simft710.c
+++ b/simulators/simft710.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simyaesu simyaesu.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simft736.c
+++ b/simulators/simft736.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simft897 simft897.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simft736.c
+++ b/simulators/simft736.c
@@ -69,7 +69,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simft747gx.c
+++ b/simulators/simft747gx.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simft747gx simft747gx.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simft747gx.c
+++ b/simulators/simft747gx.c
@@ -68,7 +68,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simft817.c
+++ b/simulators/simft817.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simft897 simft897.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simft817.c
+++ b/simulators/simft817.c
@@ -70,7 +70,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simft818.c
+++ b/simulators/simft818.c
@@ -91,7 +91,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simft818.c
+++ b/simulators/simft818.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simyaesu simyaesu.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simft847.c
+++ b/simulators/simft847.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simft897 simft897.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simft847.c
+++ b/simulators/simft847.c
@@ -69,7 +69,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simft897.c
+++ b/simulators/simft897.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simft897 simft897.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simft897.c
+++ b/simulators/simft897.c
@@ -69,7 +69,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simft990.c
+++ b/simulators/simft990.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simft990 simft990.c
 // emulates 1.2 ROM FT990 which can only read 1492 bytes
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this

--- a/simulators/simft990.c
+++ b/simulators/simft990.c
@@ -126,7 +126,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simft991.c
+++ b/simulators/simft991.c
@@ -94,7 +94,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simft991.c
+++ b/simulators/simft991.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simyaesu simyaesu.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simftdx101.c
+++ b/simulators/simftdx101.c
@@ -102,7 +102,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simftdx101.c
+++ b/simulators/simftdx101.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simyaesu simyaesu.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simftdx1200.c
+++ b/simulators/simftdx1200.c
@@ -93,7 +93,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simftdx1200.c
+++ b/simulators/simftdx1200.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simyaesu simyaesu.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simftdx3000.c
+++ b/simulators/simftdx3000.c
@@ -92,7 +92,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simftdx3000.c
+++ b/simulators/simftdx3000.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simyaesu simyaesu.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simftdx5000.c
+++ b/simulators/simftdx5000.c
@@ -94,7 +94,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simftdx5000.c
+++ b/simulators/simftdx5000.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simyaesu simyaesu.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simic2730.c
+++ b/simulators/simic2730.c
@@ -540,7 +540,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simic2730.c
+++ b/simulators/simic2730.c
@@ -1,9 +1,6 @@
 // simicom will show the pts port to use for rigctl on Unix
 // using virtual serial ports on Windows is to be developed yet
 // Needs a lot of improvement to work on all Icoms
-// gcc -g -Wall -o simicom simicom.c -lhamlib
-// On mingw in the hamlib src directory
-// gcc -static -I../include -g -Wall -o simicom simicom.c -L../../build/src/.libs -lhamlib -lwsock32 -lws2_32
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simic275.c
+++ b/simulators/simic275.c
@@ -1,9 +1,6 @@
 // simicom will show the pts port to use for rigctl on Unix
 // using virtual serial ports on Windows is to be developed yet
 // Needs a lot of improvement to work on all Icoms
-// gcc -g -Wall -o simicom simicom.c -lhamlib
-// On mingw in the hamlib src directory
-// gcc -static -I../include -g -Wall -o simicom simicom.c -L../../build/src/.libs -lhamlib -lwsock32 -lws2_32
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simic275.c
+++ b/simulators/simic275.c
@@ -535,7 +535,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simic7000.c
+++ b/simulators/simic7000.c
@@ -1,9 +1,6 @@
 // simicom will show the pts port to use for rigctl on Unix
 // using virtual serial ports on Windows is to be developed yet
 // Needs a lot of improvement to work on all Icoms
-// gcc -g -Wall -o simicom simicom.c -lhamlib
-// On mingw in the hamlib src directory
-// gcc -static -I../include -g -Wall -o simicom simicom.c -L../../build/src/.libs -lhamlib -lwsock32 -lws2_32
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simic7000.c
+++ b/simulators/simic7000.c
@@ -553,7 +553,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simic705.c
+++ b/simulators/simic705.c
@@ -584,7 +584,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simic705.c
+++ b/simulators/simic705.c
@@ -1,9 +1,6 @@
 // simicom will show the pts port to use for rigctl on Unix
 // using virtual serial ports on Windows is to be developed yet
 // Needs a lot of improvement to work on all Icoms
-// gcc -g -Wall -o simicom simicom.c -lhamlib
-// On mingw in the hamlib src directory
-// gcc -static -I../include -g -Wall -o simicom simicom.c -L../../build/src/.libs -lhamlib -lwsock32 -lws2_32
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simic7100.c
+++ b/simulators/simic7100.c
@@ -1,9 +1,6 @@
 // simicom will show the pts port to use for rigctl on Unix
 // using virtual serial ports on Windows is to be developed yet
 // Needs a lot of improvement to work on all Icoms
-// gcc -g -Wall -o simicom simicom.c -lhamlib
-// On mingw in the hamlib src directory
-// gcc -static -I../include -g -Wall -o simicom simicom.c -L../../build/src/.libs -lhamlib -lwsock32 -lws2_32
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simic7100.c
+++ b/simulators/simic7100.c
@@ -499,7 +499,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simic7200.c
+++ b/simulators/simic7200.c
@@ -1,9 +1,6 @@
 // simicom will show the pts port to use for rigctl on Unix
 // using virtual serial ports on Windows is to be developed yet
 // Needs a lot of improvement to work on all Icoms
-// gcc -g -Wall -o simicom simicom.c -lhamlib
-// On mingw in the hamlib src directory
-// gcc -static -I../include -g -Wall -o simicom simicom.c -L../../build/src/.libs -lhamlib -lwsock32 -lws2_32
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simic7200.c
+++ b/simulators/simic7200.c
@@ -829,7 +829,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simic7300.c
+++ b/simulators/simic7300.c
@@ -740,7 +740,7 @@ char *name = ptsname(fd);
 
 if (name == NULL)
 {
-    perror("pstname");
+    perror("ptsname");
     return -1;
 }
 

--- a/simulators/simic7300.c
+++ b/simulators/simic7300.c
@@ -1,9 +1,6 @@
 // simicom will show the pts port to use for rigctl on Unix
 // using virtual serial ports on Windows is to be developed yet
 // Needs a lot of improvement to work on all Icoms
-// gcc -g -Wall -o simicom simicom.c -lhamlib
-// On mingw in the hamlib src directory
-// gcc -static -I../include -g -Wall -o simicom simicom.c -L../../build/src/.libs -lhamlib -lwsock32 -lws2_32
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simic7600.c
+++ b/simulators/simic7600.c
@@ -1,9 +1,6 @@
 // simicom will show the pts port to use for rigctl on Unix
 // using virtual serial ports on Windows is to be developed yet
 // Needs a lot of improvement to work on all Icoms
-// gcc -g -Wall -o simicom simicom.c -lhamlib
-// On mingw in the hamlib src directory
-// gcc -static -I../include -g -Wall -o simicom simicom.c -L../../build/src/.libs -lhamlib -lwsock32 -lws2_32
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simic7600.c
+++ b/simulators/simic7600.c
@@ -651,7 +651,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simic7610.c
+++ b/simulators/simic7610.c
@@ -1,8 +1,5 @@
 // using virtual serial ports on Windows is to be developed yet
 // Needs a lot of improvement to work on all Icoms
-// gcc -g -Wall -o simicom simicom.c -lhamlib
-// On mingw in the hamlib src directory
-// gcc -static -I../include -g -Wall -o simicom simicom.c -L../../build/src/.libs -lhamlib -lwsock32 -lws2_32
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simic7610.c
+++ b/simulators/simic7610.c
@@ -757,7 +757,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simic7700.c
+++ b/simulators/simic7700.c
@@ -1,9 +1,6 @@
 // simicom will show the pts port to use for rigctl on Unix
 // using virtual serial ports on Windows is to be developed yet
 // Needs a lot of improvement to work on all Icoms
-// gcc -g -Wall -o simicom simicom.c -lhamlib
-// On mingw in the hamlib src directory
-// gcc -static -I../include -g -Wall -o simicom simicom.c -L../../build/src/.libs -lhamlib -lwsock32 -lws2_32
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simic7700.c
+++ b/simulators/simic7700.c
@@ -718,7 +718,7 @@ char *name = ptsname(fd);
 
 if (name == NULL)
 {
-    perror("pstname");
+    perror("ptsname");
     return -1;
 }
 

--- a/simulators/simic7851.c
+++ b/simulators/simic7851.c
@@ -821,7 +821,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simic7851.c
+++ b/simulators/simic7851.c
@@ -1,8 +1,5 @@
 // using virtual serial ports on Windows is to be developed yet
 // Needs a lot of improvement to work on all Icoms
-// gcc -g -Wall -o simicom simicom.c -lhamlib
-// On mingw in the hamlib src directory
-// gcc -static -I../include -g -Wall -o simicom simicom.c -L../../build/src/.libs -lhamlib -lwsock32 -lws2_32
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simic905.c
+++ b/simulators/simic905.c
@@ -1,9 +1,6 @@
 // simicom will show the pts port to use for rigctl on Unix
 // using virtual serial ports on Windows is to be developed yet
 // Needs a lot of improvement to work on all Icoms
-// gcc -g -Wall -o simicom simicom.c -lhamlib
-// On mingw in the hamlib src directory
-// gcc -static -I../include -g -Wall -o simicom simicom.c -L../../build/src/.libs -lhamlib -lwsock32 -lws2_32
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simic905.c
+++ b/simulators/simic905.c
@@ -618,7 +618,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simic910.c
+++ b/simulators/simic910.c
@@ -1,9 +1,6 @@
 // simicom will show the pts port to use for rigctl on Unix
 // using virtual serial ports on Windows is to be developed yet
 // Needs a lot of improvement to work on all Icoms
-// gcc -g -Wall -o simicom simicom.c -lhamlib
-// On mingw in the hamlib src directory
-// gcc -static -I../include -g -Wall -o simicom simicom.c -L../../build/src/.libs -lhamlib -lwsock32 -lws2_32
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simic910.c
+++ b/simulators/simic910.c
@@ -621,7 +621,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simic9100.c
+++ b/simulators/simic9100.c
@@ -1,9 +1,6 @@
 // simicom will show the pts port to use for rigctl on Unix
 // using virtual serial ports on Windows is to be developed yet
 // Needs a lot of improvement to work on all Icoms
-// gcc -g -Wall -o simicom simicom.c -lhamlib
-// On mingw in the hamlib src directory
-// gcc -static -I../include -g -Wall -o simicom simicom.c -L../../build/src/.libs -lhamlib -lwsock32 -lws2_32
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simic9100.c
+++ b/simulators/simic9100.c
@@ -554,7 +554,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simic9700.c
+++ b/simulators/simic9700.c
@@ -1,9 +1,6 @@
 // simicom will show the pts port to use for rigctl on Unix
 // using virtual serial ports on Windows is to be developed yet
 // Needs a lot of improvement to work on all Icoms
-// gcc -g -Wall -o simicom simicom.c -lhamlib
-// On mingw in the hamlib src directory
-// gcc -static -I../include -g -Wall -o simicom simicom.c -L../../build/src/.libs -lhamlib -lwsock32 -lws2_32
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simic9700.c
+++ b/simulators/simic9700.c
@@ -583,7 +583,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simicgeneric.c
+++ b/simulators/simicgeneric.c
@@ -421,7 +421,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simicgeneric.c
+++ b/simulators/simicgeneric.c
@@ -1,9 +1,6 @@
 // simicom will show the pts port to use for rigctl on Unix
 // using virtual serial ports on Windows is to be developed yet
 // Needs a lot of improvement to work on all Icoms
-// gcc -g -Wall -o simicom simicom.c -lhamlib
-// On mingw in the hamlib src directory
-// gcc -static -I../include -g -Wall -o simicom simicom.c -L../../build/src/.libs -lhamlib -lwsock32 -lws2_32
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simicr8600.c
+++ b/simulators/simicr8600.c
@@ -415,7 +415,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simicr8600.c
+++ b/simulators/simicr8600.c
@@ -1,9 +1,6 @@
 // simicom will show the pts port to use for rigctl on Unix
 // using virtual serial ports on Windows is to be developed yet
 // Needs a lot of improvement to work on all Icoms
-// gcc -g -Wall -o simicom simicom.c -lhamlib
-// On mingw in the hamlib src directory
-// gcc -static -I../include -g -Wall -o simicom simicom.c -L../../build/src/.libs -lhamlib -lwsock32 -lws2_32
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simid5100.c
+++ b/simulators/simid5100.c
@@ -411,7 +411,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simid5100.c
+++ b/simulators/simid5100.c
@@ -1,9 +1,6 @@
 // simicom will show the pts port to use for rigctl on Unix
 // using virtual serial ports on Windows is to be developed yet
 // Needs a lot of improvement to work on all Icoms
-// gcc -g -Wall -o simicom simicom.c -lhamlib
-// On mingw in the hamlib src directory
-// gcc -static -I../include -g -Wall -o simicom simicom.c -L../../build/src/.libs -lhamlib -lwsock32 -lws2_32
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simjupiter.c
+++ b/simulators/simjupiter.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simft897 simft897.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simjupiter.c
+++ b/simulators/simjupiter.c
@@ -69,7 +69,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simkenwood.c
+++ b/simulators/simkenwood.c
@@ -88,7 +88,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simkenwood.c
+++ b/simulators/simkenwood.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simyaesu simyaesu.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simmicom.c
+++ b/simulators/simmicom.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simspid simspid.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simmicom.c
+++ b/simulators/simmicom.c
@@ -75,7 +75,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simorion.c
+++ b/simulators/simorion.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simorion simorion.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simorion.c
+++ b/simulators/simorion.c
@@ -66,7 +66,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simpmr171.c
+++ b/simulators/simpmr171.c
@@ -82,7 +82,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simpmr171.c
+++ b/simulators/simpmr171.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simprm171 simprm171.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simpowersdr.c
+++ b/simulators/simpowersdr.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simyaesu simyaesu.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simpowersdr.c
+++ b/simulators/simpowersdr.c
@@ -89,7 +89,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simqrplabs.c
+++ b/simulators/simqrplabs.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simyaesu simyaesu.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simqrplabs.c
+++ b/simulators/simqrplabs.c
@@ -68,7 +68,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simrotorez.c
+++ b/simulators/simrotorez.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simspid simspid.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simrotorez.c
+++ b/simulators/simrotorez.c
@@ -67,7 +67,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simspid.c
+++ b/simulators/simspid.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simspid simspid.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simspid.c
+++ b/simulators/simspid.c
@@ -69,7 +69,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simtmd700.c
+++ b/simulators/simtmd700.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simyaesu simyaesu.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if  0

--- a/simulators/simtmd700.c
+++ b/simulators/simtmd700.c
@@ -88,7 +88,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simtmd710.c
+++ b/simulators/simtmd710.c
@@ -88,7 +88,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simtmd710.c
+++ b/simulators/simtmd710.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simyaesu simyaesu.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simtrusdx.c
+++ b/simulators/simtrusdx.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simyaesu simyaesu.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simtrusdx.c
+++ b/simulators/simtrusdx.c
@@ -70,7 +70,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simts450.c
+++ b/simulators/simts450.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simyaesu simyaesu.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simts450.c
+++ b/simulators/simts450.c
@@ -70,7 +70,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simts590.c
+++ b/simulators/simts590.c
@@ -77,7 +77,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simts590.c
+++ b/simulators/simts590.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simyaesu simyaesu.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simts890.c
+++ b/simulators/simts890.c
@@ -209,7 +209,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simts890.c
+++ b/simulators/simts890.c
@@ -1,6 +1,5 @@
 //#define TRACE /* Full traffic trace if enabled */
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simts890 -l hamlib simts890.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if  0

--- a/simulators/simts950.c
+++ b/simulators/simts950.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simyaesu simyaesu.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/simulators/simts950.c
+++ b/simulators/simts950.c
@@ -68,7 +68,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simts990.c
+++ b/simulators/simts990.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simyaesu simyaesu.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if  0

--- a/simulators/simts990.c
+++ b/simulators/simts990.c
@@ -83,7 +83,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simxiegug90.c
+++ b/simulators/simxiegug90.c
@@ -436,7 +436,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simxiegug90.c
+++ b/simulators/simxiegug90.c
@@ -1,9 +1,6 @@
 // simicom will show the pts port to use for rigctl on Unix
 // using virtual serial ports on Windows is to be developed yet
 // Needs a lot of improvement to work on all Icoms
-// gcc -g -Wall -o simicom simicom.c -lhamlib
-// On mingw in the hamlib src directory
-// gcc -static -I../include -g -Wall -o simicom simicom.c -L../../build/src/.libs -lhamlib -lwsock32 -lws2_32
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if  0

--- a/simulators/simxiegux108g.c
+++ b/simulators/simxiegux108g.c
@@ -428,7 +428,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simxiegux108g.c
+++ b/simulators/simxiegux108g.c
@@ -1,9 +1,6 @@
 // simicom will show the pts port to use for rigctl on Unix
 // using virtual serial ports on Windows is to be developed yet
 // Needs a lot of improvement to work on all Icoms
-// gcc -g -Wall -o simicom simicom.c -lhamlib
-// On mingw in the hamlib src directory
-// gcc -static -I../include -g -Wall -o simicom simicom.c -L../../build/src/.libs -lhamlib -lwsock32 -lws2_32
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if  0

--- a/simulators/simxiegux6100.c
+++ b/simulators/simxiegux6100.c
@@ -441,7 +441,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simxiegux6100.c
+++ b/simulators/simxiegux6100.c
@@ -1,9 +1,6 @@
 // simicom will show the pts port to use for rigctl on Unix
 // using virtual serial ports on Windows is to be developed yet
 // Needs a lot of improvement to work on all Icoms
-// gcc -g -Wall -o simicom simicom.c -lhamlib
-// On mingw in the hamlib src directory
-// gcc -static -I../include -g -Wall -o simicom simicom.c -L../../build/src/.libs -lhamlib -lwsock32 -lws2_32
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if  0

--- a/simulators/simyaesu.c
+++ b/simulators/simyaesu.c
@@ -97,7 +97,7 @@ int openPort(char *comport) // doesn't matter for using pts devices
 
     if (name == NULL)
     {
-        perror("pstname");
+        perror("ptsname");
         return -1;
     }
 

--- a/simulators/simyaesu.c
+++ b/simulators/simyaesu.c
@@ -1,5 +1,4 @@
 // can run this using rigctl/rigctld and socat pty devices
-// gcc -o simyaesu simyaesu.c
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #if 0

--- a/src/debug.c
+++ b/src/debug.c
@@ -325,7 +325,7 @@ vprintf_cb_t HAMLIB_API rig_set_debug_callback(vprintf_cb_t cb, rig_ptr_t arg)
 
 
 /**
- * \brief Change the output stream from `stderr` a different stream.
+ * \brief Change the output stream from `stderr` to a different stream.
  *
  * \param stream The stream to direct debugging output.
  *

--- a/src/extamp.c
+++ b/src/extamp.c
@@ -259,7 +259,7 @@ const struct confparams *HAMLIB_API amp_ext_lookup_tok(AMP *amp,
  * \note As this function calls amp_ext_lookup(), it can be considered a
  * higher level API.
  *
- * \return The token ID or RIG_CONF_END if there is a lookup failure.
+ * \return The token ID or #RIG_CONF_END if there is a lookup failure.
  *
  * \sa amp_ext_lookup()
  */

--- a/src/misc.c
+++ b/src/misc.c
@@ -339,7 +339,7 @@ double morse_code_dot_to_millis(int wpm)
 
 /**
  * \brief Convert duration of tenths of morse code dots to milliseconds at the given speed.
- * \param tenths_of_dots number of 1/10ths of dots
+ * \param dot10ths number of 1/10ths of dots
  * \param wpm morse code speed in words per minute
  * \return int duration in milliseconds
  *
@@ -1448,7 +1448,7 @@ const char *HAMLIB_API rig_stragclevel(enum agc_level_e level)
 
 /**
  * \brief Convert a enum agc_level_e to value
- * \param integer...
+ * \param agcLevel level to convert
  * \return agc_level_e value
  */
 value_t rig_valueagclevel(enum agc_level_e agcLevel)
@@ -1468,7 +1468,7 @@ value_t rig_valueagclevel(enum agc_level_e agcLevel)
 
 /**
  * \brief Convert a value to agc_level_e -- constrains the range
- * \param integer...
+ * \param agcValue value to convert
  * \return agc_level_e
  */
 enum agc_level_e rig_levelagcvalue(int agcValue)
@@ -1499,7 +1499,7 @@ enum agc_level_e rig_levelagcvalue(int agcValue)
 
 /**
  * \brief Convert AGC string... to agc_level_e
- * \param mode AGC string...
+ * \param agcString AGC string to convert
  * \return agc_level_e
  */
 enum agc_level_e rig_levelagcstr(const char *agcString)
@@ -2358,7 +2358,8 @@ const char *HAMLIB_API rot_strstatus(rot_status_t status)
 
 /**
  * \brief Get pointer to rig function instead of using rig->caps
- * \param RIG* and rig_function_e
+ * \param rig_model
+ * \param rig_function
  * \return the corresponding function pointer
  */
 void *HAMLIB_API rig_get_function_ptr(rig_model_t rig_model,
@@ -2650,7 +2651,8 @@ void *HAMLIB_API rig_get_function_ptr(rig_model_t rig_model,
 /**
  * \brief Get integer/long instead of using rig->caps
  *  watch out for integer values that may be negative -- if needed must change hamlib
- * \param RIG* and rig_caps_int_e
+ * \param rig_model
+ * \param rig_caps
  * \return the corresponding long value -- -RIG_EINVAL is the only error possible
  */
 uint64_t HAMLIB_API rig_get_caps_int(rig_model_t rig_model,
@@ -2751,7 +2753,7 @@ static const struct
 
 /**
  * \brief Convert enum RIG_COMM_STATUS... to alpha string
- * \param vfo RIG_COMM_STATUS_...
+ * \param status RIG_COMM_STATUS_...
  * \return alpha string
  */
 const char *HAMLIB_API rig_strcommstatus(rig_comm_status_t status)

--- a/src/rig.c
+++ b/src/rig.c
@@ -6893,8 +6893,8 @@ int HAMLIB_API rig_set_powerstat(RIG *rig, powerstat_t status)
  * \param rig   The rig handle
  * \param status    The location where to store the current status
  *
- *  Retrieve the status of the radio. See RIG_POWER_ON, RIG_POWER_OFF and
- *  RIG_POWER_STANDBY defines for the \a status.
+ *  Retrieve the status of the radio. See #RIG_POWER_ON, #RIG_POWER_OFF and
+ *  #RIG_POWER_STANDBY defines for the \a status.
  *
  * \return RIG_OK if the operation has been successful, otherwise
  * a negative value if an error occurred (in which case, cause is

--- a/src/rig.c
+++ b/src/rig.c
@@ -75,6 +75,11 @@
 #include "cache.h"
 
 /**
+ * \brief Hamlib short license name
+ *
+ */
+const char *hamlib_license = "LGPL";
+/**
  * \brief Hamlib release number
  *
  * The version number has the format x.y.z
@@ -84,7 +89,6 @@
  * the hamlib_version string.  Changing the size provokes a warning from the
  * dynamic loader.
  */
-const char *hamlib_license = "LGPL";
 //! @cond Doxygen_Suppress
 const char hamlib_version[21] = "Hamlib " PACKAGE_VERSION;
 #if INTPTR_MAX == INT128_MAX
@@ -94,6 +98,7 @@ const char hamlib_version[21] = "Hamlib " PACKAGE_VERSION;
 #else
 #define ARCHBITS "32-bit"
 #endif
+//! @endcond
 const char *hamlib_version2 = "Hamlib " PACKAGE_VERSION " " HAMLIBDATETIME " "
                               ARCHBITS;
 HAMLIB_EXPORT_VAR(int) cookie_use;
@@ -101,7 +106,6 @@ HAMLIB_EXPORT_VAR(int) skip_init;
 HAMLIB_EXPORT_VAR(int) lock_mode; // for use by rigctld
 HAMLIB_EXPORT_VAR(powerstat_t)
 rig_powerstat; // for use by both rigctld and rigctl
-//! @endcond
 
 struct rig_caps caps_test;
 

--- a/src/rot_ext.c
+++ b/src/rot_ext.c
@@ -362,7 +362,7 @@ const struct confparams *HAMLIB_API rot_ext_lookup_tok(ROT *rot,
  * \note As this function calls rot_ext_lookup(), it can be considered a
  * higher level API.
  *
- * \return The token ID or RIG_CONF_END if there is a lookup failure.
+ * \return The token ID or #RIG_CONF_END if there is a lookup failure.
  *
  * \sa rot_ext_lookup()
  */


### PR DESCRIPTION
The first commit replaces a string in an error message that was copied to all simulators.
The second commit removes examples of compile commands that are wrong and/or incomplete.
The other commits fix Doxygen comments and in some cases (commit 56b075ab and 24eafbd2) move a definition to be below the relevant comment.