### PR TITLE
Reduce output from cppcheck.sh

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,8 @@ Version 5.x -- future
 
 Version 4.7.0
         * 2025-12-01 (target)
+	* Reduce/repair excess output from cppcheck.sh - mostly cosmetic changes (WIP)
+	  Output from `wc -l cppcheck.log` - 4.6.2: 981  now: 732
         * Remove dead getopt code.  GitHub PR #1709. (TNX Daniele Forsi)
         * Move rig_cache to separate(calloc) storage. Prepare for other moves.
           Issue #1420
@@ -25,8 +27,8 @@ Version 4.6.3
           five years from 2020 to 2025.  Mike passed away on March 28, 2025 due to
           complications from ALS (Lou Gehrig's disease).
 
-        * JRC: Removed RIG_FUNC_FAGC from 535D as erroneous, Added RIG_FUNC_NB2                                                    
-          functionality to both 535D and 545. (TNX Mark Fine)                                                                      
+        * JRC: Removed RIG_FUNC_FAGC from 535D as erroneous, Added RIG_FUNC_NB2
+          functionality to both 535D and 545. (TNX Mark Fine)
         * Restore IC-7300 spectrum data callback - regression in 4.6 (n3gb)
         * Add locking to rig_[gs]et_level() - fixes sending CW from tlf (n3gb)
         * Fix attempt to use memory returned by setlocale() after being freed (TNX Mooneer Salem)

--- a/cppcheck.sh
+++ b/cppcheck.sh
@@ -5,6 +5,19 @@ set -x
 # There are things that could still be done...especially in the C++ area
 echo "Ideally there should be no errors or warnings"
 
+# We need the generated include files, not just the base
+# If this is not the build directory, try to find one
+BUILDINC=""
+if ! test -f Makefile; then
+    # Find mine, YMMV
+    if test -d build; then
+	BUILDINC="-I build/src -I build/include -I build/include/hamlib"
+    # Put code here to find your build directory and set BUILDINC
+    else
+	echo "Unknown build directory, some includes won't be found"
+    fi
+fi
+	
 # We do suppress some errors which are expected or other code
 # There are quite a few C++ items to take care of still if anybody cares
 SUPPRESS="\
@@ -23,7 +36,7 @@ SUPPRESS="\
 --suppress=*:extra/gnuradio/wfm.h \
 --suppress=*:extra/gnuradio/gnuradio.cc \
 --suppress=missingIncludeSystem \
---suppress=*:style/rigs/adat/adat.c
+"
 
 #CHECK="\
 #-D RIG_LEVEL_LINEOUT=1 \
@@ -83,6 +96,7 @@ if test $# -eq 0 ; then
                  -I include/hamlib/ \
                  -I lib \
                  -I security \
+		 $BUILDINC \
                  -q \
                  --force \
                  --enable=all \
@@ -100,6 +114,7 @@ else
                  -I include/hamlib/ \
                  -I lib \
                  -I security \
+		 $BUILDINC \
                  -q \
                  --force \
                  --enable=all \

--- a/rigs/adat/adat.c
+++ b/rigs/adat/adat.c
@@ -2170,7 +2170,6 @@ int adat_cmd_fn_set_freq(RIG *pRig)
     }
     else
     {
-        // cppcheck-suppress constVariablePointer
         const adat_priv_data_ptr pPriv = (adat_priv_data_ptr) STATE(pRig)->priv;
         char acBuf[ ADAT_BUFSZ + 1 ];
 
@@ -2226,7 +2225,6 @@ int adat_cmd_fn_set_vfo(RIG *pRig)
     }
     else
     {
-        // cppcheck-suppress constVariablePointer
         const adat_priv_data_ptr pPriv = (adat_priv_data_ptr) STATE(pRig)->priv;
         char acBuf[ ADAT_BUFSZ + 1 ];
 
@@ -2350,7 +2348,7 @@ int adat_cmd_fn_set_ptt(RIG *pRig)
     else
     {
         adat_priv_data_ptr  pPriv    = (adat_priv_data_ptr) STATE(pRig)->priv;
-        char *pcPTTStr = NULL;
+        const char *pcPTTStr = NULL;
 
         // Switch PTT
 
@@ -2690,7 +2688,6 @@ const char *adat_get_info(RIG *pRig)
 
         if (nRC == RIG_OK)
         {
-            // cppcheck-suppress constVariablePointer
             const adat_priv_data_ptr pPriv = (adat_priv_data_ptr) STATE(pRig)->priv;
 
             snprintf(acBuf, 2048,
@@ -2774,7 +2771,6 @@ int adat_get_freq(RIG *pRig, vfo_t vfo, freq_t *freq)
     }
     else
     {
-        // cppcheck-suppress constVariablePointer
         const adat_priv_data_ptr pPriv = (adat_priv_data_ptr) STATE(pRig)->priv;
 
         nRC = adat_transaction(pRig, &adat_cmd_list_get_freq);
@@ -2932,7 +2928,6 @@ int adat_get_mode(RIG *pRig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
     }
     else
     {
-        // cppcheck-suppress constVariablePointer
         const adat_priv_data_ptr pPriv = (adat_priv_data_ptr) STATE(pRig)->priv;
 
         nRC =  adat_transaction(pRig, &adat_cmd_list_get_mode);
@@ -2975,7 +2970,6 @@ int adat_get_vfo(RIG *pRig, vfo_t *vfo)
     }
     else
     {
-        // cppcheck-suppress constVariablePointer
         const adat_priv_data_ptr pPriv = (adat_priv_data_ptr) STATE(pRig)->priv;
 
         nRC = adat_transaction(pRig, &adat_cmd_list_get_vfo);
@@ -3055,7 +3049,6 @@ int adat_get_ptt(RIG *pRig, vfo_t vfo, ptt_t *ptt)
     }
     else
     {
-        // cppcheck-suppress constVariablePointer
         const adat_priv_data_ptr pPriv = (adat_priv_data_ptr) STATE(pRig)->priv;
 
         nRC = adat_transaction(pRig, &adat_cmd_list_get_ptt);
@@ -3316,7 +3309,6 @@ int adat_get_conf(RIG *pRig, hamlib_token_t token, char *val)
     }
     else
     {
-        // cppcheck-suppress constVariablePointer
         const adat_priv_data_ptr pPriv = (adat_priv_data_ptr) STATE(pRig)->priv;
 
         switch (token)

--- a/rigs/icom/ic7300.c
+++ b/rigs/icom/ic7300.c
@@ -42,9 +42,9 @@ int ic7300_set_clock(RIG *rig, int year, int month, int day, int hour,
 int ic7300_get_clock(RIG *rig, int *year, int *month, int *day,
                      int *hour,
                      int *min, int *sec, double *msec, int *utc_offset);
-int ic9700_set_clock(RIG *rig, int year, int month, int day, int hour,
+static int ic9700_set_clock(RIG *rig, int year, int month, int day, int hour,
                      int min, int sec, double msec, int utc_offset);
-int ic9700_get_clock(RIG *rig, int *year, int *month, int *day,
+static int ic9700_get_clock(RIG *rig, int *year, int *month, int *day,
                      int *hour,
                      int *min, int *sec, double *msec, int *utc_offset);
 
@@ -2165,7 +2165,7 @@ int ic7300_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
 }
 
 // if hour < 0 then only date will be set
-int ic9700_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
+static int ic9700_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
                      int sec, double msec, int utc_offset)
 {
     int cmd = 0x1a;
@@ -2219,7 +2219,7 @@ int ic9700_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
     return retval;
 }
 
-int ic9700_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
+static int ic9700_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
                      int *min, int *sec, double *msec, int *utc_offset)
 {
     int cmd = 0x1a;

--- a/rigs/icom/ic7600.c
+++ b/rigs/icom/ic7600.c
@@ -172,7 +172,7 @@ static const struct icom_priv_caps ic7600_priv_caps =
 
 
 // if hour < 0 then only date will be set
-int ic7600_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
+static int ic7600_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
                      int sec, double msec, int utc_offset)
 {
     int cmd = 0x1a;
@@ -226,7 +226,7 @@ int ic7600_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
     return retval;
 }
 
-int ic7600_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
+static int ic7600_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
                      int *min, int *sec, double *msec, int *utc_offset)
 {
     int cmd = 0x1a;

--- a/rigs/icom/ic7610.c
+++ b/rigs/icom/ic7610.c
@@ -253,7 +253,7 @@ static const struct icom_priv_caps ic7610_priv_caps =
 
 
 // if hour < 0 then only date will be set
-int ic7610_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
+static int ic7610_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
                      int sec, double msec, int utc_offset)
 {
     int cmd = 0x1a;
@@ -307,7 +307,7 @@ int ic7610_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
     return retval;
 }
 
-int ic7610_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
+static int ic7610_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
                      int *min, int *sec, double *msec, int *utc_offset)
 {
     int cmd = 0x1a;

--- a/rigs/icom/ic7700.c
+++ b/rigs/icom/ic7700.c
@@ -144,7 +144,7 @@ static const struct icom_priv_caps ic7700_priv_caps =
 };
 
 // if hour < 0 then only date will be set
-int ic7700_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
+static int ic7700_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
                      int sec, double msec, int utc_offset)
 {
     int cmd = 0x1a;
@@ -198,7 +198,7 @@ int ic7700_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
     return retval;
 }
 
-int ic7700_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
+static int ic7700_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
                      int *min, int *sec, double *msec, int *utc_offset)
 {
     int cmd = 0x1a;

--- a/rigs/icom/ic7760.c
+++ b/rigs/icom/ic7760.c
@@ -143,7 +143,7 @@ static const struct icom_priv_caps ic7760_priv_caps =
 };
 
 // if hour < 0 then only date will be set
-int ic7760_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
+static int ic7760_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
                      int sec, double msec, int utc_offset)
 {
     int cmd = 0x1a;
@@ -197,7 +197,7 @@ int ic7760_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
     return retval;
 }
 
