### PR TITLE
Fix segfault when executing the dump_caps command

### DIFF
--- a/rigs/dummy/netrigctl.c
+++ b/rigs/dummy/netrigctl.c
@@ -861,8 +861,9 @@ static int netrigctl_open(RIG *rig)
 
                 for (i = 0; p != NULL && i < RIG_SETTING_MAX; ++i)
                 {
-                    int level;
-                    sscanf(p, "%d", &level);
+                    int idx, level;
+                    sscanf(p, "%d", &idx);
+                    level = rig_idx2setting(idx);
 
                     rig->caps->parm_gran[i].step.s = 0;
 


### PR DESCRIPTION
Need to convert the level number 0..63 to the level bit mask.

The segfault happened when trying to print a string in `rig_sprintf_parm_gran()` because the data wasn't initialized properly in `netrigctl_open()` which is 676 lines long!

Steps to reproduce
```
tests/rigctld -m 1 &
tests/rigctl -m 2 dump_caps
```
