### PR TITLE
Quell warning from clang

### DIFF
--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -2290,7 +2290,7 @@ int kenwood_set_rit_new(RIG *rig, vfo_t vfo, shortfreq_t rit)
     char rdbuf[10];
 
     ENTERFUNC;
-    if (abs(rit) > 9999) { RETURNFUNC(-RIG_EINVAL); }
+    if (labs(rit) > 9999) { RETURNFUNC(-RIG_EINVAL); }
     retval = kenwood_get_rit_new(rig, vfo, &oldrit);
     if (retval != RIG_OK) { RETURNFUNC(retval); }
     if (rit == oldrit)  // if the new value is the same


### PR DESCRIPTION
This warning was seen on MacOS and on Debian 12 and 13 using clang:

```
CC       kenwood.lo
kenwood.c:2293:9: warning: absolute value function 'abs' given an argument of type 'shortfreq_t' (aka 'long') but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
 2293 |     if (abs(rit) > 9999) { RETURNFUNC(-RIG_EINVAL); }
      |         ^
kenwood.c:2293:9: note: use function 'labs' instead
 2293 |     if (abs(rit) > 9999) { RETURNFUNC(-RIG_EINVAL); }
      |         ^~~
      |         labs
1 warning generated.
```

Closes issue #1806 on GitHub