### PR TITLE
Deprecate rig_get_conf, clean up switch fallthroughs

### DIFF
--- a/c++/rigclass.cc
+++ b/c++/rigclass.cc
@@ -87,11 +87,19 @@ void Rig::setConf(const char *name, const char *val)
 
 void Rig::getConf(hamlib_token_t token, char *val)
 {
-	CHECK_RIG( rig_get_conf(theRig, token, val) );
+	CHECK_RIG( rig_get_conf2(theRig, token, val, 128) );
 }
 void Rig::getConf(const char *name, char *val)
 {
-	CHECK_RIG( rig_get_conf(theRig, tokenLookup(name), val) );
+	CHECK_RIG( rig_get_conf2(theRig, tokenLookup(name), val, 128) );
+}
+void Rig::getConf2(hamlib_token_t token, char *val, int val_len)
+{
+	CHECK_RIG( rig_get_conf2(theRig, token, val, val_len) );
+}
+void Rig::getConf2(const char *name, char *val, int val_len)
+{
+	CHECK_RIG( rig_get_conf2(theRig, tokenLookup(name), val, val_len) );
 }
 
 hamlib_token_t Rig::tokenLookup(const char *name)

--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -86,8 +86,16 @@
 #if __has_c_attribute(fallthrough)
 #define HL_FALLTHROUGH [[fallthrough]];
 #else
-/* Fall back */
+/* Fall back to nothing */
 #define HL_FALLTHROUGH
+#endif
+
+// Macro to mark function or variable as deprecated/obsolete
+#if __has_c_attribute(deprecated)
+#define HL_DEPRECATED [[deprecated]]
+#else
+// Make it vanish
+#define HL_DEPRECATED
 #endif
 
 /**
@@ -2959,7 +2967,7 @@ rig_set_conf HAMLIB_PARAMS((RIG *rig,
                             hamlib_token_t token,
                             const char *val));
 // deprecating rig_get_conf
-extern HAMLIB_EXPORT(int)
+HL_DEPRECATED extern HAMLIB_EXPORT(int)
 rig_get_conf HAMLIB_PARAMS((RIG *rig,
                             hamlib_token_t token,
                             char *val));

--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -73,6 +73,23 @@
 #include <hamlib/riglist.h>
 //#include <hamlib/config.h>
 
+/* Define macros for handling attributes, if the compiler implements them
+ *   Should be available in c23-capable compilers, or c++11 ones
+ */
+// From ISO/IEC 9899:202y n3301 working draft
+#ifndef __has_c_attribute
+#define __has_c_attribute(x) 0
+#endif
+
+// Macro to mark fallthrough as OK
+// Squelch warnings if -Wimplicit-fallthrough added to CFLAGS
+#if __has_c_attribute(fallthrough)
+#define HL_FALLTHROUGH [[fallthrough]];
+#else
+/* Fall back */
+#define HL_FALLTHROUGH
+#endif
+
 /**
  * \addtogroup rig
  * @{

--- a/include/hamlib/rigclass.h
+++ b/include/hamlib/rigclass.h
@@ -56,8 +56,10 @@ public:
 
     void setConf(hamlib_token_t token, const char *val);
     void setConf(const char *name, const char *val);
-    void getConf(hamlib_token_t token, char *val);
-    void getConf(const char *name, char *val);
+    HL_DEPRECATED void getConf(hamlib_token_t token, char *val);
+    HL_DEPRECATED void getConf(const char *name, char *val);
+    void getConf2(hamlib_token_t token, char *val, int val_len);
+    void getConf2(const char *name, char *val, int val_len);
     hamlib_token_t tokenLookup(const char *name);
 
     void setFreq(freq_t freq, vfo_t vfo = RIG_VFO_CURR);

--- a/rigs/flexradio/dttsp.c
+++ b/rigs/flexradio/dttsp.c
@@ -462,7 +462,7 @@ static int dttsp_get_conf2(RIG *rig, hamlib_token_t token, char *val, int val_le
         /* if it's not for the dttsp backend, maybe it's for the tuner */
         if (priv->tuner)
         {
-            return rig_get_conf(priv->tuner, token, val);
+            return rig_get_conf2(priv->tuner, token, val, val_len);
         }
         else
         {

--- a/rigs/icom/icom.c
+++ b/rigs/icom/icom.c
@@ -3393,6 +3393,7 @@ int icom_set_vfo(RIG *rig, vfo_t vfo)
             rig_debug(RIG_DEBUG_ERR, "%s: unknown vfo '%s'\n", __func__,
                       rig_strvfo(rs->current_vfo));
         }
