### PR TITLE
Fix usage and usage texts

### DIFF
--- a/tests/ampctl.c
+++ b/tests/ampctl.c
@@ -490,7 +490,9 @@ void usage()
         "  -v, --verbose                 set verbose mode, cumulative (-v to -vvvvv)\n"
         "  -Z, --debug-time-stamps       enable time stamps for debug messages\n"
         "  -h, --help                    display this help and exit\n"
-        "  -V, --version                 output version information and exit\n\n"
+        "  -V, --version                 output version information and exit\n"
+        "  -                             read commands from standard input\n"
+        "\n"
     );
 
     usage_amp(stdout);

--- a/tests/ampctl.c
+++ b/tests/ampctl.c
@@ -475,7 +475,7 @@ void usage()
            "Send COMMANDs to a connected amplifier.\n\n");
 
     printf(
-        "  -m, --model=ID                select amplifier model number. See model list\n"
+        "  -m, --model=ID                select amplifier model number. See model list (-l)\n"
         "  -r, --amp-file=DEVICE         set device of the amplifier to operate on\n"
         "  -s, --serial-speed=BAUD       set serial speed of the serial port\n"
         "  -t, --send-cmd-term=CHAR      set send_cmd command termination char\n"
@@ -487,7 +487,7 @@ void usage()
         "  -i, --read-history            read prior interactive session history\n"
         "  -I, --save-history            save current interactive session history\n"
 #endif
-        "  -v, --verbose                 set verbose mode, cumulative\n"
+        "  -v, --verbose                 set verbose mode, cumulative (-v to -vvvvv)\n"
         "  -Z, --debug-time-stamps       enable time stamps for debug messages\n"
         "  -h, --help                    display this help and exit\n"
         "  -V, --version                 output version information and exit\n\n"

--- a/tests/ampctld.c
+++ b/tests/ampctld.c
@@ -725,7 +725,7 @@ void usage()
            "Daemon serving COMMANDs to a connected amplifier.\n\n");
 
     printf(
-        "  -m, --model=ID                select amplifier model number. See model list\n"
+        "  -m, --model=ID                select amplifier model number. See model list (-l)\n"
         "  -r, --amp-file=DEVICE         set device of the amplifier to operate on\n"
         "  -s, --serial-speed=BAUD       set serial speed of the serial port\n"
         "  -t, --port=NUM                set TCP listening port, default %s\n"
@@ -734,7 +734,7 @@ void usage()
         "  -L, --show-conf               list all config parameters\n"
         "  -l, --list                    list all model numbers and exit\n"
         "  -u, --dump-caps               dump capabilities and exit\n"
-        "  -v, --verbose                 set verbose mode, cumulative\n"
+        "  -v, --verbose                 set verbose mode, cumulative (-v to -vvvvv)\n"
         "  -Z, --debug-time-stamps       enable time stamps for debug messages\n"
         "  -h, --help                    display this help and exit\n"
         "  -V, --version                 output version information and exit\n\n",

--- a/tests/rigctl.c
+++ b/tests/rigctl.c
@@ -932,7 +932,7 @@ void usage(void)
 
 
     printf(
-        "  -m, --model=ID                select radio model number. See model list\n"
+        "  -m, --model=ID                select radio model number. See model list (-l)\n"
         "  -r, --rig-file=DEVICE         set device of the radio to operate on\n"
         "  -p, --ptt-file=DEVICE         set device of the PTT device to operate on\n"
         "  -d, --dcd-file=DEVICE         set device of the DCD device to operate on\n"
@@ -941,7 +941,7 @@ void usage(void)
         "  -s, --serial-speed=BAUD       set serial speed of the serial port\n"
         "  -c, --civaddr=ID              set CI-V address, decimal (for Icom rigs only)\n"
         "  -t, --send-cmd-term=CHAR      set send_cmd command termination char\n"
-        "  -C, --set-conf=PARM=VAL       set config parameters\n"
+        "  -C, --set-conf=PARM=VAL[,...] set config parameters\n"
         "  -L, --show-conf               list all config parameters\n"
         "  -l, --list                    list all model numbers and exit\n"
         "  -u, --dump-caps               dump capabilities and exit\n"

--- a/tests/rigctl.c
+++ b/tests/rigctl.c
@@ -957,7 +957,9 @@ void usage(void)
         "  -h, --help                    display this help and exit\n"
         "  -V, --version                 output version information and exit\n"
         "  -!, --cookie                  use cookie control\n"
-        "  -#, --skip-init               skip rig initialization\n\n"
+        "  -#, --skip-init               skip rig initialization\n"
+        "  -                             read commands from standard input\n"
+        "\n"
     );
 
     usage_rig(stdout);

--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -1508,7 +1508,7 @@ void usage(void)
 
 
     printf(
-        "  -m, --model=ID                select radio model number. See model list\n"
+        "  -m, --model=ID                select radio model number. See model list (-l)\n"
         "  -r, --rig-file=DEVICE         set device of the radio to operate on\n"
         "  -p, --ptt-file=DEVICE         set device of the PTT device to operate on\n"
         "  -d, --dcd-file=DEVICE         set device of the DCD device to operate on\n"
@@ -1519,7 +1519,7 @@ void usage(void)
         "  -t, --port=NUM                set TCP listening port, default %s\n"
         "  -S, --separator=CHAR          set char as rigctld response separator, default is \\n\n"
         "  -T, --listen-addr=IPADDR      set listening IP address, default ANY\n"
-        "  -C, --set-conf=PARM=VAL       set config parameters\n"
+        "  -C, --set-conf=PARM=VAL[,...] set config parameters\n"
         "  -L, --show-conf               list all config parameters\n"
         "  -l, --list                    list all model numbers and exit\n"
         "  -u, --dump-caps               dump capabilities and exit\n"
@@ -1527,7 +1527,7 @@ void usage(void)
         "  -v, --verbose                 set verbose mode, cumulative (-v to -vvvvv)\n"
         "  -W, --twiddle_timeout=SECONDS timeout after detecting vfo manual change\n"
         "  -w, --twiddle_rit=SECONDS     suppress VFOB getfreq so RIT can be twiddled\n"
-        "  -x, --uplink                  set uplink get_freq ignore, 1=Sub, 2=Main\n"
+        "  -x, --uplink=OPTION           set uplink get_freq ignore: option 1=Sub, 2=Main\n"
         "  -Z, --debug-time-stamps       enable time stamps for debug messages\n"
         "  -A, --password=PASSWORD       set password for rigctld access (NOT IMPLEMENTED)\n"
         "  -R, --rigctld-idle            make rigctld close the rig when no clients are connected\n"

--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -81,7 +81,7 @@
  *      keep up to date SHORT_OPTIONS, usage()'s output and man page. thanks.
  * TODO: add an option to read from a file
  */
-#define SHORT_OPTIONS "m:r:p:d:P:D:s:S:c:T:t:C:W:w:x:z:lLuovhVZRA:b"
+#define SHORT_OPTIONS "m:r:p:d:P:D:s:S:c:T:t:C:W:w:x:lLuovhVZRA:b"
 static struct option long_options[] =
 {
     {"model",           1, 0, 'm'},

--- a/tests/rigctlsync.c
+++ b/tests/rigctlsync.c
@@ -80,7 +80,7 @@
  * NB: do NOT use -W since it's reserved by POSIX.
  * TODO: add an option to read from a file
  */
-#define SHORT_OPTIONS "B:m:M:r:R:p:d:P:D:s:S:c:C:lLuvhVZ"
+#define SHORT_OPTIONS "Bm:M:r:R:p:d:P:D:s:S:c:C:lLuvhVZ"
 static struct option long_options[] =
 {
     {"mapa2b",          0, 0, 'B'},

--- a/tests/rigctlsync.c
+++ b/tests/rigctlsync.c
@@ -215,12 +215,6 @@ int main(int argc, char *argv[])
 
     printf("rigctlsync Version 1.0\n");
 
-    if (argc < 3)
-    {
-        usage();
-        return 1;
-    }
-
     while (1)
     {
         int c;
@@ -491,10 +485,10 @@ int main(int argc, char *argv[])
     rig_debug(RIG_DEBUG_VERBOSE, "%s",
               "Report bugs to <hamlib-developer@lists.sourceforge.net>\n\n");
 
-    if (argc == 1)
+    if (argc < 3)
     {
         usage();
-        exit(2);
+        exit(1);
     }
 
     my_rig = rig_init(my_model[0]);

--- a/tests/rigctltcp.c
+++ b/tests/rigctltcp.c
@@ -1523,7 +1523,7 @@ void usage(void)
 
 
     printf(
-        "  -m, --model=ID                select radio model number. See model list\n"
+        "  -m, --model=ID                select radio model number. See model list (-l)\n"
         "  -r, --rig-file=DEVICE         set device of the radio to operate on\n"
         "  -p, --ptt-file=DEVICE         set device of the PTT device to operate on\n"
         "  -d, --dcd-file=DEVICE         set device of the DCD device to operate on\n"
@@ -1540,12 +1540,12 @@ void usage(void)
         "  -u, --dump-caps               dump capabilities and exit\n"
         "  -o, --vfo                     do not default to VFO_CURR, require extra vfo arg\n"
         "  -v, --verbose                 set verbose mode, cumulative (-v to -vvvvv)\n"
-        "  -W, --twiddle_timeout         timeout after detecting vfo manual change\n"
-        "  -w, --twiddle_rit             suppress VFOB getfreq so RIT can be twiddled\n"
+        "  -W, --twiddle_timeout=SECONDS timeout after detecting vfo manual change\n"
+        "  -w, --twiddle_rit=SECONDS     suppress VFOB getfreq so RIT can be twiddled\n"
         "  -x, --uplink                  set uplink get_freq ignore, 1=Sub, 2=Main\n"
         "  -Z, --debug-time-stamps       enable time stamps for debug messages\n"
-        "  -M, --multicast-addr=addr     set multicast UDP address, default 0.0.0.0 (off), recommend 224.0.1.1\n"
-        "  -n, --multicast-port=port     set multicast UDP port, default 4531\n"
+        "  -M, --multicast-addr=ADDR     set multicast UDP address, default 0.0.0.0 (off), recommend 224.0.1.1\n"
+        "  -n, --multicast-port=PORT     set multicast UDP port, default 4531\n"
         "  -A, --password                set password for rigctld access\n"
         "  -R, --rigctld-idle            make rigctld close the rig when no clients are connected\n"
         "  -h, --help                    display this help and exit\n"

--- a/tests/rigmem.c
+++ b/tests/rigmem.c
@@ -408,22 +408,22 @@ void version()
 
 void usage()
 {
-    printf("Usage: rigmem [OPTION]... COMMAND...FILE\n"
+    printf("Usage: rigmem [OPTION]... COMMAND... FILE\n"
            "Backup/restore COMMANDs to a connected radio transceiver or receiver.\n\n");
 
 
     printf(
-        "  -m, --model=ID                select radio model number. See model list\n"
+        "  -m, --model=ID                select radio model number. See model list (rigctl -l)\n"
         "  -r, --rig-file=DEVICE         set device of the radio to operate on\n"
         "  -s, --serial-speed=BAUD       set serial speed of the serial port\n"
         "  -c, --civaddr=ID              set CI-V address, decimal (for Icom rigs only)\n"
         "  -C, --set-conf=PARM=VAL       set config parameters\n"
-        "  -p, --set-separator=SEP       set character separator instead of the CSV comma\n"
+        "  -p, --set-separator=CHAR      set character separator instead of the CSV comma\n"
         "  -a, --all                     bypass mem_caps, apply to all fields of channel_t\n"
 #ifdef HAVE_XML2
         "  -x, --xml                     use XML format instead of CSV\n"
 #endif
-        "  -v, --verbose                 set verbose mode, cumulative\n"
+        "  -v, --verbose                 set verbose mode, cumulative (-v to -vvvvv)\n"
         "  -h, --help                    display this help and exit\n"
         "  -V, --version                 output version information and exit\n\n"
     );

--- a/tests/rigsmtr.c
+++ b/tests/rigsmtr.c
@@ -414,16 +414,16 @@ void usage()
            "Input S-Meter vs Azimuth.\n\n");
 
     printf(
-        "  -m, --model=ID                select radio model number. See model list\n"
+        "  -m, --model=ID                select radio model number. See model list (rigctl -l)\n"
         "  -r, --rig-file=DEVICE         set device of the radio to operate on\n"
         "  -s, --serial-speed=BAUD       set serial speed of the serial port\n"
         "  -c, --civaddr=ID              set CI-V address, decimal (for Icom rigs only)\n"
-        "  -C, --set-conf=PARM=VAL       set config parameters\n"
-        "  -M, --rot-model=ID            select rotator model number. See model list\n"
+        "  -C, --set-conf=PARM=VAL[,...] set config parameters\n"
+        "  -M, --rot-model=ID            select rotator model number. See model list (rotctl -l)\n"
         "  -R, --rot-file=DEVICE         set device of the rotator to operate on\n"
         "  -S, --rot-serial-speed=BAUD   set serial speed of the serial port\n"
         "  -N, --rot-set-conf=PARM=VAL   set rotator config parameters\n"
-        "  -v, --verbose                 set verbose mode, cumulative\n"
+        "  -v, --verbose                 set verbose mode, cumulative (-v to -vvvvv)\n"
         "  -h, --help                    display this help and exit\n"
         "  -V, --version                 output version information and exit\n\n"
     );

--- a/tests/rigswr.c
+++ b/tests/rigswr.c
@@ -357,14 +357,14 @@ void usage()
 
 
     printf(
-        "  -m, --model=ID                select radio model number. See model list\n"
+        "  -m, --model=ID                select radio model number. See model list (rigctl -l)\n"
         "  -r, --rig-file=DEVICE         set device of the radio to operate on\n"
         "  -s, --serial-speed=BAUD       set serial speed of the serial port\n"
         "  -c, --civaddr=ID              set CI-V address, decimal (for Icom rigs only)\n"
-        "  -C, --set-conf=PARM=VAL       set config parameters\n"
+        "  -C, --set-conf=PARM=VAL[,...] set config parameters\n"
         "  -p, --ptt-file=DEVICE         set device of the PTT device to operate on\n"
         "  -P, --ptt-type=TYPE           set type of the PTT device to operate on\n"
-        "  -v, --verbose                 set verbose mode, cumulative\n"
+        "  -v, --verbose                 set verbose mode, cumulative (-v to -vvvvv)\n"
         "  -h, --help                    display this help and exit\n"
         "  -V, --version                 output version information and exit\n\n"
     );

--- a/tests/rotctl.c
+++ b/tests/rotctl.c
@@ -534,12 +534,12 @@ void usage()
            "Send COMMANDs to a connected antenna rotator.\n\n");
 
     printf(
-        "  -m, --model=ID                select rotator model number. See model list\n"
+        "  -m, --model=ID                select rotator model number. See model list (-l)\n"
         "  -r, --rot-file=DEVICE         set device of the rotator to operate on\n"
         "  -R, --rot-file2=DEVICE        set device of the 2nd rotator controller to operate on\n"
         "  -s, --serial-speed=BAUD       set serial speed of the serial port\n"
         "  -t, --send-cmd-term=CHAR      set send_cmd command termination char\n"
-        "  -C, --set-conf=PARM=VAL       set config parameters\n"
+        "  -C, --set-conf=PARM=VAL[,...] set config parameters\n"
         "  -o, --set-azoffset=VAL        set offset for azimuth\n"
         "  -O, --set-eloffset=VAL        set offset for elevation\n"
         "  -L, --show-conf               list all config parameters\n"
@@ -549,7 +549,7 @@ void usage()
         "  -i, --read-history            read prior interactive session history\n"
         "  -I, --save-history            save current interactive session history\n"
 #endif
-        "  -v, --verbose                 set verbose mode, cumulative\n"
+        "  -v, --verbose                 set verbose mode, cumulative (-v to -vvvvv)\n"
         "  -Z, --debug-time-stamps       enable time stamps for debug messages\n"
         "  -h, --help                    display this help and exit\n"
         "  -V, --version                 output version information and exit\n\n"

--- a/tests/rotctl.c
+++ b/tests/rotctl.c
@@ -552,7 +552,9 @@ void usage()
         "  -v, --verbose                 set verbose mode, cumulative (-v to -vvvvv)\n"
         "  -Z, --debug-time-stamps       enable time stamps for debug messages\n"
         "  -h, --help                    display this help and exit\n"
-        "  -V, --version                 output version information and exit\n\n"
+        "  -V, --version                 output version information and exit\n"
+        "  -                             read commands from standard input\n"
+        "\n"
     );
 
     usage_rot(stdout);

--- a/tests/rotctld.c
+++ b/tests/rotctld.c
@@ -768,19 +768,19 @@ void usage()
            "Daemon serving COMMANDs to a connected antenna rotator.\n\n");
 
     printf(
-        "  -m, --model=ID                select rotator model number. See model list\n"
+        "  -m, --model=ID                select rotator model number. See model list (-l)\n"
         "  -r, --rot-file=DEVICE         set device of the rotator to operate on\n"
         "  -R, --rot-file2=DEVICE        set device of the 2nd rotator controller to operate on\n"
         "  -s, --serial-speed=BAUD       set serial speed of the serial port\n"
         "  -t, --port=NUM                set TCP listening port, default %s\n"
         "  -T, --listen-addr=IPADDR      set listening IP address, default ANY\n"
-        "  -C, --set-conf=PARM=VAL       set config parameters\n"
-        "  -o, --set-azoffset==VAL       set offset for azimuth\n"
-        "  -O, --set-eloffset==VAL       set offset for elevation\n"
+        "  -C, --set-conf=PARM=VAL[,...] set config parameters\n"
+        "  -o, --set-azoffset=VAL        set offset for azimuth\n"
+        "  -O, --set-eloffset=VAL        set offset for elevation\n"
         "  -L, --show-conf               list all config parameters\n"
         "  -l, --list                    list all model numbers and exit\n"
         "  -u, --dump-caps               dump capabilities and exit\n"
-        "  -v, --verbose                 set verbose mode, cumulative\n"
+        "  -v, --verbose                 set verbose mode, cumulative (-v to -vvvvv)\n"
         "  -Z, --debug-time-stamps       enable time stamps for debug messages\n"
         "  -h, --help                    display this help and exit\n"
         "  -V, --version                 output version information and exit\n\n",


### PR DESCRIPTION
This PR changes some code:
- removes `-z` from rigctld because it isn't implemented
- fixes `--mapa2b` `--version` and `--help` in rigctlsync

and changes some strings:
- adds `-v to -vvvvv` to all programs that support the option `--verbose` (closes #1728)
- adds `-l` to all programs that support this option `--model`
- adds some missing option arguments
- adds the description of the option `-` to all programs that support it
- change some texts to be identical or more similar