-int ic7760_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
+static int ic7760_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
                      int *min, int *sec, double *msec, int *utc_offset)
 {
     int cmd = 0x1a;

--- a/rigs/icom/ic7800.c
+++ b/rigs/icom/ic7800.c
@@ -34,9 +34,9 @@
 #include "bandplan.h"
 #include "ic7300.h"
 
-int ic7800_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
+static int ic7800_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
                      int sec, double msec, int utc_offset);
-int ic7800_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
+static int ic7800_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
                      int *min, int *sec, double *msec, int *utc_offset);
 
 #define IC7800_ALL_RX_MODES (RIG_MODE_AM|RIG_MODE_CW|RIG_MODE_CWR|RIG_MODE_SSB|RIG_MODE_RTTY|RIG_MODE_RTTYR|RIG_MODE_FM|RIG_MODE_PSK|RIG_MODE_PSKR|RIG_MODE_PKTLSB|RIG_MODE_PKTUSB|RIG_MODE_PKTAM|RIG_MODE_PKTFM)
@@ -429,7 +429,7 @@ int ic7800_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 }
 
 // if hour < 0 then only date will be set
-int ic7800_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
+static int ic7800_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
                      int sec, double msec, int utc_offset)
 {
     int cmd = 0x1a;
@@ -483,7 +483,7 @@ int ic7800_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
     return retval;
 }
 
-int ic7800_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
+static int ic7800_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
                      int *min, int *sec, double *msec, int *utc_offset)
 {
     int cmd = 0x1a;

--- a/rigs/icom/ic785x.c
+++ b/rigs/icom/ic785x.c
@@ -116,8 +116,8 @@
 extern int ic7800_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val);
 extern int ic7800_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val);
 
-int ic785x_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val);
-int ic785x_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val);
+static int ic785x_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val);
+static int ic785x_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val);
 
 struct cmdparams ic785x_extcmds[] =
 {
@@ -498,12 +498,12 @@ struct rig_caps ic785x_caps =
     .hamlib_check_rig_caps = HAMLIB_CHECK_RIG_CAPS
 };
 
-int ic785x_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
+static int ic785x_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
     return ic7800_set_level(rig, vfo, level, val);
 }
 
-int ic785x_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
+static int ic785x_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
     return ic7800_get_level(rig, vfo, level, val);
 }

--- a/rigs/icom/ic821h.c
+++ b/rigs/icom/ic821h.c
@@ -54,7 +54,7 @@ static const struct icom_priv_caps ic821h_priv_caps =
 
 // split could be on VFOA/B or Main/Sub
 // If Main/Sub we assume we're doing satmode
-int ic821h_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
+static int ic821h_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
 {
     int retval = -RIG_EINTERNAL;
 

--- a/rigs/icom/ic910.c
+++ b/rigs/icom/ic910.c
@@ -135,7 +135,7 @@ static const struct icom_priv_caps ic910_priv_caps =
     .r2i_mode = ic910_r2i_mode
 };
 
-int ic910_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
+static int ic910_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
 {
     switch (func)
     {
@@ -152,7 +152,7 @@ int ic910_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
     }
 }
 
-int ic910_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
+static int ic910_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
 {
     switch (func)
     {
@@ -167,7 +167,7 @@ int ic910_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
     }
 }
 
-int ic910_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
+static int ic910_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
@@ -182,7 +182,7 @@ int ic910_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
     }
 }
 
-int ic910_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
+static int ic910_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 

--- a/rigs/icom/icr30.c
+++ b/rigs/icom/icr30.c
@@ -99,7 +99,7 @@ static int icr30_r2i_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width,
  * This function handles the -N modes for IC-R30
  */
 
-int icr30_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
+static int icr30_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
     if (mode & (RIG_MODE_AMN | RIG_MODE_FMN))
     {

--- a/rigs/icom/id5100.c
+++ b/rigs/icom/id5100.c
@@ -72,9 +72,9 @@ enum
 
 #define ID5100_PARM_ALL RIG_PARM_NONE
 
-int id5100_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo);
+static int id5100_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo);
 
