### PR TITLE
Fix bindigs for get_split_vfo() get_vfo_info() get_ant()

### DIFF
--- a/bindings/python/test_rig.py
+++ b/bindings/python/test_rig.py
@@ -131,10 +131,8 @@ class TestClass:
         assert isinstance(rig.get_ts(), int)
         assert isinstance(rig.get_ts(Hamlib.RIG_VFO_CURR), int)
         assert isinstance(rig.get_vfo(), int)
-        with raises(TypeError):
-            assert rig.get_vfo_info(Hamlib.RIG_VFO_CURR) is None  # FIXME
-            assert rig.get_vfo_info(Hamlib.RIG_VFO_CURR, 2) is None  # FIXME
-            assert rig.get_vfo_info(Hamlib.RIG_VFO_CURR, 2, 3) is None  # FIXME
+        assert isinstance(rig.get_vfo_info(), list)
+        assert isinstance(rig.get_vfo_info(Hamlib.RIG_VFO_CURR), list)
         assert isinstance(rig.get_xit(), int)
         assert isinstance(rig.get_xit(Hamlib.RIG_VFO_CURR), int)
         # assert rig_has_get_func(0)  FIXME not defined

--- a/bindings/python/test_rig.py
+++ b/bindings/python/test_rig.py
@@ -74,8 +74,9 @@ class TestClass:
         assert rig.ext_token_lookup("") is None
         option = Hamlib.value_t()
         ant = 0  # FIXME should use a RIG_ANT_* constant but it isn't available in the bindings
-        assert isinstance(rig.get_ant(option, ant), list)
-        assert isinstance(rig.get_ant(option, ant, Hamlib.RIG_VFO_CURR), list)
+        with raises(AssertionError):  # FIXME
+            assert len(rig.get_ant(option, ant)) == 4
+            assert len(rig.get_ant(option, ant, Hamlib.RIG_VFO_CURR)) == 4
         assert option.i == 0
         assert rig.get_chan_all() is None
         channel = 0
@@ -109,8 +110,8 @@ class TestClass:
         assert isinstance(rig.get_level_i(0), int)
         assert isinstance(rig.get_mem(), int)
         assert isinstance(rig.get_mem(Hamlib.RIG_VFO_CURR), int)
-        assert isinstance(rig.get_mode(), list)
-        assert isinstance(rig.get_mode(Hamlib.RIG_VFO_CURR), list)
+        assert len(rig.get_mode()) == 2
+        assert len(rig.get_mode(Hamlib.RIG_VFO_CURR)) == 2
         assert rig.get_parm(0) is None
         assert isinstance(rig.get_parm_f(0), float)
         assert isinstance(rig.get_parm_i(0), int)
@@ -125,14 +126,14 @@ class TestClass:
         assert isinstance(rig.get_rptr_shift(Hamlib.RIG_VFO_CURR), int)
         assert isinstance(rig.get_split_freq(), float)
         assert isinstance(rig.get_split_freq(Hamlib.RIG_VFO_CURR), float)
-        assert isinstance(rig.get_split_mode(), list)
-        assert isinstance(rig.get_split_mode(Hamlib.RIG_VFO_CURR), list)
+        assert len(rig.get_split_mode()) == 2
+        assert len(rig.get_split_mode(Hamlib.RIG_VFO_CURR)) == 2
         assert isinstance(rig.get_trn(), int)  # deprecated
         assert isinstance(rig.get_ts(), int)
         assert isinstance(rig.get_ts(Hamlib.RIG_VFO_CURR), int)
         assert isinstance(rig.get_vfo(), int)
-        assert isinstance(rig.get_vfo_info(), list)
-        assert isinstance(rig.get_vfo_info(Hamlib.RIG_VFO_CURR), list)
+        assert len(rig.get_vfo_info()) == 5
+        assert len(rig.get_vfo_info(Hamlib.RIG_VFO_CURR)) == 5
         assert isinstance(rig.get_xit(), int)
         assert isinstance(rig.get_xit(Hamlib.RIG_VFO_CURR), int)
         # assert rig_has_get_func(0)  FIXME not defined

--- a/bindings/python/test_rig.py
+++ b/bindings/python/test_rig.py
@@ -59,6 +59,11 @@ class TestClass:
         assert rig.get_split_vfo() == [5000000, 1]
         assert rig.get_split_vfo(Hamlib.RIG_VFO_CURR) == [5000000, 1]
 
