### PR TITLE
Add names to threads created in src/*.c, if possible.

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -85,7 +85,7 @@ void *rig_poll_routine(void *arg)
     rig_debug(RIG_DEBUG_VERBOSE, "%s(%d): Starting rig poll routine thread\n",
               __FILE__, __LINE__);
 
-#if defined(_GNU_SOURCE)
+#if _GNU_SOURCE
     pthread_setname_np(pthread_self(), "rig_poll");
 #endif
 

--- a/src/event.c
+++ b/src/event.c
@@ -85,6 +85,10 @@ void *rig_poll_routine(void *arg)
     rig_debug(RIG_DEBUG_VERBOSE, "%s(%d): Starting rig poll routine thread\n",
               __FILE__, __LINE__);
 
+#if defined(_GNU_SOURCE)
+    pthread_setname_np(pthread_self(), "rig_poll");
+#endif
+
     // Rig cache time should be equal to rig poll interval (should be set automatically by rigctld at least)
     rig_set_cache_timeout_ms(rig, HAMLIB_CACHE_ALL, rs->poll_interval);
 

--- a/src/microham.c
+++ b/src/microham.c
@@ -750,7 +750,11 @@ static void *read_device(void *p)
     fd_set fds;
     struct timeval tv;
 
-    // the bytes from the microHam decive come in "frames"
+#if defined(_GNU_SOURCE)
+    pthread_setname_np(pthread_self(), "uham_read");
+#endif
+
+    // the bytes from the microHam device come in "frames"
     // a frame is a four-byte sequence. The first byte has the MSB unset,
     // then come three bytes with the MSB set
     // What comes here is an "infinite" loop. However this thread

--- a/src/microham.c
+++ b/src/microham.c
@@ -750,7 +750,7 @@ static void *read_device(void *p)
     fd_set fds;
     struct timeval tv;
 
-#if defined(_GNU_SOURCE)
+#if _GNU_SOURCE
     pthread_setname_np(pthread_self(), "uham_read");
 #endif
 

--- a/src/multicast.c
+++ b/src/multicast.c
@@ -1,3 +1,4 @@
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -386,6 +387,10 @@ void *multicast_thread(void *vrig)
     ptt_t ptt, pttsave = 0;
     struct rig_cache *cachep = CACHE(rig);
     struct rig_state *rs = STATE(rig);
+
+#if defined(_GNU_SOURCE)
+    pthread_setname_np(pthread_self(), "multicast");
+#endif
 
     rs->multicast->runflag = 1;
 

--- a/src/multicast.c
+++ b/src/multicast.c
@@ -388,7 +388,7 @@ void *multicast_thread(void *vrig)
     struct rig_cache *cachep = CACHE(rig);
     struct rig_state *rs = STATE(rig);
 
-#if defined(_GNU_SOURCE)
+#if _GNU_SOURCE
     pthread_setname_np(pthread_self(), "multicast");
 #endif
 

--- a/src/network.c
+++ b/src/network.c
@@ -18,6 +18,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 /**
  * \addtogroup rig_internal
@@ -1022,6 +1023,10 @@ void *multicast_publisher(void *arg)
     int socket_fd = args->socket_fd;
     ssize_t send_result;
 
+#if defined(_GNU_SOURCE)
+    pthread_setname_np(pthread_self(), "mcast_pub");
+#endif
+
     rig_debug(RIG_DEBUG_VERBOSE, "%s(%d): Starting multicast publisher\n", __FILE__,
               __LINE__);
 
@@ -1360,6 +1365,10 @@ void *multicast_receiver(void *arg)
 
     struct sockaddr_in dest_addr;
     int socket_fd = args->socket_fd;
+
+#if defined(_GNU_SOURCE)
+    pthread_setname_np(pthread_self(), "mcast_rx");
+#endif
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s(%d): Starting multicast receiver\n", __FILE__,
               __LINE__);

--- a/src/network.c
+++ b/src/network.c
@@ -1023,7 +1023,7 @@ void *multicast_publisher(void *arg)
     int socket_fd = args->socket_fd;
     ssize_t send_result;
 
-#if defined(_GNU_SOURCE)
+#if _GNU_SOURCE
     pthread_setname_np(pthread_self(), "mcast_pub");
 #endif
 
@@ -1366,7 +1366,7 @@ void *multicast_receiver(void *arg)
     struct sockaddr_in dest_addr;
     int socket_fd = args->socket_fd;
 
-#if defined(_GNU_SOURCE)
+#if _GNU_SOURCE
     pthread_setname_np(pthread_self(), "mcast_rx");
 #endif
 

--- a/src/rig.c
+++ b/src/rig.c
@@ -50,8 +50,8 @@
  * \example ../tests/testrig.c
  */
 
-#include "hamlib/rig.h"
 #include "hamlib/config.h"
+#include "hamlib/rig.h"
 #include "fifo.h"
 
 #include <stdlib.h>
@@ -8629,6 +8629,10 @@ void *async_data_handler(void *arg)
     // TODO: add initial support for async in Kenwood kenwood_transaction (+one) functions -> add transaction_active flag usage
     // TODO: add initial support for async in Yaesu newcat_get_cmd/set_cmd (+validate) functions -> add transaction_active flag usage
 
+#if defined(_GNU_SOURCE)
+    pthread_setname_np(pthread_self(), "async_data");
+#endif
+
     while (rs->async_data_handler_thread_run)
     {
         int frame_length;
@@ -8720,6 +8724,10 @@ void *morse_data_handler(void *arg)
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: Starting morse data handler thread\n",
               __func__);
+
+#if defined(_GNU_SOURCE)
+    pthread_setname_np(pthread_self(), "Morse_data");
+#endif
 
     if (STATE(rig)->fifo_morse == NULL)
     {

--- a/src/rig.c
+++ b/src/rig.c
@@ -8629,7 +8629,7 @@ void *async_data_handler(void *arg)
     // TODO: add initial support for async in Kenwood kenwood_transaction (+one) functions -> add transaction_active flag usage
     // TODO: add initial support for async in Yaesu newcat_get_cmd/set_cmd (+validate) functions -> add transaction_active flag usage
 
-#if defined(_GNU_SOURCE)
+#if _GNU_SOURCE
     pthread_setname_np(pthread_self(), "async_data");
 #endif
 
@@ -8725,7 +8725,7 @@ void *morse_data_handler(void *arg)
     rig_debug(RIG_DEBUG_VERBOSE, "%s: Starting morse data handler thread\n",
               __func__);
 
-#if defined(_GNU_SOURCE)
+#if _GNU_SOURCE
     pthread_setname_np(pthread_self(), "Morse_data");
 #endif
 


### PR DESCRIPTION
So I can tell them apart from application threads.
Also fix missing/misplaced '#include "config.h"' directives so they compile portably.

Started on this while fixing thread locking, but never got it fit to merge.
