### PR TITLE
Feature/tests

### DIFF
--- a/tests/ampctl.c
+++ b/tests/ampctl.c
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
     int retcode;        /* generic return code from functions */
     int exitcode;
 
-    int verbose = 0;
+    int verbose = RIG_DEBUG_NONE;
     int show_conf = 0;
     int dump_caps_opt = 0;
 

--- a/tests/ampctl.c
+++ b/tests/ampctl.c
@@ -132,6 +132,7 @@ int main(int argc, char *argv[])
     int serial_rate = 0;
     char conf_parms[MAXCONFLEN] = "";
 
+    rig_set_debug(verbose);
     while (1)
     {
         int c;
@@ -216,6 +217,7 @@ int main(int argc, char *argv[])
 
         case 'v':
             verbose++;
+            rig_set_debug(verbose);
             break;
 
         case 'L':
@@ -223,7 +225,6 @@ int main(int argc, char *argv[])
             break;
 
         case 'l':
-            rig_set_debug(0);
             list_models();
             exit(0);
 
@@ -240,8 +241,6 @@ int main(int argc, char *argv[])
             exit(1);
         }
     }
-
-    rig_set_debug(verbose);
 
     rig_debug(RIG_DEBUG_VERBOSE, "ampctl %s\n", hamlib_version2);
     rig_debug(RIG_DEBUG_VERBOSE, "%s",

--- a/tests/ampctld.c
+++ b/tests/ampctld.c
@@ -179,6 +179,7 @@ int main(int argc, char *argv[])
 #endif
 #endif
 
+    rig_set_debug(verbose);
     while (1)
     {
         int c;
@@ -245,6 +246,7 @@ int main(int argc, char *argv[])
 
         case 'v':
             verbose++;
+            rig_set_debug(verbose);
             break;
 
         case 'L':
@@ -268,8 +270,6 @@ int main(int argc, char *argv[])
             exit(1);
         }
     }
-
-    rig_set_debug(verbose);
 
     rig_debug(RIG_DEBUG_VERBOSE, "ampctld, %s\n", hamlib_version2);
     rig_debug(RIG_DEBUG_VERBOSE, "%s",

--- a/tests/ampctld.c
+++ b/tests/ampctld.c
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
 
     int retcode;        /* generic return code from functions */
 
-    int verbose = 0;
+    int verbose = RIG_DEBUG_NONE;
     int show_conf = 0;
     int dump_caps_opt = 0;
     const char *amp_file = NULL;

--- a/tests/rigctl.c
+++ b/tests/rigctl.c
@@ -203,7 +203,7 @@ int main(int argc, char *argv[])
     int retcode;        /* generic return code from functions */
     int exitcode;
 
-    int verbose = 0;
+    int verbose = RIG_DEBUG_NONE;
     int show_conf = 0;
     int dump_caps_opt = 0;
     int ignore_rig_open_error = 0;

--- a/tests/rigctl.c
+++ b/tests/rigctl.c
@@ -240,6 +240,7 @@ int main(int argc, char *argv[])
 
     if (err) { rig_debug(RIG_DEBUG_ERR, "%s: setvbuf err=%s\n", __func__, strerror(err)); }
 
+    rig_set_debug(verbose);
     while (1)
     {
         int c;
@@ -438,6 +439,7 @@ int main(int argc, char *argv[])
 
         case 'v':
             verbose++;
+            rig_set_debug(verbose);
             break;
 
         case 'L':
@@ -445,7 +447,6 @@ int main(int argc, char *argv[])
             break;
 
         case 'l':
-            rig_set_debug(verbose);
             list_models();
             exit(0);
 
@@ -466,8 +467,6 @@ int main(int argc, char *argv[])
             exit(1);
         }
     }
-
-    rig_set_debug(verbose);
 
     SNPRINTF(rigstartup, sizeof(rigstartup), "%s(%d) Startup:", __FILE__, __LINE__);
 

--- a/tests/rigctlcom.c
+++ b/tests/rigctlcom.c
@@ -227,6 +227,7 @@ int main(int argc, char *argv[])
 
     printf("rigctlcom Version 1.6\n");
 
