### PR TITLE
Fix initialization of comm_status

### DIFF
--- a/bindings/python/test_rig.py
+++ b/bindings/python/test_rig.py
@@ -47,10 +47,12 @@ class TestClass:
         assert rig is not None
 
         assert rig.state.comm_state == 0
+        assert rig.state.comm_status == Hamlib.RIG_COMM_STATUS_DISCONNECTED
         assert rig.set_conf("rig_pathname", rig_file) is None
         assert rig.set_conf("serial_speed", str(serial_speed)) is None
         assert rig.open() is None
         assert rig.state.comm_state == 1
+        assert rig.state.comm_status == Hamlib.RIG_COMM_STATUS_OK
         info = rig.get_info()
         assert isinstance(info, str)
 
@@ -116,6 +118,7 @@ class TestClass:
 
         assert rig.close() is None
         assert rig.state.comm_state == 0
+        assert rig.state.comm_status == Hamlib.RIG_COMM_STATUS_DISCONNECTED
         info = rig.get_info()
         assert info is None
 

--- a/src/rig.c
+++ b/src/rig.c
@@ -669,7 +669,7 @@ RIG *HAMLIB_API rig_init(rig_model_t rig_model)
     rs->async_data_enabled = 0;
     //    rs->depth = 1;
     rs->comm_state = 0;
-    rs->comm_status = RIG_COMM_STATUS_CONNECTING;
+    rs->comm_status = RIG_COMM_STATUS_DISCONNECTED;
     rs->tuner_control_pathname = DEFAULT_TUNER_CONTROL_PATHNAME;
     strncpy(rs->client_version, "Hamlib", sizeof(rs->client_version));
 


### PR DESCRIPTION
This PR fixes a problem in the lifecycle of a connection tracked with `rig->comm_status` that made appear that a connection was in progress even before `rig_open()` was called. It also updates the test which showed this issue.

The function `rig_init()` doesn't touch the hardware, it's `rig_open()` that initiates the connection and in fact the first use of comm_status in `rig_open()` is when it gets the value `RIG_COMM_STATUS_CONNECTING` and `rig_close()` sets it to `RIG_COMM_STATUS_DISCONNECTED`.