### PR TITLE
Verbosity reduction

### DIFF
--- a/rigs/dummy/dummy.c
+++ b/rigs/dummy/dummy.c
@@ -353,10 +353,7 @@ static int dummy_cleanup(RIG *rig)
     free(priv->ext_parms);
     free(priv->magic_conf);
 
-    if (rs->priv)
-    {
-        free(rs->priv);
-    }
+    free(priv);
 
     rs->priv = NULL;
 

--- a/rigs/icom/frame.c
+++ b/rigs/icom/frame.c
@@ -124,7 +124,7 @@ int icom_frame_fix_preamble(int frame_len, unsigned char *frame)
  * return RIG_OK if transaction completed,
  * or a negative value otherwise indicating the error.
  */
-int icom_one_transaction(RIG *rig, unsigned char cmd, int subcmd,
+static int icom_one_transaction(RIG *rig, unsigned char cmd, int subcmd,
                          const unsigned char *payload, int payload_len, unsigned char *data,
                          int *data_len)
 {

--- a/rigs/icom/icf8101.c
+++ b/rigs/icom/icf8101.c
@@ -190,7 +190,7 @@ static const struct icom_priv_caps icf8101_priv_caps =
     .r2i_mode = icf8101_r2i_mode
 };
 
-int icf8101_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
+static int icf8101_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
 {
     switch (func)
     {
@@ -199,7 +199,7 @@ int icf8101_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
     }
 }
 
-int icf8101_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
+static int icf8101_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
 {
     switch (func)
     {
@@ -208,7 +208,7 @@ int icf8101_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
     }
 }
 
-int icf8101_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
+static int icf8101_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
 {
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
@@ -223,7 +223,7 @@ int icf8101_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
     }
 }
 
-int icf8101_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
+static int icf8101_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
@@ -237,24 +237,24 @@ int icf8101_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     }
 }
 
-int icf8101_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
+static int icf8101_set_split_freq(RIG *rig, vfo_t vfo, freq_t tx_freq)
 {
     return rig_set_freq(rig, RIG_VFO_B, tx_freq);
 }
 
-int icf8101_get_split_freq(RIG *rig, vfo_t vfo, freq_t *tx_freq)
+static int icf8101_get_split_freq(RIG *rig, vfo_t vfo, freq_t *tx_freq)
 {
     return rig_get_freq(rig, RIG_VFO_B, tx_freq);
 }
 
