### PR TITLE
Use unique separator character for each rigctld connection

### DIFF
--- a/doc/man1/rigctld.1
+++ b/doc/man1/rigctld.1
@@ -25,6 +25,7 @@ rigctld \- TCP radio control daemon
 .OP \-D type
 .OP \-s baud
 .OP \-c id
+.OP \-S char
 .OP \-T IPADDR
 .OP \-t number
 .OP \-C parm=val

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -497,9 +497,9 @@ void hash_delete_all()
 
 
 // modifies s to remove quotes
-void strip_quotes(char *s)
+static void strip_quotes(char *s)
 {
-    char *s2 = strdup(s);
+    char *s2;
     char *p;
 
     if (s[0] != '\"') { return; } // no quotes
@@ -510,6 +510,7 @@ void strip_quotes(char *s)
     if (p) { *p = 0; }
 
     strcpy(s, s2);
+    free(s2);
 }
 
 #ifdef HAVE_LIBREADLINE

--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -1161,6 +1161,7 @@ void *handle_socket(void *arg)
     char serv[NI_MAXSERV];
     char send_cmd_term = '\r';  /* send_cmd termination char */
     int ext_resp = 0;
+    char my_resp_sep = resp_sep;  // Separator for this connection, initial default
     rig_powerstat = RIG_POWER_ON; // defaults to power on
     struct timespec powerstat_check_time;
 
@@ -1209,7 +1210,7 @@ void *handle_socket(void *arg)
 #else
     mutex_rigctld(1);
     retcode = rig_open(my_rig);
-    mutex_rigctld(1);
+    mutex_rigctld(0);
 
     if (RIG_OK == retcode && verbose > RIG_DEBUG_ERR)
     {
@@ -1250,8 +1251,8 @@ void *handle_socket(void *arg)
                       __func__,
                       handle_data_arg->vfo_mode, handle_data_arg->use_password);
             retcode = rigctl_parse(handle_data_arg->rig, fsockin, fsockout, NULL, 0,
-                                   mutex_rigctld,
-                                   1, 0, &handle_data_arg->vfo_mode, send_cmd_term, &ext_resp, &resp_sep,
+                                   mutex_rigctld, 1, 0, &handle_data_arg->vfo_mode,
+                                   send_cmd_term, &ext_resp, &my_resp_sep,
                                    handle_data_arg->use_password);
 
             if (retcode != 0) { rig_debug(RIG_DEBUG_VERBOSE, "%s: rigctl_parse retcode=%d\n", __func__, retcode); }


### PR DESCRIPTION
Copy global default separator into thread-local storage

Fix memory leak, and small omission in man page.

All for master, rigctld.c for 4.6.x

Fixes #1748
