### PR TITLE
Revert 17b404a6c71f3d0bd60153a9191088e6cc9960c5

### DIFF
--- a/include/hamlib/rotator.h
+++ b/include/hamlib/rotator.h
@@ -909,7 +909,6 @@ dec2dmmm HAMLIB_PARAMS((double dec,
 extern HAMLIB_EXPORT(double)
 dmmm2dec HAMLIB_PARAMS((int degrees,
                         double minutes,
-                        double seconds,
                         int sw));
 
 extern HAMLIB_EXPORT(setting_t) rot_parse_func(const char *s);

--- a/rotators/meade/meade.c
+++ b/rotators/meade/meade.c
@@ -353,8 +353,8 @@ static int meade_get_position(ROT *rot, azimuth_t *az, elevation_t *el)
     rig_debug(RIG_DEBUG_VERBOSE, "%s: az=%03d:%02d:%02d, el=%03d:%02d:%02d\n",
               __func__, az_degrees, az_minutes, az_seconds, el_degrees, el_minutes,
               el_seconds);
-    *az = dmmm2dec(az_degrees, az_minutes, az_seconds, az_seconds);
-    *el = dmmm2dec(el_degrees, el_minutes, el_seconds, el_seconds);
+    *az = dms2dec(az_degrees, az_minutes, az_seconds, 0);
+    *el = dms2dec(el_degrees, el_minutes, el_seconds, 0);
     return RIG_OK;
 }
 

--- a/src/locator.c
+++ b/src/locator.c
@@ -217,14 +217,13 @@ double HAMLIB_API dms2dec(int degrees, int minutes, double seconds, int sw)
  *
  * \param degrees Degrees, whole degrees.
  * \param minutes Minutes, decimal minutes.
- * \param seconds Seconds, decimal seconds.
  * \param sw South or West.
  *
  * Convert a degrees decimal minutes (D M.MMM) notation common on many GPS
  * units to a decimal degrees (D.DDD) angle value.
  *
- * \note For the parameters \a degrees > 360, \a minutes > 60.0, \a seconds >
- * 60.0 are allowed, but the resulting angle will not be normalized.
+ * \note For the parameters \a degrees > 360, \a minutes > 60.0 are allowed, but
+ * the resulting angle will not be normalized.
  *
  * When the variable \a sw is passed a value of 1, the returned decimal
  * degrees value will be negative (*South* or *West*).  When passed a value of
@@ -234,7 +233,7 @@ double HAMLIB_API dms2dec(int degrees, int minutes, double seconds, int sw)
  *
  * \sa dec2dmmm()
  */
-double HAMLIB_API dmmm2dec(int degrees, double minutes, double seconds, int sw)
+double HAMLIB_API dmmm2dec(int degrees, double minutes, int sw)
 {
     double st;
 
@@ -250,7 +249,7 @@ double HAMLIB_API dmmm2dec(int degrees, double minutes, double seconds, int sw)
         minutes = fabs(minutes);
     }
 
-    st = (double)degrees + (minutes / 60) + (seconds / 3600);
+    st = (double)degrees + minutes / 60;
 
     if (sw == 1)
     {

--- a/tests/rotctl_parse.c
+++ b/tests/rotctl_parse.c
@@ -2769,8 +2769,7 @@ declare_proto_rot(d_mm2dec)
     CHKSCN1ARG(sscanf(arg2, "%lf", &min));
     CHKSCN1ARG(sscanf(arg3, "%d", &sw));
 
-    dec_deg = dmmm2dec(deg, min, sw,
-                       0.0); // we'll add real seconds when somebody asks for it
+    dec_deg = dmmm2dec(deg, min, sw);
 
     if ((interactive && prompt) || (interactive && !prompt && ext_resp))
     {


### PR DESCRIPTION
These changes were unnecessary as the real bug is that the incorrect function was being called in meade.c.

Closes GitHub issue #268.