### PR TITLE
Fix disabling rigs/winradio and rotators/indi and modify CI to build minimal or (mostly) complete

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -76,14 +76,12 @@ jobs:
       run: grep README Makefile.am
     - name: configure
       if: runner.os != 'macOS'
-      run: ./configure ${{ matrix.configure_args }}
+      run: ./configure ${{ matrix.configure_args }} --enable-silent-rules
     - name: configure on macOS
       if: runner.os == 'macOS'
-      run: ./configure ${{ matrix.configure_args }} --without-python-binding
+      run: ./configure ${{ matrix.configure_args }} --enable-silent-rules --without-python-binding
     - name: make
-      run: make -j 4
-    - name: make check
-      run: make check
+      run: make -j 4 V=0 --no-print-directory
     - name: make distcheck
-      run: make distcheck
+      run: make distcheck V=0 --no-print-directory
 

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -12,6 +12,41 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+        configure_args:
+          - >
+            --enable-html-matrix=no
+            --enable-parallel=no
+            --enable-pytest=no
+            --enable-shared=yes
+            --enable-static=yes
+            --enable-usrp=no
+            --enable-winradio=no
+            --with-cxx-binding=no
+            --with-indi=no
+            --with-libusb=no
+            --with-lua-binding=no
+            --with-perl-binding=no
+            --with-python-binding=no
+            --with-readline=no
+            --with-tcl-binding=no
+            --with-xml-support=no
+          - >
+            --enable-html-matrix=yes
+            --enable-parallel=yes
+            --enable-pytest=yes
+            --enable-shared=yes
+            --enable-static=yes
+            --enable-usrp=no
+            --enable-winradio=yes
+            --with-cxx-binding=yes
+            --with-indi=yes
+            --with-libusb=yes
+            --with-lua-binding=yes
+            --with-perl-binding=yes
+            --with-python-binding=yes
+            --with-readline=yes
+            --with-tcl-binding=yes
+            --with-xml-support=yes
 
     steps:
     - uses: actions/checkout@v4
@@ -41,10 +76,10 @@ jobs:
       run: grep README Makefile.am
     - name: configure
       if: runner.os != 'macOS'
-      run: ./configure --with-lua-binding --with-perl-binding --with-python-binding --with-tcl-binding
+      run: ./configure ${{ matrix.configure_args }}
     - name: configure on macOS
       if: runner.os == 'macOS'
-      run: ./configure --without-python-binding
+      run: ./configure ${{ matrix.configure_args }} --without-python-binding
     - name: make
       run: make -j 4
     - name: make check

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,19 +13,28 @@ EXTRA_DIST = PLAN LICENSE hamlib.m4 hamlib.pc.in README.md README.developer \
 doc_DATA = ChangeLog COPYING COPYING.LIB LICENSE \
 	README.md README.betatester README.developer
 
-SUBDIRS = macros include lib security \
-	$(BACKEND_LIST) \
+SUBDIRS = \
+	$(AMP_BACKEND_LIST) \
+	$(BINDINGS) \
 	$(RIG_BACKEND_LIST) \
 	$(ROT_BACKEND_LIST) \
-	$(AMP_BACKEND_LIST) \
-    security \
+	doc \
+	include \
+	lib \
+	macros \
+	security \
 	src \
-	$(BINDINGS) \
-	tests doc
+	tests
 
 ## Static list of distributed directories.
-DIST_SUBDIRS = macros include lib src c++ bindings tests doc android scripts rotators/indi simulators\
-	security $(BACKEND_LIST) $(RIG_BACKEND_LIST) $(ROT_BACKEND_LIST) $(AMP_BACKEND_LIST)
+DIST_SUBDIRS = \
+	$(SUBDIRS) \
+	android \
+	bindings \
+	c++ \
+	rotators/indi \
+	scripts \
+	simulators
 
 # Install any third party macros into our tree for distribution
 ACLOCAL_AMFLAGS = -I macros --install 

--- a/Makefile.am
+++ b/Makefile.am
@@ -28,6 +28,7 @@ SUBDIRS = \
 
 ## Static list of distributed directories.
 DIST_SUBDIRS = \
+	$(RIG_BACKEND_OPTIONAL_LIST) \
 	$(SUBDIRS) \
 	android \
 	bindings \