-int id5100_set_vfo(RIG *rig, vfo_t vfo)
+static int id5100_set_vfo(RIG *rig, vfo_t vfo)
 {
     struct rig_state *rs = STATE(rig);
     struct icom_priv_data *priv = (struct icom_priv_data *) rs->priv;
@@ -147,7 +147,7 @@ int id5100_set_vfo(RIG *rig, vfo_t vfo)
 }
 
 
-int id5100_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
+static int id5100_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
     int cmd = C_SET_FREQ;
     int subcmd = -1;
@@ -208,7 +208,7 @@ static int id5100_get_freq2(RIG *rig, vfo_t vfo, freq_t *freq)
     return RIG_OK;
 }
 
-int id5100_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
+static int id5100_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
     struct rig_state *rs = STATE(rig);
     struct icom_priv_data *priv = (struct icom_priv_data *) rs->priv;
@@ -356,7 +356,7 @@ if (vfo == RIG_VFO_MAIN && priv->dual_watch_main_sub == MAIN_ON_LEFT)
  */
 #define ID5100_STR_CAL  UNKNOWN_IC_STR_CAL
 
-int id5100_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
+static int id5100_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
     int retval;
     unsigned char modebuf;
@@ -390,7 +390,7 @@ int id5100_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     return retval;
 }
 
-int id5100_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
+static int id5100_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
 {
     int retval;
     int mode_len;
@@ -421,7 +421,7 @@ int id5100_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
     return RIG_OK;
 }
 
-int id5100_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
+static int id5100_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
 {
     struct rig_state *rs = STATE(rig);
     struct icom_priv_data *priv = (struct icom_priv_data *) rs->priv;
@@ -463,7 +463,7 @@ int id5100_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
 }
 
 
-int id5100_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
+static int id5100_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
 {
     int freq_len = 5;
     int retval;
@@ -484,7 +484,7 @@ int id5100_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
     RETURNFUNC(retval);
 }
 
-int id5100_get_split_freq(RIG *rig, vfo_t vfo, freq_t *tx_freq)
+static int id5100_get_split_freq(RIG *rig, vfo_t vfo, freq_t *tx_freq)
 {
     int retval;
     //struct rig_state *rs = STATE(rig);

--- a/rigs/icom/xiegu.c
+++ b/rigs/icom/xiegu.c
@@ -132,7 +132,7 @@ static int x108g_rig_open(RIG *rig)
     RETURNFUNC(RIG_OK);
 }
 
