### PR TITLE
Small fixes and lots of  cppcheck tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ config.sub
 config.log
 config.status
 configure
+cppcheck.log
 depcomp
 hamlib.pc
 hamlib.spec

--- a/amplifiers/elecraft/kpa.c
+++ b/amplifiers/elecraft/kpa.c
@@ -90,7 +90,7 @@ int kpa_close(AMP *amp)
     return RIG_OK;
 }
 
-int kpa_flushbuffer(AMP *amp)
+static int kpa_flushbuffer(AMP *amp)
 {
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 

--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -3888,7 +3888,7 @@ locator2longlat HAMLIB_PARAMS((double *longitude,
                                double *latitude,
                                const char *locator));
 
-extern HAMLIB_EXPORT(char*) rig_make_md5(char *pass);
+extern HAMLIB_EXPORT(char*) rig_make_md5(const char *pass);
 
 extern HAMLIB_EXPORT(int) rig_set_lock_mode(RIG *rig, int lock);
 extern HAMLIB_EXPORT(int) rig_get_lock_mode(RIG *rig, int *lock);

--- a/rigs/dummy/dummy.c
+++ b/rigs/dummy/dummy.c
@@ -2312,7 +2312,7 @@ static int dummy_mW2power(RIG *rig, float *power, unsigned int mwpower,
 static int m_year, m_month, m_day, m_hour, m_min, m_sec, m_utc_offset;
 static double m_msec;
 
-int dummy_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
+static int dummy_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
                     int sec, double msec, int utc_offset)
 {
     int retval = RIG_OK;
@@ -2337,7 +2337,7 @@ int dummy_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
     return retval;
 }
 
-int dummy_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
+static int dummy_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
                     int *min, int *sec, double *msec, int *utc_offset)
 {
     int retval = RIG_OK;

--- a/rigs/flexradio/dttsp.c
+++ b/rigs/flexradio/dttsp.c
@@ -439,7 +439,7 @@ int dttsp_set_conf(RIG *rig, hamlib_token_t token, const char *val)
  * Assumes rig!=NULL, STATE(rig)->priv!=NULL
  *  and val points to a buffer big enough to hold the conf value.
  */
-int dttsp_get_conf2(RIG *rig, hamlib_token_t token, char *val, int val_len)
+static int dttsp_get_conf2(RIG *rig, hamlib_token_t token, char *val, int val_len)
 {
     struct dttsp_priv_data *priv;
     struct rig_state *rs;

--- a/rigs/icom/ic7100.c
+++ b/rigs/icom/ic7100.c
@@ -211,7 +211,7 @@ static const struct icom_priv_caps ic7100_priv_caps =
 };
 
 // if hour < 0 then only date will be set
-int ic7100_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
+static int ic7100_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
                      int sec, double msec, int utc_offset)
 {
     int cmd = 0x1a;
@@ -265,7 +265,7 @@ int ic7100_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
     return retval;
 }
 
-int ic7100_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
+static int ic7100_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
                      int *min, int *sec, double *msec, int *utc_offset)
 {
     int cmd = 0x1a;

--- a/rigs/icom/ic7200.c
+++ b/rigs/icom/ic7200.c
@@ -95,8 +95,8 @@
     } }
 
 