--- a/Makefile.am
+++ b/Makefile.am
@@ -29,11 +29,11 @@ SUBDIRS = \
 ## Static list of distributed directories.
 DIST_SUBDIRS = \
 	$(RIG_BACKEND_OPTIONAL_LIST) \
+	$(ROT_BACKEND_OPTIONAL_LIST) \
 	$(SUBDIRS) \
 	android \
 	bindings \
 	c++ \
-	rotators/indi \
 	scripts \
 	simulators
 

--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,7 @@ dnl here but will be added later, e.g. "winradio".
 RIG_BACKEND_LIST="rigs/adat rigs/alinco rigs/aor rigs/barrett rigs/codan rigs/dorji rigs/drake rigs/dummy rigs/elad rigs/flexradio rigs/icom rigs/icmarine rigs/jrc rigs/kachina rigs/kenwood rigs/kit rigs/lowe rigs/pcr rigs/prm80 rigs/racal rigs/rft rigs/rs rigs/skanti rigs/tapr rigs/tentec rigs/tuner rigs/uniden rigs/wj rigs/yaesu rigs/gomspace rigs/mds rigs/anytone rigs/motorola rigs/commradio rigs/guohetec"
 RIG_BACKEND_OPTIONAL_LIST=""
 ROT_BACKEND_LIST="rotators/amsat rotators/apex rotators/ars rotators/celestron rotators/cnctrk rotators/grbltrk rotators/easycomm rotators/ether6 rotators/flir rotators/fodtrack rotators/gs232a rotators/heathkit rotators/m2 rotators/meade rotators/rotorez rotators/sartek rotators/saebrtrack rotators/spid rotators/ts7400 rotators/prosistel rotators/ioptron rotators/satel rotators/skywatcher rotators/radant"
+ROT_BACKEND_OPTIONAL_LIST=""
 # Amplifiers are all in the amplifiers directory
 AMP_BACKEND_LIST="amplifiers/elecraft amplifiers/gemini amplifiers/expert"
 
@@ -435,11 +436,12 @@ AS_IF([test x"$cf_with_indi_support" != "xno"], [
 	    cf_with_indi_support=no
 	])
 
-	AS_IF([test x"$cf_with_indi_support" != "xno"], [
-	    ROT_BACKEND_LIST="$ROT_BACKEND_LIST rotators/indi"
-	])
     ])
 ])
+AS_IF([test x"$cf_with_indi_support" != "xno"],
+	[ROT_BACKEND_LIST="$ROT_BACKEND_LIST rotators/indi"],
+	[ROT_BACKEND_OPTIONAL_LIST="$ROT_BACKEND_OPTIONAL_LIST rotators/indi"]
+)
 
 dnl Check if libgd-dev is installed, so we can enable rigmatrix
 AC_MSG_CHECKING([whether to build HTML rig feature matrix])
@@ -860,6 +862,7 @@ for be in ${ROT_BACKEND_LIST} ; do
 	ROT_BACKENDEPS="${ROT_BACKENDEPS} \$(top_builddir)/rotators/${ROTDIR}/libhamlib-${ROTDIR}.la"
 done
 
+AC_SUBST([ROT_BACKEND_OPTIONAL_LIST])
 AC_SUBST([ROT_BACKEND_LIST])
 AC_SUBST([ROT_BACKENDEPS])
 

--- a/configure.ac
+++ b/configure.ac
@@ -66,7 +66,8 @@ dnl added to AC_CONFIG_FILES near the end of this file.  See README.developer
 dnl Beware of duplication should a backend directory include both rig and
 dnl rotor definitions, e.g. "dummy".  Optional backends will not be listed
 dnl here but will be added later, e.g. "winradio".