-int xiegu_rig_open(RIG *rig)
+static int xiegu_rig_open(RIG *rig)
 {
     int retval;
     unsigned char id[4];

--- a/rigs/kenwood/elecraft.c
+++ b/rigs/kenwood/elecraft.c
@@ -22,6 +22,7 @@
  *  the complete text of the GNU Lesser Public License version 2.1.
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include <string.h>
 #include <stdio.h>
@@ -77,9 +78,9 @@ const struct confparams elecraft_ext_levels[] =
 
 
 /* Private function declarations */
-int verify_kenwood_id(RIG *rig, char *id);
-int elecraft_get_extension_level(RIG *rig, const char *cmd, int *ext_level);
-int elecraft_get_firmware_revision_level(RIG *rig, const char *cmd,
+static int verify_kenwood_id(RIG *rig, char *id);
+static int elecraft_get_extension_level(RIG *rig, const char *cmd, int *ext_level);
+static int elecraft_get_firmware_revision_level(RIG *rig, const char *cmd,
         char *fw_rev, size_t fw_rev_sz);
 
 /* Shared backend function definitions */
@@ -419,10 +420,10 @@ int elecraft_close(RIG *rig)
 
 /* Tests for Kenwood ID string of "017" */
 
-int verify_kenwood_id(RIG *rig, char *id)
+static int verify_kenwood_id(RIG *rig, char *id)
 {
     int err;
-    char *idptr;
+    const char *idptr;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
@@ -472,11 +473,11 @@ int verify_kenwood_id(RIG *rig, char *id)
 
 /* Determines K2 and K3 extension level */
 
-int elecraft_get_extension_level(RIG *rig, const char *cmd, int *ext_level)
+static int elecraft_get_extension_level(RIG *rig, const char *cmd, int *ext_level)
 {
     int err, i;
     char buf[KENWOOD_MAX_BUF_LEN];
-    char *bufptr;
+    const char *bufptr;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
@@ -511,7 +512,7 @@ int elecraft_get_extension_level(RIG *rig, const char *cmd, int *ext_level)
 
 /* Determine firmware revision level */
 
-int elecraft_get_firmware_revision_level(RIG *rig, const char *cmd,
+static int elecraft_get_firmware_revision_level(RIG *rig, const char *cmd,
         char *fw_rev, size_t fw_rev_sz)
 {
     int err;

--- a/rigs/kenwood/flex.c
+++ b/rigs/kenwood/flex.c
@@ -23,6 +23,7 @@
  *  the complete text of the GNU Lesser Public License version 2.1.
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include <string.h>
 
@@ -31,10 +32,10 @@
 
 /* Private helper functions */
 
-int verify_flexradio_id(RIG *rig, char *id)
+static int verify_flexradio_id(RIG *rig, char *id)
 {
     int err;
-    char *idptr;
+    const char *idptr;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 

--- a/rigs/kenwood/flex6xxx.c
+++ b/rigs/kenwood/flex6xxx.c
@@ -22,6 +22,7 @@
  *  the complete text of the GNU Lesser Public License version 2.1.
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -321,7 +322,7 @@ static int powersdr_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode,
 
 static int flex6k_find_width(rmode_t mode, pbwidth_t width, int *ridx)
 {
-    int *w_a; // Width array, these are all ordered in descending order!
+    const int *w_a; // Width array, these are all ordered in descending order!
     int idx = 0;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
@@ -372,7 +373,7 @@ static int flex6k_find_width(rmode_t mode, pbwidth_t width, int *ridx)
 
 static int powersdr_find_width(rmode_t mode, pbwidth_t width, int *ridx)
 {
-    int *w_a; // Width array, these are all ordered in descending order!
+    const int *w_a; // Width array, these are all ordered in descending order!
     int idx = 0;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
@@ -576,7 +577,7 @@ static int powersdr_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 /*
  * flex6k_get_ptt
  */
-int flex6k_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
+static int flex6k_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
 {
     const char *ptt_cmd;
     int err;
@@ -604,7 +605,7 @@ int flex6k_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
     return RIG_OK;
 }
 
-int flex6k_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
+static int flex6k_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 {
     const char *ptt_cmd;
     char response[16] = "";
@@ -642,7 +643,7 @@ int flex6k_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 /*
  * powersdr_set_level
  */
-int powersdr_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
+static int powersdr_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
     char cmd[KENWOOD_MAX_BUF_LEN];
     int retval;
@@ -741,7 +742,7 @@ int powersdr_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 /*
  * flek6k_set_level
  */
-int flex6k_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
+static int flex6k_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
     char cmd[KENWOOD_MAX_BUF_LEN];
     int retval;
@@ -778,10 +779,10 @@ int flex6k_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 /*
  * flex6k_get_level
  */
-int flex6k_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
+static int flex6k_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
     char lvlbuf[KENWOOD_MAX_BUF_LEN];
-    char *cmd;
+    const char *cmd;
     int retval;
     int len, ans;
 
@@ -840,10 +841,10 @@ int flex6k_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 /*
  * powersdr_get_level
  */
-int powersdr_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
+static int powersdr_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
     char lvlbuf[KENWOOD_MAX_BUF_LEN];
-    char *cmd;
+    const char *cmd;
     int retval;
     int len, ans;
     rmode_t mode;
@@ -1143,7 +1144,7 @@ int powersdr_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     return RIG_OK;
 }
 
-int powersdr_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
+static int powersdr_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
 {
     char cmd[KENWOOD_MAX_BUF_LEN];
 
@@ -1174,10 +1175,10 @@ int powersdr_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
     return kenwood_transaction(rig, cmd, NULL, 0);
 }
 
-int powersdr_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
+static int powersdr_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
 {
     char lvlbuf[KENWOOD_MAX_BUF_LEN];
-    char *cmd;
+    const char *cmd;
     int retval;
     int len, ans;
 
@@ -1234,7 +1235,7 @@ int powersdr_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
     return RIG_OK;
 }
 
-int powersdr_set_parm(RIG *rig, setting_t parm, value_t val)
+static int powersdr_set_parm(RIG *rig, setting_t parm, value_t val)
 {
     ENTERFUNC;
     char cmd[KENWOOD_MAX_BUF_LEN];
@@ -1263,7 +1264,7 @@ int powersdr_set_parm(RIG *rig, setting_t parm, value_t val)
     RETURNFUNC(retval);
 }
 
-int powersdr_get_parm(RIG *rig, setting_t parm, value_t *val)
+static int powersdr_get_parm(RIG *rig, setting_t parm, value_t *val)
 {
     char cmd[KENWOOD_MAX_BUF_LEN];
     char buf[KENWOOD_MAX_BUF_LEN];

--- a/rigs/kenwood/k2.c
+++ b/rigs/kenwood/k2.c
@@ -21,6 +21,7 @@
  *  the complete text of the GNU Lesser Public License version 2.1.
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include <stdlib.h>
 #include <string.h>
@@ -95,16 +96,16 @@ struct k2_filt_lst_s k2_fwmd_cw;
 struct k2_filt_lst_s k2_fwmd_rtty;
 
 /* K2 specific rig_caps API function declarations */
-int k2_open(RIG *rig);
-int k2_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width);
-int k2_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width);
-int k2_get_ext_level(RIG *rig, vfo_t vfo, hamlib_token_t token, value_t *val);
-int k2_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op);
+static int k2_open(RIG *rig);
+static int k2_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width);
+static int k2_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width);
+static int k2_get_ext_level(RIG *rig, vfo_t vfo, hamlib_token_t token, value_t *val);
+static int k2_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op);
 
 /* Private function declarations */
-int k2_probe_mdfw(RIG *rig, struct kenwood_priv_data *priv);
-int k2_mdfw_rest(RIG *rig, const char *mode, const char *fw);
-int k2_pop_fw_lst(RIG *rig, const char *cmd);
+static int k2_probe_mdfw(RIG *rig, struct kenwood_priv_data *priv);
+static int k2_mdfw_rest(RIG *rig, const char *mode, const char *fw);
+static int k2_pop_fw_lst(RIG *rig, const char *cmd);
 
 
 /*
@@ -258,7 +259,7 @@ struct rig_caps k2_caps =
 /* k2_open()
  *
  */
-int k2_open(RIG *rig)
+static int k2_open(RIG *rig)
 {
     int err;
     struct kenwood_priv_data *priv = STATE(rig)->priv;
@@ -289,7 +290,7 @@ int k2_open(RIG *rig)
  * wider than the passed value and sets the radio accordingly.
  */
 
-int k2_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
+static int k2_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
 
     int err;
@@ -425,12 +426,12 @@ int k2_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
  * by the radio and returns it to the caller.
  */
 
-int k2_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
+static int k2_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
 {
     int err;
     char buf[KENWOOD_MAX_BUF_LEN];
     char tmp[16];
-    char *bufptr;
+    const char *bufptr;
     pbwidth_t temp_w;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
@@ -491,7 +492,7 @@ int k2_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
  *      STRING: val.cs for set, val.s for get
  *      CHECKBUTTON: val.i 0/1
  */
-int k2_get_ext_level(RIG *rig, vfo_t vfo, hamlib_token_t token, value_t *val)
+static int k2_get_ext_level(RIG *rig, vfo_t vfo, hamlib_token_t token, value_t *val)
 {
     char buf[KENWOOD_MAX_BUF_LEN];
     int err;
@@ -544,7 +545,7 @@ int k2_get_ext_level(RIG *rig, vfo_t vfo, hamlib_token_t token, value_t *val)
 /* Probes for mode and filter settings, based on information
  * by Chris Bryant, G3WIE.
  */
-int k2_probe_mdfw(RIG *rig, struct kenwood_priv_data *priv)
+static int k2_probe_mdfw(RIG *rig, struct kenwood_priv_data *priv)
 {
     int err, i, c;
     char buf[KENWOOD_MAX_BUF_LEN];
@@ -678,7 +679,7 @@ int k2_probe_mdfw(RIG *rig, struct kenwood_priv_data *priv)
 
 
 /* Restore mode, filter, and ext_lvl to original values */
-int k2_mdfw_rest(RIG *rig, const char *mode, const char *fw)
+static int k2_mdfw_rest(RIG *rig, const char *mode, const char *fw)
 {
     int err;
 
@@ -720,7 +721,7 @@ int k2_mdfw_rest(RIG *rig, const char *mode, const char *fw)
 
 
 /* Populate k2_filt_lst_s structure for each mode */
-int k2_pop_fw_lst(RIG *rig, const char *cmd)
+static int k2_pop_fw_lst(RIG *rig, const char *cmd)
 {
     int err, f;
     char fcmd[16];
@@ -806,7 +807,7 @@ int k2_pop_fw_lst(RIG *rig, const char *cmd)
     return RIG_OK;
 }
 
-int k2_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op)
+static int k2_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op)
 {
     char buf[32];
 

--- a/rigs/kenwood/k3.c
+++ b/rigs/kenwood/k3.c
@@ -165,9 +165,13 @@ static int k3_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status);
 static int k3_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op);
 static int k3_power2mW(RIG *rig, unsigned int *mwpower, float power, freq_t freq,
                 rmode_t mode);
+static int kx3_get_bar_graph_level(RIG *rig, float *level);
+static int k3_send_voice_mem(RIG *rig, vfo_t vfo, int ch);
+static int k3_stop_voice_mem(RIG *rig, vfo_t vfo);
+static int k3_stop_morse(RIG *rig, vfo_t vfo);
 
 /* Private helper functions */
-int set_rit_xit(RIG *rig, shortfreq_t rit);
+static int set_rit_xit(RIG *rig, shortfreq_t rit);
 static int k3_set_nb_level(RIG *rig, float dsp_nb, float if_nb);
 static int k3_get_nb_level(RIG *rig, float *dsp_nb, float *if_nb);
 static int k3_get_bar_graph_level(RIG *rig, float *smeter, float *pwr, float *alc,
@@ -191,11 +195,6 @@ static int k4_stop_morse(RIG *rig, vfo_t vfo);
  * Part of info comes from http://www.elecraft.com/K2_Manual_Download_Page.htm#K3
  * look for K3 Programmer's Reference PDF
  */
-static int kx3_get_bar_graph_level(RIG *rig, float *level);
-static int k3_send_voice_mem(RIG *rig, vfo_t vfo, int ch);
-static int k3_stop_voice_mem(RIG *rig, vfo_t vfo);
-static int k3_stop_morse(RIG *rig, vfo_t vfo);
-
 struct rig_caps k3_caps =
 {
     RIG_MODEL(RIG_MODEL_K3),
@@ -2611,7 +2610,7 @@ static int k3_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
  * RIT/XIT to an arbitrary offset.  When rit == 0, the RIT/XIT offset is
  * cleared.
  */
-int set_rit_xit(RIG *rig, shortfreq_t rit)
+static int set_rit_xit(RIG *rig, shortfreq_t rit)
 {
     int err;
 

--- a/rigs/kenwood/k3.c
+++ b/rigs/kenwood/k3.c
@@ -21,6 +21,7 @@
  *  the complete text of the GNU Lesser Public License version 2.1.
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -143,47 +144,43 @@ static struct kenwood_priv_caps k3_priv_caps  =
 
 
 /* K3 specific function declarations */
-int k3_set_freq(RIG *rig, vfo_t vfo, freq_t freq);
-int k3_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width);
-int k3_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width);
-int k3_get_vfo(RIG *rig, vfo_t *vfo);
-int k3_set_vfo(RIG *rig, vfo_t vfo);
-int k3_set_ext_level(RIG *rig, vfo_t vfo, hamlib_token_t token, value_t val);
-int k3_get_ext_level(RIG *rig, vfo_t vfo, hamlib_token_t token, value_t *val);
-int k3_set_rit(RIG *rig, vfo_t vfo, shortfreq_t rit);
-int k3_set_xit(RIG *rig, vfo_t vfo, shortfreq_t rit);
-int k3_set_split_mode(RIG *rig, vfo_t vfo, rmode_t tx_mode, pbwidth_t tx_width);
-int k3_get_split_mode(RIG *rig, vfo_t vfo, rmode_t *tx_mode,
+static int k3_set_freq(RIG *rig, vfo_t vfo, freq_t freq);
+static int k3_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width);
+static int k3_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width);
+static int k3_get_vfo(RIG *rig, vfo_t *vfo);
+static int k3_set_vfo(RIG *rig, vfo_t vfo);
+static int k3_set_ext_level(RIG *rig, vfo_t vfo, hamlib_token_t token, value_t val);
+static int k3_get_ext_level(RIG *rig, vfo_t vfo, hamlib_token_t token, value_t *val);
+static int k3_set_rit(RIG *rig, vfo_t vfo, shortfreq_t rit);
+static int k3_set_xit(RIG *rig, vfo_t vfo, shortfreq_t rit);
+static int k3_set_split_mode(RIG *rig, vfo_t vfo, rmode_t tx_mode, pbwidth_t tx_width);
+static int k3_get_split_mode(RIG *rig, vfo_t vfo, rmode_t *tx_mode,
                       pbwidth_t *tx_width);
-int k3_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val);
-int k3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val);
-int kx3_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val);
-int kx3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val);
-int k3_set_func(RIG *rig, vfo_t vfo, setting_t func, int status);
-int k3_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status);
-int k3_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op);
-int k3_power2mW(RIG *rig, unsigned int *mwpower, float power, freq_t freq,
+static int k3_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val);
+static int k3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val);
+static int kx3_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val);
+static int kx3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val);
+static int k3_set_func(RIG *rig, vfo_t vfo, setting_t func, int status);
+static int k3_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status);
+static int k3_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op);
+static int k3_power2mW(RIG *rig, unsigned int *mwpower, float power, freq_t freq,
                 rmode_t mode);
 
 /* Private helper functions */
 int set_rit_xit(RIG *rig, shortfreq_t rit);