+        HL_FALLTHROUGH     // Fall into outer default
 
     default:
         if (priv->x25cmdfails == 0 || priv_caps->x25x26_always)
@@ -9111,12 +9112,14 @@ static int icom_parse_spectrum_frame(RIG *rig, size_t length,
 
         case SCOPE_MODE_FIXED:
             cache->spectrum_mode = RIG_SPECTRUM_MODE_FIXED;
+            HL_FALLTHROUGH
 
         case SCOPE_MODE_SCROLL_C:
             if (cache->spectrum_mode == RIG_SPECTRUM_MODE_NONE)
             {
                 cache->spectrum_mode = RIG_SPECTRUM_MODE_CENTER_SCROLL;
             }
+            HL_FALLTHROUGH
 
         case SCOPE_MODE_SCROLL_F:
             if (cache->spectrum_mode == RIG_SPECTRUM_MODE_NONE)

--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -5600,7 +5600,7 @@ int kenwood_send_morse(RIG *rig, vfo_t vfo, const char *msg)
                 SNPRINTF(morsebuf, sizeof morsebuf, "KY2%s", m2);
                 break;
             }
-            /* FALL THROUGH */
+            HL_FALLTHROUGH
 
         default:
             /* the command must consist of 28 bytes 0x20 padded */

--- a/rigs/yaesu/ft847.c
+++ b/rigs/yaesu/ft847.c
@@ -1298,6 +1298,7 @@ static int get_freq_and_mode(RIG *rig, vfo_t vfo, freq_t *freq, rmode_t *mode,
 
     case MD_CWN:
         *width = rig_passband_narrow(rig, RIG_MODE_CW);
+        HL_FALLTHROUGH
 
     case MD_CW:
         *mode = RIG_MODE_CW;
@@ -1305,6 +1306,7 @@ static int get_freq_and_mode(RIG *rig, vfo_t vfo, freq_t *freq, rmode_t *mode,
 
     case MD_CWNR:
         *width = rig_passband_narrow(rig, RIG_MODE_CW);
+        HL_FALLTHROUGH
 
     case MD_CWR:
         *mode = RIG_MODE_CWR;
@@ -1312,6 +1314,7 @@ static int get_freq_and_mode(RIG *rig, vfo_t vfo, freq_t *freq, rmode_t *mode,
 
     case MD_AMN:
         *width = rig_passband_narrow(rig, RIG_MODE_AM);
+        HL_FALLTHROUGH
 
     case MD_AM:
         *mode = RIG_MODE_AM;
@@ -1319,6 +1322,7 @@ static int get_freq_and_mode(RIG *rig, vfo_t vfo, freq_t *freq, rmode_t *mode,
 
     case MD_FMN:
         *width = rig_passband_narrow(rig, RIG_MODE_FM);
+        HL_FALLTHROUGH
 
     case MD_FM:
         *mode = RIG_MODE_FM;

--- a/rigs/yaesu/ft920.c
+++ b/rigs/yaesu/ft920.c
@@ -794,6 +794,7 @@ static int ft920_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
         {
             return err;
         }
+        HL_FALLTHROUGH
 
     case RIG_VFO_MEM:                   /* MEM TUNE or user doesn't care */
     case RIG_VFO_MAIN:
@@ -965,6 +966,7 @@ static int ft920_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         {
             return err;
         }
+        HL_FALLTHROUGH
 
     case RIG_VFO_MEM:                   /* MEM TUNE or user doesn't care */
     case RIG_VFO_MAIN:

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -4414,9 +4414,9 @@ int newcat_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
         case RIG_METER_VDD:  SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), format, 5);
             break;
 
+        default:
             rig_debug(RIG_DEBUG_ERR, "%s: unknown val.i=%d\n", __func__, val.i);
-
-        default: RETURNFUNC(-RIG_EINVAL);
+            RETURNFUNC(-RIG_EINVAL);
         }
 
         break;

--- a/src/iofunc.c
+++ b/src/iofunc.c
@@ -408,8 +408,8 @@ int HAMLIB_API port_close(hamlib_port_t *p, rig_port_t port_type)
         default:
             rig_debug(RIG_DEBUG_ERR, "%s(): Unknown port type %d\n",
                       __func__, port_type);
+            HL_FALLTHROUGH
 
-        /* fall through */
         case RIG_PORT_DEVICE:
             ret = close(p->fd);
         }