-int ic7200_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val);
-int ic7200_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val);
+static int ic7200_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val);
+static int ic7200_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val);
 
 /*
  * IC-7200 rig capabilities.
@@ -295,7 +295,7 @@ struct rig_caps ic7200_caps =
     .hamlib_check_rig_caps = HAMLIB_CHECK_RIG_CAPS
 };
 
-int ic7200_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
+static int ic7200_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
     unsigned char cmdbuf[MAXFRAMELEN];
 
@@ -312,7 +312,7 @@ int ic7200_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
     }
 }
 
-int ic7200_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
+static int ic7200_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
     unsigned char cmdbuf[MAXFRAMELEN];
 

--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -231,7 +231,7 @@ struct confparams kenwood_cfg_params[] =
     { RIG_CONF_END, NULL, }
 };
 
-int remove_nonprint(char *s)
+static int remove_nonprint(char *s)
 {
     int i, j = 0;
     if (s == NULL) return 0;
@@ -392,7 +392,7 @@ transaction_write:
         skip |= strncmp(cmdstr, "RD", 2) == 0;
         skip |= strncmp(cmdstr, "KYW", 3) == 0;
         skip |= strncmp(cmdstr, "KY ", 3) == 0;
-	skip |= strncmp(cmdstr, "KY0", 3) == 0;
+        skip |= strncmp(cmdstr, "KY0", 3) == 0;
         skip |= strncmp(cmdstr, "KY2", 3) == 0;
         skip |= strncmp(cmdstr, "PS1", 3) == 0;
         skip |= strncmp(cmdstr, "PS0", 3) == 0;
@@ -770,7 +770,7 @@ int kenwood_safe_transaction(RIG *rig, const char *cmd, char *buf,
         if (checklen && length != expected) /* worth retrying as some rigs
                                    occasionally send short results */
         {
-            // QRPLABS can't seem top decide if they give 37 or 38 bytes for IF command
+            // QRPLABS can't seem to decide if they give 37 or 38 bytes for IF command
             if (strncmp(cmd, "IF", 2) == 0 && rig->caps->rig_model == RIG_MODEL_QRPLABS) { break; }
 
             struct kenwood_priv_data *priv = STATE(rig)->priv;
@@ -5575,6 +5575,14 @@ int kenwood_send_morse(RIG *rig, vfo_t vfo, const char *msg)
             SNPRINTF(morsebuf, sizeof(morsebuf), "KY %s", m2);
             break;
 
+        case RIG_MODEL_TS590S:
+        //??case RIG_MODEL_TS590SG:
+            /* The command must consist of 28 bytes right aligned.
+             * See https://github.com/Hamlib/Hamlib/issues/1634
+             */
+            SNPRINTF(morsebuf, sizeof(morsebuf), "KY %24s", m2);
+            break;
+
         case RIG_MODEL_TS890S:
             SNPRINTF(morsebuf, sizeof morsebuf, "KY2%s", m2);
             break;
@@ -5588,11 +5596,6 @@ int kenwood_send_morse(RIG *rig, vfo_t vfo, const char *msg)
                 break;
             }
             /* FALL THROUGH */
-
-          case RIG_MODEL_TS590S:
-            /* the command must consist of 28 bytes right aligned */
-              SNPRINTF(morsebuf, sizeof(morsebuf), "KY %24s", m2);
-	            break;
 
         default:
             /* the command must consist of 28 bytes 0x20 padded */

--- a/rigs/kenwood/kenwood.h
+++ b/rigs/kenwood/kenwood.h
@@ -28,7 +28,7 @@
 #include "token.h"
 #include "idx_builtin.h"
 
-#define BACKEND_VER "20250107"
+#define BACKEND_VER "20250515"
 
 #define EOM_KEN ';'
 #define EOM_TH '\r'

--- a/rigs/kenwood/ts2000.c
+++ b/rigs/kenwood/ts2000.c
@@ -266,7 +266,7 @@ static struct kenwood_priv_caps  ts2000_priv_caps  =
  * Function definitions below
  */
 
-int ts2000_init(RIG *rig)
+static int ts2000_init(RIG *rig)
 {
     struct kenwood_priv_data *priv;
     int retval;

--- a/rigs/kenwood/ts480.c
+++ b/rigs/kenwood/ts480.c
@@ -169,7 +169,7 @@ const struct confparams ts480_ext_levels[] =
  * kenwood_ts480_get_info
  * Assumes rig!=NULL
  */
-const char *
+static const char *
 kenwood_ts480_get_info(RIG *rig)
 {
     char firmbuf[50];
@@ -313,7 +313,7 @@ static int ts480_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
  * WARNING: The commands differ slightly from the general versions in kenwood.c
  * e.g.: "SQ"=>"SQ0" , "AG"=>"AG0"
  */
-int kenwood_ts480_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
+static int kenwood_ts480_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
     char levelbuf[16];
     int kenwood_val;
@@ -489,7 +489,7 @@ static int ts480_read_meters(RIG *rig, int *swr, int *comp, int *alc)
  * kenwood_ts480_get_level
  * Assumes rig!=NULL, val!=NULL
  */
-int
+static int
 kenwood_ts480_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
     char ackbuf[50];
@@ -1204,7 +1204,7 @@ static struct kenwood_priv_caps ts480_priv_caps =
     .slope_filter_low = ts480_slope_filter_low,
 };
 
-int ts480_init(RIG *rig)
+static int ts480_init(RIG *rig)
 {
     struct kenwood_priv_data *priv;
     int retval;
@@ -1227,7 +1227,7 @@ int ts480_init(RIG *rig)
     RETURNFUNC(RIG_OK);
 }
 
-int qrplabs_open(RIG *rig)
+static int qrplabs_open(RIG *rig)
 {
     int retval;
     char buf[64];
@@ -1279,7 +1279,7 @@ int qdx_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 }
 
 
-int qrplabs_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
+static int qrplabs_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
                       int *min, int *sec, double *msec, int *utc_offset)
 {
     char tm_cmd[32];
@@ -1295,7 +1295,7 @@ int qrplabs_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
     return retval;
 }
 
