### PR TITLE
Fix make check

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -94,4 +94,4 @@ jobs:
       run: make distcheck V=0 --no-print-directory AM_DISTCHECK_CONFIGURE_FLAGS="${{ matrix.configure_args }} --without-perl-binding"
     - name: make distcheck on macOS
       if: runner.os == 'macOS'
-      run: make distcheck V=0 --no-print-directory AM_DISTCHECK_CONFIGURE_FLAGS="${{ matrix.configure_args }} --without-perl-binding --without-lua-binding PYTHON=/opt/homebrew/bin/python3"
+      run: make distcheck V=0 --no-print-directory AM_DISTCHECK_CONFIGURE_FLAGS="${{ matrix.configure_args }} --without-perl-binding --without-lua-binding --without-tcl-binding PYTHON=/opt/homebrew/bin/python3"

--- a/bindings/Makefile.am
+++ b/bindings/Makefile.am
@@ -177,7 +177,7 @@ hamlibtcl_wrap.c: $(SWGDEP)
 		-I$(top_srcdir)/bindings \
 		-o $@ $$(test -f hamlib.swg || echo '$(srcdir)/')hamlib.swg
 
-do_subst = sed -e 's,[@]tcldir[@],$(tcldir),g'
+do_subst = sed -e 's,[@]tcldir[@],$(tcldir),g' -e 's,[@]builddir[@],$(builddir),g'
 
 tcltest.tcl: tcltest.tcl.in Makefile
 	$(AM_V_GEN)$(do_subst) < $(srcdir)/tcltest.tcl.in > tcltest.tcl

--- a/bindings/Makefile.am
+++ b/bindings/Makefile.am
@@ -186,8 +186,7 @@ all-tcl: pkgIndex.tcl $(tcl_ltlib) tcltest.tcl
 
 check-tcl: all-tcl
 	$(AM_V_at)cp $(builddir)/pkgIndex.tcl $(builddir)/.libs
-	$(AM_V_at)TCLLIBPATH=$(builddir)/.libs tclsh $(builddir)/tcltest.tcl \
-		|| echo "Tcl test failed" 1>&2
+	$(AM_V_at)TCLLIBPATH=$(builddir)/.libs tclsh $(builddir)/tcltest.tcl
 	$(AM_V_at)rm -f $(builddir)/.libs/pkgIndex.tcl
 
 install-tcl:
@@ -220,8 +219,7 @@ Hamliblua_la_LTLIBRARIES = $(luaexec_ltlib)
 all-lua: $(luaexec_ltlib)
 
 check-lua: all-lua
-	$(AM_V_at)LUA_CPATH="$(abs_builddir)/.libs/?.so" $(LUA) $(srcdir)/luatest.lua \
-		|| echo "Lua test failed" 1>&2
+	$(AM_V_at)LUA_CPATH="$(abs_builddir)/.libs/?.so" $(LUA) $(srcdir)/luatest.lua
 
 Hamlib.lua: hamliblua_wrap.c
 

--- a/bindings/tcltest.tcl.in
+++ b/bindings/tcltest.tcl.in
@@ -6,7 +6,8 @@ exec tclsh "$0" "$@"
 lappend ::auto_path @tcldir@
 
 ## Brute force loading
-#load "@tcldir@/hamlibtcl.so" Hamlib
+# load "@tcldir@/hamlibtcl.so" Hamlib ; # from the installation directory
+load "@builddir@/.libs/hamlibtcl.so" Hamlib ; # from the build directory
 
 ## Preferred package loading
 package require hamlib


### PR DESCRIPTION
This PR changes `Makefile.am` to stop `make check` if an error happens when running the Tcl or the Lua tests (Perl and Python already stopped).

The failures in running the Tcl tests went unnoticed, such as in [a recent CI run](https://github.com/Hamlib/Hamlib/actions/runs/16550365122/job/46804305394?pr=1790#step:11:1644):
```
 couldn't load file "./.libs/hamlibtcl-4.7": ./.libs/hamlibtcl-4.7: cannot open shared object file: No such file or directory
    while executing
"load ./.libs/hamlibtcl-4.7 Hamlib"
    ("package ifneeded hamlib 4.7" script)
    invoked from within
"package require hamlib"
    (file "./tcltest.tcl" line 12)
Tcl test failed
```

The same could happen for Lua tests.