--- a/src/rig.c
+++ b/src/rig.c
@@ -3611,8 +3611,8 @@ int HAMLIB_API rig_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
         {
             ptt = RIG_PTT_ON;
         }
+        HL_FALLTHROUGH
 
-    /* fall through */
     case RIG_PTT_RIG_MICDATA:
         if (caps->set_ptt == NULL)
         {

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -2014,7 +2014,7 @@ int print_conf_list(const struct confparams *cfp, rig_ptr_t data)
     int i;
     char buf[128] = "";
 
-    rig_get_conf(rig, cfp->token, buf);
+    rig_get_conf2(rig, cfp->token, buf, sizeof(buf));
     printf("%s: \"%s\"\n" "\t" "Default: %s, Value: %s\n",
            cfp->name,
            cfp->tooltip,
@@ -2078,7 +2078,7 @@ int print_conf_list2(const struct confparams *cfp, rig_ptr_t data)
     RIG *rig = (RIG *) data;
     char buf[128] = "";
 
-    rig_get_conf(rig, cfp->token, buf);
+    rig_get_conf2(rig, cfp->token, buf, sizeof(buf));
     fprintf(stdout, "%s: \"%s\"\n" "\t" "Default: %s, Value: %s\n",
             cfp->name,
             cfp->tooltip,
@@ -6025,7 +6025,7 @@ declare_proto_rig(get_conf)
     else
     {
         char value[4096]; // no max value known -- should we limit it?
-        ret = rig_get_conf(rig, mytoken, value);
+        ret = rig_get_conf2(rig, mytoken, value, sizeof(value));
 
         if (ret != RIG_OK)
         {

--- a/tests/rotctld.c
+++ b/tests/rotctld.c
@@ -246,6 +246,7 @@ int main(int argc, char *argv[])
 
         case 'O':
             el_offset = atof(optarg);
+            break;
 
         case 'v':
             verbose++;

--- a/tests/uthash.h
+++ b/tests/uthash.h
@@ -412,15 +412,25 @@ do {                                                                            
   hashv += keylen;                                                               \
   switch ( _hj_k ) {                                                             \
      case 11: hashv += ( (unsigned)_hj_key[10] << 24 );                          \
+              HL_FALLTHROUGH                                                     \
      case 10: hashv += ( (unsigned)_hj_key[9] << 16 );                           \
+              HL_FALLTHROUGH                                                     \
      case 9:  hashv += ( (unsigned)_hj_key[8] << 8 );                            \
+              HL_FALLTHROUGH                                                     \
      case 8:  _hj_j += ( (unsigned)_hj_key[7] << 24 );                           \
+              HL_FALLTHROUGH                                                     \
      case 7:  _hj_j += ( (unsigned)_hj_key[6] << 16 );                           \
+              HL_FALLTHROUGH                                                     \
      case 6:  _hj_j += ( (unsigned)_hj_key[5] << 8 );                            \
+              HL_FALLTHROUGH                                                     \
      case 5:  _hj_j += _hj_key[4];                                               \
+              HL_FALLTHROUGH                                                     \
      case 4:  _hj_i += ( (unsigned)_hj_key[3] << 24 );                           \
+              HL_FALLTHROUGH                                                     \
      case 3:  _hj_i += ( (unsigned)_hj_key[2] << 16 );                           \
+              HL_FALLTHROUGH                                                     \
      case 2:  _hj_i += ( (unsigned)_hj_key[1] << 8 );                            \
+              HL_FALLTHROUGH                                                     \
      case 1:  _hj_i += _hj_key[0];                                               \
   }                                                                              \
   HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                             \
@@ -547,7 +557,9 @@ do {                                                                   \
   uint32_t _mur_k1=0;                                                  \
   switch((keylen) & 3) {                                               \
     case 3: _mur_k1 ^= _mur_tail[2] << 16;                             \
+            HL_FALLTHROUGH                                             \
     case 2: _mur_k1 ^= _mur_tail[1] << 8;                              \
+            HL_FALLTHROUGH                                             \
     case 1: _mur_k1 ^= _mur_tail[0];                                   \
     _mur_k1 *= _mur_c1;                                                \
     _mur_k1 = MUR_ROTL32(_mur_k1,15);                                  \


### PR DESCRIPTION
Add macros for annotating fall through and deprecation, if the compiler is capable.
Repair or annotate all fallthroughs in `switch` statements.
Deprecate `rig_get_conf()` (from NEWS file)
Fix internal uses of `rig_get_conf()`
