### PR TITLE
Fix some options ignored when running configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -445,11 +445,9 @@ AC_MSG_CHECKING([whether to build HTML rig feature matrix])
 AC_ARG_ENABLE([html-matrix],
     [AS_HELP_STRING([--disable-html-matrix],
 	[do not generate HTML rig feature matrix (requires libgd-dev) @<:@default=check@:>@])],
-	[cf_enable_html_matrix=no],
+	[cf_enable_html_matrix=$enable_html_matrix],
 	[cf_enable_html_matrix=check]
     )
-
-AC_MSG_RESULT([$cf_enable_html_matrix])
 
 AS_IF([test x"$cf_enable_html_matrix" != "xno"],
     [AC_CHECK_HEADERS([gd.h],
@@ -462,6 +460,7 @@ AS_IF([test x"$cf_enable_html_matrix" != "xno"],
 	)
     ])
 
+AC_MSG_RESULT([$cf_enable_html_matrix])
 AM_CONDITIONAL([HTML_MATRIX], [test x"${cf_enable_html_matrix}" = "xyes"])
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -734,8 +734,11 @@ AC_MSG_CHECKING([whether to build winradio backend])
 AC_ARG_ENABLE([winradio],
 	      [AS_HELP_STRING([--disable-winradio],
 			      [do not build winradio backend @<:@default=yes@:>@])],
-	      [cf_with_winradio="no"],
-	      [cf_with_winradio="yes" AC_DEFINE([HAVE_WINRADIO],[1],[Define if winradio backend is built])])
+	      [cf_with_winradio="${enable_winradio}"],
+	      [cf_with_winradio="yes" ])
+AS_IF([test x"${cf_with_winradio}" = "xyes"],
+      [AC_DEFINE([HAVE_WINRADIO],[1],[Define if winradio backend is built])]
+)
 AC_MSG_RESULT([$cf_with_winradio])
 
 dnl Parallel port device disable

--- a/configure.ac
+++ b/configure.ac
@@ -637,14 +637,14 @@ AS_IF([test x"${build_tcl}" = "xyes"],[
             AC_MSG_WARN([Unable to find Tcl pkgconfig])
             SC_PATH_TCLCONFIG
             SC_LOAD_TCLCONFIG
-        ])
 
-    tcl_save_CPPFLAGS=$CPPFLAGS
-    CPPFLAGS="$CPPFLAGS $TCL_INCLUDE_SPEC"
-    AC_CHECK_HEADERS([tcl.h],
-	[],
-	[AC_MSG_ERROR([Unable to find Tcl headers])])
-    CPPFLAGS=$tcl_save_CPPFLAGS
+            tcl_save_CPPFLAGS=$CPPFLAGS
+            CPPFLAGS="$CPPFLAGS $TCL_INCLUDE_SPEC"
+            AC_CHECK_HEADERS([tcl.h],
+            [],
+            [AC_MSG_ERROR([Unable to find Tcl headers])])
+            CPPFLAGS=$tcl_save_CPPFLAGS
+        ])
 
     BINDING_LIST="${BINDING_LIST} tcl"
     BINDING_ALL="${BINDING_ALL} all-tcl"

--- a/configure.ac
+++ b/configure.ac
@@ -403,7 +403,7 @@ AC_MSG_CHECKING([whether to use INDI in rigctl/rotctl])
     AC_ARG_WITH([indi],
         [AS_HELP_STRING([--without-indi],
     	[disable INDI in rigctl/rotctl @<:@default=yes@:>@])],
-    	[cf_with_indi_support=yes],
+    	[cf_with_indi_support=$with_indi],
     	[cf_with_indi_support=no]
     )
 #])

--- a/configure.ac
+++ b/configure.ac
@@ -381,7 +381,7 @@ AC_MSG_CHECKING([whether to use readline in rigctl/rotctl])
 AC_ARG_WITH([readline],
     [AS_HELP_STRING([--without-readline],
 	[disable readline in rigctl/rotctl @<:@default=yes@:>@])],
-	[cf_with_readline_support=no],
+	[cf_with_readline_support=$with_readline],
 	[cf_with_readline_support=yes]
     )
 

