### PR TITLE
Fix issue where Hamlib attempts to use memory returned by setlocale() after being freed.

### DIFF
--- a/include/num_stdio.h
+++ b/include/num_stdio.h
@@ -23,6 +23,8 @@
 #define _NUM_STDIO_H 1
 
 #include <locale.h>
+#include <string.h>
+#include <assert.h>
 
 /*
  * This header file is internal to Hamlib and its backends,
@@ -36,27 +38,42 @@
 #define num_sscanf(a...) \
     ({ int __ret; char *__savedlocale; \
        __savedlocale = setlocale(LC_NUMERIC, NULL); \
+       if (__savedlocale != NULL) { \
+           __savedlocale = strdup(__savedlocale); \
+           assert(__savedlocale != NULL); \
+       } \
        setlocale(LC_NUMERIC, "C"); \
        __ret = sscanf(a); \
        setlocale(LC_NUMERIC, __savedlocale); \
+       if (__savedlocale != NULL) free(__savedlocale); \
        __ret; \
      })
 
 #define num_sprintf(s, a...) \
     ({ int __ret; char *__savedlocale; \
        __savedlocale = setlocale(LC_NUMERIC, NULL); \
+       if (__savedlocale != NULL) { \
+           __savedlocale = strdup(__savedlocale); \
+           assert(__savedlocale != NULL); \
+       } \
        setlocale(LC_NUMERIC, "C"); \
        __ret = sprintf(s, a); \
        setlocale(LC_NUMERIC, __savedlocale); \
+       if (__savedlocale != NULL) free(__savedlocale); \
        __ret; \
      })
 
 #define num_snprintf(s, n, a...) \
     ({ int __ret; char *__savedlocale; \
        __savedlocale = setlocale(LC_NUMERIC, NULL); \
+       if (__savedlocale != NULL) { \
+           __savedlocale = strdup(__savedlocale); \
+           assert(__savedlocale != NULL); \
+       } \
        setlocale(LC_NUMERIC, "C"); \
        __ret = snprintf(s, n, a); \
        setlocale(LC_NUMERIC, __savedlocale); \
+       if (__savedlocale != NULL) free(__savedlocale); \
        __ret; \
      })
 

--- a/include/num_stdio.h
+++ b/include/num_stdio.h
@@ -23,6 +23,7 @@
 #define _NUM_STDIO_H 1
 
 #include <locale.h>
+#include <stdlib.h>
 #include <string.h>
 #include <assert.h>
 


### PR DESCRIPTION
While debugging another issue with the application I help maintain (FreeDV), I noticed the following AddressSanitizer error occurring on `rig_open()`:

```
==584731==ERROR: AddressSanitizer: heap-use-after-free on address 0x5020000c0030 at pc 0xea44a9c08a24 bp 0xea4451791760 sp 0xea4451790f40
READ of size 4 at 0x5020000c0030 thread T18
    #0 0xea44a9c08a20 in setlocale ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:3492
    #1 0xea44a8ce4908  (/lib/aarch64-linux-gnu/libhamlib.so.4+0x104908) (BuildId: a00e7288dce3ad5ed6f3a54b3bbf2d67382be4c8)
    #2 0xea44a8c75a18 in rig_open (/lib/aarch64-linux-gnu/libhamlib.so.4+0x95a18) (BuildId: a00e7288dce3ad5ed6f3a54b3bbf2d67382be4c8)
    #3 0xc9015a827c2c in HamlibRigController::connectImpl_() /home/parallels/freedv-gui/src/rig_control/HamlibRigController.cpp:364
    #4 0xc9015a83c728 in void std::__invoke_impl<void, void (HamlibRigController::*&)(), HamlibRigController*&>(std::__invoke_memfun_deref, void (HamlibRigController::*&)(), HamlibRigController*&) (/home/parallels/freedv-gui/build_linux/src/freedv+0x3cc728) (BuildId: 19780869902532b8b9aaee0f89d47003aec8a6d2)
...
previously allocated by thread T0 here:
    #0 0xea44a9c776d0 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0xea44a768d62c in __GI___strdup string/strdup.c:42
    #2 0xea44a7625424 in __GI_setlocale locale/setlocale.c:366
    #3 0xea44a805a3d4 in wxSetlocale(int, char const*) (/lib/aarch64-linux-gnu/libwx_baseu-3.2.so.0+0x13a3d4) (BuildId: 35d565bbdd2ce5462df434bac604205304223978)
    #4 0xea44a80c1754  (/lib/aarch64-linux-gnu/libwx_baseu-3.2.so.0+0x1a1754) (BuildId: 35d565bbdd2ce5462df434bac604205304223978)
    #5 0xea44a80c19bc  (/lib/aarch64-linux-gnu/libwx_baseu-3.2.so.0+0x1a19bc) (BuildId: 35d565bbdd2ce5462df434bac604205304223978)
    #6 0xea44a80b52f8  (/lib/aarch64-linux-gnu/libwx_baseu-3.2.so.0+0x1952f8) (BuildId: 35d565bbdd2ce5462df434bac604205304223978)
    #7 0xea44a807cc60 in wxUILocale::UseDefault() (/lib/aarch64-linux-gnu/libwx_baseu-3.2.so.0+0x15cc60) (BuildId: 35d565bbdd2ce5462df434bac604205304223978)
    #8 0xc9015a54b570 in MainApp::OnInit() /home/parallels/freedv-gui/src/main.cpp:518
...
```

This appears to be due to Hamlib violating the semantics of `setlocale()` in that it can't rely on memory returned by it existing after a subsequent call to it. (More info [here](https://www.gnu.org/software/libc/manual/html_node/Setting-the-Locale.html).) This PR adds `strdup()` calls everywhere where `setlocale()` is used to avoid touching already deleted memory when restoring the application's locale.