### PR TITLE
Fix IC-705 filter selection and bandwidth handling for FM and WFM

### DIFF
--- a/rigs/icom/frame.c
+++ b/rigs/icom/frame.c
@@ -814,15 +814,27 @@ void icom2rig_mode(RIG *rig, unsigned char md, int pd, rmode_t *mode,
     rig_debug(RIG_DEBUG_TRACE, "%s: mode=0x%02x, pd=%d\n", __func__, md, pd);
 
     // Some rigs return fixed with for FM mode
-    if ((RIG_IS_IC7300 || RIG_IS_IC9700) && (md == S_FM || md == S_WFM))
-    {
-        *mode = RIG_MODE_FM;
+    if (RIG_IS_IC7300 || RIG_IS_IC9700 || RIG_IS_IC705) {
+        if (md == S_FM) {
+            *mode = RIG_MODE_FM;
 
-        if (*width == 1) { *width = 15000; }
-        else if (*width == 2) { *width = 10000; }
-        else { *width = 7000; }
+            if (*width == 1) { *width = 15000; }
+            else if (*width == 2) { *width = 10000; }
+            else { *width = 7000; }
 
-        return;
+            return;
+        } else if (md == S_WFM) {
+           
+            // For IC-705, *width will always be 1
+            // At least this works for IC-705
+
+            *mode = RIG_MODE_WFM;
+            *width = 200000;
+
+            return;
+        }
+        // If not FM nor SFM mode,
+        // fall down this block for further processing
     }
 
     *width = RIG_PASSBAND_NORMAL;

--- a/rigs/icom/ic7300.c
+++ b/rigs/icom/ic7300.c
@@ -637,7 +637,8 @@ static const struct icom_priv_caps IC705_priv_caps =
     .x1cx03_possibly = 1,
     .x1ax03_supported = 1,
     .mode_with_filter = 1,
-    .data_mode_supported = 1
+    .data_mode_supported = 1,
+    .fm_filters = { 7000, 10000, 15000 }
 };
 
 static const struct icom_priv_caps IC905_priv_caps =
@@ -1498,6 +1499,7 @@ struct rig_caps ic705_caps =
         {RIG_MODE_FM | RIG_MODE_PKTFM, kHz(10)},
         {RIG_MODE_FM | RIG_MODE_PKTFM, kHz(7)},
         {RIG_MODE_FM | RIG_MODE_PKTFM, kHz(15)},
+        {RIG_MODE_WFM, kHz(200)},
         RIG_FLT_END,
     },
 


### PR DESCRIPTION
This pull request (PR) solves the bug for IC-705 with rigctl when entering the command `M FM 0` after `M WFM 0` *did not* change the mode properly to (narrow) FM. This PR also explicitly defines WFM bandwidth to 200 kHz, which is the case for IC-705, and the only valid filter choice for WFM is 1 (one).

This PR includes the following fixes:

* A partial rollback of https://github.com/Hamlib/Hamlib/pull/1719/commits/a395b91be6bd19d760e57005ecb8079b15af9ede; IC-705 now uses `icom_set_mode_x26()` instead of `icom_set_mode_without_data()`
* Enable `.fm_filters` in `IC705_priv_caps`, which is mandatory for handling FM filter settings properly
* `icom2rig_mode()`: handle FM and WFM separately and correctly at least for IC-705, no changes for IC-7300 and IC-9700
* `icom_get_mode_without_data()`: add WFM to the code, which assumes that values from `icom2rig_mode()` are correct
* `icom_set_mode_x26()`: When `RIG_PASSBAND_NORMAL` or `RIG_PASSBAND_NOCHANGE` are passed to the parameter `width`, the command value `buf[2]` is forcefully set to 1 (the widest bandwidth (15kHz for IC-705, IC-7300, and IC-9700)). This prevents an invalid value of 0 from being passed to the radio as a filter selection value of the command 0x26.
* Add WFM freq to `ic705_caps.filters`.