+        # FIXME should use a RIG_ANT_* constant but it isn't available in the bindings
+        RIG_ANT_UNKNOWN = 1<<30
+        assert rig.get_ant(Hamlib.RIG_VFO_A) == [RIG_ANT_UNKNOWN, RIG_ANT_UNKNOWN, Hamlib.RIG_VFO_A, 0]
+        assert rig.get_ant(Hamlib.RIG_VFO_A, Hamlib.RIG_VFO_A) == [RIG_ANT_UNKNOWN, RIG_ANT_UNKNOWN, Hamlib.RIG_VFO_A, 0]
+
         assert rig.close() is None
         assert rig.state.comm_state == 0
         info = rig.get_info()
@@ -72,12 +77,6 @@ class TestClass:
 
         assert rig.close() is None
         assert rig.ext_token_lookup("") is None
-        option = Hamlib.value_t()
-        ant = 0  # FIXME should use a RIG_ANT_* constant but it isn't available in the bindings
-        with raises(AssertionError):  # FIXME
-            assert len(rig.get_ant(option, ant)) == 4
-            assert len(rig.get_ant(option, ant, Hamlib.RIG_VFO_CURR)) == 4
-        assert option.i == 0
         assert rig.get_chan_all() is None
         channel = 0
         readonly = 0
@@ -158,10 +157,12 @@ class TestClass:
         assert rig.scan(0, 0, 0) is None
         assert rig.send_dtmf(0, "") is None
         assert rig.send_morse(0, "") is None
+        # FIXME should use a RIG_ANT_* constant but it isn't available in the bindings
+        RIG_ANT_1 = 1<<0
         option = Hamlib.value_t()
-        option.i = 0  # FIXME should use a RIG_ANT_* constant but it isn't available in the bindings
+        option.i = 0
         assert rig.set_ant(Hamlib.RIG_VFO_CURR, option) is None
-        assert rig.set_ant(Hamlib.RIG_VFO_CURR, option, 0) is None
+        assert rig.set_ant(Hamlib.RIG_VFO_CURR, option, RIG_ANT_1) is None
         assert rig.set_bank(0, 0) is None
         channel = Hamlib.channel()
         channel = Hamlib.channel(0)

--- a/bindings/python/test_rig.py
+++ b/bindings/python/test_rig.py
@@ -50,6 +50,15 @@ class TestClass:
         assert rig.state.comm_state == 1
         info = rig.get_info()
         assert isinstance(info, str)
+
+        assert rig.set_split_vfo(-600000, Hamlib.RIG_VFO_A) is None
+        assert rig.get_split_vfo(Hamlib.RIG_VFO_TX) == [-600000, 1]
+        assert rig.set_split_vfo(5000000, Hamlib.RIG_VFO_B) is None
+        assert rig.get_split_vfo(Hamlib.RIG_VFO_TX) == [5000000, 2]
+        assert rig.set_split_vfo(5000000, Hamlib.RIG_VFO_CURR) is None
+        assert rig.get_split_vfo() == [5000000, 1]
+        assert rig.get_split_vfo(Hamlib.RIG_VFO_CURR) == [5000000, 1]
+
         assert rig.close() is None
         assert rig.state.comm_state == 0
         info = rig.get_info()
@@ -118,9 +127,6 @@ class TestClass:
         assert isinstance(rig.get_split_freq(Hamlib.RIG_VFO_CURR), float)
         assert isinstance(rig.get_split_mode(), list)
         assert isinstance(rig.get_split_mode(Hamlib.RIG_VFO_CURR), list)
-        with raises(TypeError):
-            assert rig.get_split_vfo() is None  # FIXME
-            assert rig.get_split_vfo(Hamlib.RIG_VFO_CURR) is None  # FIXME
         assert isinstance(rig.get_trn(), int)  # deprecated
         assert isinstance(rig.get_ts(), int)
         assert isinstance(rig.get_ts(Hamlib.RIG_VFO_CURR), int)

--- a/bindings/rig.swg
+++ b/bindings/rig.swg
@@ -473,7 +473,7 @@ typedef channel_t * const_channel_t_p;
 	METHOD1VGET(get_rit, shortfreq_t)
 	METHOD1VGET(get_xit, shortfreq_t)
 	METHOD1VGET(get_ts, shortfreq_t)
-	extern void get_ant(ant_t *OUTPUT, ant_t *OUTPUT, ant_t *OUTPUT, value_t *OUTPUT, ant_t ant, vfo_t vfo = RIG_VFO_CURR);
+	extern void get_ant(ant_t *OUTPUT, ant_t *OUTPUT, ant_t *OUTPUT, signed int *OUTPUT, ant_t ant, vfo_t vfo = RIG_VFO_CURR);
 	void get_vfo_info (int *satmode, split_t *split, pbwidth_t *width, rmode_t *mode, freq_t *freq, vfo_t vfo = RIG_VFO_CURR)
 	{ self->error_status = rig_get_vfo_info(self->rig, vfo, freq, mode, width, split, satmode); }
 	METHOD1VGET(get_mem, int)
