### PR TITLE
Deprecate rot_get_conf and amp_get_conf, too

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,11 +14,13 @@ Version 5.x -- future
 
 Version 4.7.0
         * 2025-12-01 (target)
+	* Functions rig_get_conf, rot_get_conf, amp_get_conf deprecated;
+          use *_get_conf2() instead.
         * Fix handling of unprintable characters in kenwood.c that broke radios
           such as the TM-D710/TM-V71 that use EOM_TH (\r) as the command terminator.
           (TNX, Lars Kellogg-Stedman and George Baltz).
         * Reduce/repair excess output from cppcheck.sh - mostly cosmetic changes (WIP)
-          Output from `wc -l cppcheck.log` - 4.6.2: 981  now: 673
+          Output from `wc -l cppcheck.log` - 4.6.2: 981  now: 642
         * Remove dead getopt code.  GitHub PR #1709. (TNX Daniele Forsi)
         * Move rig_cache to separate(calloc) storage. Prepare for other moves.
           Issue #1420

--- a/c++/ampclass.cc
+++ b/c++/ampclass.cc
@@ -74,13 +74,21 @@ void Amplifier::setConf(const char *name, const char *val)
 	CHECK_AMP( amp_set_conf(theAmp, tokenLookup(name), val) );
 }
 
-void Amplifier::getConf(hamlib_token_t token, char *val)
+HL_DEPRECATED void Amplifier::getConf(hamlib_token_t token, char *val)
 {
-	CHECK_AMP( amp_get_conf(theAmp, token, val) );
+	CHECK_AMP( amp_get_conf2(theAmp, token, val, 128) );
 }
-void Amplifier::getConf(const char *name, char *val)
+HL_DEPRECATED void Amplifier::getConf(const char *name, char *val)
 {
-	CHECK_AMP( amp_get_conf(theAmp, tokenLookup(name), val) );
+	CHECK_AMP( amp_get_conf2(theAmp, tokenLookup(name), val, 128) );
+}
+void Amplifier::getConf2(hamlib_token_t token, char *val, int val_len)
+{
+	CHECK_AMP( amp_get_conf2(theAmp, token, val, val_len) );
+}
+void Amplifier::getConf2(const char *name, char *val, int val_len)
+{
+	CHECK_AMP( amp_get_conf2(theAmp, tokenLookup(name), val, val_len) );
 }
 
 hamlib_token_t Amplifier::tokenLookup(const char *name)

--- a/c++/rotclass.cc
+++ b/c++/rotclass.cc
@@ -73,13 +73,21 @@ void Rotator::setConf(const char *name, const char *val)
 	CHECK_ROT( rot_set_conf(theRot, tokenLookup(name), val) );
 }
 
-void Rotator::getConf(hamlib_token_t token, char *val)
+HL_DEPRECATED void Rotator::getConf(hamlib_token_t token, char *val)
 {
-	CHECK_ROT( rot_get_conf(theRot, token, val) );
+	CHECK_ROT( rot_get_conf2(theRot, token, val, 128) );
 }
-void Rotator::getConf(const char *name, char *val)
+HL_DEPRECATED void Rotator::getConf(const char *name, char *val)
 {
-	CHECK_ROT( rot_get_conf(theRot, tokenLookup(name), val) );
+	CHECK_ROT( rot_get_conf2(theRot, tokenLookup(name), val, 128) );
+}
+void Rotator::getConf2(hamlib_token_t token, char *val, int val_len)
+{
+	CHECK_ROT( rot_get_conf2(theRot, token, val, val_len) );
+}
+void Rotator::getConf2(const char *name, char *val, int val_len)
+{
+	CHECK_ROT( rot_get_conf2(theRot, tokenLookup(name), val, val_len) );
 }
 
 hamlib_token_t Rotator::tokenLookup(const char *name)

--- a/include/hamlib/ampclass.h
+++ b/include/hamlib/ampclass.h
@@ -57,6 +57,8 @@ public:
     void setConf(const char *name, const char *val);
     void getConf(hamlib_token_t token, char *val);
     void getConf(const char *name, char *val);
+    void getConf2(hamlib_token_t token, char *val, int val_len);
+    void getConf2(const char *name, char *val, int val_len);
     hamlib_token_t tokenLookup(const char *name);
 
     void setFreq(freq_t freq);

