### PR TITLE
Make a C++11 compiler mandatory if INDI or C++ binding are requested

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -68,6 +68,7 @@ jobs:
       run: |
         brew install autoconf
         brew install automake
+        brew install libnova
         brew install libtool
         brew install grep
         brew install swig
@@ -86,7 +87,7 @@ jobs:
       run: ./configure ${{ matrix.configure_args }}
     - name: configure on macOS
       if: runner.os == 'macOS'
-      run: ./configure ${{ matrix.configure_args }} --without-lua-binding PYTHON=/opt/homebrew/bin/python3
+      run: ./configure ${{ matrix.configure_args }} --with-indi=detect --without-lua-binding PYTHON=/opt/homebrew/bin/python3
     - name: make
       run: make -j 4 V=0 --no-print-directory
     - name: make distcheck
@@ -94,4 +95,4 @@ jobs:
       run: make distcheck V=0 --no-print-directory AM_DISTCHECK_CONFIGURE_FLAGS="${{ matrix.configure_args }} --without-perl-binding"
     - name: make distcheck on macOS
       if: runner.os == 'macOS'
-      run: make distcheck V=0 --no-print-directory AM_DISTCHECK_CONFIGURE_FLAGS="${{ matrix.configure_args }} --without-perl-binding --without-lua-binding --without-tcl-binding PYTHON=/opt/homebrew/bin/python3"
+      run: make distcheck V=0 --no-print-directory AM_DISTCHECK_CONFIGURE_FLAGS="${{ matrix.configure_args }} --with-indi=detect --without-perl-binding --without-lua-binding --without-tcl-binding PYTHON=/opt/homebrew/bin/python3"

--- a/configure.ac
+++ b/configure.ac
@@ -111,10 +111,10 @@ AC_PROG_AWK
 AC_PROG_INSTALL
 AC_PROG_LN_S
 
-AS_IF([test -z "$CXX"], [
-	cf_with_cxx=yes,
-	cf_with_cxx=no
-])
+AS_IF([test -z "$CXX"],
+	[cf_with_cxx=no],
+	[cf_with_cxx=yes]
+)
 AM_CONDITIONAL([ENABLE_CXX], [test x"${cf_with_cxx}" = "xyes"])
 
 dnl Broke on older Automake, so test for its existence.

--- a/configure.ac
+++ b/configure.ac
@@ -111,7 +111,7 @@ AC_PROG_AWK
 AC_PROG_INSTALL
 AC_PROG_LN_S
 
-dml check whether CXX is functional
+dnl check whether CXX is functional
 AX_CXX_COMPILE_STDCXX([11],[noext],[optional])
 AS_IF([test "$HAVE_CXX11" = 1],
        [cf_with_cxx=yes],

--- a/configure.ac
+++ b/configure.ac
@@ -407,18 +407,23 @@ AC_MSG_CHECKING([whether to use INDI in rotctl/rotctld])
 
 AC_ARG_WITH([indi],
     [AS_HELP_STRING([--without-indi],
-        [disable INDI in rotctl/rotctld @<:@default=yes:>@])],
+        [disable INDI in rotctl/rotctld @<:@default=detect:>@])],
     [cf_with_indi_support=$withval],
-    [cf_with_indi_support=yes]
+    [cf_with_indi_support=detect]
 )
 
 AC_MSG_RESULT([$cf_with_indi_support])
 
