### PR TITLE
Revert commit ae95564 anche change the test to suit

### DIFF
--- a/bindings/python/test_startup.py
+++ b/bindings/python/test_startup.py
@@ -31,7 +31,7 @@ class TestClass:
         assert my_rig.get_conf("retry") == '5'
 
         assert my_rig.error_status == Hamlib.RIG_OK
-        assert Hamlib.rigerror(my_rig.error_status) == "Command completed successfully\n"
+        assert Hamlib.rigerror2(my_rig.error_status) == "Command completed successfully\n"
 
         assert my_rig.set_freq(Hamlib.RIG_VFO_B, 5700000000) is None
         assert my_rig.set_vfo(Hamlib.RIG_VFO_B) is None

--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -3770,10 +3770,11 @@ extern HAMLIB_EXPORT_VAR(char) debugmsgsave2[DEBUGMSGSAVE_SIZE];  // last-1 debu
 // debugmsgsave3 is deprecated
 extern HAMLIB_EXPORT_VAR(char) debugmsgsave3[DEBUGMSGSAVE_SIZE];  // last-2 debug msg
 #define rig_debug_clear() { debugmsgsave[0] = debugmsgsave2[0] = debugmsgsave3[0] = 0; };
-#if !defined(__cplusplus) && defined(__GNUC__)
-#define ATTRIBUTE_FORMAT_PRINTF __attribute__((__format__ (__printf__, 2, 3)))
-#else
-#define ATTRIBUTE_FORMAT_PRINTF
+#ifndef __cplusplus
+#ifdef __GNUC__
+// doing the debug macro with a dummy sprintf allows gcc to check the format string
+#define rig_debug(debug_level,fmt,...) do { snprintf(debugmsgsave2,sizeof(debugmsgsave2),fmt,__VA_ARGS__);rig_debug(debug_level,fmt,##__VA_ARGS__); add2debugmsgsave(debugmsgsave2); } while(0)
+#endif
 #endif
 
 // Measuring elapsed time -- local variable inside function when macro is used
@@ -3785,7 +3786,7 @@ extern HAMLIB_EXPORT_VAR(char) debugmsgsave3[DEBUGMSGSAVE_SIZE];  // last-2 debu
 
 extern HAMLIB_EXPORT(void)
 rig_debug HAMLIB_PARAMS((enum rig_debug_level_e debug_level,
-                         const char *fmt, ...)) ATTRIBUTE_FORMAT_PRINTF;
+                         const char *fmt, ...));
 
 extern HAMLIB_EXPORT(vprintf_cb_t)
 rig_set_debug_callback HAMLIB_PARAMS((vprintf_cb_t cb,

--- a/src/debug.c
+++ b/src/debug.c
@@ -202,6 +202,7 @@ void HAMLIB_API rig_set_debug_time_stamp(int flag)
  * The formatted character string is passed to the `vfprintf`(3) C library
  * call and follows its format specification.
  */
+#undef rig_debug
 void HAMLIB_API rig_debug(enum rig_debug_level_e debug_level,
                           const char *fmt, ...)
 {


### PR DESCRIPTION
This reverts commit https://github.com/Hamlib/Hamlib/commit/ae9556462a2989b8b97af0d6e320558ffa0e1f3e.

The change for ATTRIBUTE_FORMAT_PRINTF was good but I'm not re-adding it because it generates a duplicate definition warning when building the INDI driver because is is defined also in /usr/include/libindi/indidevapi.h with this different code:
```
/* enable warnings for printf-style functions */
#ifndef ATTRIBUTE_FORMAT_PRINTF
# ifdef __GNUC__
#  define ATTRIBUTE_FORMAT_PRINTF(A, B) __attribute__((format(printf, (A), (B))))
# else
#  define ATTRIBUTE_FORMAT_PRINTF(A, B)
# endif
#endif
```