### PR TITLE
Improve Doxygen comments

### DIFF
--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -2646,13 +2646,13 @@ typedef int (*spectrum_cb_t)(RIG *,
  * Events from the rig are received through async io,
  * so callback functions will be called from the SIGIO sighandler context.
  *
- * Don't set these fields directly, use rig_set_freq_callback et. al. instead.
+ * Don't set these fields directly, use rig_set_freq_callback() et. al. instead.
  *
  * Callbacks suit event based programming very well,
  * really appropriate in a GUI.
  *
- * \sa rig_set_freq_callback(), rig_set_mode_callback(), rig_set_vfo_callback(),
- *     rig_set_ptt_callback(), rig_set_dcd_callback()
+ * \sa rig_set_dcd_callback(), rig_set_freq_callback(), rig_set_mode_callback(),
+ *     rig_set_ptt_callback(), rig_set_spectrum_callback(), rig_set_vfo_callback()
  */
 // Do NOT add/remove from this structure -- it will break DLL backwards compatibility
 struct rig_callbacks {

--- a/rigs/aor/ar7030p.c
+++ b/rigs/aor/ar7030p.c
@@ -467,7 +467,7 @@ static const char *ar7030p_get_info(RIG *rig)
     return (p);
 }
 
-/*
+/**
  * \brief Set receiver frequency
  *
  * \param rig Pointer to rig struct
@@ -527,7 +527,7 @@ static int ar7030p_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     return (rc);
 }
 
-/*
+/**
  * \brief Get receiver frequency
  *
  * \param rig Pointer to rig struct
@@ -583,7 +583,7 @@ static int ar7030p_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
     return (rc);
 }
 
-/*
+/**
  * \brief Set receiver mode
  *
  * \param rig Pointer to rig struct
@@ -649,7 +649,7 @@ static int ar7030p_set_mode(RIG *rig, vfo_t vfo, rmode_t mode,
     return (rc);
 }
 
-/*
+/**
  * \brief Get receiver mode and bandwidth
  *
  * \param rig Pointer to rig struct
@@ -693,7 +693,7 @@ static int ar7030p_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode,
     return (rc);
 }
 
-/*
+/**
  * \brief Get memory channel parameters
  *
  * \param rig Pointer to rig struct
@@ -817,7 +817,7 @@ static void ar7030p_get_memory(RIG *rig, const unsigned int chan,
 }
 #endif /* unused */
 
-/*
+/**
  * \brief Set receiver levels
  *
  * \param rig Pointer to rig struct
@@ -995,7 +995,7 @@ static int ar7030p_set_level(RIG *rig, vfo_t vfo, setting_t level,
 }
 
 
-/*
+/**
  * \brief Get receiver levels
  *
  * \param rig Pointer to rig struct
@@ -1468,7 +1468,7 @@ static int ar7030p_set_ts(RIG *rig, vfo_t vfo, shortfreq_t ts)
     return (rc);
 }
 
-/*
+/**
  * \brief Get receiver tuning step size
  *
  * \param rig Pointer to rig struct
@@ -1505,7 +1505,7 @@ static int ar7030p_get_ts(RIG *rig, vfo_t vfo, shortfreq_t *ts)
     return (rc);
 }
 
-/*
+/**
  * \brief Set receiver power status
  *
  * \param rig Pointer to rig struct
@@ -1541,7 +1541,7 @@ static int ar7030p_set_powerstat(RIG *rig, powerstat_t status)
     return (-RIG_ENIMPL);
 }
 
-/*
+/**
  * \brief Get receiver power status
  *
  * \param rig Pointer to rig struct
@@ -1580,7 +1580,7 @@ static int ar7030p_get_powerstat(RIG *rig, powerstat_t *status)
     return (rc);
 }
 
-/*
+/**
  * \brief Reset receiver
  *
  * \param rig Pointer to rig struct

--- a/rigs/aor/ar7030p_utils.c
+++ b/rigs/aor/ar7030p_utils.c
@@ -512,7 +512,7 @@ static int setAddr(RIG *rig, enum PAGE_e page, unsigned int addr)
     return (rc);
 }
 
-/*
+/**
  * \brief Write one byte to the receiver
  *
  * \param rig Pointer to rig struct
@@ -553,8 +553,8 @@ int writeByte(RIG *rig, enum PAGE_e page, unsigned int addr, unsigned char x)
     return (rc);
 }
 
-/*
- * \brief Write two bytes to the receiver
+/**
+ * brief  Write two bytes to the receiver
  *
  * \param rig  Pointer to rig struct
  * \param page Memory page number (0-4, 15)
@@ -580,7 +580,7 @@ int writeShort(RIG *rig, enum PAGE_e page, unsigned int addr, unsigned short x)
     return (rc);
 }
 
-/*
+/**
  * \brief Write three bytes to the receiver
  *
  * \param rig  Pointer to rig struct
@@ -615,7 +615,7 @@ int write3Bytes(RIG *rig, enum PAGE_e page, unsigned int addr, unsigned int x)
 
 #ifdef XXREMOVEDXX
 // this function is not referenced anywhere
-/*
+/**
  * \brief Write unsigned int (4 bytes) to the receiver
  *
  * \param rig  Pointer to rig struct
@@ -655,7 +655,7 @@ int writeInt(RIG *rig, enum PAGE_e page, unsigned int addr, unsigned int x)
 }
 #endif
 
-/*
+/**
  * \brief Read one byte from the receiver
  *
  * \param rig Pointer to rig struct
@@ -696,7 +696,7 @@ int readByte(RIG *rig, enum PAGE_e page, unsigned int addr, unsigned char *x)
     return (rc);
 }
 
-/*
+/**
  * \brief Read an unsigned short (two bytes) from the receiver
  *
  * \param rig Pointer to rig struct
@@ -733,7 +733,7 @@ int readShort(RIG *rig, enum PAGE_e page, unsigned int addr, unsigned short *x)
     return (rc);
 }
 
-/*
+/**
  * \brief Read an unsigned int (three bytes) from the receiver
  *
  * \param rig Pointer to rig struct
@@ -778,7 +778,7 @@ int read3Bytes(RIG *rig, enum PAGE_e page, unsigned int addr, unsigned int *x)
 
 #ifdef XXREMOVEDXX
 // this function is not referenced anywhere
-/*
+/**
  * \brief Read an unsigned int (four bytes) from the receiver
  *
  * \param rig Pointer to rig struct
@@ -826,7 +826,7 @@ int readInt(RIG *rig, enum PAGE_e page, unsigned int addr, unsigned int *x)
 }
 #endif
 
-/*
+/**
  * \brief Read raw AGC value from the radio
  *
  * \param rig Pointer to rig struct
@@ -857,7 +857,7 @@ int readSignal(RIG *rig, unsigned char *x)
 
 #ifdef XXREMOVEDXX
 // this function is not referenced anywhere
-/*
+/**
  * \brief Flush I/O with radio
  *
  * \param rig Pointer to rig struct
@@ -879,7 +879,7 @@ int flushBuffer(RIG *rig)
 }
 #endif
 
-/*
+/**
  * \brief Lock receiver for remote operations
  *
  * \param rig Pointer to rig struct
@@ -919,7 +919,7 @@ int lockRx(RIG *rig, enum LOCK_LVL_e level)
     return (rc);
 }
 
-/*
+/**
  * \brief Convert one byte BCD value to int
  *
  * \param bcd BCD value (0-99)
@@ -949,7 +949,7 @@ int bcd2Int(const unsigned char bcd)
     return (rc);
 }
 
-/*
+/**
  * \brief Convert raw AGC value to calibrated level in dBm
  *
  * \param rig Pointer to rig struct
@@ -1073,7 +1073,7 @@ int getCalLevel(RIG *rig, unsigned char rawAgc, int *dbm)
     return (rc);
 }
 
-/*
+/**
  * \brief Get bandwidth of given filter
  *
  * \param rig Pointer to rig struct
@@ -1103,7 +1103,7 @@ int getFilterBW(RIG *rig, enum FILTER_e filter)
     return (rc);
 }
 
-/*
+/**
  * \brief Convert DDS steps to frequency in Hz
  *
  * \param steps DDS count
@@ -1119,7 +1119,7 @@ freq_t ddsToHz(const unsigned int steps)
     return (rc);
 }
 
-/*
+/**
  * \brief Convert frequency in Hz to DDS steps
  *
  * \param freq Frequency in Hz
@@ -1155,7 +1155,7 @@ unsigned int hzToDDS(const freq_t freq)
     return (rc);
 }
 
-/*
+/**
  * \brief Convert PBS/BFO steps to frequency in Hz
  *
  * \param steps PBS/BFO offset steps
@@ -1186,8 +1186,8 @@ float pbsToHz(const unsigned char steps)
 
 #ifdef XXREMOVEDXX
 // this function is not referenced anywhere
-/*
- * \brief Convert PBS/BFO offset frequency in Hz to steps
+/**
+ * brief Convert PBS/BFO offset frequency in Hz to steps
  *
  * \param freq Offset frequency in Hz
  *
@@ -1228,8 +1228,8 @@ unsigned char hzToPBS(const float freq)
 }
 #endif
 
-/*
- * \brief Convert native Mode to Hamlib mode
+/**
+ * brief Convert native Mode to Hamlib mode
  *
  * \param mode Native mode value
  *
@@ -1279,8 +1279,8 @@ rmode_t modeToHamlib(const unsigned char mode)
     return (rc);
 }
 
-/*
- * \brief Convert Hamlib Mode to native mode
+/**
+ * brief Convert Hamlib Mode to native mode
  *
  * \param mode Hamlib mode value
  *
@@ -1330,8 +1330,8 @@ unsigned char modeToNative(const rmode_t mode)
     return (rc);
 }
 
-/*
- * \brief Convert native AGC speed to Hamlib AGC speed
+/**
+ * brief Convert native AGC speed to Hamlib AGC speed
  *
  * \param agc Native AGC speed value
  *
@@ -1369,8 +1369,8 @@ enum agc_level_e agcToHamlib(const unsigned char agc)
     return (rc);
 }
 
-/*
- * \brief Convert Hamlib AGC speed to native AGC speed
+/**
+ * brief Convert Hamlib AGC speed to native AGC speed
  *
  * \param agc Hamlib AGC speed value
  *
@@ -1412,8 +1412,8 @@ unsigned char agcToNative(const enum agc_level_e agc)
     return (rc);
 }
 
-/*
- * \brief Get page size
+/**
+ * brief Get page size
  *
  * \param page Page to get size of
  *
@@ -1439,8 +1439,8 @@ int pageSize(const enum PAGE_e page)
     return (rc);
 }
 
-/*
- * \brief Set and execute IR controller code
+/**
+ * brief Set and execute IR controller code
  *
  * \param code IR code to execute
  *

--- a/src/amplifier.c
+++ b/src/amplifier.c
@@ -962,7 +962,7 @@ int HAMLIB_API amp_get_powerstat(AMP *amp, powerstat_t *status)
 /**
  * \brief Get the address of amplifier data structure(s)
  *
- * \sa rig_data_pointer
+ * \sa rig_data_pointer(), rot_data_pointer()
  *
  */
 void *HAMLIB_API amp_data_pointer(AMP *amp, rig_ptrx_t idx)

--- a/src/extamp.c
+++ b/src/extamp.c
@@ -62,7 +62,7 @@
  * not strictly positive.
  *
  * \returns A zero value which means a normal end of iteration, or a
- * **negative value** which means an abnormal end,
+ * **negative value** which means an abnormal end.
  *
  * \retval RIG_OK All extension levels elements successfully processed.
  * \retval -RIG_EINVAL \a amp or \a cfunc is NULL or inconsistent.

--- a/src/rig.c
+++ b/src/rig.c
@@ -9056,7 +9056,7 @@ int morse_data_handler_set_keyspd(RIG *rig, int keyspd)
 }
 #endif
 
-/*
+/**
  * \brief Get the address of a Hamlib data structure
  * \param rig Pointer to main data anchor
  * \param idx enum for which pointer requested
@@ -9069,7 +9069,7 @@ int morse_data_handler_set_keyspd(RIG *rig, int keyspd)
  * Note: This is meant for use by the HAMLIB_???PORT macros mostly. Only
  *  compatibility with them is supported.
  *
- * \sa amp_data_pointer, rot_data_pointer
+ * \sa amp_data_pointer(), rot_data_pointer()
  */
 HAMLIB_EXPORT(void *) rig_data_pointer(RIG *rig, rig_ptrx_t idx)
 {

--- a/src/rotator.c
+++ b/src/rotator.c
@@ -1089,7 +1089,7 @@ int HAMLIB_API rot_get_status(ROT *rot, rot_status_t *status)
 /**
  * \brief Get the address of rotator data structure(s)
  *
- * \sa rig_data_pointer
+ * \sa amp_data_pointer(), rig_data_pointer()
  *
  */
 void *HAMLIB_API rot_data_pointer(ROT *rot, rig_ptrx_t idx)


### PR DESCRIPTION
Adds missing cross-references. Fix tagging of comment blocks in "aor" even if the rigs aren't included in the generated documentation.