### PR TITLE
Fixes and improvements for rigctl

### DIFF
--- a/rigs/dummy/dummy.c
+++ b/rigs/dummy/dummy.c
@@ -1701,7 +1701,7 @@ static int dummy_set_parm(RIG *rig, setting_t parm, value_t val)
 
     if (RIG_PARM_IS_STRING(parm))
     {
-        strcpy(pstr, val.cs);
+        SNPRINTF(pstr, sizeof(pstr), "%s", val.cs);
     }
     else
     {

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -3944,7 +3944,7 @@ declare_proto_rig(get_parm)
         if (val.i == 1) { s = "BUG"; }
         else if (val.i == 2) { s = "PADDLE"; }
 
-        fprintf(fout, "%s%cv", s, resp_sep);
+        fprintf(fout, "%s%c", s, resp_sep);
     }
     else if (RIG_PARM_IS_FLOAT(parm))
     {

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -3719,11 +3719,10 @@ declare_proto_rig(set_parm)
 
     parm = rig_parse_parm(arg1);
 
-    if (parm == RIG_PARM_BANDSELECT && !strcmp(arg2, "?"))
+    if ((parm == RIG_PARM_BANDSELECT || parm == RIG_PARM_KEYERTYPE) && !strcmp(arg2, "?"))
     {
         char s[SPRINTF_MAX_SIZE];
-        rig_sprintf_parm_gran(s, sizeof(s) - 1, RIG_PARM_BANDSELECT,
-                              rig->caps->parm_gran);
+        rig_sprintf_parm_gran(s, sizeof(s) - 1, parm, rig->caps->parm_gran);
         char *p = strchr(s, ')');
 
         if (p) { *p = 0; }

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -3944,7 +3944,8 @@ declare_proto_rig(get_parm)
     {
         const char *cs;
 
-        if (strcmp(val.cs, "0") == 0) {cs = "STRAIGHT";}
+        if (val.cs == NULL) {cs = "(null)";}
+        else if (strcmp(val.cs, "0") == 0) {cs = "STRAIGHT";}
         else if (strcmp(val.cs, "1") == 0) {cs = "BUG";}
         else if (strcmp(val.cs, "2") == 0) {cs = "PADDLE";}
         else {cs = "UNKNOWN";}

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -3942,12 +3942,14 @@ declare_proto_rig(get_parm)
 
     if (parm == RIG_PARM_KEYERTYPE)
     {
-        char *s = "STRAIGHT";
+        const char *cs;
 
-        if (val.i == 1) { s = "BUG"; }
-        else if (val.i == 2) { s = "PADDLE"; }
+        if (strcmp(val.cs, "0") == 0) {cs = "STRAIGHT";}
+        else if (strcmp(val.cs, "1") == 0) {cs = "BUG";}
+        else if (strcmp(val.cs, "2") == 0) {cs = "PADDLE";}
+        else {cs = "UNKNOWN";}
 
-        fprintf(fout, "%s%c", s, resp_sep);
+        fprintf(fout, "%s%c", cs, resp_sep);
     }
     else if (RIG_PARM_IS_FLOAT(parm))
     {

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -3812,11 +3812,13 @@ declare_proto_rig(set_parm)
     }
     else if (RIG_PARM_IS_STRING(parm))
     {
+#if 0
         if (parm == RIG_PARM_KEYERTYPE)
         {
             val.i = atoi(arg2);
         }
         else
+#endif
         {
             val.cs = arg2;
         }

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -3745,6 +3745,7 @@ declare_proto_rig(set_parm)
         if (strcmp(arg2, "STRAIGHT") == 0) {arg2 = "0";}
         else if (strcmp(arg2, "BUG") == 0) {arg2 = "1";}
         else if (strcmp(arg2, "PADDLE") == 0) {arg2 = "2";}
+        else {RETURNFUNC2(-RIG_EINVAL)}
     }
 
     parm = rig_parse_parm(arg1);

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -3717,7 +3717,9 @@ declare_proto_rig(set_parm)
         RETURNFUNC2(RIG_OK);
     }
 
-    if (strcmp(arg1, "BANDSELECT") == 0 && !strcmp(arg2, "?"))
+    parm = rig_parse_parm(arg1);
+
+    if (parm == RIG_PARM_BANDSELECT && !strcmp(arg2, "?"))
     {
         char s[SPRINTF_MAX_SIZE];
         rig_sprintf_parm_gran(s, sizeof(s) - 1, RIG_PARM_BANDSELECT,
@@ -3740,15 +3742,13 @@ declare_proto_rig(set_parm)
         else { RETURNFUNC2(-RIG_EINTERNAL); }
     }
 
-    if (strcmp(arg1, "KEYERTYPE") == 0 && strcmp(arg2, "?") != 0)
+    if (parm == RIG_PARM_KEYERTYPE && strcmp(arg2, "?") != 0)
     {
         if (strcmp(arg2, "STRAIGHT") == 0) {arg2 = "0";}
         else if (strcmp(arg2, "BUG") == 0) {arg2 = "1";}
         else if (strcmp(arg2, "PADDLE") == 0) {arg2 = "2";}
         else {RETURNFUNC2(-RIG_EINVAL)}
     }
-
-    parm = rig_parse_parm(arg1);
 
     if (!rig_has_set_parm(rig, parm))
     {


### PR DESCRIPTION
This PR fixes some segfaults and adds the handling of `set_parm KEYERTYPE ?` in rigctl.

The dummy driver initializes its parameters to zero:
> memset(priv->parms, 0, RIG_SETTING_MAX * sizeof(value_t));

which crashed the code that tried to use the zero as a string pointer.

I'm confused about the fact that RIG_PARM_KEYERTYPE is a string `STRAIGHT BUG PADDLE` but `rigctl_parse.c` converts the string back and forth to an integer that is stored as ASCII string `"0", "1", "2"`. I didn't find any rig that uses a `RIG_KEYERTYPE_*` value, so I wonder if the code was finished, because some lines that instead stored an integer that were disabled with `#if 0`  and I had to disable identical code a few lines below.
(lines 3784-3790 and 3814-3820)
```
#if 0
            if (parm == RIG_PARM_KEYERTYPE)
            {
                val.i = atoi(arg2);
            }
            else
#endif
```