### PR TITLE
Fix setting antenna number 3 for Yaesu FTDX3000

### DIFF
--- a/rigs/yaesu/ft3000.c
+++ b/rigs/yaesu/ft3000.c
@@ -155,20 +155,21 @@ static int ft3000_set_ant(RIG *rig, vfo_t vfo, ant_t ant, value_t option)
 
     switch (ant)
     {
-    case 1:
+    case RIG_ANT_1:
         cmd = "AN01;"; // R3/1 ANT1/ANT3
         break;
 
-    case 2:
+    case RIG_ANT_2:
         cmd = "AN02;"; // RE/2 ANT2/ANT3
         break;
 
-    case 3:
+    case RIG_ANT_3:
         cmd = "AN03;"; // TRX ANT3
         break;
 
     default:
-        rig_debug(RIG_DEBUG_ERR, "%s: expected 1,2,3 got %u\n", __func__, ant);
+        rig_debug(RIG_DEBUG_ERR, "%s: expected one of %u,%u,%u got %u\n", __func__,
+                  RIG_ANT_1, RIG_ANT_2, RIG_ANT_3, ant);
         RETURNFUNC(-RIG_EINVAL);
     }
 


### PR DESCRIPTION
The argument ant_t ant is a bit mask, not a scalar, so the correct decimal value for choosing antenna 3 would be 4, not 3.
 Also use the defines instead of magic numbers.