-int icf8101_set_split_freq_mode(RIG *rig, vfo_t vfo, freq_t tx_freq,
+static int icf8101_set_split_freq_mode(RIG *rig, vfo_t vfo, freq_t tx_freq,
                                 rmode_t mode, pbwidth_t width)
 {
     rig_set_freq(rig, RIG_VFO_B, tx_freq);
     return rig_set_mode(rig, RIG_VFO_B, mode, -1);
 }
 
-int icf8101_get_split_freq_mode(RIG *rig, vfo_t vfo, freq_t *tx_freq,
+static int icf8101_get_split_freq_mode(RIG *rig, vfo_t vfo, freq_t *tx_freq,
                                 rmode_t *mode, pbwidth_t *width)
 {
     rig_get_freq(rig, RIG_VFO_B, tx_freq);
@@ -263,7 +263,7 @@ int icf8101_get_split_freq_mode(RIG *rig, vfo_t vfo, freq_t *tx_freq,
 
 
 
-int icf8101_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
+static int icf8101_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
 {
     unsigned char cmdbuf[4];
     int ack_len;
@@ -277,7 +277,7 @@ int icf8101_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
                             &ack_len);
 }
 
-int icf8101_get_split_vfo(RIG *rig, vfo_t vfo, split_t *split, vfo_t *tx_vfo)
+static int icf8101_get_split_vfo(RIG *rig, vfo_t vfo, split_t *split, vfo_t *tx_vfo)
 {
     int retval;
     int ack_len;
@@ -299,7 +299,7 @@ int icf8101_get_split_vfo(RIG *rig, vfo_t vfo, split_t *split, vfo_t *tx_vfo)
     return retval;
 }
 
-int icf8101_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
+static int icf8101_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 {
     unsigned char ackbuf[MAXFRAMELEN], pttbuf[2];
     int ack_len = sizeof(ackbuf), retval;
@@ -350,7 +350,7 @@ int icf8101_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
  * icf8101_get_ptt
  * Assumes rig!=NULL, STATE(rig)->priv!=NULL, ptt!=NULL
  */
-int icf8101_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
+static int icf8101_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
 {
     unsigned char pttbuf[MAXFRAMELEN];
     int ptt_len, retval;

--- a/rigs/icom/icom.c
+++ b/rigs/icom/icom.c
@@ -1454,7 +1454,7 @@ static int icom_band_changing(RIG *rig, freq_t test_freq)
 }
 
 static int icom_set_freq_x25(RIG *rig, vfo_t vfo, freq_t freq, int freq_len,
-                             unsigned char *freqbuf)
+                             const unsigned char *freqbuf)
 {
     struct rig_state *rs = STATE(rig);
     struct icom_priv_data *priv = (struct icom_priv_data *) rs->priv;
@@ -2789,7 +2789,6 @@ static int icom_get_mode_without_data(RIG *rig, vfo_t vfo, rmode_t *mode,
 
     if (--mode_len == 3)
     {
-        // cppcheck-suppress redundantAssignment
         priv_data->filter = modebuf[2];
         rig_debug(RIG_DEBUG_TRACE,
                   "%s(%d): modebuf[0]=0x%02x, modebuf[1]=0x%02x, modebuf[2]=0x%02x, mode_len=%d, filter=%d\n",

--- a/src/network.c
+++ b/src/network.c
@@ -184,7 +184,7 @@ static void handle_error(enum rig_debug_level_e lvl, const char *msg)
 
 #define TRACE rig_debug(RIG_DEBUG_ERR, "TRACE %s(%d)\n", __func__,__LINE__);
 
-int network_init()
+static int network_init()
 {
     int retval = -RIG_EINTERNAL;
 #ifdef __MINGW32__
@@ -830,7 +830,6 @@ static int multicast_publisher_write_packet_header(RIG *rig,
     return RIG_OK;
 }
 
-// cppcheck-suppress unusedFunction
 int network_publish_rig_poll_data(RIG *rig)
 {
     const struct rig_state *rs = STATE(rig);
@@ -854,7 +853,6 @@ int network_publish_rig_poll_data(RIG *rig)
     return result;
 }
 
-// cppcheck-suppress unusedFunction
 int network_publish_rig_transceive_data(RIG *rig)
 {
     const struct rig_state *rs = STATE(rig);

--- a/src/sprintflst.c
+++ b/src/sprintflst.c
@@ -207,16 +207,19 @@ int rig_sprintf_func(char *str, int nlen, setting_t func)
     {
         const char *ms = rig_strfunc(func & rig_idx2setting(i));
 
-        if (!ms || !ms[0])
+        if (!ms)
         {
             rig_debug(RIG_DEBUG_ERR, "%s: unknown RIG_FUNC=%x\n", __func__, i);
             continue;    /* unknown, FIXME! */
         }
 
-        strcat(str, ms);
-        strcat(str, " ");
-        len += strlen(ms) + 1;
-        check_buffer_overflow(str, len, nlen);
+        if (ms[0])
+        {
+            strcat(str, ms);
+            strcat(str, " ");
+            len += strlen(ms) + 1;
+            check_buffer_overflow(str, len, nlen);
+        }
     }
 
     return len;

--- a/tests/ampctl_parse.c
+++ b/tests/ampctl_parse.c
@@ -1554,7 +1554,7 @@ static int hash_model_list(const struct amp_caps *caps, void *data)
     return 1;  /* !=0, we want them all ! */
 }
 
-void print_model_list()
+static void print_model_list()
 {
     struct mod_lst *s;
 

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -2101,7 +2101,7 @@ static int hash_model_list(const struct rig_caps *caps, void *data)
 }
 
 
-void print_model_list()
+static void print_model_list()
 {
     struct mod_lst *s;
 

--- a/tests/rotctl_parse.c
+++ b/tests/rotctl_parse.c
@@ -1638,7 +1638,7 @@ static int hash_model_list(const struct rot_caps *caps, void *data)
     return 1;  /* !=0, we want them all ! */
 }
 
-void print_model_list()
+static void print_model_list()
 {
     struct mod_lst *s;
 


### PR DESCRIPTION
Silence the batch of RIG_DEBUG_ERR messages produced by \dump_caps.  They're not really errors, but are rather jarring when you're checking out a new application, like I was with not1mm.
And the usual batch of cppcheck nags.
