### PR TITLE
Correct powerstat check on Icom R75

### DIFF
--- a/rigs/icom/icr75.c
+++ b/rigs/icom/icr75.c
@@ -245,7 +245,7 @@ struct rig_caps icr75_caps =
     .scan =  icom_scan,
     .set_ts =  icom_set_ts,
     .set_powerstat = icom_set_powerstat,
-    .get_powerstat = icom_get_powerstat,
+    //.get_powerstat = icom_get_powerstat,
 
     .set_channel = icr75_set_channel,
     .get_channel = icr75_get_channel,


### PR DESCRIPTION
The R75 for some reason rejects the powerstat query and returns an error. Commented out  .get_powerstat to correct that. Applications should initially assume it's on, then internally track power status, since you can still turn it off.