-int qrplabs_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
+static int qrplabs_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
                       int sec, double msec, int utc_offset)
 {
     char tm_cmd[32];
@@ -2356,7 +2356,7 @@ const struct confparams malachite_cfg_parms[] =
     { RIG_CONF_END, NULL, }
 };
 
-int malachite_init(RIG *rig)
+static int malachite_init(RIG *rig)
 {
     struct kenwood_priv_data *priv;
     int retval;
@@ -2374,7 +2374,7 @@ int malachite_init(RIG *rig)
     RETURNFUNC(RIG_OK);
 }
 
-int malachite_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
+static int malachite_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
 {
     int post_write_delay_save = STATE(rig)->post_write_delay;
     STATE(rig)->post_write_delay = 0;
@@ -2383,7 +2383,7 @@ int malachite_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
     return retval;
 }
 
-int malachite_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
+static int malachite_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
     int post_write_delay_save = STATE(rig)->post_write_delay;
     ENTERFUNC;
@@ -2393,7 +2393,7 @@ int malachite_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
     RETURNFUNC(retval);
 }
 
-int malachite_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
+static int malachite_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
     int retval;
     struct rig_cache *cachep = CACHE(rig);

--- a/rigs/kenwood/ts570.c
+++ b/rigs/kenwood/ts570.c
@@ -242,7 +242,7 @@ static int ts570_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
  * extends kenwood_set_func
  * Assumes rig!=NULL, val!=NULL
  */
-int ts570_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
+static int ts570_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
 {
     char fctbuf[6];
 
@@ -278,7 +278,7 @@ int ts570_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
  * extends kenwood_get_func
  * Assumes rig!=NULL, val!=NULL
  */
-int ts570_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
+static int ts570_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
 {
     char fctbuf[50];
     size_t fct_len;
@@ -342,7 +342,7 @@ int ts570_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
  *
  * set levels of most functions
  */
-int
+static int
 ts570_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
     char levelbuf[16];
@@ -400,7 +400,7 @@ ts570_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
  * ts570_get_level
  * Assumes rig!=NULL, val!=NULL
  */
-int
+static int
 ts570_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
     char ackbuf[50];
@@ -515,7 +515,7 @@ ts570_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 /*
  * ts570_get_split_vfo
  */
-int ts570_get_split_vfo(RIG *rig, vfo_t vfo, split_t *split, vfo_t *tx_vfo)
+static int ts570_get_split_vfo(RIG *rig, vfo_t vfo, split_t *split, vfo_t *tx_vfo)
 {
     char ack[10];
     char ack2[10];
@@ -568,7 +568,7 @@ int ts570_get_split_vfo(RIG *rig, vfo_t vfo, split_t *split, vfo_t *tx_vfo)
 /*
  * ts570_set_split_vfo
  */
-int ts570_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t txvfo)
+static int ts570_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t txvfo)
 {
     char cmdbuf[16], ackbuf[20];
     int retval;
@@ -683,7 +683,7 @@ int ts570_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t txvfo)
     .ctcss_tone=1       \
 }
 
-int ts570_set_channel(RIG *rig, vfo_t vfo, const channel_t *chan)
+static int ts570_set_channel(RIG *rig, vfo_t vfo, const channel_t *chan)
 {
     char cmdbuf[30];
     int retval;
@@ -746,7 +746,7 @@ int ts570_set_channel(RIG *rig, vfo_t vfo, const channel_t *chan)
     return RIG_OK;
 }
 