@@ -623,9 +623,11 @@ void Rig_get_split_freq_mode(Rig *self, vfo_t vfo, freq_t *tx_freq, rmode_t *tx_
 /*
  * these ones return 4 values
  */
-void Rig_get_ant(Rig *self, ant_t *ant_rx, ant_t *ant_tx, ant_t *ant_curr, value_t *option, ant_t ant, vfo_t vfo)
+void Rig_get_ant(Rig *self, ant_t *ant_rx, ant_t *ant_tx, ant_t *ant_curr, signed int *option, ant_t ant, vfo_t vfo)
 {
-	self->error_status = rig_get_ant(self->rig, vfo, ant, option, ant_curr, ant_tx, ant_rx);
+	value_t value;
+	self->error_status = rig_get_ant(self->rig, vfo, ant, &value, ant_curr, ant_tx, ant_rx);
+	*option = value.i;
 }
 
 struct channel *Rig_get_chan_all(Rig *self)

--- a/bindings/rig.swg
+++ b/bindings/rig.swg
@@ -30,8 +30,14 @@
 %include <hamlib/riglist.h>
 %include <hamlib/rig.h>
 
-%apply unsigned int *OUTPUT { vfo_t * };
+%apply int *OUTPUT { int *};
+
+%apply unsigned int *OUTPUT { ant_t * };
+%apply double *OUTPUT { freq_t * };
+%apply shortfreq_t *OUTPUT { pbwidth_t * };
+%apply uint64_t *OUTPUT { rmode_t * };
 %apply int *OUTPUT { split_t * };
+%apply unsigned int *OUTPUT { vfo_t * };
 
 %inline %{
 
@@ -468,7 +474,8 @@ typedef channel_t * const_channel_t_p;
 	METHOD1VGET(get_xit, shortfreq_t)
 	METHOD1VGET(get_ts, shortfreq_t)
 	extern void get_ant(ant_t *OUTPUT, ant_t *OUTPUT, ant_t *OUTPUT, value_t *OUTPUT, ant_t ant, vfo_t vfo = RIG_VFO_CURR);
-    extern void get_vfo_info (int *satmode, split_t *split, pbwidth_t *width, rmode_t *mode, freq_t *freq, vfo_t vfo = RIG_VFO_CURR);
+	void get_vfo_info (int *satmode, split_t *split, pbwidth_t *width, rmode_t *mode, freq_t *freq, vfo_t vfo = RIG_VFO_CURR)
+	{ self->error_status = rig_get_vfo_info(self->rig, vfo, freq, mode, width, split, satmode); }
 	METHOD1VGET(get_mem, int)
 	METHOD1GET(get_powerstat, powerstat_t)
 	METHOD1GET(get_trn, int)
@@ -620,11 +627,6 @@ void Rig_get_ant(Rig *self, ant_t *ant_rx, ant_t *ant_tx, ant_t *ant_curr, value
 {
 	self->error_status = rig_get_ant(self->rig, vfo, ant, option, ant_curr, ant_tx, ant_rx);
 }
-void Rig_get_vfo_info (Rig *self, int *satmode, split_t *split, pbwidth_t *width, rmode_t *mode, freq_t *freq, vfo_t vfo)
-{
-    self->error_status = rig_get_vfo_info(self->rig, vfo, freq, mode, width, split, satmode); 
-}
-
 
 struct channel *Rig_get_chan_all(Rig *self)
 {

--- a/bindings/rig.swg
+++ b/bindings/rig.swg
@@ -30,6 +30,9 @@
 %include <hamlib/riglist.h>
 %include <hamlib/rig.h>
 
+%apply unsigned int *OUTPUT { vfo_t * };
+%apply int *OUTPUT { split_t * };
+
 %inline %{
 
 #pragma SWIG nowarn=451


### PR DESCRIPTION
This PR tells SWIG how to handle the arguments that hold the results; being a fix of old code, this could go both in 4.6.x and in master.

I'm putting the `%apply` directives early in the *.swg file otherwise I wasn't able to make them work (I found the SWIG documentation hard to follow), for now there isn't ambiguity because all those datatypes are used as outputs when are pointers and as input when they aren't pointers, see the case of

 `get_split_vfo(split_t *split, vfo_t *tx_vfo, vfo_t vfo = RIG_VFO_CURR)`
