### PR TITLE
Fix debug messages shown even from disabled levels

### DIFF
--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -3770,11 +3770,10 @@ extern HAMLIB_EXPORT_VAR(char) debugmsgsave2[DEBUGMSGSAVE_SIZE];  // last-1 debu
 // debugmsgsave3 is deprecated
 extern HAMLIB_EXPORT_VAR(char) debugmsgsave3[DEBUGMSGSAVE_SIZE];  // last-2 debug msg
 #define rig_debug_clear() { debugmsgsave[0] = debugmsgsave2[0] = debugmsgsave3[0] = 0; };
-#ifndef __cplusplus
-#ifdef __GNUC__
-// doing the debug macro with a dummy sprintf allows gcc to check the format string
-#define rig_debug(debug_level,fmt,...) do { snprintf(debugmsgsave2,sizeof(debugmsgsave2),fmt,__VA_ARGS__);rig_debug(debug_level,fmt,##__VA_ARGS__); add2debugmsgsave(debugmsgsave2); } while(0)
-#endif
+#if !defined(__cplusplus) && defined(__GNUC__)
+#define ATTRIBUTE_FORMAT_PRINTF __attribute__((__format__ (__printf__, 2, 3)))
+#else
+#define ATTRIBUTE_FORMAT_PRINTF
 #endif
 
 // Measuring elapsed time -- local variable inside function when macro is used
@@ -3786,7 +3785,7 @@ extern HAMLIB_EXPORT_VAR(char) debugmsgsave3[DEBUGMSGSAVE_SIZE];  // last-2 debu
 
 extern HAMLIB_EXPORT(void)
 rig_debug HAMLIB_PARAMS((enum rig_debug_level_e debug_level,
-                         const char *fmt, ...));
+                         const char *fmt, ...)) ATTRIBUTE_FORMAT_PRINTF;
 
 extern HAMLIB_EXPORT(vprintf_cb_t)
 rig_set_debug_callback HAMLIB_PARAMS((vprintf_cb_t cb,

--- a/src/debug.c
+++ b/src/debug.c
@@ -202,7 +202,6 @@ void HAMLIB_API rig_set_debug_time_stamp(int flag)
  * The formatted character string is passed to the `vfprintf`(3) C library
  * call and follows its format specification.
  */
-#undef rig_debug
 void HAMLIB_API rig_debug(enum rig_debug_level_e debug_level,
                           const char *fmt, ...)
 {


### PR DESCRIPTION
This PR should probably go to version 4.7. These attributed are supported by gcc an clang, I tested that both compilers issue a warning when passing a wrong format string.

Messages from ENTERFUNC and RETURNFUNC where stored in an internal buffer even whe debug_level wasn't TRACE and they were returned when calling `rigerror()`, which also was breaking the Python tests that I'm writing..

Fixes confusing messages from rigctl, ampctl and rotctl when verbosity level was zero:
```
$ tests/rigctl \set_freq foo
error = *1:event.c(272):rig_poll_routine_start entered
*1:event.c(312):rig_poll_routine_start returning(0) 
rig.c(303):add_opened_rig entered
rig.c(315):add_opened_rig returning2(0) 
rig.c(1672):rig_open returning2(0) 
*1:rig.c(6915):rig_get_powerstat entered
*rig.c(6929) trace
**2:dummy.c(1636):dummy_get_powerstat entered
event.c(86): Starting rig poll routine thread
*1:rig.c(6942):rig_get_powerstat returning(0) 
Backend version: 20240709.0, Status: Stable
rigctl_parse: called, interactive=0
rig_set_cache_timeout_ms: called selection=0, ms=1000
rig_set_cache_timeout_ms: called selection=0, ms=1000
rigctl_parse: vfo_opt=0
rigctl_parse.c(2171):rigctl_set_freq entered
rigctl_set_freq: chkarg err
rigctl_parse.c(2173):rigctl_set_freq returning2(-1) Invalid parameter

Invalid parameter

$ tests/ampctl \set_freq foo
error = ampctl Hamlib 4.7~git 2025-05-06T21:37:57Z SHA=87d397 64-bit
Report bugs to <hamlib-developer@lists.sourceforge.net>

amp_init called
initamps4_dummy: _init called
amp_register (1)
amp_register (2)
dummy_amp_init called
amp_open called
dummy_amp_open called
ser_set_dtr: DTR=0
ser_set_rts: RTS=0
Backend version: 20200112.0, Status: Stable
Invalid parameter

$ tests/rotctl \set_pos a b
error = rotctl Hamlib 4.7~git 2025-05-06T21:37:57Z SHA=87d397 64-bit
Report bugs to <hamlib-developer@lists.sourceforge.net>

rot_init called
initrots4_dummy: _init called
rot_register (1)
rot_register (2)
rot_register (3)
rot_register (4)
dummy_rot_init called
rot_open called
ser_set_dtr: DTR=0
ser_set_rts: RTS=0
dummy_rot_open called
dummy_rot_open: dummy rotator so simulating speed
Backend version: 20220531.0, Status: Stable
Invalid parameter
```
After this patch those programs print just `error = Invalid parameter`.
