### PR TITLE
Remove double call to rig_token_lookup() and rot_token_lookup()

### DIFF
--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -6102,7 +6102,7 @@ declare_proto_rig(set_conf)
     }
     else
     {
-        ret = rig_set_conf(rig, rig_token_lookup(rig, arg1), arg2);
+        ret = rig_set_conf(rig, mytoken, arg2);
     }
 
     return (ret);

--- a/tests/rotctl_parse.c
+++ b/tests/rotctl_parse.c
@@ -1738,7 +1738,7 @@ declare_proto_rot(set_conf)
     }
     else
     {
-        ret = rot_set_conf(rot, rot_token_lookup(rot, arg1), arg2);
+        ret = rot_set_conf(rot, mytoken, arg2);
     }
 
     return (ret);


### PR DESCRIPTION
As mentioned by Mike in issue #1564, rotctl/rotctld were doing double calls (in fact `set_conf()` of `rotctl_parse.c`) was calling `rot_token_lookup()`; a similar thing were doing rigctl/rigctld (in `set_conf()` of `rigctl_parse.c`). This PR fixes both cases, using an existing variable.

The code in `ampctl_parse.c` is very different and wasn't doing the token lookup twice.

Test case:
```
tests/rigctl --set-conf=rig_pathname=test,write_delay=1,timeout=2 --show-conf Q | grep --no-group-separator -A1 -E "(rig_pathname|^write_delay|^timeout):"

tests/rotctl --set-conf=rot_pathname=test,write_delay=1,timeout=2 --show-conf Q | grep --no-group-separator -A1 -E "(rot_pathname|^write_delay|^timeout):"
```

Output should be unchanged by the changes in this PR:
```
rig_pathname: "Path name to the device file of the rig"
        Default: /dev/rig, Value: test
write_delay: "Delay in ms between each byte sent out"
        Default: 0, Value: 1
timeout: "Timeout in ms"
        Default: 0, Value: 2
Command 'Q' not found!
rot_pathname: "Path name to the device file of the rotator"
        Default: /dev/rotator, Value: test
write_delay: "Delay in ms between each byte sent out"
        Default: 0, Value: 1
timeout: "Timeout in ms"
        Default: 0, Value: 2
```