-int ts570_get_xit(RIG *rig, vfo_t vfo, shortfreq_t *rit)
+static int ts570_get_xit(RIG *rig, vfo_t vfo, shortfreq_t *rit)
 {
     char infobuf[50];
     int retval;
@@ -780,7 +780,7 @@ int ts570_get_xit(RIG *rig, vfo_t vfo, shortfreq_t *rit)
     return RIG_OK;
 }
 
-int ts570_set_rit(RIG *rig, vfo_t vfo, shortfreq_t rit)
+static int ts570_set_rit(RIG *rig, vfo_t vfo, shortfreq_t rit)
 {
     char buf[50];
     unsigned char c;
@@ -840,7 +840,7 @@ int ts570_set_rit(RIG *rig, vfo_t vfo, shortfreq_t rit)
     return RIG_OK;
 }
 
-int ts570_set_xit(RIG *rig, vfo_t vfo, shortfreq_t rit)
+static int ts570_set_xit(RIG *rig, vfo_t vfo, shortfreq_t rit)
 {
     char buf[50];
     unsigned char c;

--- a/rigs/kenwood/ts590.c
+++ b/rigs/kenwood/ts590.c
@@ -185,7 +185,7 @@ const struct confparams ts590_ext_levels[] =
  * This is not documented in the manual as of 3/11/15 but confirmed from Kenwood
  * "TY" produces "TYK 00" for example
  */
-const char *ts590_get_info(RIG *rig)
+static const char *ts590_get_info(RIG *rig)
 {
     char firmbuf[10];
     int retval;

--- a/rigs/kenwood/ts870s.c
+++ b/rigs/kenwood/ts870s.c
@@ -265,7 +265,7 @@ static int ts870s_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     return retval;
 }
 
-int ts870s_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
+static int ts870s_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
     char levelbuf[16];
     int intval;

--- a/rigs/kenwood/ts890s.c
+++ b/rigs/kenwood/ts890s.c
@@ -290,13 +290,13 @@ static int kenwood_ts890_get_level(RIG *rig, vfo_t vfo, setting_t level,
     case RIG_LEVEL_STRENGTH:
     case RIG_LEVEL_RFPOWER_METER_WATTS:
     {
-        cal_table_float_t *table;
+        const cal_table_float_t *table;
         ptt_t ptt = RIG_PTT_OFF;
         /* Values taken from the TS-890S In-Depth Manual (IDM), p. 8
          * 0.03 - 21.5 MHz, Preamp 1
          */
         /* Meter Type 1 - Kenwood specific, factory default */
-        static cal_table_float_t meter_type1 =
+        static const cal_table_float_t meter_type1 =
         {
             9, { { 0, -28.4f}, { 3, -26}, {11, -19.5f},
                 {19, -13}, {27, -6.5f}, {35, 0},
@@ -304,7 +304,7 @@ static int kenwood_ts890_get_level(RIG *rig, vfo_t vfo, setting_t level,
             }
         };
         /* Meter Type 2 - IARU recommended */
-        static cal_table_float_t meter_type2 =
+        static const cal_table_float_t meter_type2 =
         {
             9, { { 0, -54}, { 3, -48}, {11, -36},
                 {19, -24}, {27, -12}, {35, 0},
@@ -462,7 +462,7 @@ static int ts890_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
         return retval;
     }
 
-    *status = current[2] & mask ? 1 : 0;
+    *status = (current[2] & mask) ? 1 : 0;
     return RIG_OK;
 }
 

--- a/rigs/kenwood/xg3.c
+++ b/rigs/kenwood/xg3.c
@@ -75,22 +75,22 @@ static struct kenwood_priv_caps xg3_priv_caps =
 
 
 /* XG3 specific rig_caps API function declarations */
-int xg3_init(RIG *rig);
-int xg3_open(RIG *rig);
-int xg3_set_vfo(RIG *rig, vfo_t vfo);
-int xg3_get_vfo(RIG *rig, vfo_t *vfo);
-int xg3_set_freq(RIG *rig, vfo_t vfo, freq_t freq);
-int xg3_get_freq(RIG *rig, vfo_t vfo, freq_t *freq);
-int xg3_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt);
-int xg3_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt);
-int xg3_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val);
-int xg3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val);
-int xg3_set_powerstat(RIG *rig, powerstat_t status);
-int xg3_get_powerstat(RIG *rig, powerstat_t *status);
-int xg3_set_mem(RIG *rig, vfo_t vfo, int ch);
-int xg3_get_mem(RIG *rig, vfo_t vfo, int *ch);
-int xg3_set_parm(RIG *rig, setting_t parm, value_t val);
-int xg3_get_parm(RIG *rig, setting_t parm, value_t *val);
+static int xg3_init(RIG *rig);
+static int xg3_open(RIG *rig);
+static int xg3_set_vfo(RIG *rig, vfo_t vfo);
+static int xg3_get_vfo(RIG *rig, vfo_t *vfo);
+static int xg3_set_freq(RIG *rig, vfo_t vfo, freq_t freq);
+static int xg3_get_freq(RIG *rig, vfo_t vfo, freq_t *freq);
+static int xg3_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt);
+static int xg3_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt);
+static int xg3_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val);
+static int xg3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val);
+static int xg3_set_powerstat(RIG *rig, powerstat_t status);
+static int xg3_get_powerstat(RIG *rig, powerstat_t *status);
+static int xg3_set_mem(RIG *rig, vfo_t vfo, int ch);
+static int xg3_get_mem(RIG *rig, vfo_t vfo, int *ch);
+static int xg3_set_parm(RIG *rig, setting_t parm, value_t val);
+static int xg3_get_parm(RIG *rig, setting_t parm, value_t *val);
 
 
 /*
@@ -183,7 +183,7 @@ struct rig_caps xg3_caps =
 /*
  * xg3_init()
  */
