### PR TITLE
Make the dummy rig more similar to other rigs

### DIFF
--- a/bindings/python/test_rig.py
+++ b/bindings/python/test_rig.py
@@ -51,13 +51,13 @@ class TestClass:
         info = rig.get_info()
         assert isinstance(info, str)
 
-        assert rig.set_split_vfo(-600000, Hamlib.RIG_VFO_A) is None
-        assert rig.get_split_vfo(Hamlib.RIG_VFO_TX) == [-600000, 1]
-        assert rig.set_split_vfo(5000000, Hamlib.RIG_VFO_B) is None
-        assert rig.get_split_vfo(Hamlib.RIG_VFO_TX) == [5000000, 2]
-        assert rig.set_split_vfo(5000000, Hamlib.RIG_VFO_CURR) is None
-        assert rig.get_split_vfo() == [5000000, 1]
-        assert rig.get_split_vfo(Hamlib.RIG_VFO_CURR) == [5000000, 1]
+        assert rig.set_split_vfo(Hamlib.RIG_SPLIT_OFF, Hamlib.RIG_VFO_A) is None
+        assert rig.get_split_vfo(Hamlib.RIG_VFO_TX) == [Hamlib.RIG_SPLIT_OFF, Hamlib.RIG_VFO_A]
+        assert rig.set_split_vfo(Hamlib.RIG_SPLIT_ON, Hamlib.RIG_VFO_B) is None
+        assert rig.get_split_vfo(Hamlib.RIG_VFO_TX) == [Hamlib.RIG_SPLIT_ON, Hamlib.RIG_VFO_B]
+        assert rig.set_split_vfo(Hamlib.RIG_SPLIT_OFF, Hamlib.RIG_VFO_CURR) is None
+        assert rig.get_split_vfo() == [Hamlib.RIG_SPLIT_OFF, Hamlib.RIG_VFO_B]
+        assert rig.get_split_vfo(Hamlib.RIG_VFO_CURR) == [Hamlib.RIG_SPLIT_OFF, Hamlib.RIG_VFO_B]
 
         # FIXME should use a RIG_ANT_* constant but it isn't available in the bindings
         RIG_ANT_UNKNOWN = 1<<30

--- a/rigs/dummy/dummy.c
+++ b/rigs/dummy/dummy.c
@@ -1823,6 +1823,7 @@ static int dummy_set_ant(RIG *rig, vfo_t vfo, ant_t ant, value_t option)
     case RIG_ANT_2:
     case RIG_ANT_3:
     case RIG_ANT_4:
+    case RIG_ANT_5:
         curr->ant = ant;
         break;
 
@@ -1860,6 +1861,7 @@ static int dummy_get_ant(RIG *rig, vfo_t vfo, ant_t ant, value_t *option,
     case RIG_ANT_2:
     case RIG_ANT_3:
     case RIG_ANT_4:
+    case RIG_ANT_5:
         *ant_curr = ant;
         break;
 
@@ -2463,14 +2465,14 @@ struct rig_caps dummy_caps =
     .agc_levels = { RIG_AGC_OFF, RIG_AGC_SUPERFAST, RIG_AGC_FAST, RIG_AGC_MEDIUM, RIG_AGC_SLOW, RIG_AGC_AUTO, RIG_AGC_USER },
     .rx_range_list1 =  { {
             .startf = kHz(150), .endf = MHz(1500), .modes = DUMMY_MODES,
-            .low_power = -1, .high_power = -1, DUMMY_VFOS, RIG_ANT_1 | RIG_ANT_2 | RIG_ANT_3 | RIG_ANT_4,
+            .low_power = -1, .high_power = -1, DUMMY_VFOS, RIG_ANT_1 | RIG_ANT_2 | RIG_ANT_3 | RIG_ANT_4 | RIG_ANT_5,
             .label = "Dummy#1"
         },
         RIG_FRNG_END,
     },
     .tx_range_list1 =  { {
             .startf = kHz(150), .endf = MHz(1500), .modes = DUMMY_MODES,
-            .low_power = W(5), .high_power = W(100), DUMMY_VFOS, RIG_ANT_1 | RIG_ANT_2 | RIG_ANT_3 | RIG_ANT_4,
+            .low_power = W(5), .high_power = W(100), DUMMY_VFOS, RIG_ANT_1 | RIG_ANT_2 | RIG_ANT_3 | RIG_ANT_4 | RIG_ANT_5,
             .label = "Dummy#1"
         },
         RIG_FRNG_END,

--- a/rigs/dummy/dummy.c
+++ b/rigs/dummy/dummy.c
@@ -1114,11 +1114,25 @@ static int dummy_set_split_vfo(RIG *rig, vfo_t vfo, split_t split, vfo_t tx_vfo)
     rig_debug(RIG_DEBUG_VERBOSE, "%s: split=%d, vfo=%s, tx_vfo=%s\n",
               __func__, split, rig_strvfo(vfo), rig_strvfo(tx_vfo));
 
+    switch (split)
+    {
+        case RIG_SPLIT_OFF:
+            priv->split = RIG_SPLIT_OFF;
+            break;
+
+        case RIG_SPLIT_ON:
+            priv->split = RIG_SPLIT_ON;
+            break;
+
+        default:
+            rig_debug(RIG_DEBUG_ERR, "%s: unsupported split %d", __func__, split);
+            RETURNFUNC(-RIG_EINVAL);
+    }
+
     if (tx_vfo == RIG_VFO_NONE || tx_vfo == RIG_VFO_CURR) { tx_vfo = priv->curr_vfo; }
 
     if (tx_vfo == RIG_VFO_CURR || tx_vfo == RIG_VFO_TX) { tx_vfo = vfo_fixup(rig, vfo, CACHE(rig)->split); }
 
-    priv->split = split;
     priv->tx_vfo = tx_vfo;
 
     RETURNFUNC(RIG_OK);

--- a/rigs/dummy/dummy.c
+++ b/rigs/dummy/dummy.c
@@ -197,7 +197,7 @@ static void init_chan(RIG *rig, vfo_t vfo, channel_t *chan)
     chan->rit = 0;
     chan->xit = 0;
     chan->tuning_step = 0;
-    chan->ant = 0;
+    chan->ant = RIG_ANT_NONE;
 
     chan->funcs = (setting_t)0;
     memset(chan->levels, 0, RIG_SETTING_MAX * sizeof(value_t));


### PR DESCRIPTION
This PR adds to the dummy rig:
* antenna number 5
* a check for the split value and a fixed test (I mistakenly thought that the `split` argument was a frequency offset, instead of an on/off switch)
* a define instead of a plain number to mean "no antenna"

These changes were initially in #1790 with the difference that now I set chan->ant to RIG_ANT_NONE instead of RIG_ANT_1.