### PR TITLE
Fix MinGW64/MSYS2 w/GCC 15.1 warning

### DIFF
--- a/src/rig.c
+++ b/src/rig.c
@@ -621,7 +621,7 @@ RIG *HAMLIB_API rig_init(rig_model_t rig_model)
      * and especially  the callbacks
      */
     needed = sizeof(RIG);
-    rig_debug(RIG_DEBUG_TRACE, "Requesting %zd bytes for rig_struct\n", needed);
+    rig_debug(RIG_DEBUG_TRACE, "Requesting %zu bytes for rig_struct\n", needed);
     rig = calloc(1, needed);
 
     if (rig == NULL)
@@ -654,7 +654,7 @@ RIG *HAMLIB_API rig_init(rig_model_t rig_model)
 
     // Allocate space for cached data
     needed = sizeof(struct rig_cache);
-    rig_debug(RIG_DEBUG_TRACE, "Requesting %zd bytes for rig_cache\n", needed);
+    rig_debug(RIG_DEBUG_TRACE, "Requesting %zu bytes for rig_cache\n", needed);
     CACHE(rig) = calloc(1, needed);
     if (!CACHE(rig))
     {


### PR DESCRIPTION
As reported by Steve, VK3SIR on the mailing list:

On compilation, through a fully up-to-date MinGW64/MSYS2 environment, we receive the following warnings:

....
make[3]: Entering directory '/home/sir/src/hamlib/build/src'
  CC       rig.lo
../../src/src/rig.c: In function 'rig_init':
../../src/src/rig.c:624:45: warning: unknown conversion type character 'z' in format [-Wformat=]
  624 |     rig_debug(RIG_DEBUG_TRACE, "Requesting %zd bytes for rig_struct\n", needed);
      |                                             ^
../../src/src/rig.c:624:32: warning: too many arguments for format [-Wformat-extra-args]
  624 |     rig_debug(RIG_DEBUG_TRACE, "Requesting %zd bytes for rig_struct\n", needed);
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../src/src/rig.c:657:45: warning: unknown conversion type character 'z' in format [-Wformat=]
  657 |     rig_debug(RIG_DEBUG_TRACE, "Requesting %zd bytes for rig_cache\n", needed);
      |                                             ^
../../src/src/rig.c:657:32: warning: too many arguments for format [-Wformat-extra-args]
  657 |     rig_debug(RIG_DEBUG_TRACE, "Requesting %zd bytes for rig_cache\n", needed);
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  CC       serial.lo
....

The '%z' modifier is also found in rigs/icom/icom.c but with a 'u' conversion specifier.  Turns out that since 'needed' in this function is of type 'size_t' which is an unsigned integer so the 'u' is required.