-RIG_BACKEND_LIST="rigs/adat rigs/alinco rigs/aor rigs/barrett rigs/codan rigs/dorji rigs/drake rigs/dummy rigs/elad rigs/flexradio rigs/icom rigs/icmarine rigs/jrc rigs/kachina rigs/kenwood rigs/kit rigs/lowe rigs/pcr rigs/prm80 rigs/racal rigs/rft rigs/rs rigs/skanti rigs/tapr rigs/tentec rigs/tuner rigs/uniden rigs/winradio rigs/wj rigs/yaesu rigs/gomspace rigs/mds rigs/anytone rigs/motorola rigs/commradio rigs/guohetec"
+RIG_BACKEND_LIST="rigs/adat rigs/alinco rigs/aor rigs/barrett rigs/codan rigs/dorji rigs/drake rigs/dummy rigs/elad rigs/flexradio rigs/icom rigs/icmarine rigs/jrc rigs/kachina rigs/kenwood rigs/kit rigs/lowe rigs/pcr rigs/prm80 rigs/racal rigs/rft rigs/rs rigs/skanti rigs/tapr rigs/tentec rigs/tuner rigs/uniden rigs/wj rigs/yaesu rigs/gomspace rigs/mds rigs/anytone rigs/motorola rigs/commradio rigs/guohetec"
+RIG_BACKEND_OPTIONAL_LIST=""
 ROT_BACKEND_LIST="rotators/amsat rotators/apex rotators/ars rotators/celestron rotators/cnctrk rotators/grbltrk rotators/easycomm rotators/ether6 rotators/flir rotators/fodtrack rotators/gs232a rotators/heathkit rotators/m2 rotators/meade rotators/rotorez rotators/sartek rotators/saebrtrack rotators/spid rotators/ts7400 rotators/prosistel rotators/ioptron rotators/satel rotators/skywatcher rotators/radant"
 # Amplifiers are all in the amplifiers directory
 AMP_BACKEND_LIST="amplifiers/elecraft amplifiers/gemini amplifiers/expert"
@@ -778,19 +779,12 @@ AC_MSG_RESULT([$cf_with_parallel])
 DL_LIBS=""
 
 AS_IF([test x"${cf_with_winradio}" = "xyes"],
-      [RIGS_BACKEND_LIST="$RIGS_BACKEND_LIST rigs/winradio"
+      [RIG_BACKEND_LIST="$RIG_BACKEND_LIST rigs/winradio"
 dnl Check for libdl and set DL_LIBS if found--used for linradio WR-G313 backend.
        AC_CHECK_LIB([dl], [dlopen], [DL_LIBS="-ldl"],
 		    [AC_MSG_WARN([dlopen was not found in libdl--linradio backend will be disabled])])
-      ])
-
-# Still need -ldl if we have it
-AS_IF([test x"${cf_with_winradio}" = "xno"],
-      [RIGS_BACKEND_LIST="$RIGS_BACKEND_LIST"
-dnl Check for libdl and set DL_LIBS if found--used for linradio WR-G313 backend.
-       AC_CHECK_LIB([dl], [dlopen], [DL_LIBS="-ldl"],
-		    [AC_MSG_WARN([dlopen was not found in libdl--linradio backend will be disabled])])
-      ])
+      ],
+      [RIG_BACKEND_OPTIONAL_LIST="$RIG_BACKEND_OPTIONAL_LIST rigs/winradio"])
 
 dnl Set conditional compilation for G-313.
 AS_CASE(["$host_os"],
@@ -850,6 +844,7 @@ for be in ${RIG_BACKEND_LIST} ; do
 	RIG_BACKENDEPS="${RIG_BACKENDEPS} \$(top_builddir)/rigs/${RIGDIR}/libhamlib-${RIGDIR}.la"
 done
 
+AC_SUBST([RIG_BACKEND_OPTIONAL_LIST])
 AC_SUBST([RIG_BACKEND_LIST])
 AC_SUBST([RIG_BACKENDEPS])
 


### PR DESCRIPTION
This fixes #1737 fixing the use of `--enable-winradio=yes/no` and `--with-indi=yes/no`

The main issue was that dependencies where created for both rigs/winradio and rotators/indi even when they where configured to not build, so the makefiles were building them in all cases, so I added new variables to hold the paths for the optional drivers, to exclude them from `make all` and similar targets but to include them in `make dist` and similar.

To verify that everything works as expected I modified the CI action:
* remove the simple `make check` because `make distcheck` does the same and more, but it only builds with the default options set
* repeat the configure+make steps setting all options to no and to yes, with some exceptions:
  * shared and static libraries are build in all cases
  * usrp is not built because there isn't a package in Ubuntu to be installed with apt (it needs to be checked out from a repository, but it's a different issue)
  * Python bindings fail to build in macOS so they are disabled for now
  * there is an inconsistency in the final output of `configure` where if pytest is installed it prints `Enable Python tests yes` even if the Python binding aren't built and the tests will not run
* reduce the clutter in the output on the CI (errors and warnings are still shown)