### PR TITLE
Fix exit statuses

### DIFF
--- a/tests/rigctlcom.c
+++ b/tests/rigctlcom.c
@@ -413,7 +413,7 @@ int main(int argc, char *argv[])
     if (argc == 1)
     {
         usage();
-        exit(2);
+        exit(1);
     }
 
     my_rig = rig_init(my_model);
@@ -443,7 +443,7 @@ int main(int argc, char *argv[])
     if (my_model > 5 && !rig_file)
     {
         fprintf(stderr, "-r rig com port not provided\n");
-        exit(2);
+        exit(1);
     }
 
     if (rig_file)
@@ -454,7 +454,7 @@ int main(int argc, char *argv[])
     if (!rig_file2)
     {
         fprintf(stderr, "-R com port not provided\n");
-        exit(2);
+        exit(1);
     }
 
     strncpy(my_com.pathname, rig_file2, HAMLIB_FILPATHLEN - 1);

--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -783,7 +783,7 @@ int main(int argc, char *argv[])
     else
     {
         fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(retcode));
-        exit(2);
+        exit(1);
     }
 
     saved_result = result;
@@ -798,7 +798,7 @@ int main(int argc, char *argv[])
         {
             handle_error(RIG_DEBUG_ERR, "socket");
             freeaddrinfo(saved_result);     /* No longer needed */
-            exit(2);
+            exit(1);
         }
 
         const int optval = 1;

--- a/tests/rotctld.c
+++ b/tests/rotctld.c
@@ -423,7 +423,7 @@ int main(int argc, char *argv[])
     if (retcode != 0)
     {
         fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(retcode));
-        exit(2);
+        exit(1);
     }
 
     saved_result = result;


### PR DESCRIPTION
This PS makes the error statuses consistent with the man pages (in other words: `1` for errors caused by user input, `2` for errors returned by rig/rotator/amplifier).