### PR TITLE
Fix build when USRP is enabled

### DIFF
--- a/rigs/kit/usrp.c
+++ b/rigs/kit/usrp.c
@@ -19,6 +19,8 @@
  *
  */
 
+#include <hamlib/config.h>
+
 /*
  * Compile only this model if usrp is available
  */

--- a/rigs/kit/usrp_impl.cc
+++ b/rigs/kit/usrp_impl.cc
@@ -30,7 +30,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
-#include <usrp_standard.h>
+#include <usrp/usrp_standard.h>
 
 #include "usrp_impl.h"
 #include "token.h"
@@ -46,7 +46,7 @@ struct usrp_priv_data {
 int usrp_init(RIG *rig)
 {
     // cppcheck-suppress leakReturnValNotUsed
-	STATE(rig)->priv = static_cast<struct usrp_priv_data*>malloc(sizeof(struct usrp_priv_data));
+	STATE(rig)->priv = static_cast<struct usrp_priv_data*>(malloc(sizeof(struct usrp_priv_data)));
 	if (!STATE(rig)->priv) {
 		/* whoops! memory shortage! */
 		return -RIG_ENOMEM;
@@ -69,7 +69,7 @@ int usrp_cleanup(RIG *rig)
 
 int usrp_open(RIG *rig)
 {
-	struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>STATE(rig)->priv;
+	struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>(STATE(rig)->priv);
 
 	int which_board = 0;
 	int decim = 125;
@@ -83,7 +83,7 @@ int usrp_open(RIG *rig)
 
 int usrp_close(RIG *rig)
 {
-	struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>STATE(rig)->priv;
+	struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>(STATE(rig)->priv);
 
     if (!priv)
     {
@@ -101,7 +101,7 @@ int usrp_close(RIG *rig)
  */
 int usrp_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 {
-	struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>STATE(rig)->priv;
+	struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>(STATE(rig)->priv);
 
     if (!priv)
     {
@@ -111,7 +111,7 @@ int usrp_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 
 	switch(token) {
 		case TOK_IFMIXFREQ:
-			sscanf(val, "%"SCNfreq, &priv->if_mix_freq);
+			sscanf(val, "%" SCNfreq, &priv->if_mix_freq);
 			break;
 		default:
 			return -RIG_EINVAL;
@@ -126,7 +126,7 @@ int usrp_set_conf(RIG *rig, hamlib_token_t token, const char *val)
  */
 int usrp_get_conf(RIG *rig, hamlib_token_t token, char *val)
 {
-	const struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>STATE(rig)->priv;
+	const struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>(STATE(rig)->priv);
 
     if (!priv)
     {
@@ -136,7 +136,7 @@ int usrp_get_conf(RIG *rig, hamlib_token_t token, char *val)
 
 	switch(token) {
 		case TOK_IFMIXFREQ:
-			sprintf(val, "%"PRIfreq, priv->if_mix_freq);
+			sprintf(val, "%" PRIfreq, priv->if_mix_freq);
 			break;
 		default:
 			return -RIG_EINVAL;
@@ -148,7 +148,7 @@ int usrp_get_conf(RIG *rig, hamlib_token_t token, char *val)
 
 int usrp_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-	const struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>STATE(rig)->priv;
+	const struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>(STATE(rig)->priv);
 	int chan = 0;
 
     if (!priv)
@@ -166,7 +166,7 @@ int usrp_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
 int usrp_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
-	const struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>STATE(rig)->priv;
+	const struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>(STATE(rig)->priv);
 	int chan = 0;
 
     if (!priv)


### PR DESCRIPTION
The USRP code may be old but these fixes are trivial (a missing include ad some missing parentheses and spaces).

This allows `make distcheck AM_DISTCHECK_CONFIGURE_FLAGS="--enable-usrp"` to succeed.

Compile-tested because I do not own the hardware.