-AS_IF([test x"$cf_with_indi_support" = "xyes"], [
-    AS_IF([test x"${cf_with_cxx}" != "xyes"], [
-        AC_MSG_ERROR([INDI support needs a C++ compiler.])
-    ])
-])
+case "${cf_with_indi_support}" in
+  detect)   cf_with_indi_support=$cf_with_cxx ;;
+  yes)
+            AS_IF([test x"${cf_with_cxx}" != "xyes"],
+                [AC_MSG_ERROR([INDI support needs a C++ compiler.])]
+            )
+            ;;
+  no)       ;;
+    *)      AC_MSG_ERROR([invalid value for --without-indi: ${cf_with_indi_support}]) ;;
+esac
 
 AS_IF([test x"$cf_with_indi_support" != "xno"], [
     # macros/ax_lib_nova.m4

--- a/configure.ac
+++ b/configure.ac
@@ -414,37 +414,35 @@ AC_ARG_WITH([indi],
 
 AC_MSG_RESULT([$cf_with_indi_support])
 
-case "${cf_with_indi_support}" in
-  detect)   cf_with_indi_support=$cf_with_cxx ;;
-  yes)
-            AS_IF([test x"${cf_with_cxx}" != "xyes"],
-                [AC_MSG_ERROR([INDI support needs a C++ compiler.])]
-            )
-            ;;
-  no)       ;;
-    *)      AC_MSG_ERROR([invalid value for --without-indi: ${cf_with_indi_support}]) ;;
-esac
-
 AS_IF([test x"$cf_with_indi_support" != "xno"], [
     # macros/ax_lib_nova.m4
     AX_LIB_NOVA
 
-    AS_IF([test x"$ax_cv_lib_nova" = "xno"], [
-	AC_MSG_WARN([libnova support not found, required by INDI.])
-	cf_with_indi_support=no
-	])
-
-    AS_IF([test x"$ax_cv_lib_nova" != "xno"], [
-	# macros/ax_lib_indi.m4
-	AX_LIB_INDI
-
-	AS_IF([test x"$ax_cv_lib_indi" = "xno"], [
-	    AC_MSG_WARN([INDI support not found.])
-	    cf_with_indi_support=no
-	])
-
-    ])
+    # macros/ax_lib_indi.m4
+    AX_LIB_INDI
 ])