-int xg3_init(RIG *rig)
+static int xg3_init(RIG *rig)
 {
     struct kenwood_priv_data *priv;
     int i;
@@ -225,7 +225,7 @@ int xg3_init(RIG *rig)
 /*
  * xg3_open()
  */
-int xg3_open(RIG *rig)
+static int xg3_open(RIG *rig)
 {
     int err;
     ptt_t ptt;
@@ -245,7 +245,7 @@ int xg3_open(RIG *rig)
 }
 
 
-int xg3_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
+static int xg3_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
     char levelbuf[16];
 
@@ -275,7 +275,7 @@ int xg3_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 /*
  * kenwood_get_level
  */
-int xg3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
+static int xg3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
     char cmdbuf[32], replybuf[32];
     int retval;
@@ -343,7 +343,7 @@ int xg3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 /*
  * xg3_get_vfo
  */
-int xg3_get_vfo(RIG *rig, vfo_t *vfo)
+static int xg3_get_vfo(RIG *rig, vfo_t *vfo)
 {
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
@@ -359,7 +359,7 @@ int xg3_get_vfo(RIG *rig, vfo_t *vfo)
 /*
  * xg3_set_vfo
  */
-int xg3_set_vfo(RIG *rig, vfo_t vfo)
+static int xg3_set_vfo(RIG *rig, vfo_t vfo)
 {
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
@@ -379,7 +379,7 @@ int xg3_set_vfo(RIG *rig, vfo_t vfo)
 /*
  * xg3_set_freq
  */
-int xg3_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
+static int xg3_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
     int err;
     vfo_t tvfo;
@@ -422,7 +422,7 @@ int xg3_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 /*
  * xg3_get_freq
  */
-int xg3_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
+static int xg3_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
     struct hamlib_port *rp;
     char freqbuf[50];
@@ -494,7 +494,7 @@ int xg3_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 /*
  * xg3_set_powerstat
  */
-int xg3_set_powerstat(RIG *rig, powerstat_t status)
+static int xg3_set_powerstat(RIG *rig, powerstat_t status)
 {
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
@@ -514,7 +514,7 @@ int xg3_set_powerstat(RIG *rig, powerstat_t status)
 /*
  * xg3_get_powerstat
  */
-int xg3_get_powerstat(RIG *rig, powerstat_t *status)
+static int xg3_get_powerstat(RIG *rig, powerstat_t *status)
 {
     const char *cmd = "G";      // any command to test will do
     char buf[6];
@@ -540,7 +540,7 @@ int xg3_get_powerstat(RIG *rig, powerstat_t *status)
 /*
  * xg3_set_mem
  */
-int xg3_set_mem(RIG *rig, vfo_t vfo, int ch)
+static int xg3_set_mem(RIG *rig, vfo_t vfo, int ch)
 {
     char cmdbuf[32];
     int retval;
@@ -569,7 +569,7 @@ int xg3_set_mem(RIG *rig, vfo_t vfo, int ch)
 /*
  * xg3_get_mem
  */
-int xg3_get_mem(RIG *rig, vfo_t vfo, int *ch)
+static int xg3_get_mem(RIG *rig, vfo_t vfo, int *ch)
 {
     char cmdbuf[32];
     char reply[32];
@@ -602,7 +602,7 @@ int xg3_get_mem(RIG *rig, vfo_t vfo, int *ch)
 /*
  * xg3_set_ptt
  */
-int xg3_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
+static int xg3_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 {
     int retval;
 
@@ -622,7 +622,7 @@ int xg3_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 /*
  * kenwood_get_ptt
  */
-int xg3_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
+static int xg3_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
 {
     char pttbuf[6];
     int retval;
@@ -650,7 +650,7 @@ int xg3_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
 /*
  * xg3_set_parm
  */
-int xg3_set_parm(RIG *rig, setting_t parm, value_t val)
+static int xg3_set_parm(RIG *rig, setting_t parm, value_t val)
 {
     int ival;
     char cmdbuf[16];
@@ -679,7 +679,7 @@ int xg3_set_parm(RIG *rig, setting_t parm, value_t val)
 /*
  * xg3_get_parm
  */
-int xg3_get_parm(RIG *rig, setting_t parm, value_t *val)
+static int xg3_get_parm(RIG *rig, setting_t parm, value_t *val)
 {
     int ival;
     char replybuf[6];

--- a/rigs/tentec/jupiter.c
+++ b/rigs/tentec/jupiter.c
@@ -257,7 +257,7 @@ static int tt538_transaction(RIG *rig, const char *cmd, int cmd_len,
 
     retval = tentec_transaction(rig, cmd, cmd_len, data, data_len);
 
-    if (data == NULL || (data != NULL && data_len > 0))
+    if (data == NULL || data_len > 0)
     {
         return retval;
     }

--- a/rigs/yaesu/ft3000.c
+++ b/rigs/yaesu/ft3000.c
@@ -144,7 +144,7 @@ int ftdx3000_ext_tokens[] =
     TOK_BACKEND_NONE
 };
 
-int ft3000_set_ant(RIG *rig, vfo_t vfo, ant_t ant, value_t option)
+static int ft3000_set_ant(RIG *rig, vfo_t vfo, ant_t ant, value_t option)
 {
     char *cmd;
     int err;
@@ -181,7 +181,7 @@ int ft3000_set_ant(RIG *rig, vfo_t vfo, ant_t ant, value_t option)
     RETURNFUNC(RIG_OK);
 }
 
-int ft3000_get_ant(RIG *rig, vfo_t vfo, ant_t dummy, value_t *option,
+static int ft3000_get_ant(RIG *rig, vfo_t vfo, ant_t dummy, value_t *option,
                    ant_t *ant_curr, ant_t *ant_tx, ant_t *ant_rx)
 {
     struct newcat_priv_data *priv = (struct newcat_priv_data *)STATE(rig)->priv;

--- a/rigs/yaesu/ft857.c
+++ b/rigs/yaesu/ft857.c
@@ -928,11 +928,11 @@ int ft857_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         rig_get_cache(rig, vfo, &freq, &freq_ms, &mode, &mode_ms, &width,
                       &width_ms);
 
-        if (144000000.0f >= freq && 148000000.0f <= freq)
+        if (144000000.0f <= freq && 148000000.0f > freq)
         {
             return ft857_get_pometer_level(rig, val, &rig->caps->rfpower_meter_cal, 2.0);
         }
-        else if (420000000.0f >= freq && 450000000.0f <= freq)
+        else if (420000000.0f <= freq && 450000000.0f > freq)
         {
             return ft857_get_pometer_level(rig, val, &rig->caps->rfpower_meter_cal, 5.0);
         }

--- a/rigs/yaesu/pmr171.c
+++ b/rigs/yaesu/pmr171.c
@@ -333,7 +333,7 @@ struct rig_caps pmr171_caps =
 //*****************************************************/
 #include <stdint.h>
 
-uint16_t CRC16Check(const unsigned char *buf, int len)
+static uint16_t CRC16Check(const unsigned char *buf, int len)
 {
     uint16_t crc = 0xFFFF; // Initial value
     uint16_t polynomial = 0x1021; // Polynomial x^16 + x^12 + x^5 + 1
@@ -479,7 +479,7 @@ rmode_t pmr171_modes[GUOHE_MODE_TABLE_MAX] =
     RIG_MODE_RTTY // not functioning
 };
 
-rmode_t guohe2rmode(unsigned char mode, const rmode_t mode_table[])
+static rmode_t guohe2rmode(unsigned char mode, const rmode_t mode_table[])
 {
     rig_debug(RIG_DEBUG_VERBOSE, "%s called, mode=0x%02x\n", __func__,
               mode);
@@ -494,7 +494,7 @@ rmode_t guohe2rmode(unsigned char mode, const rmode_t mode_table[])
     return (mode_table[mode]);
 }
 
-unsigned char rmode2guohe(rmode_t mode, const rmode_t mode_table[])
+static unsigned char rmode2guohe(rmode_t mode, const rmode_t mode_table[])
 {
     rig_debug(RIG_DEBUG_VERBOSE, "%s called, mode=%s\n", __func__,
               rig_strrmode(mode));
@@ -519,7 +519,7 @@ unsigned char rmode2guohe(rmode_t mode, const rmode_t mode_table[])
 /**
  * Converting to Big-endian bytes
  */
-unsigned char *to_be(unsigned char data[],
+static unsigned char *to_be(unsigned char data[],
                      unsigned long long freq,
                      unsigned int byte_len)
 {
@@ -538,7 +538,7 @@ unsigned char *to_be(unsigned char data[],
 }
 
 
-unsigned long long from_be(const unsigned char data[],
+static unsigned long long from_be(const unsigned char data[],
                            unsigned int byte_len)
 {
     int i;

--- a/security/aes.c
+++ b/security/aes.c
@@ -434,7 +434,7 @@ uint32 KT3[256];
 
 /* AES key scheduling routine */
 
-int aes_set_key(aes_context *ctx, uint8 *key, int nbits)
+int aes_set_key(aes_context *ctx, const uint8 *key, int nbits)
 {
     int i;
     uint32 *RK, *SK;
@@ -591,7 +591,7 @@ int aes_set_key(aes_context *ctx, uint8 *key, int nbits)
 
 /* AES 128-bit block encryption routine */
 
-void aes_encrypt(aes_context *ctx, uint8 input[16], uint8 output[16])
+void aes_encrypt(aes_context *ctx, const uint8 input[16], uint8 output[16])
 {
     uint32 *RK, X0, X1, X2, X3, Y0, Y1, Y2, Y3;
 
@@ -681,7 +681,7 @@ void aes_encrypt(aes_context *ctx, uint8 input[16], uint8 output[16])
 
 /* AES 128-bit block decryption routine */
 
-void aes_decrypt(aes_context *ctx, uint8 input[16], uint8 output[16])
+void aes_decrypt(aes_context *ctx, const uint8 input[16], uint8 output[16])
 {
     uint32 *RK, X0, X1, X2, X3, Y0, Y1, Y2, Y3;
 

--- a/security/aes.h
+++ b/security/aes.h
@@ -17,8 +17,8 @@ typedef struct
 }
 aes_context;
 
-int  aes_set_key( aes_context *ctx, uint8 *key, int nbits );
-void aes_encrypt( aes_context *ctx, uint8 input[16], uint8 output[16] );
-void aes_decrypt( aes_context *ctx, uint8 input[16], uint8 output[16] );
+int  aes_set_key( aes_context *ctx, const uint8 *key, int nbits );
+void aes_encrypt( aes_context *ctx, const uint8 input[16], uint8 output[16] );
+void aes_decrypt( aes_context *ctx, const uint8 input[16], uint8 output[16] );
 
 #endif /* aes.h */

--- a/security/md5.c
+++ b/security/md5.c
@@ -292,7 +292,7 @@ unsigned char *make_hash(const char *arg)
     return digest;
 }
 
-char *rig_make_md5(char *pass)
+char *rig_make_md5(const char *pass)
 {
     const unsigned char *hash = make_hash(pass);
     char *md5str = make_digest(hash, 16);

--- a/security/sha256.c
+++ b/security/sha256.c
@@ -53,7 +53,7 @@ void sha256_starts(sha256_context *ctx)
     ctx->state[7] = 0x5BE0CD19;
 }
 
-void sha256_process(sha256_context *ctx, uint8 data[64])
+void sha256_process(sha256_context *ctx, const uint8 data[64])
 {
     uint32 temp1, temp2, W[64];
     uint32 A, B, C, D, E, F, G, H;

--- a/simulators/simts890.c
+++ b/simulators/simts890.c
@@ -180,9 +180,9 @@ const int stepvalues[4][10] =   // Step sizes in Hz
 int stepsize[4] = { 1000, 500, 10000, 5000}; // Defaults by modeclass
 
 /* Function prototypes */
-int freq2band(int freq);
-kvfop_t newvfo(kvfop_t ovfo, int band);
-void swapvfos(kvfop_t *vfoset[]);
+static int freq2band(int freq);
+static kvfop_t newvfo(kvfop_t ovfo, int band);
+static void swapvfos(kvfop_t *vfoset[]);
 // Extracted from rig.h
 int hl_usleep(unsigned long usec);  // Until it's replaced
 
@@ -409,24 +409,6 @@ int main(int argc, char *argv[])
         else if (strncmp(buf, "RA", 2) == 0)
         {
             sscanf(buf, "RA%d", &ra);
-        }
-        else if (strcmp(buf, "RG;") == 0)
-        {
-            hl_usleep(mysleep * 000);
-            pbuf = "RG255;";
-            OUTPUT(pbuf);
-        }
-        else if (strcmp(buf, "MG;") == 0)
-        {
-            hl_usleep(mysleep * 1000);
-            pbuf = "MG050;";
-            OUTPUT(pbuf);
-        }
-        else if (strcmp(buf, "AG;") == 0)
-        {
-            hl_usleep(mysleep * 1000);
-            pbuf = "AG100;";
-            OUTPUT(pbuf);
         }
         else if (strcmp(buf, "FV;") == 0)
         {
@@ -1529,7 +1511,7 @@ int main(int argc, char *argv[])
  *
  * Returns band # or negative if invalid input
  */
-int freq2band(int freq)
+static int freq2band(int freq)
 {
     int i, retval = -1;  // Assume the worst
 
@@ -1553,7 +1535,7 @@ int freq2band(int freq)
  *        new band
  * Return: new vfo pointer
  */
-kvfop_t newvfo(kvfop_t ovfo, int band)
+static kvfop_t newvfo(kvfop_t ovfo, int band)
 {
     int vfonum, slot;
 
@@ -1566,7 +1548,7 @@ kvfop_t newvfo(kvfop_t ovfo, int band)
 /* Reverse the function of vfoA and vfoB
  * No status returned
  */
-void swapvfos(kvfop_t *vfoset[])
+static void swapvfos(kvfop_t *vfoset[])
 {
     kvfop_t *temp;
 

--- a/simulators/simts990.c
+++ b/simulators/simts990.c
@@ -197,13 +197,6 @@ int main(int argc, char *argv[])
             write(fd, pbuf, strlen(pbuf));
             continue;
         }
-        else if (strcmp(buf, "MG;") == 0)
-        {
-            hl_usleep(mysleep * 1000);
-            pbuf = "MG050;";
-            write(fd, pbuf, strlen(pbuf));
-            continue;
-        }
         else if (strcmp(buf, "AG;") == 0)
         {
             hl_usleep(mysleep * 1000);

--- a/src/sprintflst.c
+++ b/src/sprintflst.c
@@ -40,7 +40,7 @@
 
 // just doing a warning message for now
 // eventually should make this -RIG_EINTERNAL
-int check_buffer_overflow(char *str, int len, int nlen)
+static int check_buffer_overflow(char *str, int len, int nlen)
 {
     if (len + 32 >= nlen) // make sure at least 32 bytes are available
     {


### PR DESCRIPTION
All should go into master, with commit 4 (bad freq tests) and maybe 1 (bad merge) possibly cherry-picked for 4.6.3.

- Commit 4 only affects ft857 power level reporting
- Commit 1 really only affects TS-990S with firmware from 2016 or earlier.

Most were found with cppcheck; cppcheck.log showed over 1000 items.  A lot were style hints, false positives, internal cppcheck errors(unhandled syntax, incorrect parameters, etc).  This gets rid of about 70 squawks that looked interesting.  I may go through the rest of the missing static tags later.
