### PR TITLE
Fix make distcheck

### DIFF
--- a/bindings/Makefile.am
+++ b/bindings/Makefile.am
@@ -22,11 +22,15 @@ SWGDEP = \
 
 EXTRA_DIST = $(SWGFILES) \
 	Makefile.PL perltest.pl tcltest.tcl.in \
+	python/conftest.py \
 	python/generate_tests.py \
 	python/test_Hamlib_Amp_class.py \
-	python/test_Hamlib_class.py \
 	python/test_Hamlib_Rig_class.py \
 	python/test_Hamlib_Rot_class.py \
+	python/test_Hamlib_class.py \
+	python/test_amp.py \
+	python/test_rig.py \
+	python/test_rot.py \
 	python/test_startup.py \
 	luatest.lua README.python
 

--- a/bindings/python/conftest.py
+++ b/bindings/python/conftest.py
@@ -20,6 +20,12 @@ def pytest_addoption(parser):
                         metavar='ID', help='select rotator model number')
         parser.addoption('--rot-file', default=None,
                         metavar='DEVICE', help='set device of the rotator to operate on')
+    else:
+        # fallbacks for invocations through a Makefile
+        parser.addoption('--model', type=int, default=1)
+        parser.addoption('--amp-file', default=None)
+        parser.addoption('--rig-file', default=None)
+        parser.addoption('--rot-file', default=None)
     parser.addoption('--serial-speed', type=int, default=0,
                      metavar='BAUD', help='set serial speed of the serial port')
     parser.addoption('--hamlib-verbose', action='count', default=0,


### PR DESCRIPTION
This PR:
* adds missing files with Python tests needed to run `make distcheck`
* provides some default values for those tests