### PR TITLE
Don't remove non-printable characters if they are essential to the me…

### DIFF
--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -444,8 +444,14 @@ transaction_read:
               (int)strlen(buffer), buffer);
 
     // this fixes the case when some corrupt data is returned
-    // let's us be a little more robust about funky serial data
-    remove_nonprint(buffer);
+    // let us be a little more robust about funky serial data
+    // If the terminator is printable(usually ';'), then there should be
+    //   no nonprintables in the message; if it isn't(usually '\r') then
+    //   don't touch the buffer
+    if (isprint(caps->cmdtrm))
+    {
+        remove_nonprint(buffer);
+    }
 
     if (retval < 0)
     {


### PR DESCRIPTION
…ssage.

Remove them IFF the EOM is printable.

Related to issue #1652
Fixes #1698 and #1767

This should go into master and the 4.6.x branch, if there might be a 4.6.4 in a month or two.