-int k3_set_nb_level(RIG *rig, float dsp_nb, float if_nb);
-int k3_get_nb_level(RIG *rig, float *dsp_nb, float *if_nb);
-int k3_get_bar_graph_level(RIG *rig, float *smeter, float *pwr, float *alc,
+static int k3_set_nb_level(RIG *rig, float dsp_nb, float if_nb);
+static int k3_get_nb_level(RIG *rig, float *dsp_nb, float *if_nb);
+static int k3_get_bar_graph_level(RIG *rig, float *smeter, float *pwr, float *alc,
                            int *mode_tx);
-int k4_get_bar_graph_level(RIG *rig, float *swr, float *pwr, float *alc,
+static int k4_get_bar_graph_level(RIG *rig, float *swr, float *pwr, float *alc,
                            int *mode_tx);
-int kx3_get_bar_graph_level(RIG *rig, float *level);
-int k3_send_voice_mem(RIG *rig, vfo_t vfo, int ch);
-int k3_stop_voice_mem(RIG *rig, vfo_t vfo);
-int k3_stop_morse(RIG *rig, vfo_t vfo);
 
 /* K4 functions */
-int k4_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt);
-int k4_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt);
-int k4_send_voice_mem(RIG *rig, vfo_t vfo, int ch);
-int k4_stop_voice_mem(RIG *rig, vfo_t vfo);
-int k4_stop_morse(RIG *rig, vfo_t vfo);
+static int k4_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt);
+static int k4_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt);
+static int k4_send_voice_mem(RIG *rig, vfo_t vfo, int ch);
+static int k4_stop_voice_mem(RIG *rig, vfo_t vfo);
+static int k4_stop_morse(RIG *rig, vfo_t vfo);
 
 /*
  * K3 rig capabilities.
@@ -194,28 +191,11 @@ int k4_stop_morse(RIG *rig, vfo_t vfo);
  * Part of info comes from http://www.elecraft.com/K2_Manual_Download_Page.htm#K3
  * look for K3 Programmer's Reference PDF
  */
-int kx3_get_bar_graph_level(RIG *rig, float *level);
-int k3_send_voice_mem(RIG *rig, vfo_t vfo, int ch);
-int k3_stop_voice_mem(RIG *rig, vfo_t vfo);
-int k3_stop_morse(RIG *rig, vfo_t vfo);
+static int kx3_get_bar_graph_level(RIG *rig, float *level);
+static int k3_send_voice_mem(RIG *rig, vfo_t vfo, int ch);
+static int k3_stop_voice_mem(RIG *rig, vfo_t vfo);
+static int k3_stop_morse(RIG *rig, vfo_t vfo);
 
