### PR TITLE
Implement send_raw for the Perl bindings

### DIFF
--- a/bindings/perltest.pl
+++ b/bindings/perltest.pl
@@ -68,6 +68,15 @@ print "Attenuators:\t\t@$att\n";
 print "\nSending Morse, '73'\n";
 $rig->send_morse($Hamlib::RIG_VFO_A, "73");
 
+print "\nSending raw string\n";
+$send = "test string 012\n";
+
+$reply = $rig->send_raw($send, "\n");
+exit(1) if(!$reply eq $send);
+
+$reply = $rig->send_raw($send, "1");
+exit(1) if(!$reply eq "test string 01");
+
 $rig->close();
 
 

--- a/bindings/rig.swg
+++ b/bindings/rig.swg
@@ -782,6 +782,17 @@ int *rig_spectrum_cb_python(RIG *rig, struct rig_spectrum_line *rig_spectrum_lin
 	}
 #endif
 
+#ifdef SWIGPERL
+	char *send_raw(char *send, char *term, char *returnstr)
+	{
+		returnstr[0] = '\0';
+		int count;
+
+		count = rig_send_raw(self->rig, send, strlen(send), returnstr, MAX_RETURNSTR, term);
+		self->error_status = count < 0 ? count : RIG_OK;
+	}
+#endif
+
 //#ifndef SWIGJAVA
 	/* TODO */
 	void get_level(setting_t level, vfo_t vfo = RIG_VFO_CURR)


### PR DESCRIPTION
Doesn't allow '\0' embedded in the strings to be sent or received.

Closes #1479.