### PR TITLE
Fix dump_caps and dump_state

### DIFF
--- a/tests/dumpcaps.c
+++ b/tests/dumpcaps.c
@@ -148,6 +148,18 @@ int dumpcaps(RIG *rig, FILE *fout)
         fprintf(fout, "Rig capable (Mic/Data)\n");
         break;
 
+    case RIG_PTT_CM108:
+        fprintf(fout, "CM108 GPIO pin\n");
+        break;
+
+    case RIG_PTT_GPIO:
+        fprintf(fout, "GPIO pin\n");
+        break;
+
+    case RIG_PTT_GPION:
+        fprintf(fout, "GPIO pin inverted\n");
+        break;
+
     default:
         fprintf(fout, "Unknown\n");
         strcat(warnbuf, " PTT_TYPE");

--- a/tests/dumpcaps.c
+++ b/tests/dumpcaps.c
@@ -124,28 +124,28 @@ int dumpcaps(RIG *rig, FILE *fout)
 
     switch (caps->ptt_type)
     {
+    case RIG_PTT_NONE:
+        fprintf(fout, "None\n");
+        break;
+
     case RIG_PTT_RIG:
         fprintf(fout, "Rig capable\n");
-        break;
-
-    case RIG_PTT_RIG_MICDATA:
-        fprintf(fout, "Rig capable (Mic/Data)\n");
-        break;
-
-    case RIG_PTT_PARALLEL:
-        fprintf(fout, "Parallel port (DATA0)\n");
-        break;
-
-    case RIG_PTT_SERIAL_RTS:
-        fprintf(fout, "Serial port (CTS/RTS)\n");
         break;
 
     case RIG_PTT_SERIAL_DTR:
         fprintf(fout, "Serial port (DTR/DSR)\n");
         break;
 
-    case RIG_PTT_NONE:
-        fprintf(fout, "None\n");
+    case RIG_PTT_SERIAL_RTS:
+        fprintf(fout, "Serial port (CTS/RTS)\n");
+        break;
+
+    case RIG_PTT_PARALLEL:
+        fprintf(fout, "Parallel port (DATA0)\n");
+        break;
+
+    case RIG_PTT_RIG_MICDATA:
+        fprintf(fout, "Rig capable (Mic/Data)\n");
         break;
 
     default:

--- a/tests/dumpstate.c
+++ b/tests/dumpstate.c
@@ -146,6 +146,18 @@ int dumpstate(RIG *rig, FILE *fout)
         fprintf(fout, "Rig capable (Mic/Data)\n");
         break;
 
+    case RIG_PTT_CM108:
+        fprintf(fout, "CM108 GPIO pin\n");
+        break;
+
+    case RIG_PTT_GPIO:
+        fprintf(fout, "GPIO pin\n");
+        break;
+
+    case RIG_PTT_GPION:
+        fprintf(fout, "GPIO pin inverted\n");
+        break;
+
     default:
         fprintf(fout, "Unknown\n");
         strcat(warnbuf, " PTT_TYPE");

--- a/tests/dumpstate.c
+++ b/tests/dumpstate.c
@@ -122,28 +122,28 @@ int dumpstate(RIG *rig, FILE *fout)
 
     switch (rs->ptt_type)
     {
+    case RIG_PTT_NONE:
+        fprintf(fout, "None\n");
+        break;
+
     case RIG_PTT_RIG:
         fprintf(fout, "Rig capable\n");
-        break;
-
-    case RIG_PTT_RIG_MICDATA:
-        fprintf(fout, "Rig capable (Mic/Data)\n");
-        break;
-
-    case RIG_PTT_PARALLEL:
-        fprintf(fout, "Parallel port (DATA0)\n");
-        break;
-
-    case RIG_PTT_SERIAL_RTS:
-        fprintf(fout, "Serial port (CTS/RTS)\n");
         break;
 
     case RIG_PTT_SERIAL_DTR:
         fprintf(fout, "Serial port (DTR/DSR)\n");
         break;
 
-    case RIG_PTT_NONE:
-        fprintf(fout, "None\n");
+    case RIG_PTT_SERIAL_RTS:
+        fprintf(fout, "Serial port (CTS/RTS)\n");
+        break;
+
+    case RIG_PTT_PARALLEL:
+        fprintf(fout, "Parallel port (DATA0)\n");
+        break;
+
+    case RIG_PTT_RIG_MICDATA:
+        fprintf(fout, "Rig capable (Mic/Data)\n");
         break;
 
     default:


### PR DESCRIPTION
This PR closes #1183 by adding the code that prints the missing PTT types.
