### PR TITLE
Show the list of ranges of a set_level

### DIFF
--- a/tests/ampctl_parse.c
+++ b/tests/ampctl_parse.c
@@ -1713,6 +1713,25 @@ declare_proto_amp(set_level)
 
     level = rig_parse_level(arg1);
 
+    if (!strcmp(arg2, "?"))
+    {
+        const gran_t *gran = STATE(amp)->level_gran;
+        int idx = rig_setting2idx(level);
+
+        if (AMP_LEVEL_IS_FLOAT(level))
+        {
+            fprintf(fout, "(%f..%f/%f)%c", gran[idx].min.f,
+                    gran[idx].max.f, gran[idx].step.f, resp_sep);
+        }
+        else
+        {
+            fprintf(fout, "(%d..%d/%d)%c", gran[idx].min.i,
+                    gran[idx].max.i, gran[idx].step.i, resp_sep);
+        }
+
+        return RIG_OK;
+    }
+
     // some Java apps send comma in international setups so substitute period
     char *p = strchr(arg2, ',');
 

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -3352,9 +3352,27 @@ declare_proto_rig(set_level)
 
     level = rig_parse_level(arg1);
 
-    if ((!strcmp(arg2, "?") || arg2[0] == 0) && level == RIG_LEVEL_METER)
+    if (!strcmp(arg2, "?"))
     {
-        fprintf(fout, "COMP ALC SWR ID/IC VDD DB PO TEMP%c", resp_sep);
+        if (level == RIG_LEVEL_METER)
+        {
+            fprintf(fout, "COMP ALC SWR ID/IC VDD DB PO TEMP%c", resp_sep);
+        } else {
+            const gran_t *gran = STATE(rig)->level_gran;
+            int idx = rig_setting2idx(level);
+
+            if (RIG_LEVEL_IS_FLOAT(level))
+            {
+                fprintf(fout, "(%f..%f/%f)%c", gran[idx].min.f,
+                        gran[idx].max.f, gran[idx].step.f, resp_sep);
+            }
+            else
+            {
+                fprintf(fout, "(%d..%d/%d)%c", gran[idx].min.i,
+                        gran[idx].max.i, gran[idx].step.i, resp_sep);
+            }
+        }
+
         RETURNFUNC2(RIG_OK);
     }
 

--- a/tests/rotctl_parse.c
+++ b/tests/rotctl_parse.c
@@ -1950,6 +1950,25 @@ declare_proto_rot(set_level)
 
     level = rot_parse_level(arg1);
 
+    if (!strcmp(arg2, "?"))
+    {
+        const gran_t *gran = STATE(rot)->level_gran;
+        int idx = rig_setting2idx(level);
+
+        if (ROT_LEVEL_IS_FLOAT(level))
+        {
+            fprintf(fout, "(%f..%f/%f)%c", gran[idx].min.f,
+                    gran[idx].max.f, gran[idx].step.f, resp_sep);
+        }
+        else
+        {
+            fprintf(fout, "(%d..%d/%d)%c", gran[idx].min.i,
+                    gran[idx].max.i, gran[idx].step.i, resp_sep);
+        }
+
+        return RIG_OK;
+    }
+
     if (!rot_has_set_level(rot, level))
     {
         const struct confparams *cfp;


### PR DESCRIPTION
This PR handles the question mark `'?'` as second argument o `\set_level` for ampctl, rigctl and rotctl.

I think that the part about rigctl in this PR closes #720 which mentioned "get_level" instead of "set_level", but I think that it was an error because "get_level" doesn't have a secondary prompt to write the '?', and it makes more sense to show the range in the context of setting a value.

No amplifier has implemented a `set_level` procedure so it works in a strange way: `\set_level ?` doesn't print anything while, after this PR, `\set_level FAULT ?` and similar do print the range of the level, which is zero. The code that this PR adds is almost identical for all 3 programs so, if in future an amplifier supports setting its levels, it is likely to work just fine.

I'm going to copy some test commands in the following comments to keep this more readable.