+    rig_set_debug(verbose);
     while (1)
     {
         int c;
@@ -379,6 +380,7 @@ int main(int argc, char *argv[])
 
         case 'v':
             verbose++;
+            rig_set_debug(verbose);
             break;
 
         case 'L':
@@ -386,7 +388,6 @@ int main(int argc, char *argv[])
             break;
 
         case 'l':
-            rig_set_debug(verbose);
             list_models();
             exit(0);
 
@@ -403,8 +404,6 @@ int main(int argc, char *argv[])
             exit(1);
         }
     }
-
-    rig_set_debug(verbose);
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s, %s\n", "rigctlcom", hamlib_version2);
     rig_debug(RIG_DEBUG_VERBOSE, "%s",

--- a/tests/rigctlcom.c
+++ b/tests/rigctlcom.c
@@ -119,7 +119,7 @@ static int handle_ts2000(void *arg);
 
 static RIG *my_rig;             /* handle to rig */
 static hamlib_port_t my_com;    /* handle to virtual COM port */
-static int verbose;
+static int verbose = RIG_DEBUG_NONE;
 /* CW Skimmer can only set VFOA */
 /* IC7300 for example can run VFOA on FM and VFOB on CW */
 /* So -A/--mapa2b changes set_freq on VFOA to VFOB */

--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -288,7 +288,7 @@ int main(int argc, char *argv[])
 
     if (err) { rig_debug(RIG_DEBUG_ERR, "%s: setvbuf err=%s\n", __func__, strerror(err)); }
 
-
+    rig_set_debug(verbose);
     while (1)
     {
         int c;
@@ -494,6 +494,7 @@ int main(int argc, char *argv[])
 
         case 'v':
             verbose++;
+            rig_set_debug(verbose);
             break;
 
         case 'L':
@@ -545,8 +546,6 @@ int main(int argc, char *argv[])
     }
 
 #endif
-
-    rig_set_debug(verbose);
 
     SNPRINTF(rigstartup, sizeof(rigstartup), "%s(%d) Startup:", __FILE__, __LINE__);
 

--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -135,7 +135,7 @@ static unsigned client_count;
 
 static RIG *my_rig;             /* handle to rig (instance) */
 static volatile int rig_opened = 0;
-static int verbose;
+static int verbose = RIG_DEBUG_NONE;
 
 #ifdef HAVE_SIG_ATOMIC_T
 static sig_atomic_t volatile ctrl_c = 0;

--- a/tests/rigctlsync.c
+++ b/tests/rigctlsync.c
@@ -215,6 +215,7 @@ int main(int argc, char *argv[])
 
     printf("rigctlsync Version 1.0\n");
 
+    rig_set_debug(verbose);
     while (1)
     {
         int c;
@@ -388,6 +389,7 @@ int main(int argc, char *argv[])
 
         case 'v':
             verbose++;
+            rig_set_debug(verbose);
             break;
 
         case 'L':
@@ -395,7 +397,6 @@ int main(int argc, char *argv[])
             break;
 
         case 'l':
-            rig_set_debug(verbose);
             list_models();
             exit(0);
 
@@ -412,8 +413,6 @@ int main(int argc, char *argv[])
             exit(1);
         }
     }