-/* K4 functions */
-int k4_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt);
-int k4_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt);
-int k4_send_voice_mem(RIG *rig, vfo_t vfo, int ch);
-int k4_stop_voice_mem(RIG *rig, vfo_t vfo);
-int k4_stop_morse(RIG *rig, vfo_t vfo);
-
-/*
- * K3 rig capabilities.
- * This kit can recognize a large subset of TS-570/K2 commands and has many
- * extensions of its own.  Extension backend functions to standard Kenwood
- * command are defined in elecraft.c (shared with K2) and in this file.
- *
- * Part of info comes from http://www.elecraft.com/K2_Manual_Download_Page.htm#K3
- * look for K3 Programmer's Reference PDF
- *
- */
 struct rig_caps k3_caps =
 {
     RIG_MODEL(RIG_MODEL_K3),
@@ -1037,14 +1017,14 @@ struct rig_caps kx2_caps =
  * RIG_MODE_PKTUSB and RIG_MODE_PKTLSB can be supported.
  */
 
-int k3_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
+static int k3_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
 {
     char buf[KENWOOD_MAX_BUF_LEN];
     int err;
     rmode_t temp_m;
     pbwidth_t temp_w;
-    char *cmd_data = "DT";
-    char *cmd_bw = "BW";
+    const char *cmd_data = "DT";
+    const char *cmd_bw = "BW";
     int cmd_bw_len = 6;
     const struct kenwood_priv_data *priv = STATE(rig)->priv;
 
@@ -1191,7 +1171,7 @@ int k3_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
  * mapping seems most likely to cover the user requirements.
  */
 
-int k3_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
+static int k3_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
     int err, err2;
     char cmd_m[5];
@@ -1396,7 +1376,7 @@ int k3_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
  * We just emulate them so rigctl can work correctly.
  */
 
-int k3_set_vfo(RIG *rig, vfo_t vfo)
+static int k3_set_vfo(RIG *rig, vfo_t vfo)
 {
     ENTERFUNC;
 
@@ -1406,7 +1386,7 @@ int k3_set_vfo(RIG *rig, vfo_t vfo)
     RETURNFUNC(RIG_OK);
 }
 
-int k3_get_vfo(RIG *rig, vfo_t *vfo)
+static int k3_get_vfo(RIG *rig, vfo_t *vfo)
 {
     ENTERFUNC;
 
@@ -1427,7 +1407,7 @@ int k3_get_vfo(RIG *rig, vfo_t *vfo)
  * See Private Elecraft extra levels definitions in elecraft.c and
  * private token #define in elecraft.h
  */
-int k3_set_ext_level(RIG *rig, vfo_t vfo, hamlib_token_t token, value_t val)
+static int k3_set_ext_level(RIG *rig, vfo_t vfo, hamlib_token_t token, value_t val)
 {
     char buf[10];
 
@@ -1476,7 +1456,7 @@ int k3_set_ext_level(RIG *rig, vfo_t vfo, hamlib_token_t token, value_t val)
  *      STRING: val.cs for set, val.s for get
  *      CHECKBUTTON: val.i 0/1
  */
-int k3_get_ext_level(RIG *rig, vfo_t vfo, hamlib_token_t token, value_t *val)
+static int k3_get_ext_level(RIG *rig, vfo_t vfo, hamlib_token_t token, value_t *val)
 {
     char buf[KENWOOD_MAX_BUF_LEN];
     int err;
@@ -1544,7 +1524,7 @@ int k3_get_ext_level(RIG *rig, vfo_t vfo, hamlib_token_t token, value_t *val)
  * k3_set_rit() -- Differs from from generic Kenwood function as K3 can set
  * RIT to an arbitrary offset.  When rit == 0, the RIT offset is cleared.
  */
-int k3_set_rit(RIG *rig, vfo_t vfo, shortfreq_t rit)
+static int k3_set_rit(RIG *rig, vfo_t vfo, shortfreq_t rit)
 {
     int err;
 
@@ -1565,7 +1545,7 @@ int k3_set_rit(RIG *rig, vfo_t vfo, shortfreq_t rit)
  * k3_set_xit() -- Differs from from generic Kenwood function as K3 can set
  * XIT to an arbitrary offset.  When rit == 0, the XIT offset is cleared.
  */
-int k3_set_xit(RIG *rig, vfo_t vfo, shortfreq_t rit)
+static int k3_set_xit(RIG *rig, vfo_t vfo, shortfreq_t rit)
 {
     int err;
 
@@ -1585,7 +1565,7 @@ int k3_set_xit(RIG *rig, vfo_t vfo, shortfreq_t rit)
 /*
  * The K3 *always* uses VFOB for TX.
  */
-int k3_set_split_mode(RIG *rig, vfo_t vfo, rmode_t tx_mode, pbwidth_t tx_width)
+static int k3_set_split_mode(RIG *rig, vfo_t vfo, rmode_t tx_mode, pbwidth_t tx_width)
 {
     struct kenwood_priv_caps *caps = kenwood_caps(rig);
     char buf[32];
@@ -1761,7 +1741,7 @@ int k3_set_split_mode(RIG *rig, vfo_t vfo, rmode_t tx_mode, pbwidth_t tx_width)
 
 /* The K3 *always* uses VFOB for TX.
  */
-int k3_get_split_mode(RIG *rig, vfo_t vfo, rmode_t *tx_mode,
+static int k3_get_split_mode(RIG *rig, vfo_t vfo, rmode_t *tx_mode,
                       pbwidth_t *tx_width)
 {
     char buf[KENWOOD_MAX_BUF_LEN];
@@ -1919,7 +1899,7 @@ static int k3_get_maxpower(RIG *rig)
     return maxpower;
 }
 
-int k3_power2mW(RIG *rig,
+static int k3_power2mW(RIG *rig,
                 unsigned int *mwpower,
                 float power,
                 freq_t freq,
@@ -1931,7 +1911,7 @@ int k3_power2mW(RIG *rig,
     return RIG_OK;
 }
 
-int k3_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
+static int k3_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
     char levelbuf[16];
     int kenwood_val;
@@ -2050,7 +2030,7 @@ int k3_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 /*
  * Handle S-meter (SM, SMH) level locally and pass rest to kenwood_get_level()
  */
-int k3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
+static int k3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
     char levelbuf[16];
     int retval;
@@ -2395,7 +2375,7 @@ int k3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     return RIG_OK;
 }
 
-int kx3_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
+static int kx3_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
     int ival;
     char cmdbuf[32];
@@ -2425,7 +2405,7 @@ int kx3_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
     return k3_set_level(rig, vfo, level, val);
 }
 
-int kx3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
+static int kx3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
     int retval;
     float f;
@@ -2515,7 +2495,7 @@ int kx3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 }
 
 
-int k3_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
+static int k3_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
 {
     char buf[10];
 
@@ -2555,7 +2535,7 @@ int k3_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
     return kenwood_transaction(rig, buf, NULL, 0);
 }
 
-int k3_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op)
+static int k3_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op)
 {
     char buf[32];
     ENTERFUNC;
@@ -2593,7 +2573,7 @@ int k3_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op)
  * on the K3.  Those functions are handled here and others are passed
  * through to kenwood_get_func().
  */
-int k3_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
+static int k3_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
 {
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
@@ -2674,7 +2654,7 @@ int set_rit_xit(RIG *rig, shortfreq_t rit)
     return RIG_OK;
 }
 
-int k3_set_nb_level(RIG *rig, float dsp_nb, float if_nb)
+static int k3_set_nb_level(RIG *rig, float dsp_nb, float if_nb)
 {
     char levelbuf[16];
     int dsp_nb_raw = 0;
@@ -2722,7 +2702,7 @@ int k3_set_nb_level(RIG *rig, float dsp_nb, float if_nb)
     return kenwood_transaction(rig, levelbuf, NULL, 0);
 }
 
-int k3_get_nb_level(RIG *rig, float *dsp_nb, float *if_nb)
+static int k3_get_nb_level(RIG *rig, float *dsp_nb, float *if_nb)
 {
     char levelbuf[16];
     int retval;
@@ -2780,7 +2760,7 @@ int k4_get_bar_graph_level(RIG *rig, float *swr, float *pwr, float *alc,
     return RIG_OK;
 }
 
-int k3_get_bar_graph_level(RIG *rig, float *smeter, float *pwr, float *alc,
+static int k3_get_bar_graph_level(RIG *rig, float *smeter, float *pwr, float *alc,
                            int *mode_tx)
 {
     char levelbuf[16];
@@ -2878,7 +2858,7 @@ int k3_get_bar_graph_level(RIG *rig, float *smeter, float *pwr, float *alc,
     return RIG_OK;
 }
 
-int kx3_get_bar_graph_level(RIG *rig, float *level)
+static int kx3_get_bar_graph_level(RIG *rig, float *level)
 {
     char levelbuf[16];
     int retval;
@@ -2992,7 +2972,7 @@ int k4_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 // K3S band memory needs some time to do its thing after freq change
 // K3 probably does too
 // But what about the K4?
-int k3_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
+static int k3_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
     int retval;
     freq_t tfreq;
@@ -3012,9 +2992,9 @@ int k3_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     return retval;
 }
 
-int k3_send_voice_mem(RIG *rig, vfo_t vfo, int ch)
+static int k3_send_voice_mem(RIG *rig, vfo_t vfo, int ch)
 {
-    char *cmd;
+    const char *cmd;
     int retval;
 
     if (ch < 1 || ch > 4)
@@ -3038,7 +3018,7 @@ int k3_send_voice_mem(RIG *rig, vfo_t vfo, int ch)
     return retval;
 }
 
-int k3_stop_voice_mem(RIG *rig, vfo_t vfo)
+static int k3_stop_voice_mem(RIG *rig, vfo_t vfo)
 {
     int retval;
     retval = kenwood_transaction(rig, "SWT37;", NULL, 0);
@@ -3075,7 +3055,7 @@ int k4_stop_morse(RIG *rig, vfo_t vfo)
     return retval;
 }
 
-int k3_stop_morse(RIG *rig, vfo_t vfo)
+static int k3_stop_morse(RIG *rig, vfo_t vfo)
 {
     int retval;
     char cmd[32];

--- a/rigs/kenwood/ts890s.c
+++ b/rigs/kenwood/ts890s.c
@@ -44,7 +44,8 @@
 static int kenwood_ts890_set_level(RIG *rig, vfo_t vfo, setting_t level,
                                    value_t val)
 {
-    char levelbuf[16], *command_string;
+    char levelbuf[16];
+    const char *command_string;
     int kenwood_val, retval;
     gran_t *level_info;
 
@@ -117,7 +118,7 @@ static int kenwood_ts890_get_level(RIG *rig, vfo_t vfo, setting_t level,
     size_t ack_len, ack_len_expected, len;
     int levelint;
     int retval;
-    char *command_string;
+    const char *command_string;
     gran_t *level_info;
 
     level_info = &rig->caps->level_gran[rig_setting2idx(level)];
@@ -475,13 +476,13 @@ static int ts890s_get_split_vfo(RIG *rig, vfo_t rxvfo, split_t *split,
 {
     char buf[4];
     int retval;
-    vfo_t tvfo;
     struct rig_state *rs = STATE(rig);
     struct kenwood_priv_data *priv = rs->priv;
 
     if (RIG_OK == (retval = kenwood_safe_transaction(rig, "FT", buf, sizeof(buf),
                                 3)))
     {
+        vfo_t tvfo;
         if ('0' == buf[2])
         {
             tvfo = RIG_VFO_A;

--- a/rigs/motorola/micom.c
+++ b/rigs/motorola/micom.c
@@ -24,7 +24,7 @@
 #include <iofunc.h>
 
 // char* to start of checksum for len bytes
-unsigned int checksum(unsigned char *buf, int len)
+static unsigned int checksum(const unsigned char *buf, int len)
 {
     int checksum = 0;
     int i;
@@ -189,8 +189,8 @@ static int micom_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 static int micom_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 {
     hamlib_port_t *rp = RIGPORT(rig);
-    unsigned char on[] =  { 0x24, 0x02, 0x81, 0x13, 0x01, 0xBB, 0x03 };
-    unsigned char off[] = { 0x24, 0x02, 0x81, 0x14, 0x01, 0xBC, 0x03 };
+    static const unsigned char on[] =  { 0x24, 0x02, 0x81, 0x13, 0x01, 0xBB, 0x03 };
+    static const unsigned char off[] = { 0x24, 0x02, 0x81, 0x14, 0x01, 0xBC, 0x03 };
     int retval;
 
     set_transaction_active(rig);

--- a/src/misc.c
+++ b/src/misc.c
@@ -17,6 +17,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 /**
  * \addtogroup rig_internal
@@ -383,7 +384,7 @@ int millis_to_dot10ths(int millis, int wpm)
 int HAMLIB_API sprintf_freq(char *str, int str_len, freq_t freq)
 {
     double f;
-    char *hz;
+    const char *hz;
     int decplaces = 10;
     int retval;
 
@@ -2763,7 +2764,7 @@ void errmsg(int err, char *s, const char *func, const char *file, int line)
               rigerror(err));
 }
 
-uint32_t CRC32_function(uint8_t *buf, uint32_t len)
+uint32_t CRC32_function(const uint8_t *buf, uint32_t len)
 {
 
     uint32_t crc;
@@ -2893,7 +2894,7 @@ const char *rig_get_band_str(RIG *rig, hamlib_band_t band, int which)
         rig_debug(RIG_DEBUG_VERBOSE, "%s: bandlist=%s\n", __func__, bandlist);
         int n = 0;
         char *p = strchr(bandlist, '(') + 1;
-        char *token;
+        const char *token;
 
         if (p == NULL)
         {
@@ -2941,7 +2942,7 @@ hamlib_band_t rig_get_band(RIG *rig, freq_t freq, int band)
         rig_debug(RIG_DEBUG_VERBOSE, "%s: bandlist=%s\n", __func__, bandlist);
         // e.g. BANDSELECT(BAND160M,BAND80M,BANDUNUSED,BAND40M)
         char *p = strchr(bandlist, '(') + 1;
-        char *token;
+        const char *token;
 
         if (p == NULL)
         {
@@ -3000,7 +3001,7 @@ int rig_get_band_rig(RIG *rig, freq_t freq, const char *band)
         }
 
         char *p = strchr(bandlist, '(') + 1;
-        char *token;
+        const char *token;
 
         if (p == NULL)
         {

--- a/src/misc.h
+++ b/src/misc.h
@@ -18,6 +18,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #ifndef _MISC_H
 #define _MISC_H 1
@@ -122,7 +123,7 @@ extern HAMLIB_EXPORT(vfo_t) vfo_fixup2a(RIG *rig, vfo_t vfo, split_t split, cons
 
 extern HAMLIB_EXPORT(int) parse_hoststr(char *hoststr, int hoststr_len, char host[256], char port[6]);
 
-extern HAMLIB_EXPORT(uint32_t) CRC32_function(uint8_t *buf, uint32_t len);
+extern HAMLIB_EXPORT(uint32_t) CRC32_function(const uint8_t *buf, uint32_t len);
 
 extern HAMLIB_EXPORT(char *)date_strget(char *buf, int buflen, int localtime);
 

--- a/src/rig.c
+++ b/src/rig.c
@@ -269,7 +269,7 @@ typedef struct async_data_handler_priv_data_s
 
 static int async_data_handler_start(RIG *rig);
 static int async_data_handler_stop(RIG *rig);
-void *async_data_handler(void *arg);
+static void *async_data_handler(void *arg);
 #endif
 
 #if defined(HAVE_PTHREAD)
@@ -289,7 +289,7 @@ typedef struct morse_data_handler_priv_data_s
 static int morse_data_handler_start(RIG *rig);
 static int morse_data_handler_stop(RIG *rig);
 int morse_data_handler_set_keyspd(RIG *rig, int keyspd);
-void *morse_data_handler(void *arg);
+static void *morse_data_handler(void *arg);
 #endif
 
 /*
@@ -390,7 +390,7 @@ MUTEX(mutex_debugmsgsave);
 
 void add2debugmsgsave(const char *s)
 {
-    char *p;
+    const char *p;
     char stmp[DEBUGMSGSAVE_SIZE];
     int i, nlines;
     int maxmsg = DEBUGMSGSAVE_SIZE / 2;
@@ -2134,7 +2134,6 @@ int rig_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
     if (rs->tx_vfo == vfo && curr_band != last_band)
     {
-        struct rig_cache *cachep = CACHE(rig);
         rig_debug(RIG_DEBUG_VERBOSE, "%s: band changing to %s\n", __func__,
                   rig_get_band_str(rig, curr_band, 0));
         band_changing = 1;
@@ -4714,7 +4713,7 @@ int HAMLIB_API rig_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
     const struct rig_state *rs;
     struct rig_cache *cachep;
     int retcode, rc2;
-    vfo_t curr_vfo, tx_vfo = RIG_VFO_CURR;
+    vfo_t curr_vfo, tx_vfo;
     freq_t tfreq = 0;
 
     if (CHECK_RIG_ARG(rig))
@@ -8629,7 +8628,7 @@ static int morse_data_handler_stop(RIG *rig)
 #endif
 
 #if defined(HAVE_PTHREAD)
-void *async_data_handler(void *arg)
+static void *async_data_handler(void *arg)
 {
     struct async_data_handler_args_s *args = (struct async_data_handler_args_s *)
             arg;
@@ -8725,7 +8724,7 @@ again:
 #endif
 
 #if defined(HAVE_PTHREAD)
-void *morse_data_handler(void *arg)
+static void *morse_data_handler(void *arg)
 {
     struct morse_data_handler_args_s *args =
         (struct morse_data_handler_args_s *) arg;

--- a/tests/rigctl.c
+++ b/tests/rigctl.c
@@ -220,7 +220,7 @@ int main(int argc, char *argv[])
     ptt_type_t ptt_type = RIG_PTT_NONE;
     dcd_type_t dcd_type = RIG_DCD_NONE;
     int serial_rate = 0;
-    char *civaddr = NULL;   /* NULL means no need to set conf */
+    const char *civaddr = NULL;   /* NULL means no need to set conf */
     char conf_parms[MAXCONFLEN] = "";
     int interactive;    /* if no cmd on command line, switch to interactive */
     int prompt = 1;         /* Print prompt in rigctl */
@@ -507,7 +507,7 @@ int main(int argc, char *argv[])
     }
 
     my_rig->caps->ptt_type = ptt_type;
-    char *token = strtok(conf_parms, ",");
+    const char *token = strtok(conf_parms, ",");
     struct rig_state *rs = STATE(my_rig);
 
     while (token)
@@ -564,7 +564,7 @@ int main(int argc, char *argv[])
         if (ptt_type == RIG_PTT_NONE)
         {
             rig_debug(RIG_DEBUG_VERBOSE, "%s: defaulting to RTS PTT\n", __func__);
-            my_rig->caps->ptt_type = ptt_type = RIG_PTT_SERIAL_RTS;
+            my_rig->caps->ptt_type = RIG_PTT_SERIAL_RTS;
         }
     }
 
@@ -690,7 +690,14 @@ int main(int argc, char *argv[])
             hist_path_size = sizeof(char) * (strlen(hist_dir) + strlen(hist_file) + 1);
             hist_path = (char *)calloc(hist_path_size, sizeof(char));
 
-            SNPRINTF(hist_path, hist_path_size, "%s%s", hist_dir, hist_file);
+            if (hist_path)
+            {
+                SNPRINTF(hist_path, hist_path_size, "%s%s", hist_dir, hist_file);
+            }
+	    else
+            {
+                fprintf(stderr, "Allocation failed - no readline history\n");
+            }
         }
 
         if (rd_hist && hist_path)

--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -256,7 +256,7 @@ int main(int argc, char *argv[])
     ptt_type_t ptt_type = RIG_PTT_NONE;
     dcd_type_t dcd_type = RIG_DCD_NONE;
     int serial_rate = 0;
-    char *civaddr = NULL;   /* NULL means no need to set conf */
+    const char *civaddr = NULL;   /* NULL means no need to set conf */
     char conf_parms[MAXCONFLEN] = "";
 
     struct addrinfo hints, *result, *saved_result;
@@ -573,7 +573,7 @@ int main(int argc, char *argv[])
     }
 
     my_rig->caps->ptt_type = ptt_type;
-    char *token = strtok(conf_parms, ",");
+    const char *token = strtok(conf_parms, ",");
     struct rig_state *rs = STATE(my_rig);
 
     while (token)
@@ -643,7 +643,7 @@ int main(int argc, char *argv[])
         if (ptt_type == RIG_PTT_NONE)
         {
             rig_debug(RIG_DEBUG_VERBOSE, "%s: defaulting to RTS PTT\n", __func__);
-            my_rig->caps->ptt_type = ptt_type = RIG_PTT_SERIAL_RTS;
+            my_rig->caps->ptt_type = RIG_PTT_SERIAL_RTS;
         }
     }
 


### PR DESCRIPTION
Get rid of some more style nagging - add const/static modifiers, drop some unneeded code.
Make cppcheck.sh aware of out-of-tree building - try to find generated include files.

For master/4.7 only