--- a/configure.ac
+++ b/configure.ac
@@ -347,7 +347,7 @@ AC_MSG_CHECKING([whether to build USB dependent backends])
 AC_ARG_WITH([libusb],
     [AS_HELP_STRING([--without-libusb],
 	[disable USB dependent backends @<:@default=yes@:>@])],
-	[cf_with_libusb=no],
+	[cf_with_libusb=$with_libusb],
 	[cf_with_libusb=yes]
     )
 

--- a/configure.ac
+++ b/configure.ac
@@ -746,8 +746,11 @@ AC_MSG_CHECKING([whether to build parallel port devices])
 AC_ARG_ENABLE([parallel],
 	      [AS_HELP_STRING([--disable-parallel],
 			      [do not build parallel devices @<:@default=yes@:>@])],
-	      [cf_with_parallel="no"],
-	      [cf_with_parallel="yes" AC_DEFINE([HAVE_PARALLEL],[1],[Define if parallel devices are to be built])])
+	      [cf_with_parallel="${enable_parallel}"],
+	      [cf_with_parallel="yes"])
+AS_IF([test x"${cf_with_parallel}" = "xyes"],
+      [AC_DEFINE([HAVE_PARALLEL],[1],[Define if parallel devices are to be built])]
+)
 AC_MSG_RESULT([$cf_with_parallel])
 
 DL_LIBS=""


### PR DESCRIPTION
In `configure.ac` some usages of the macro `AC_ARG_ENABLE` are wrong and the effect is that some ignore the "yes" while others ignore the "no". It seems that in those usages the macro `AC_ARG_ENABLE` is use as it where an if-the-else, while the correct usage from [the manual](https://www.gnu.org/software/autoconf/manual/autoconf-2.66/html_node/Package-Options.html) is:
> AC_ARG_ENABLE (feature, help-string, [action-if-given], [action-if-not-given])

In the wrong usages the `action-if-given` is a constant so the value passed by the user is ignored; the value can be passed explicitly or implicitly: `--enable-foo=yes`  is the same as `--enable-foo`, while `--enable-foo=no` is the same as `disable-foo` and the macro executes `action-if-given`; if the option is entirely omitted the macro executes `action-if-not-given`.

# First case: disable everything
Bug: `--without-indi` was passed but the report has "With INDI support yes"
```
./configure --without-cxx-binding --without-perl-binding --without-python-binding --without-tcl-binding \
--without-lua-binding --without-xml-support --without-readline --without-indi --enable-html-matrix=no \
--enable-winradio=no --enable-parallel=no --enable-usrp=no --without-libusb

 Package features:
    With C++ binding                no
    With Perl binding               no
    With Python binding             no
    With TCL binding                no
    With Lua binding                no
    With rigmem XML support         no
    With Readline support           no
    With INDI support               yes  WRONG

    Enable HTML rig feature matrix  no
    Enable WinRadio                 no
    Enable Parallel                 no
    Enable USRP                     no
    Enable USB backends             no
    Enable shared libs              yes
    Enable static libs              yes
```

# Second case: enable everything
Bug: the report shows "no" in some lines but all the prerequisites are installed (except where I wrote TODO)
```
./configure --with-cxx-binding=yes --with-perl-binding=yes --with-python-binding=yes --with-tcl-binding=yes \
--with-lua-binding=yes --with-xml-support=yes --with-readline=yes --with-indi=yes --enable-html-matrix \
--enable-winradio --enable-parallel --enable-usrp --with-libusb=yes

 Package features:
    With C++ binding                yes
    With Perl binding               yes
    With Python binding             yes
    With TCL binding                no  TODO
    With Lua binding                yes
    With rigmem XML support         yes
    With Readline support           no  WRONG
    With INDI support               yes

    Enable HTML rig feature matrix  no  WRONG
    Enable WinRadio                 no  WRONG
    Enable Parallel                 no  WRONG
    Enable USRP                     no  TODO
    Enable USB backends             no  WRONG
    Enable shared libs              yes
    Enable static libs              yes
```

I'm creating a draft pull request for now because I still have to look into some cases that look different (possibly because of my local configuration):
* ~~`--with-lua-binding` doesn't find my development files~~ it works now, probably I didn't enable it by mistake
* `--with-tcl-binding` doesn't find my development files if using also either or both `--with-xml-support` `--enable-usrp`
* ~~`--with-indi` I can't see Indi in `rotctl --list`~~ my mistake
* ~~`--with-usrp` doesn't find my development files~~ I installed the wrong sources!