### PR TITLE
Fix output of dump_state

### DIFF
--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -4828,7 +4828,9 @@ declare_proto_rig(dump_state)
 
         for (i = 0; i < RIG_SETTING_MAX; ++i)
         {
-            if (RIG_LEVEL_IS_FLOAT(i))
+            setting_t level = rig_idx2setting(i);
+
+            if (RIG_LEVEL_IS_FLOAT(level))
             {
                 fprintf(fout, "%d=%g,%g,%g;", i, rs->level_gran[i].min.f,
                         rs->level_gran[i].max.f, rs->level_gran[i].step.f);
@@ -4844,10 +4846,16 @@ declare_proto_rig(dump_state)
 
         for (i = 0; i < RIG_SETTING_MAX; ++i)
         {
-            if (RIG_LEVEL_IS_FLOAT(i))
+            setting_t parm = rig_idx2setting(i);
+
+            if (RIG_PARM_IS_FLOAT(parm))
             {
                 fprintf(fout, "%d=%g,%g,%g;", i, rs->parm_gran[i].min.f,
                         rs->parm_gran[i].max.f, rs->parm_gran[i].step.f);
+            }
+            else if (RIG_PARM_IS_STRING(parm))
+            {
+                fprintf(fout, "%d=%s;", i, rs->parm_gran[i].step.cs);
             }
             else
             {


### PR DESCRIPTION
Fixes arguments to `*_IS_FLOAT` (it's levels, not indexes) and properly handles string parameters.

While it's hard to see it there is any difference in float printed as integers or vice versa, for strings 10 PARM_BANDSELECT and 11 PARM_KEYERTYPE it is easy.

Steps to reproduce:
> tests/rigctl chk_vfo dump_state

Before:
`parm_gran=[...]10=0,0,1.25587e+11;11=0,0,1.26077e+11;`

After:
`parm_gran=[...]10=BANDUNUSED,BAND70CM,BAND33CM,BAND23CM;11=STRAIGHT,BUG,PADDLE;`

~~I must be missing something because `dump_state` without `chk_vfo` shows a totally different output.~~
It is documented in the man page that `check_vfo` is needed because of this line in `rigctl_parse.c`:
>     chk_vfo_executed = 1; // this allows us to control dump_state version
