### PR TITLE
Another round of misc fixes

### DIFF
--- a/amplifiers/elecraft/kpa.c
+++ b/amplifiers/elecraft/kpa.c
@@ -566,7 +566,7 @@ int kpa_get_powerstat(AMP *amp, powerstat_t *status)
 int kpa_set_powerstat(AMP *amp, powerstat_t status)
 {
     int retval;
-    char *cmd = NULL;
+    const char *cmd = NULL;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 

--- a/amplifiers/gemini/gemini.c
+++ b/amplifiers/gemini/gemini.c
@@ -134,7 +134,7 @@ const char *gemini_get_info(AMP *amp)
     return rc->model_name;
 }
 
-int gemini_status_parse(AMP *amp)
+static int gemini_status_parse(AMP *amp)
 {
     int retval, n = 0;
     char *p;
@@ -204,7 +204,7 @@ int gemini_get_freq(AMP *amp, freq_t *freq)
 int gemini_set_freq(AMP *amp, freq_t freq)
 {
     int retval;
-    char *cmd;
+    const char *cmd;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
@@ -268,7 +268,7 @@ int gemini_get_level(AMP *amp, setting_t level, value_t *val)
 
 int gemini_set_level(AMP *amp, setting_t level, value_t val)
 {
-    char *cmd = "?";
+    const char *cmd = "?";
     int retval;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
@@ -340,7 +340,7 @@ int gemini_get_powerstat(AMP *amp, powerstat_t *status)
 int gemini_set_powerstat(AMP *amp, powerstat_t status)
 {
     int retval;
-    char *cmd = NULL;
+    const char *cmd = NULL;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 

--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -2580,7 +2580,7 @@ struct multicast_s
     int multicast_running;
     int sock;
     int seqnumber;
-    int runflag; // = 0;
+    volatile int runflag; // = 0;
     pthread_t threadid;
     // this mutex is needed to control serial access
     // as of 2023-05-13 we have main thread and multicast thread needing it

--- a/include/hamlib/rig_state.h
+++ b/include/hamlib/rig_state.h
@@ -126,6 +126,7 @@ struct rig_state {
     int twiddle_timeout;        /*!< timeout to resume from twiddling */
     // uplink allows gpredict to behave better by no reading the uplink VFO
     int uplink;                 /*!< uplink=1 will not read Sub, uplink=2 will not read Main */
+    HL_DEPRECATED
     struct rig_cache_deprecated cache; /*!< \deprecated Only here for backward compatibility */
     int vfo_opt;                /*!< Is -o switch turned on? */
     int auto_power_on;          /*!< Allow Hamlib to power on rig

--- a/rigs/anytone/anytone.h
+++ b/rigs/anytone/anytone.h
@@ -24,7 +24,7 @@ typedef struct _anytone_priv_data
 {
     ptt_t         ptt;
     vfo_t         vfo_curr;
-    int           runflag; // thread control
+    volatile int  runflag; // thread control
     char          buf[64];
     pthread_mutex_t mutex;
 } anytone_priv_data_t,

--- a/rigs/icom/icom.c
+++ b/rigs/icom/icom.c
@@ -2373,7 +2373,7 @@ static int icom_set_mode_x26(RIG *rig, vfo_t vfo, rmode_t mode,
     int ack_len = sizeof(ackbuf);
     int buf_len = 3;
     int mode_len;
-    unsigned char mode_buf[4];
+    unsigned char mode_buf[5];
 
     if (priv->x26cmdfails > 0 && !priv_caps->x25x26_always)
     {

--- a/rigs/kenwood/ts590.c
+++ b/rigs/kenwood/ts590.c
@@ -1923,6 +1923,7 @@ struct rig_caps ts590_caps =
     .get_mem =  kenwood_get_mem,
     .vfo_ops = TS590_VFO_OPS,
     .vfo_op =  kenwood_vfo_op,
+    .morse_qsize = 24,
     .hamlib_check_rig_caps = HAMLIB_CHECK_RIG_CAPS
 };
 
@@ -2353,5 +2354,6 @@ struct rig_caps ts590sg_caps =
     .get_mem =  kenwood_get_mem,
     .vfo_ops = TS590_VFO_OPS,
     .vfo_op =  kenwood_vfo_op,
+    .morse_qsize = 24,
     .hamlib_check_rig_caps = HAMLIB_CHECK_RIG_CAPS
 };

--- a/rigs/kenwood/ts890s.c
+++ b/rigs/kenwood/ts890s.c
@@ -721,5 +721,6 @@ struct rig_caps ts890s_caps =
     .get_func = ts890_get_func,
     .get_clock = kenwood_get_clock,
     .set_clock = kenwood_set_clock,
+    .morse_qsize = 24,
     .hamlib_check_rig_caps = HAMLIB_CHECK_RIG_CAPS
 };

--- a/rigs/kenwood/ts990s.c
+++ b/rigs/kenwood/ts990s.c
@@ -381,6 +381,7 @@ struct rig_caps ts990s_caps =
     .reset =  kenwood_reset,
     .get_clock = kenwood_get_clock,
     .set_clock = kenwood_set_clock,
+    .morse_qsize = 24,
     .hamlib_check_rig_caps = HAMLIB_CHECK_RIG_CAPS
 };
 

--- a/rigs/tentec/omnivii.c
+++ b/rigs/tentec/omnivii.c
@@ -274,7 +274,7 @@ static int tt588_transaction(RIG *rig, const char *cmd, int cmd_len, char *data,
         if (retval == RIG_OK)
         {
             // All responses except from "XX" terminate with EOM (i.e. \r) so that is our stop char
-            char *term = EOM;
+            const char *term = EOM;
 
             if (cmd[0] ==
                     'X') // we'll let the timeout take care of this as it shouldn't happen anyways

--- a/rigs/tentec/paragon.c
+++ b/rigs/tentec/paragon.c
@@ -326,7 +326,7 @@ int tt585_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
     struct tt585_priv_data *priv = (struct tt585_priv_data *)STATE(rig)->priv;
     int ret;
-    unsigned char *p;
+    const unsigned char *p;
 
     ret = tt585_get_status_data(rig);
 

--- a/rigs/tentec/rx331.c
+++ b/rigs/tentec/rx331.c
@@ -69,6 +69,7 @@ static int rx331_init(RIG *rig);
 static int rx331_cleanup(RIG *rig);
 static int rx331_set_conf(RIG *rig, hamlib_token_t token, const char *val);
 static int rx331_get_conf(RIG *rig, hamlib_token_t token, char *val);
+static int rx331_get_conf2(RIG *rig, hamlib_token_t token, char *val, int len);
 static int rx331_open(RIG *rig);
 static int rx331_close(RIG *rig);
 static int rx331_set_freq(RIG *rig, vfo_t vfo, freq_t freq);
@@ -178,6 +179,7 @@ struct rig_caps rx331_caps =
     .rig_close =  rx331_close,
     .set_conf =   rx331_set_conf,
     .get_conf =   rx331_get_conf,
+    .get_conf2 =  rx331_get_conf2,
     .set_freq =   rx331_set_freq,
     .get_freq =   rx331_get_freq,
     .set_mode =   rx331_set_mode,
@@ -428,6 +430,8 @@ int rx331_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
         return -RIG_EPROTO;
     }
 
+    // cppcheck doesn't grok num_sscanf()
+    // cppcheck-suppress uninitvar
     *freq = f * 1e6;
 
     return RIG_OK;
@@ -547,6 +551,7 @@ int rx331_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
         return -RIG_EPROTO;
     }
 
+    // cppcheck-suppress uninitvar
     *width = f * 1e3;
 
     return RIG_OK;

--- a/rigs/tentec/rx340.c
+++ b/rigs/tentec/rx340.c
@@ -325,6 +325,7 @@ int rx340_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
         return -RIG_EPROTO;
     }
 
+    // cppcheck-suppress uninitvar
     *freq = f * 1e6;
 
     return RIG_OK;
@@ -443,6 +444,7 @@ int rx340_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
         return -RIG_EPROTO;
     }
 
+    // cppcheck-suppress uninitvar
     *width = f * 1e3;
 
     return RIG_OK;

--- a/rigs/yaesu/ft100.c
+++ b/rigs/yaesu/ft100.c
@@ -971,14 +971,16 @@ int ft100_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
 {
 
     int ret;
-    int split = CACHE(rig)->split;
-    int ptt = CACHE(rig)->ptt;
+    int split, ptt;
 
     FT100_METER_INFO ft100_meter;
 
     if (!rig) { return -RIG_EINVAL; }
 
     if (!val) { return -RIG_EINVAL; }
+
+    split = CACHE(rig)->split;
+    ptt = CACHE(rig)->ptt;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: %s\n", __func__, rig_strlevel(level));
 

--- a/rotators/apex/apex.c
+++ b/rotators/apex/apex.c
@@ -43,12 +43,12 @@ static int apex_get_string(ROT *rot, char *s, int maxlen)
 static void *apex_read(void *arg)
 {
     ROT *rot = arg;
-    int retval = 0;
     char data[64];
     int expected_return_length = 63;
 
     while (1)
     {
+        int retval;
         retval = apex_get_string(rot, data, expected_return_length);
 
         if (strstr(data, "<VER>"))

--- a/rotators/easycomm/easycomm.c
+++ b/rotators/easycomm/easycomm.c
@@ -50,9 +50,9 @@
 static int
 easycomm_transaction(ROT *rot, const char *cmdstr, char *data, size_t data_len)
 {
-    hamlib_port_t *rotp = ROTPORT(rot);
+    hamlib_port_t *rotp;
     int retval;
-    int retry = rot->caps->retry;
+    int retry;
 
     rig_debug(RIG_DEBUG_TRACE, "%s called: %s\n", __func__, cmdstr);
 
@@ -60,6 +60,9 @@ easycomm_transaction(ROT *rot, const char *cmdstr, char *data, size_t data_len)
     {
         return -RIG_EINVAL;
     }
+
+    rotp = ROTPORT(rot);
+    retry = rot->caps->retry;
 
     do
     {

--- a/rotators/gs232a/gs232.c
+++ b/rotators/gs232a/gs232.c
@@ -225,7 +225,6 @@ gs232_rot_get_position(ROT *rot, azimuth_t *az, elevation_t *el)
     {
         rig_debug(RIG_DEBUG_WARN,
                   "%s: rotor didn't send CR...assuming it won't in the future\n", __func__);
-        retval = RIG_OK;
         expected = 11; // we won't expect the CR
         ROTPORT(rot)->retry = 3;
     }

--- a/rotators/gs232a/gs232.c
+++ b/rotators/gs232a/gs232.c
@@ -198,7 +198,7 @@ gs232_rot_set_position(ROT *rot, azimuth_t az, elevation_t el)
 static int
 gs232_rot_get_position(ROT *rot, azimuth_t *az, elevation_t *el)
 {
-    char posbuf[32];
+    char posbuf[BUFSZ];
     // these really shouldn't be static but it's fixing faulty firmware -- see below
     static int expected = 12;
     static int expected_flag = 0;

--- a/rotators/gs232a/gs232a.c
+++ b/rotators/gs232a/gs232a.c
@@ -276,7 +276,7 @@ static int gs232a_rot_set_level(ROT *rot, setting_t level, value_t val)
         }
 
         /* between 1 (slowest) and 4 (fastest) */
-        SNPRINTF(cmdstr, sizeof(cmdstr), "X%u" EOM, speed);
+        SNPRINTF(cmdstr, sizeof(cmdstr), "X%d" EOM, speed);
         retval = gs232a_transaction(rot, cmdstr, NULL, 0, 1);
 
         if (retval != RIG_OK)

--- a/rotators/gs232a/gs232b.c
+++ b/rotators/gs232a/gs232b.c
@@ -294,10 +294,10 @@ static int gs232b_rot_set_level(ROT *rot, setting_t level, value_t val)
 
     switch (level)
     {
-        int retval;
 
     case ROT_LEVEL_SPEED:
     {
+        int retval;
         int speed = val.i;
 
         if (speed < 1)
@@ -310,7 +310,7 @@ static int gs232b_rot_set_level(ROT *rot, setting_t level, value_t val)
         }
 
         /* between 1 (slowest) and 4 (fastest) */
-        SNPRINTF(cmdstr, sizeof(cmdstr), "X%u" EOM, speed);
+        SNPRINTF(cmdstr, sizeof(cmdstr), "X%d" EOM, speed);
         retval = gs232b_transaction(rot, cmdstr, NULL, 0, 1);
 
         if (retval != RIG_OK)

--- a/security/AESStringCrypt.c
+++ b/security/AESStringCrypt.c
@@ -222,6 +222,7 @@ unsigned long long AESStringCrypt(unsigned char *password,
     {
         if (fread(buffer, 1, 32, randfp) != 32)
         {
+            fclose(randfp);
             return AESSTRINGCRYPT_ERROR;
         }
 

--- a/src/network.c
+++ b/src/network.c
@@ -1348,7 +1348,7 @@ int is_wireless()
 static void *multicast_receiver(void *arg)
 {
     char data[4096];
-    char ip4[INET6_ADDRSTRLEN];
+    char ip4[INET6_ADDRSTRLEN] = "";
 
     struct multicast_receiver_args_s *args = (struct multicast_receiver_args_s *)
             arg;

--- a/src/settings.c
+++ b/src/settings.c
@@ -1266,6 +1266,8 @@ HAMLIB_EXPORT(int) rig_settings_load_all(char *settings_file)
         }
     }
 
+    fclose(fp);
+
     return RIG_OK;
 }
 


### PR DESCRIPTION
More cppcheck stuff - suppress bogus uninitialized variables errors
Update CW buffer size
Some error case fixes found by -fanalyzer

All go in master, first and last (CW message and buffer overrun) could be picked for 4.6.x.