--- a/include/hamlib/amplifier.h
+++ b/include/hamlib/amplifier.h
@@ -232,7 +232,7 @@ struct amp_caps
   int (*get_freq)(AMP *amp, freq_t *val); /*!< Pointer to backend implementation of amp_get_freq(). */
 
   int (*set_conf)(AMP *amp, hamlib_token_t token, const char *val); /*!< Pointer to backend implementation of amp_set_conf(). */
-  int (*get_conf2)(AMP *amp, hamlib_token_t token, char *val, int val_len);       /*!< Pointer to backend implementation of amp_get_conf(). */
+  int (*get_conf2)(AMP *amp, hamlib_token_t token, char *val, int val_len);       /*!< Pointer to backend implementation of amp_get_conf2(). */
   int (*get_conf)(AMP *amp, hamlib_token_t token, char *val);       /*!< Pointer to backend implementation of amp_get_conf(). */
 
   /*
@@ -310,10 +310,15 @@ extern HAMLIB_EXPORT(int)
 amp_set_conf HAMLIB_PARAMS((AMP *amp,
                             hamlib_token_t token,
                             const char *val));
-extern HAMLIB_EXPORT(int)
+HL_DEPRECATED extern HAMLIB_EXPORT(int)
 amp_get_conf HAMLIB_PARAMS((AMP *amp,
                             hamlib_token_t token,
                             char *val));
+extern HAMLIB_EXPORT(int)
+amp_get_conf2 HAMLIB_PARAMS((AMP *amp,
+                            hamlib_token_t token,
+                            char *val,
+                            int val_len));
 extern HAMLIB_EXPORT(int)
 amp_set_powerstat HAMLIB_PARAMS((AMP *amp,
                                  powerstat_t status));

--- a/include/hamlib/rotator.h
+++ b/include/hamlib/rotator.h
@@ -613,7 +613,7 @@ extern HAMLIB_EXPORT(int)
 rot_set_conf HAMLIB_PARAMS((ROT *rot,
                             hamlib_token_t token,
                             const char *val));
-extern HAMLIB_EXPORT(int)
+HL_DEPRECATED extern HAMLIB_EXPORT(int)
 rot_get_conf HAMLIB_PARAMS((ROT *rot,
                             hamlib_token_t token,
                             char *val));

--- a/include/hamlib/rotclass.h
+++ b/include/hamlib/rotclass.h
@@ -55,6 +55,8 @@ public:
     void setConf(const char *name, const char *val);
     void getConf(hamlib_token_t token, char *val);
     void getConf(const char *name, char *val);
+    void getConf2(hamlib_token_t token, char *val, int len);
+    void getConf2(const char *name, char *val, int len);
     hamlib_token_t tokenLookup(const char *name);
 
     void setPosition(azimuth_t az, elevation_t el);

--- a/rigs/anytone/anytone.c
+++ b/rigs/anytone/anytone.c
@@ -46,7 +46,7 @@
 // ---------------------------------------------------------------------------
 
 #include "anytone.h"
-int anytone_transaction(RIG *rig, unsigned char *cmd, int cmd_len,
+static int anytone_transaction(RIG *rig, unsigned char *cmd, int cmd_len,
                         unsigned char *reply, int reply_len, int expected_len);
 
 DECLARE_INITRIG_BACKEND(anytone)
@@ -94,7 +94,7 @@ DECLARE_PROBERIG_BACKEND(anytone)
 
 // AnyTone needs a keep-alive to emulate the MIC
 // Apparently to keep the rig from getting stuck in PTT if mic disconnects
-void *anytone_thread(void *vrig)
+static void *anytone_thread(void *vrig)
 {
     RIG *rig = (RIG *)vrig;
     hamlib_port_t *rp = RIGPORT(rig);
@@ -135,7 +135,7 @@ void *anytone_thread(void *vrig)
 // ---------------------------------------------------------------------------
 // anytone_send
 // ---------------------------------------------------------------------------
-int anytone_send(RIG  *rig,
+static int anytone_send(RIG  *rig,
                  unsigned char *cmd, int cmd_len)
 {
     int               retval       = RIG_OK;
@@ -154,7 +154,7 @@ int anytone_send(RIG  *rig,
 // ---------------------------------------------------------------------------
 // anytone_receive
 // ---------------------------------------------------------------------------
-int anytone_receive(RIG  *rig, unsigned char *buf, int buf_len, int expected)
+static int anytone_receive(RIG  *rig, unsigned char *buf, int buf_len, int expected)
 {
     int               retval       = RIG_OK;
     hamlib_port_t *rp = RIGPORT(rig);
@@ -178,7 +178,7 @@ int anytone_receive(RIG  *rig, unsigned char *buf, int buf_len, int expected)
 // ---------------------------------------------------------------------------
 // anytone_transaction
 // ---------------------------------------------------------------------------
-int anytone_transaction(RIG *rig, unsigned char *cmd, int cmd_len,
+static int anytone_transaction(RIG *rig, unsigned char *cmd, int cmd_len,
                         unsigned char *reply, int reply_len, int expected_len)
 {
     int retval   = RIG_OK;
@@ -293,8 +293,12 @@ int anytone_open(RIG *rig)
 int anytone_close(RIG *rig)
 {
     int retval = RIG_OK;
+    anytone_priv_data_t *p = STATE(rig)->priv;
 
     ENTERFUNC;
+
+    // Tell thread to give up
+    p->runflag = 0;
     char *cmd  = "+ADATA:00,000\r\n";
     anytone_transaction(rig, (unsigned char *)cmd, strlen(cmd), NULL, 0, 0);
 

--- a/rigs/drake/drake.c
+++ b/rigs/drake/drake.c
@@ -62,9 +62,9 @@
  */
 void drake_fix_string(char* inStr)
 {
-    char  chChkAry[3] = {0x20, 0x0d, 0x0a};
-    char* chRepAry[3] = {"<SP>", "<CR>", "<LF>"};
-    char* chPos;
+    const char  chChkAry[3] = {0x20, 0x0d, 0x0a};
+    const char* chRepAry[3] = {"<SP>", "<CR>", "<LF>"};
+    const char* chPos;
     int   newLen;
     int   offset;
     int   i;
@@ -108,7 +108,7 @@ void drake_trans_rept(char* hdrStr, char* sentStr, int sentLen, char* recdStr, i
 {
     char sent[BUFSZ];
     char recd[BUFSZ];
-    char nullStr[7] =  {'<','N','U','L','L','>',0x00};
+    const char nullStr[7] =  {'<','N','U','L','L','>',0x00};
     int  i;
     
     //in most cases each string is a buffer, so we need to ensure both command and response
@@ -1583,7 +1583,7 @@ DECLARE_PROBERIG_BACKEND(drake)
 
     close(port->fd);
 
-    if (retval != RIG_OK || id_len <= 0 || id_len >= BUFSZ)
+    if (retval != RIG_OK || id_len <= 1 || id_len >= BUFSZ)
     {
         return RIG_MODEL_NONE;
     }

--- a/rigs/icom/icr8500.c
+++ b/rigs/icom/icr8500.c
@@ -57,7 +57,7 @@
         { 238,  60 }, \
     } }
 
-int icr8500_set_func(RIG *rig, vfo_t vfo, setting_t func, int status);
+static int icr8500_set_func(RIG *rig, vfo_t vfo, setting_t func, int status);
 
 static struct icom_priv_caps icr8500_priv_caps =
 {
@@ -199,7 +199,7 @@ struct rig_caps icr8500_caps =
     .hamlib_check_rig_caps = HAMLIB_CHECK_RIG_CAPS
 };
 
-int icr8500_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
+static int icr8500_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
 {
     switch (func)
     {

--- a/rigs/yaesu/ft817.c
+++ b/rigs/yaesu/ft817.c
@@ -674,7 +674,7 @@ static inline long timediff(const struct timeval *tv1,
     return ((tv.tv_sec * 1000L) + (tv.tv_usec / 1000L));
 }
 
-static int check_cache_timeout(struct timeval *tv)
+static int check_cache_timeout(const struct timeval *tv)
 {
     struct timeval curr;
     long t;

--- a/rigs/yaesu/ft857.c
+++ b/rigs/yaesu/ft857.c
@@ -460,7 +460,7 @@ static inline long timediff(const struct timeval *tv1,
     return ((tv.tv_sec * 1000L) + (tv.tv_usec / 1000L));
 }
 
-static int check_cache_timeout(struct timeval *tv)
+static int check_cache_timeout(const struct timeval *tv)
 {
     struct timeval curr;
     long t;

--- a/rigs/yaesu/ft897.c
+++ b/rigs/yaesu/ft897.c
@@ -594,7 +594,7 @@ static inline long timediff(const struct timeval *tv1,
     return ((tv.tv_sec * 1000L) + (tv.tv_usec / 1000L));
 }
 
-static int check_cache_timeout(struct timeval *tv)
+static int check_cache_timeout(const struct timeval *tv)
 {
     struct timeval curr;
     long t;

--- a/rotators/androidsensor/androidsensor.cpp
+++ b/rotators/androidsensor/androidsensor.cpp
@@ -143,7 +143,6 @@ const struct rot_caps androidsensor_rot_caps =
 
 /* ************************************************************************* */
 
-// cppcheck-suppress syntaxError
 DECLARE_INITROT_BACKEND(androidsensor)
 {
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);

--- a/rotators/grbltrk/grbltrk.c
+++ b/rotators/grbltrk/grbltrk.c
@@ -488,7 +488,7 @@ grbltrk_rot_open(ROT *rot)
     }
     else if (rot->caps->rot_model == ROT_MODEL_GRBLTRK_NET)
     {
-        rot_get_conf(rot, TOK_PATHNAME, host);
+        rot_get_conf2(rot, TOK_PATHNAME, host, sizeof(host));
         rot_debug(RIG_DEBUG_ERR, "%s:%d ctrl via net, host [%s]\n", __func__, __LINE__,
                   host);
         grbl_net_open(rot, 23);

--- a/rotators/indi/indi_wrapper.cpp
+++ b/rotators/indi/indi_wrapper.cpp
@@ -462,9 +462,7 @@ int RotINDIClient::setPosition(azimuth_t az, elevation_t el)
     return RIG_OK;
 }
 
-// cppcheck-suppress unusedFunction
 void RotINDIClient::removeDevice(INDI::BaseDevice *dp) {}
-// cppcheck-suppress unusedFunction
 void RotINDIClient::newProperty(INDI::Property *property)
 {
     std::string name(property->getName());
@@ -491,13 +489,9 @@ void RotINDIClient::newProperty(INDI::Property *property)
         mEl = property->getNumber()->np[1].value;
     }
 }
-// cppcheck-suppress unusedFunction
 void RotINDIClient::removeProperty(INDI::Property *property) {}
-// cppcheck-suppress unusedFunction
 void RotINDIClient::newBLOB(IBLOB *bp) {}
-// cppcheck-suppress unusedFunction
 void RotINDIClient::newSwitch(ISwitchVectorProperty *svp) {}
-// cppcheck-suppress unusedFunction
 void RotINDIClient::newNumber(INumberVectorProperty *nvp)
 {
     std::string name(nvp->name);
@@ -508,22 +502,16 @@ void RotINDIClient::newNumber(INumberVectorProperty *nvp)
         mEl = nvp->np[1].value;
     }
 }
-// cppcheck-suppress unusedFunction
 void RotINDIClient::newMessage(INDI::BaseDevice *dp, int messageID) {}
-// cppcheck-suppress unusedFunction
 void RotINDIClient::newText(ITextVectorProperty *tvp) {}
-// cppcheck-suppress unusedFunction
 void RotINDIClient::newLight(ILightVectorProperty *lvp) {}
-// cppcheck-suppress unusedFunction
 void RotINDIClient::newDevice(INDI::BaseDevice *dp) {}
 
-// cppcheck-suppress unusedFunction
 void RotINDIClient::serverConnected()
 {
     rig_debug(RIG_DEBUG_VERBOSE, "indi: server connected\n");
 }
 
-// cppcheck-suppress unusedFunction
 void RotINDIClient::serverDisconnected(int exit_code)
 {
     rig_debug(RIG_DEBUG_VERBOSE, "indi: server disconnected\n");

--- a/rotators/ts7400/include/peekpoke.c
+++ b/rotators/ts7400/include/peekpoke.c
@@ -4,7 +4,7 @@
 #include<stdio.h>
 #include<fcntl.h>
 
-unsigned int parseBinary(char *str)
+unsigned int parseBinary(const char *str)
 {
     unsigned int val = 0;
 

--- a/rotators/ts7400/include/readADC.c
+++ b/rotators/ts7400/include/readADC.c
@@ -76,7 +76,7 @@ empty_calibration:
     return 0;
 }
 
-void write_calibration(int cal[NUM_CHANNELS][2])
+void write_calibration(const int cal[NUM_CHANNELS][2])
 {
     unsigned short buf[16];
     int i, j, k = 0;
@@ -107,7 +107,7 @@ static void erase_calibration()
 }
 
 int check_calibration(int cal[NUM_CHANNELS][2],
-                      int stored_cal[NUM_CHANNELS][2], int state)
+                      const int stored_cal[NUM_CHANNELS][2], int state)
 {
     double pcnt_diff;
     int i, j, erase_cal = 0;

--- a/rotators/ts7400/include/test7400ADC.c
+++ b/rotators/ts7400/include/test7400ADC.c
@@ -74,7 +74,7 @@ empty_calibration:
     return 0;
 }
 
-void write_calibration(int cal[NUM_CHANNELS][2])
+void write_calibration(const int cal[NUM_CHANNELS][2])
 {
     unsigned short buf[16];
     int i, j, k = 0;
@@ -105,7 +105,7 @@ static void erase_calibration()
 }
 
 int check_calibration(int cal[NUM_CHANNELS][2],
-                      int stored_cal[NUM_CHANNELS][2], int state)
+                      const int stored_cal[NUM_CHANNELS][2], int state)
 {
     double pcnt_diff;
     int i, j, erase_cal = 0;

--- a/security/aes.c
+++ b/security/aes.c
@@ -63,7 +63,7 @@ int do_init = 1;
 #define XTIME(x) ( ( x <<  1 ) ^ ( ( x & 0x80 ) ? 0x1B : 0x00 ) )
 #define MUL(x,y) ( ( x &&  y ) ? pow[(log[x] + log[y]) % 255] : 0 )
 
-void aes_gen_tables(void)
+static void aes_gen_tables(void)
 {
     int i;
     uint8 x, y;

--- a/security/md5.c
+++ b/security/md5.c
@@ -1,6 +1,6 @@
 #include "md5.h"
 
-char *make_digest(const unsigned char *digest, int len) /* {{{ */
+static char *make_digest(const unsigned char *digest, int len) /* {{{ */
 {
     int md5len = sizeof(char) * (len * 2 + 1);
     char *md5str = (char *) calloc(1, md5len);
@@ -64,7 +64,7 @@ char *make_digest(const unsigned char *digest, int len) /* {{{ */
  * This processes one or more 64-byte data blocks, but does NOT update
  * the bit counters.  There are no alignment requirements.
  */
-const void *body(void *ctxBuf, const void *data, size_t size)
+static const void *body(void *ctxBuf, const void *data, size_t size)
 {
     MD5_CTX *ctx = (MD5_CTX *)ctxBuf;
     const unsigned char *ptr;
@@ -174,7 +174,7 @@ const void *body(void *ctxBuf, const void *data, size_t size)
     return ptr;
 }
 
-void MD5Init(void *ctxBuf)
+static void MD5Init(void *ctxBuf)
 {
     MD5_CTX *ctx = (MD5_CTX *)ctxBuf;
     ctx->a = 0x67452301;
@@ -186,7 +186,7 @@ void MD5Init(void *ctxBuf)
     ctx->hi = 0;
 }
 
-void MD5Update(void *ctxBuf, const void *data, size_t size)
+static void MD5Update(void *ctxBuf, const void *data, size_t size)
 {
     MD5_CTX *ctx = (MD5_CTX *)ctxBuf;
     MD5_u32plus saved_lo;
@@ -229,7 +229,7 @@ void MD5Update(void *ctxBuf, const void *data, size_t size)
     memcpy(ctx->buffer, data, size);
 }
 
-void MD5Final(unsigned char *result, void *ctxBuf)
+static void MD5Final(unsigned char *result, void *ctxBuf)
 {
     MD5_CTX *ctx = (MD5_CTX *)ctxBuf;
     MD5_u32plus used, free;
@@ -282,7 +282,7 @@ void MD5Final(unsigned char *result, void *ctxBuf)
     memset(ctx, 0, sizeof(*ctx));
 }
 
-unsigned char *make_hash(const char *arg)
+static unsigned char *make_hash(const char *arg)
 {
     MD5_CTX context;
     static unsigned char digest[65];

--- a/security/sha256.c
+++ b/security/sha256.c
@@ -53,7 +53,7 @@ void sha256_starts(sha256_context *ctx)
     ctx->state[7] = 0x5BE0CD19;
 }
 
-void sha256_process(sha256_context *ctx, const uint8 data[64])
+static void sha256_process(sha256_context *ctx, const uint8 data[64])
 {
     uint32 temp1, temp2, W[64];
     uint32 A, B, C, D, E, F, G, H;

--- a/simulators/simft990.c
+++ b/simulators/simft990.c
@@ -49,7 +49,7 @@ typedef enum nc_rigid_e
     NC_RIGID_FTDX101MP       = 682
 } nc_rigid_t;
 
-void load_dat(const char *filename, unsigned char buf[1492])
+static void load_dat(const char *filename, unsigned char buf[1492])
 {
     FILE *fp = fopen(filename, "r");
     char line[4096];

--- a/src/network.c
+++ b/src/network.c
@@ -1000,7 +1000,7 @@ static int multicast_publisher_read_packet(multicast_publisher_args
     return (RIG_OK);
 }
 
-void *multicast_publisher(void *arg)
+static void *multicast_publisher(void *arg)
 {
     unsigned char spectrum_data[HAMLIB_MAX_SPECTRUM_DATA];
     char snapshot_buffer[HAMLIB_MAX_SNAPSHOT_PACKET_SIZE];
@@ -1257,7 +1257,7 @@ int is_wireless()
 #include <unistd.h>
 #include <ifaddrs.h>
 
-int is_networked(char *ipv4, int ipv4_length)
+static int is_networked(char *ipv4, int ipv4_length)
 {
     struct ifaddrs *interfaces, *iface;
     char addr_str[INET_ADDRSTRLEN];
@@ -1345,7 +1345,7 @@ int is_wireless()
 #endif
 #endif
 
-void *multicast_receiver(void *arg)
+static void *multicast_receiver(void *arg)
 {
     char data[4096];
     char ip4[INET6_ADDRSTRLEN];

--- a/tests/ampctl_parse.c
+++ b/tests/ampctl_parse.c
@@ -1501,7 +1501,7 @@ int print_conf_list(const struct confparams *cfp, rig_ptr_t data)
     int i;
     char buf[128] = "";
 
-    amp_get_conf(amp, cfp->token, buf);
+    amp_get_conf2(amp, cfp->token, buf, sizeof(buf));
     printf("%s: \"%s\"\n" "\tDefault: %s, Value: %s\n",
            cfp->name,
            cfp->tooltip,

--- a/tests/rigmatrix.c
+++ b/tests/rigmatrix.c
@@ -34,7 +34,7 @@
 
 static setting_t bitmap_func, bitmap_level, bitmap_parm, bitmap_vfo_ops;
 
-int create_png_range(const freq_range_t rx_range_list[],
+static int create_png_range(const freq_range_t rx_range_list[],
                      const freq_range_t tx_range_list[], int num);
 
 int print_caps_sum(struct rig_caps *caps, void *data)
@@ -565,7 +565,6 @@ static void draw_range(const freq_range_t range_list[],
 
     }
 }
-
 
 static int create_png_range(const freq_range_t rx_range_list[],
                      const freq_range_t tx_range_list[],

--- a/tests/rigmem.c
+++ b/tests/rigmem.c
@@ -58,7 +58,7 @@ void usage();
 void version();
 static int set_conf(RIG *rig, char *conf_parms);
 
-int clear_chans(RIG *rig, const char *infilename);
+static int clear_chans(RIG *rig, const char *infilename);
 
 /*
  * Reminder: when adding long options,
@@ -450,7 +450,7 @@ static int set_conf(RIG *rig, char *conf_parms)
 /*
  * Pretty nasty, clears everything you have in rig memory
  */
-int clear_chans(RIG *rig, const char *infilename)
+static int clear_chans(RIG *rig, const char *infilename)
 {
     int i, j, ret;
     channel_t chan;

--- a/tests/rotctl_parse.c
+++ b/tests/rotctl_parse.c
@@ -1698,7 +1698,7 @@ declare_proto_rot(get_conf)
     else
     {
         char value[4096];
-        ret = rot_get_conf(rot, rot_token_lookup(rot, arg1), value);
+        ret = rot_get_conf2(rot, rot_token_lookup(rot, arg1), value, sizeof(value));
 
         if (ret != RIG_OK)
         {
@@ -2917,7 +2917,7 @@ int print_conf_list2(const struct confparams *cfp, rig_ptr_t data, FILE *fout)
     ROT *rot = (ROT *) data;
     char buf[128] = "";
 
-    rot_get_conf(rot, cfp->token, buf);
+    rot_get_conf2(rot, cfp->token, buf, sizeof(buf));
     fprintf(fout, "%s: \"%s\"\n" "\t" "Default: %s, Value: %s\n",
             cfp->name,
             cfp->tooltip,

--- a/tests/rotctl_parse.c
+++ b/tests/rotctl_parse.c
@@ -246,7 +246,7 @@ struct test_table test_list[] =
 };
 
 
-struct test_table *find_cmd_entry(int cmd)
+static struct test_table *find_cmd_entry(int cmd)
 {
     int i;
 
@@ -286,7 +286,7 @@ struct mod_lst
 struct mod_lst *models = NULL;
 
 /* Add model information to the hash */
-void hash_add_model(int id,
+static void hash_add_model(int id,
                     const char *mfg_name,
                     const char *model_name,
                     const char *version,
@@ -309,20 +309,20 @@ void hash_add_model(int id,
 
 
 /* Hash sorting functions */
-int hash_model_id_sort(const struct mod_lst *a, const struct mod_lst *b)
+static int hash_model_id_sort(const struct mod_lst *a, const struct mod_lst *b)
 {
     return (a->id > b->id);
 }
 
 
-void hash_sort_by_model_id()
+static void hash_sort_by_model_id()
 {
     HASH_SORT(models, hash_model_id_sort);
 }
 
 
 /* Delete hash */
-void hash_delete_all()
+static void hash_delete_all()
 {
     struct mod_lst *current_model, *tmp = NULL;
 
@@ -372,7 +372,7 @@ static void rp_getline(const char *s)
 /*
  * TODO: use Lex?
  */
-char parse_arg(const char *arg)
+static char parse_arg(const char *arg)
 {
     int i;
 

--- a/tests/test2038.c
+++ b/tests/test2038.c
@@ -6,7 +6,7 @@ Does fail when compiled with gcc -m32 -o test2038 test2038.c
 #include <time.h>
 #include <string.h>
 
-int test2038(void)
+static int test2038(void)
 {
     time_t x;
 

--- a/tests/testnet.c
+++ b/tests/testnet.c
@@ -106,7 +106,7 @@ static int test_host(char *hoststr, char host[256], char port[6])
 }
 
 int
-main(int argc, char *argv[])
+main(int argc, const char *argv[])
 {
     // IPV4
     test_host("127.0.0.1", "127.0.0.1", "");

--- a/tests/testnet.c
+++ b/tests/testnet.c
@@ -25,7 +25,7 @@
 #  include <arpa/inet.h>
 #endif
 
-int rig_network_addr(char *hoststr, char *portstr)
+static int rig_network_addr(char *hoststr, char *portstr)
 {
 
     struct in6_addr serveraddr;
@@ -73,7 +73,7 @@ int rig_network_addr(char *hoststr, char *portstr)
     return 0;
 }
 
-int test_host(char *hoststr, char host[256], char port[6])
+static int test_host(char *hoststr, char host[256], char port[6])
 {
     int status;
     char host2[256], port2[6];

--- a/tests/testtrn.c
+++ b/tests/testtrn.c
@@ -14,7 +14,7 @@
 #define SERIAL_PORT "/dev/ttyS0"
 
 
-int myfreq_event(RIG *rig, vfo_t vfo, freq_t freq, rig_ptr_t arg)
+static int myfreq_event(RIG *rig, vfo_t vfo, freq_t freq, rig_ptr_t arg)
 {
     int *count_ptr = (int *) arg;
 


### PR DESCRIPTION
Mark as deprecated - to be removed in 5.0 - Issue #924 
More cppcheck tweaks