-
-    rig_set_debug(verbose);
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s, %s\n", "rigctlsync", hamlib_version2);
     rig_debug(RIG_DEBUG_VERBOSE, "%s",

--- a/tests/rigctlsync.c
+++ b/tests/rigctlsync.c
@@ -109,7 +109,7 @@ void usage();
 static RIG *my_rig;             /* handle to rig */
 static RIG
 *my_rig_sync;        /* rig the gets synchronized -- freq only for now */
-static int verbose;
+static int verbose = RIG_DEBUG_NONE;
 /* CW Skimmer can only set VFOA */
 /* IC7300 for example can run VFOA on FM and VFOB on CW */
 /* So -A/--mapa2b changes set_freq on VFOA to VFOB */

--- a/tests/rigctltcp.c
+++ b/tests/rigctltcp.c
@@ -289,7 +289,7 @@ int main(int argc, char *argv[])
 
     if (err) { rig_debug(RIG_DEBUG_ERR, "%s: setvbuf err=%s\n", __func__, strerror(err)); }
 
-
+    rig_set_debug(verbose);
     while (1)
     {
         int c;
@@ -481,6 +481,7 @@ int main(int argc, char *argv[])
 
         case 'v':
             verbose++;
+            rig_set_debug(verbose);
             break;
 
         case 'L':
@@ -547,8 +548,6 @@ int main(int argc, char *argv[])
     }
 
 #endif
-
-    rig_set_debug(verbose);
 
     SNPRINTF(rigstartup, sizeof(rigstartup), "%s(%d) Startup:", __FILE__, __LINE__);
 

--- a/tests/rigctltcp.c
+++ b/tests/rigctltcp.c
@@ -139,7 +139,7 @@ static unsigned client_count;
 
 static RIG *my_rig;             /* handle to rig (instance) */
 static volatile int rig_opened = 0;
-static int verbose;
+static int verbose = RIG_DEBUG_NONE;
 
 #ifdef HAVE_SIG_ATOMIC_T
 static sig_atomic_t volatile ctrl_c;

--- a/tests/rigmem.c
+++ b/tests/rigmem.c
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
 
     int retcode;        /* generic return code from functions */
 
-    int verbose = 0;
+    int verbose = RIG_DEBUG_NONE;
 #ifdef HAVE_XML2
     int xml = 0;
 #endif

--- a/tests/rigmem.c
+++ b/tests/rigmem.c
@@ -105,6 +105,7 @@ int main(int argc, char *argv[])
     char conf_parms[MAXCONFLEN] = "";
     extern char csv_sep;
 
+    rig_set_debug(verbose);
     while (1)
     {
         int c;
@@ -182,6 +183,7 @@ int main(int argc, char *argv[])
 
         case 'v':
             verbose++;
+            rig_set_debug(verbose);
             break;
 
         default:

--- a/tests/rigsmtr.c
+++ b/tests/rigsmtr.c
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
 
     int retcode;        /* generic return code from functions */
 
-    int verbose = 0;
+    int verbose = RIG_DEBUG_NONE;
     const char *rig_file = NULL, *rot_file = NULL;
     int serial_rate = 0;
     int rot_serial_rate = 0;

--- a/tests/rigsmtr.c
+++ b/tests/rigsmtr.c
@@ -89,6 +89,7 @@ int main(int argc, char *argv[])
     elevation_t elevation;
     unsigned step = 1000000;    /* 1e6 us */
 
+    rig_set_debug(verbose);
     while (1)
     {
         int c;
@@ -172,6 +173,7 @@ int main(int argc, char *argv[])
 
         case 'v':
             verbose++;
+            rig_set_debug(verbose);
             break;
 
         default:

--- a/tests/rigswr.c
+++ b/tests/rigswr.c
@@ -79,6 +79,7 @@ int main(int argc, char *argv[])
     freq_t step = kHz(100);
     value_t pwr;
 
+    rig_set_debug(verbose);
     while (1)
     {
         int c;
@@ -173,6 +174,7 @@ int main(int argc, char *argv[])
 
         case 'v':
             verbose++;
+            rig_set_debug(verbose);
             break;
 
         default:

--- a/tests/rigswr.c
+++ b/tests/rigswr.c
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
 
     int retcode;        /* generic return code from functions */
 
-    int verbose = 0;
+    int verbose = RIG_DEBUG_NONE;
     const char *rig_file = NULL, *ptt_file = NULL;
     ptt_type_t ptt_type = RIG_PTT_NONE;
     int serial_rate = 0;

--- a/tests/rotctl.c
+++ b/tests/rotctl.c
@@ -140,6 +140,7 @@ int main(int argc, char *argv[])
     azimuth_t az_offset = 0;
     elevation_t el_offset = 0;
 
+    rig_set_debug(verbose);
     while (1)
     {
         int c;
@@ -237,6 +238,7 @@ int main(int argc, char *argv[])
 
         case 'v':
             verbose++;
+            rig_set_debug(verbose);
             break;
 
         case 'L':
@@ -244,7 +246,6 @@ int main(int argc, char *argv[])
             break;
 
         case 'l':
-            rig_set_debug(0);
             list_models();
             exit(0);
 
@@ -261,8 +262,6 @@ int main(int argc, char *argv[])
             exit(1);
         }
     }
-
-    rig_set_debug(verbose);
 
     rig_debug(RIG_DEBUG_VERBOSE, "rotctl %s\n", hamlib_version2);
     rig_debug(RIG_DEBUG_VERBOSE, "%s",

--- a/tests/rotctl.c
+++ b/tests/rotctl.c
@@ -118,7 +118,7 @@ int main(int argc, char *argv[])
     int retcode;        /* generic return code from functions */
     int exitcode;
 
-    int verbose = 0;
+    int verbose = RIG_DEBUG_NONE;
     int show_conf = 0;
     int dump_caps_opt = 0;
 

--- a/tests/rotctld.c
+++ b/tests/rotctld.c
@@ -152,7 +152,7 @@ int main(int argc, char *argv[])
 
     int retcode;        /* generic return code from functions */
 
-    int verbose = 0;
+    int verbose = RIG_DEBUG_NONE;
     int show_conf = 0;
     int dump_caps_opt = 0;
     const char *rot_file = NULL;

--- a/tests/rotctld.c
+++ b/tests/rotctld.c
@@ -172,6 +172,7 @@ int main(int argc, char *argv[])
 #endif
     struct handle_data *arg;
 
+    rig_set_debug(verbose);
     while (1)
     {
         int c;
@@ -250,6 +251,7 @@ int main(int argc, char *argv[])
 
         case 'v':
             verbose++;
+            rig_set_debug(verbose);
             break;
 
         case 'L':
@@ -273,8 +275,6 @@ int main(int argc, char *argv[])
             exit(1);
         }
     }
-
-    rig_set_debug(verbose);
 
     rig_debug(RIG_DEBUG_VERBOSE, "rotctld, %s\n", hamlib_version2);
     rig_debug(RIG_DEBUG_VERBOSE, "%s",


### PR DESCRIPTION
The final goal of this PR is checking that `--help` and `?` of the main test commands print the expected text for Dummy.
One issue is that the debug output is printed mixed to the output of `tests/ampctl --help`, like this:
```
usage_amp: nbspace left=3
F: set_freq    (Frequency(Hz))
usage_amp: nbspace left=16
f: get_freq    ()
usage_amp: nbspace left=11
l: get_level   (Level)
usage_amp: nbspace left=-2
L: set_level   (Level, Level Value)
usage_amp: nbspace left=13
w: send_cmd    (Cmd)
usage_amp: nbspace left=16
?: dump_state  ()
usage_amp: nbspace left=16
1: dump_caps   ()
usage_amp: nbspace left=16
_: get_info    ()
usage_amp: nbspace left=11
R: reset       (Reset)
usage_amp: nbspace left=4
?: set_powerstat(Power Status)
usage_amp: nbspace left=16
?: get_powerstat()
```
The easy fix would be deleting the line that prints that debug messages, which isn't present in rigctl and rotctl, however I think that it is a bug or a missing feature that `debug,c` sets the debug level to trace and the user could not change it before `getopt_long` loop ends (only `--help` and `--list` are affected).

Other test programs override the choice of the user with this logic:
> rigmem.c:    rig_set_debug(verbose < 2 ? RIG_DEBUG_WARN : verbose);
> rigsmtr.c:    rig_set_debug(verbose < 2 ? RIG_DEBUG_WARN : verbose);
> rigswr.c:    rig_set_debug(verbose < 2 ? RIG_DEBUG_WARN : verbose);

which IMHO is wrong because they can't run quietly, but they aren't the main programs.

so:
* I'm replacing `0` with `RIG_DEBUG_NONE`, `RIG_DEBUG_ERROR` would be more appropriate but we are missing a quiet option ('q' and 'Q' are reserved for `quit` in interactive mode, but maybe one can be reused in the command line)
* I'm setting the verbosity level each time that `-v` is handled so that the current behavior can be restored with `-vvvvv`
* I'm directing the output of `--help` to `stderr` when the program is about to do `exit(1)`
* I'm directing the output of error messages to `stderr`, missing any comment, I don't know if it was sent to `stdout` on purpose, but if running those program in a script cheching if stderr is not empty seems the only way to detect errors, maybe it's unneeded, so this part ch be dropped)
* I'm deleting some duplicated code and making some help test identical
* I'm adding 2 scripts
  *  one to compare the output of `--help` with a reference file (this allowed me to make some refactoring making sure that I didn't change the help texts)
  *  one to compare the output of all internal commands of ampctl, rigctl, rotcl, which without this PR changes every time because the debug message at trace level print memory addresses (pointer) that change at every run, and also some debug messages about the cache are printed in different order, that's why I though about redirecting debug messages to stderr

Setting as draft because it depends on #1849 an maybe other changes will be needed.