### PR TITLE
Correct and update mapping of D_AGC values

### DIFF
--- a/rigs/icom/icom.c
+++ b/rigs/icom/icom.c
@@ -3879,20 +3879,32 @@ int icom_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
             // Legacy mapping that does not apply to all rigs
             switch (val.i)
             {
-            case RIG_AGC_SLOW:
-                cmdbuf[0] = D_AGC_SLOW;
+            case RIG_AGC_OFF:
+                cmdbuf[0] = D_AGC_OFF;
                 break;
 
-            case RIG_AGC_MEDIUM:
-                cmdbuf[0] = D_AGC_MID;
+            case RIG_AGC_SUPERFAST:
+                cmdbuf[0] = D_AGC_SUPERFAST;
                 break;
 
             case RIG_AGC_FAST:
                 cmdbuf[0] = D_AGC_FAST;
                 break;
 
-            case RIG_AGC_SUPERFAST:
-                cmdbuf[0] = D_AGC_SUPERFAST;
+            case RIG_AGC_SLOW:
+                cmdbuf[0] = D_AGC_SLOW;
+                break;
+
+            case RIG_AGC_USER:
+                cmdbuf[0] = D_AGC_USER;
+                break;
+
+            case RIG_AGC_MEDIUM:
+                cmdbuf[0] = D_AGC_MID;
+                break;
+
+            case RIG_AGC_AUTO:
+                cmdbuf[0] = D_AGC_AUTO;
                 break;
 
             default:
@@ -4526,20 +4538,32 @@ int icom_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         {
             switch (icom_val)
             {
-            case D_AGC_SLOW:
+            case D_AGC_OFF:
+                val->i = RIG_AGC_OFF;
+                break;
+
+           case D_AGC_SUPERFAST:
+                val->i = RIG_AGC_SUPERFAST;
+                break;
+
+           case D_AGC_FAST:
+                val->i = RIG_AGC_FAST;
+                break;
+
+           case D_AGC_SLOW:
                 val->i = RIG_AGC_SLOW;
+                break;
+
+           case D_AGC_USER:
+                val->i = RIG_AGC_USER;
                 break;
 
             case D_AGC_MID:
                 val->i = RIG_AGC_MEDIUM;
                 break;
 
-            case D_AGC_FAST:
-                val->i = RIG_AGC_FAST;
-                break;
-
-            case D_AGC_SUPERFAST:
-                val->i = RIG_AGC_SUPERFAST;
+            case D_AGC_AUTO:
+                val->i = RIG_AGC_AUTO;
                 break;
 
             default:

--- a/rigs/icom/icom_defs.h
+++ b/rigs/icom/icom_defs.h
@@ -232,10 +232,13 @@
 /*
  * Set AGC (S_FUNC_AGC) data
  */
-#define D_AGC_FAST	0x00
-#define D_AGC_MID	0x01
-#define D_AGC_SLOW	0x02
-#define D_AGC_SUPERFAST	0x03 /* IC746 pro */
+#define D_AGC_OFF	0x00
+#define D_AGC_SUPERFAST	0x01 //was 0x03 /* IC746 pro */
+#define D_AGC_FAST	0x02 //was 0x00
+#define D_AGC_SLOW	0x03 //was 0x02
+#define D_AGC_USER	0x04
+#define D_AGC_MID	0x05 //was 0x01
+#define D_AGC_AUTO	0x06
 
 /*
  * Set antenna (C_SET_ANT) subcommands


### PR DESCRIPTION
Ref issue[#1775](https://github.com/Hamlib/Hamlib/issues/1775)
 Part 1 : Corrects the mapping of D_AGC values to currently enumerated AGC set, including those likely not available when originally coded.
 
 Part 2 will separately provide alternate mapping, if required, in backends (such as IC746 Pro) that require it.
