### PR TITLE
Fixed jrc_set_chan

### DIFF
--- a/rigs/jrc/jrc.c
+++ b/rigs/jrc/jrc.c
@@ -1459,6 +1459,8 @@ int jrc_set_chan(RIG *rig, vfo_t vfo, const channel_t *chan)
                  chan->levels[rig_setting2idx(RIG_LEVEL_AGC)].i);
     }
 
+    cmdbuf[priv->mem_len - 1] = 0x0d;
+ 
     return jrc_transaction(rig, cmdbuf, strlen(cmdbuf), NULL, NULL);
 }
 


### PR DESCRIPTION
set_chan() was correctly creating and sending the command, and returning RIG_OK. However, radio was actually ignoring it because command wasn't terminated with a CR. This is now corrected.