### PR TITLE
Fix/typos

### DIFF
--- a/doc/man1/rotctld.1
+++ b/doc/man1/rotctld.1
@@ -159,6 +159,7 @@ rotctld -T 127.0.0.1 (bind only to 127.0.0.1)
 .in +4n
 rotctl -m 2 (binds to all interfaces)
 rotctl -m 2 -r 127.0.0.1 (bind only to 127.0.0.1)
+.EE
 .
 .TP
 .BR \-t ", " \-\-port = \fInumber\fP

--- a/rigs/dummy/amp_dummy.c
+++ b/rigs/dummy/amp_dummy.c
@@ -186,7 +186,7 @@ static int dummy_amp_get_level(AMP *amp, setting_t level, value_t *val)
         return RIG_OK;
 
     case AMP_LEVEL_NH:
-        rig_debug(RIG_DEBUG_VERBOSE, "%s AMP_LEVEL_UH\n", __func__);
+        rig_debug(RIG_DEBUG_VERBOSE, "%s AMP_LEVEL_NH\n", __func__);
         val->i = flag == 0 ? 0 : 8370;
         return RIG_OK;
 


### PR DESCRIPTION
This PR:

- fixes the formatting of a man page (the following paragraph was rendered as verbatim text with hard line breaks)
- fixes a typing error in a debug message in the dummy driver

This could wait for 4.7.0