+
+AS_IF([test x"$cf_with_indi_support" = "xyes"], [
+    AS_IF([test x"$cf_with_cxx" = "xno"],
+        [AC_MSG_ERROR([INDI support needs a C++ compiler.])]
+    )
+
+    AS_IF([test x"$ax_cv_lib_nova" = "xno"],
+        [AC_MSG_ERROR([libnova support not found, required by INDI.])]
+    )
+
+    AS_IF([test x"$ax_cv_lib_indi" = "xno"],
+        [AC_MSG_ERROR([libindi support not found, required by INDI.])]
+    )
+])
+
+AS_IF([test x"$cf_with_indi_support" = "xdetect"], [
+    AS_IF([test x"$cf_with_cxx" = "xno" -o x"$ax_cv_lib_nova" = "xno" -o x"$ax_cv_lib_indi" = "xno"],
+          [cf_with_indi_support=no],
+          [cf_with_indi_support=yes]
+    )
+])
+
 AS_IF([test x"$cf_with_indi_support" != "xno"],
 	[ROT_BACKEND_LIST="$ROT_BACKEND_LIST rotators/indi"],
 	[ROT_BACKEND_OPTIONAL_LIST="$ROT_BACKEND_OPTIONAL_LIST rotators/indi"]

--- a/configure.ac
+++ b/configure.ac
@@ -401,20 +401,17 @@ AS_IF([test x"$ax_cv_lib_readline" = "xno"], [
 
 dnl Check if INDI support in rigctl/rotctl is wanted
 AC_MSG_CHECKING([whether to use INDI in rigctl/rotctl])
-#AS_IF([test x"${cf_with_cxx_binding}" = "xyes"], [
-    AC_ARG_WITH([indi],
-        [AS_HELP_STRING([--without-indi],
-    	[disable INDI in rigctl/rotctl @<:@default=yes@:>@])],
-    	[cf_with_indi_support=$with_indi],
-    	[cf_with_indi_support=no]
-    )
-#])
 
-AS_IF([test x"$cf_with_indi_support" != "xno"], [
-    # INDI support needs a C++ compiler, tested for presence above.
+AC_ARG_WITH([indi],
+    [AS_HELP_STRING([--without-indi],
+    [disable INDI in rigctl/rotctl @<:@default=yes@:>@])],
+    [cf_with_indi_support=$withval],
+    [cf_with_indi_support=yes]
+)
+
+AS_IF([test x"$cf_with_indi_support" = "xyes"], [
     AS_IF([test x"${cf_with_cxx}" != "xyes"], [
-	AC_MSG_WARN([INDI support needs a C++ compiler.])
-	cf_with_indi_support=no
+        AC_MSG_ERROR([INDI support needs a C++ compiler.])
     ])
 ])
 
@@ -556,8 +553,14 @@ AC_ARG_WITH([cxx-binding],
 	    [AS_HELP_STRING([--without-cxx-binding],
 			    [do not build C++ binding @<:@default=yes@:>@])],
 	    [cf_with_cxx_binding=$withval],
-	    [cf_with_cxx_binding=$cf_with_cxx])
+	    [cf_with_cxx_binding=yes])
 AC_MSG_RESULT([$cf_with_cxx_binding])
+
+AS_IF([test x"$cf_with_cxx_binding" = "xyes"], [
+    AS_IF([test x"${cf_with_cxx}" != "xyes"], [
+        AC_MSG_ERROR([C++ binding needs a C++ compiler.])
+    ])
+])
 
 AS_IF([test x"${cf_with_cxx_binding}" = "xyes"],
       [BINDINGS="${BINDINGS} c++"])
@@ -816,7 +819,7 @@ AS_IF([test x"${DL_LIBS}" = "x-ldl"],
 AC_SUBST([DL_LIBS])
 
 dnl check for c++11
-AX_CXX_COMPILE_STDCXX([11],[noext],[mandatory])
+AX_CXX_COMPILE_STDCXX([11],[noext],[optional])
 
 
 dnl stuff that requires C++ support

--- a/configure.ac
+++ b/configure.ac
@@ -111,11 +111,13 @@ AC_PROG_AWK
 AC_PROG_INSTALL
 AC_PROG_LN_S
 
-AS_IF([test -z "$CXX"],
-	[cf_with_cxx=no],
-	[cf_with_cxx=yes]
+dml check whether CXX is functional
+AX_CXX_COMPILE_STDCXX([11],[noext],[optional])
+AS_IF([test "$HAVE_CXX11" = 1],
+       [cf_with_cxx=yes],
+       [cf_with_cxx=no]
 )
-AM_CONDITIONAL([ENABLE_CXX], [test x"${cf_with_cxx}" = "xyes"])
+AM_CONDITIONAL([ENABLE_CXX], [test "$HAVE_CXX11" = 1])
 
 dnl Broke on older Automake, so test for its existence.
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
@@ -820,9 +822,6 @@ AS_IF([test x"${DL_LIBS}" = "x-ldl"],
       [AC_CHECK_HEADERS([dlfcn.h])])
 
 AC_SUBST([DL_LIBS])
-
-dnl check for c++11
-AX_CXX_COMPILE_STDCXX([11],[noext],[optional])
 
 
 dnl stuff that requires C++ support

--- a/configure.ac
+++ b/configure.ac
@@ -409,6 +409,8 @@ AC_ARG_WITH([indi],
     [cf_with_indi_support=yes]
 )
 
+AC_MSG_RESULT([$cf_with_indi_support])
+
 AS_IF([test x"$cf_with_indi_support" = "xyes"], [
     AS_IF([test x"${cf_with_cxx}" != "xyes"], [
         AC_MSG_ERROR([INDI support needs a C++ compiler.])

--- a/configure.ac
+++ b/configure.ac
@@ -555,22 +555,27 @@ BINDING_LIST=""
 BINDING_LIB_TARGETS=""
 
 
-dnl Check if cxx-binding not wanted, default is to build it
+dnl Check if cxx-binding not wanted, default is to build it if a C++ compiler is available
 
 # C++ binding
 AC_MSG_CHECKING([whether to build C++ binding])
 AC_ARG_WITH([cxx-binding],
 	    [AS_HELP_STRING([--without-cxx-binding],
-			    [do not build C++ binding @<:@default=yes@:>@])],
+			[do not build C++ binding @<:@default=detect@:>@])],
 	    [cf_with_cxx_binding=$withval],
-	    [cf_with_cxx_binding=yes])
+	    [cf_with_cxx_binding=detect])
 AC_MSG_RESULT([$cf_with_cxx_binding])
 
-AS_IF([test x"$cf_with_cxx_binding" = "xyes"], [
-    AS_IF([test x"${cf_with_cxx}" != "xyes"], [
-        AC_MSG_ERROR([C++ binding needs a C++ compiler.])
-    ])
-])
+case "${cf_with_cxx_binding}" in
+  detect)   cf_with_cxx_binding=$cf_with_cxx ;;
+  yes)
+            AS_IF([test x"${cf_with_cxx}" != "xyes"],
+                [AC_MSG_ERROR([C++ binding needs a C++ compiler.])]
+            )
+            ;;
+  no)       ;;
+  *)        AC_MSG_ERROR([invalid value for --without-cxx-binding: ${cf_with_cxx_binding}]) ;;
+esac
 
 AS_IF([test x"${cf_with_cxx_binding}" = "xyes"],
       [BINDINGS="${BINDINGS} c++"])

--- a/configure.ac
+++ b/configure.ac
@@ -402,12 +402,12 @@ AS_IF([test x"$ax_cv_lib_readline" = "xno"], [
     cf_with_readline_support=no
     ])
 
-dnl Check if INDI support in rigctl/rotctl is wanted
-AC_MSG_CHECKING([whether to use INDI in rigctl/rotctl])
+dnl Check if INDI support in rotctl/rotctld is wanted
+AC_MSG_CHECKING([whether to use INDI in rotctl/rotctld])
 
 AC_ARG_WITH([indi],
     [AS_HELP_STRING([--without-indi],
-    [disable INDI in rigctl/rotctl @<:@default=yes@:>@])],
+        [disable INDI in rotctl/rotctld @<:@default=yes:>@])],
     [cf_with_indi_support=$withval],
     [cf_with_indi_support=yes]
 )

--- a/configure.ac
+++ b/configure.ac
@@ -111,9 +111,10 @@ AC_PROG_AWK
 AC_PROG_INSTALL
 AC_PROG_LN_S
 
-# TODO: check whether CXX is functional
-AC_CHECK_PROG([cf_with_cxx], ["${CXX}"], [yes], [no])
-
+AS_IF([test -z "$CXX"], [
+	cf_with_cxx=yes,
+	cf_with_cxx=no
+])
 AM_CONDITIONAL([ENABLE_CXX], [test x"${cf_with_cxx}" = "xyes"])
 
 dnl Broke on older Automake, so test for its existence.

--- a/configure.ac
+++ b/configure.ac
@@ -407,7 +407,7 @@ AC_MSG_CHECKING([whether to use INDI in rotctl/rotctld])
 
 AC_ARG_WITH([indi],
     [AS_HELP_STRING([--without-indi],
-        [disable INDI in rotctl/rotctld @<:@default=detect:>@])],
+        [disable INDI in rotctl/rotctld @<:@default=detect@:>@])],
     [cf_with_indi_support=$withval],
     [cf_with_indi_support=detect]
 )


### PR DESCRIPTION
Otherwise make it optional.

Fixes issue #1730.

Regardless if a C++ compiler is installed or not, nothing changes when running `configure` without arguments or with explicit `--with-cxx-binding --with-indi`.

If a C++ compiler is NOT installed, before this PR the configure script fails even if called as:
> ./configure --without-cxx-binding --without-indi
```
configure: error: *** A compiler with support for C++11 language features is required.
```
We can simulate the absence of a C++ compiler passing `CXX=/usr/bin/false` to configure:
> ./configure  CXX=/usr/bin/false --without-indi --without-cxx-binding 

With this PR, configure succeeds and prints
```
    With C++ binding                no
...
    With INDI support               no
```
The build succeeds.