### PR TITLE
Remove unused code and reduce amount of debug output of grbltrk.c

### DIFF
--- a/rotators/grbltrk/grbltrk.c
+++ b/rotators/grbltrk/grbltrk.c
@@ -155,7 +155,7 @@ grbl_request(ROT *rot, char *request, uint32_t req_size, char *response,
         if (fail_count >= 10)
         {
             rot_debug(RIG_DEBUG_ERR, "%s too much xfer fail! exit\n", __func__);
-            return -RIG_EPROTO;
+            return retval;
         }
 
         rig_flush(rotp);
@@ -198,7 +198,7 @@ grbl_init(ROT *rot)
         if (retval != RIG_OK)
         {
             rot_debug(RIG_DEBUG_ERR, "grbl_request [%s] fail\n", grbl_init_list[i]);
-            return -RIG_EIO;
+            return retval;
         }
     }
 

--- a/rotators/grbltrk/grbltrk.c
+++ b/rotators/grbltrk/grbltrk.c
@@ -174,6 +174,8 @@ grbl_init(ROT *rot)
     char rsp[RSIZE];
     uint32_t resp_size;
 
+    rot_debug(RIG_DEBUG_TRACE, "%s:%d\n", __func__, __LINE__);
+
     /* get total config */
     grbl_request(rot, grbl_get_config, strlen(grbl_get_config), rsp, &resp_size);
 
@@ -444,65 +446,13 @@ grbltrk_rot_set_conf(ROT *rot, hamlib_token_t token, const char *val)
 }
 
 static int
-grbltrk_rot_init(ROT *rot)
-{
-    int r = RIG_OK;
-
-    rot_debug(RIG_DEBUG_TRACE, "%s:%d rot->caps->rot_model: %d\n", __func__, __LINE__,
-              rot->caps->rot_model);
-
-    return r;
-}
-
-static int
-grbl_net_open(ROT *rot, int port)
-{
-    //network_open(ROTPORT(rot), port);
-
-    //rot_debug(RIG_DEBUG_TRACE, "%s:%d network_fd: %d\n", __func__, __LINE__, ROTPORT(rot)->fd);
-    rot_debug(RIG_DEBUG_TRACE, "%s:%d \n", __func__, __LINE__);
-
-    return 0;
-}
-
-static int
 grbltrk_rot_open(ROT *rot)
 {
     int r = RIG_OK;
-    char host[128] = {0};
-    //char ip[32];
-    //int port;
 
-    //rot_debug(RIG_DEBUG_TRACE, "%s:%d rot->caps->rot_model: %d\n", __func__, __LINE__, rot->caps->rot_model);
-    if (rot->caps->rot_model == ROT_MODEL_GRBLTRK_SER)
-    {
-        rot_debug(RIG_DEBUG_TRACE, "%s:%d ctrl via serial\n", __func__, __LINE__);
-    }
-    else if (rot->caps->rot_model == ROT_MODEL_GRBLTRK_NET)
-    {
-        rot_get_conf2(rot, TOK_PATHNAME, host, sizeof(host));
-        rot_debug(RIG_DEBUG_TRACE, "%s:%d ctrl via net, host [%s]\n", __func__, __LINE__,
-                  host);
-        grbl_net_open(rot, 23);
-
-#if 0
-
-        if (sscanf(host, "%[^:]:%d", ip, &port) == 2)
-        {
-            grbl_net_open(rot, ip, port);
-        }
-        else
-        {
-            grbl_net_open(rot, NULL, 0); /* use default ip & port */
-        }
-
-#endif
-
-    }
+    rot_debug(RIG_DEBUG_TRACE, "%s:%d\n", __func__, __LINE__);
 
     grbl_init(rot);
-
-    //rot_debug(RIG_DEBUG_TRACE, "%s:%d\n", __func__, __LINE__);
 
     return r;
 }
@@ -518,11 +468,7 @@ grbltrk_rot_close(ROT *rot)
 {
     int r = RIG_OK;
 
-    if (rot->caps->rot_model == ROT_MODEL_GRBLTRK_SER)
-    {
-        rot_debug(RIG_DEBUG_TRACE, "%s:%d\n", __func__, __LINE__);
-    }
-    else if (rot->caps->rot_model == ROT_MODEL_GRBLTRK_NET)
+    if (rot->caps->rot_model == ROT_MODEL_GRBLTRK_NET)
     {
         rot_debug(RIG_DEBUG_TRACE, "%s:%d\n", __func__, __LINE__);
         grbl_net_close(rot);
@@ -563,7 +509,6 @@ const struct rot_caps grbltrk_serial_rot_caps =
     .min_el =     0,
     .max_el =     90,
 
-    .rot_init     =  grbltrk_rot_init,
     .rot_open     =  grbltrk_rot_open,
 
     .set_position =  grbltrk_rot_set_position,
@@ -595,7 +540,6 @@ const struct rot_caps grbltrk_net_rot_caps =
     .min_el =     0,
     .max_el =     90,
 
-    .rot_init     =  grbltrk_rot_init,
     .rot_open     =  grbltrk_rot_open,
     .rot_close    =  grbltrk_rot_close,
 

--- a/rotators/grbltrk/grbltrk.c
+++ b/rotators/grbltrk/grbltrk.c
@@ -448,11 +448,11 @@ grbltrk_rot_set_conf(ROT *rot, hamlib_token_t token, const char *val)
 static int
 grbltrk_rot_open(ROT *rot)
 {
-    int r = RIG_OK;
+    int r;
 
     rot_debug(RIG_DEBUG_TRACE, "%s:%d\n", __func__, __LINE__);
 
-    grbl_init(rot);
+    r = grbl_init(rot);
 
     return r;
 }

--- a/rotators/grbltrk/grbltrk.c
+++ b/rotators/grbltrk/grbltrk.c
@@ -224,7 +224,7 @@ grbltrk_rot_set_position(ROT *rot, azimuth_t curr_az, elevation_t curr_el)
 
     /* az:x: 0 - 360 */
     /* el:y: 0 - 90 */
-    rot_debug(RIG_DEBUG_ERR,
+    rot_debug(RIG_DEBUG_TRACE,
               "%s: (prev_x) = (%.3f); (prev_az) = (%.3f); (prev_el) = (%.3f); (curr_az, curr_el) = (%.3f, %.3f)\n",
               __func__,
               prev_x, prev_az, prev_el, curr_az, curr_el);
@@ -238,7 +238,7 @@ grbltrk_rot_set_position(ROT *rot, azimuth_t curr_az, elevation_t curr_el)
             (curr_az > 0   && curr_az < 90))
     {
 
-        rot_debug(RIG_DEBUG_ERR, "%s:%d\n", __func__, __LINE__);
+        rot_debug(RIG_DEBUG_TRACE, "%s:%d\n", __func__, __LINE__);
 
         if (prev_x >= XDEGREE2MM(270))
         {
@@ -254,7 +254,7 @@ grbltrk_rot_set_position(ROT *rot, azimuth_t curr_az, elevation_t curr_el)
     else if ((prev_az > 0   && prev_az < 90) &&
              (curr_az > 270 && curr_az < 360))
     {
-        rot_debug(RIG_DEBUG_ERR, "%s:%d\n", __func__, __LINE__);
+        rot_debug(RIG_DEBUG_TRACE, "%s:%d\n", __func__, __LINE__);
 
         if (prev_x >= XDEGREE2MM(360))
         {
@@ -269,12 +269,12 @@ grbltrk_rot_set_position(ROT *rot, azimuth_t curr_az, elevation_t curr_el)
     }
     else if (curr_az == 0 && curr_el == 0)
     {
-        rot_debug(RIG_DEBUG_ERR, "%s: reset\n", __func__);
+        rot_debug(RIG_DEBUG_TRACE, "%s: reset\n", __func__);
         curr_x = 0;
     }
     else
     {
-        rot_debug(RIG_DEBUG_ERR, "%s:%d prev_x: %.3f\n", __func__, __LINE__, prev_x);
+        rot_debug(RIG_DEBUG_TRACE, "%s:%d prev_x: %.3f\n", __func__, __LINE__, prev_x);
 
         x[0] = XDEGREE2MM(curr_az) - XDEGREE2MM(360);
         x[1] = XDEGREE2MM(curr_az);
@@ -303,7 +303,7 @@ grbltrk_rot_set_position(ROT *rot, azimuth_t curr_az, elevation_t curr_el)
         }
 
         curr_x = x[min_index];
-        rot_debug(RIG_DEBUG_ERR, "min_index: %d; curr_x: %.3f\n", min_index, curr_x);
+        rot_debug(RIG_DEBUG_TRACE, "min_index: %d; curr_x: %.3f\n", min_index, curr_x);
     }
 
     y = YDEGREE2MM(curr_el);
@@ -341,7 +341,7 @@ grbltrk_rot_get_position(ROT *rot, azimuth_t *az, elevation_t *el)
 
     int i;
 
-    rot_debug(RIG_DEBUG_ERR, "%s called\n", __func__);
+    rot_debug(RIG_DEBUG_TRACE, "%s called\n", __func__);
 
     //snprintf(req, sizeof(req), "?\r\n");
 
@@ -371,7 +371,7 @@ grbltrk_rot_get_position(ROT *rot, azimuth_t *az, elevation_t *el)
         //<Idle|MPos:0.000,0.000,0.000|FS:0,0|Pn:P|WCO:5.000,0.000,0.000>
         sscanf(rsp, "%[^'|']|MPos:%f,%f,%255s", dummy0, &mpos[0], &mpos[1], dummy1);
 
-        //rot_debug(RIG_DEBUG_ERR, "%s: (%.3f, %.3f) (%.3f, %.3f)\n", __func__, mpos[0], mpos[1], wpos[0], wpos[1]);
+        //rot_debug(RIG_DEBUG_TRACE, "%s: (%.3f, %.3f) (%.3f, %.3f)\n", __func__, mpos[0], mpos[1], wpos[0], wpos[1]);
 
         //*az = (azimuth_t) mpos[0] / 0.111;
         //*el = (elevation_t) mpos[1] / 0.111;
@@ -383,9 +383,7 @@ grbltrk_rot_get_position(ROT *rot, azimuth_t *az, elevation_t *el)
             (*az) = (*az) + 360;
         }
 
-        //rot_debug(RIG_DEBUG_ERR, "%s: (az, el) = (%.3f, %.3f)\n", __func__, *az, *el);
-
-        rot_debug(RIG_DEBUG_ERR, "%s: (az, el) = (%.3f, %.3f)\n", __func__, *az, *el);
+        rot_debug(RIG_DEBUG_TRACE, "%s: (az, el) = (%.3f, %.3f)\n", __func__, *az, *el);
 
         return RIG_OK;
 
@@ -401,7 +399,7 @@ grbltrk_rot_set_conf(ROT *rot, hamlib_token_t token, const char *val)
 {
     uint32_t resp_size, len;
 
-    rot_debug(RIG_DEBUG_ERR, "token: %ld; value: [%s]\n", token, val);
+    rot_debug(RIG_DEBUG_TRACE, "token: %ld; value: [%s]\n", token, val);
 
     len = strlen(val);
 
@@ -432,7 +430,7 @@ grbltrk_rot_set_conf(ROT *rot, hamlib_token_t token, const char *val)
         req[i] = '\n';
         len = strlen(req);
 
-        rot_debug(RIG_DEBUG_ERR, "send gcode [%s]\n", req);
+        rot_debug(RIG_DEBUG_TRACE, "send gcode [%s]\n", req);
         retval = grbl_request(rot, req, len, rsp, &resp_size);
 
         if (retval < 0)
@@ -450,7 +448,7 @@ grbltrk_rot_init(ROT *rot)
 {
     int r = RIG_OK;
 
-    rot_debug(RIG_DEBUG_ERR, "%s:%d rot->caps->rot_model: %d\n", __func__, __LINE__,
+    rot_debug(RIG_DEBUG_TRACE, "%s:%d rot->caps->rot_model: %d\n", __func__, __LINE__,
               rot->caps->rot_model);
 
     return r;
@@ -461,8 +459,8 @@ grbl_net_open(ROT *rot, int port)
 {
     //network_open(ROTPORT(rot), port);
 
-    //rot_debug(RIG_DEBUG_ERR, "%s:%d network_fd: %d\n", __func__, __LINE__, ROTPORT(rot)->fd);
-    rot_debug(RIG_DEBUG_ERR, "%s:%d \n", __func__, __LINE__);
+    //rot_debug(RIG_DEBUG_TRACE, "%s:%d network_fd: %d\n", __func__, __LINE__, ROTPORT(rot)->fd);
+    rot_debug(RIG_DEBUG_TRACE, "%s:%d \n", __func__, __LINE__);
 
     return 0;
 }
@@ -475,15 +473,15 @@ grbltrk_rot_open(ROT *rot)
     //char ip[32];
     //int port;
 
-    //rot_debug(RIG_DEBUG_ERR, "%s:%d rot->caps->rot_model: %d\n", __func__, __LINE__, rot->caps->rot_model);
+    //rot_debug(RIG_DEBUG_TRACE, "%s:%d rot->caps->rot_model: %d\n", __func__, __LINE__, rot->caps->rot_model);
     if (rot->caps->rot_model == ROT_MODEL_GRBLTRK_SER)
     {
-        rot_debug(RIG_DEBUG_ERR, "%s:%d ctrl via serial\n", __func__, __LINE__);
+        rot_debug(RIG_DEBUG_TRACE, "%s:%d ctrl via serial\n", __func__, __LINE__);
     }
     else if (rot->caps->rot_model == ROT_MODEL_GRBLTRK_NET)
     {
         rot_get_conf2(rot, TOK_PATHNAME, host, sizeof(host));
-        rot_debug(RIG_DEBUG_ERR, "%s:%d ctrl via net, host [%s]\n", __func__, __LINE__,
+        rot_debug(RIG_DEBUG_TRACE, "%s:%d ctrl via net, host [%s]\n", __func__, __LINE__,
                   host);
         grbl_net_open(rot, 23);
 
@@ -504,7 +502,7 @@ grbltrk_rot_open(ROT *rot)
 
     grbl_init(rot);
 
-    //rot_debug(RIG_DEBUG_ERR, "%s:%d\n", __func__, __LINE__);
+    //rot_debug(RIG_DEBUG_TRACE, "%s:%d\n", __func__, __LINE__);
 
     return r;
 }
@@ -522,15 +520,15 @@ grbltrk_rot_close(ROT *rot)
 
     if (rot->caps->rot_model == ROT_MODEL_GRBLTRK_SER)
     {
-        rot_debug(RIG_DEBUG_ERR, "%s:%d\n", __func__, __LINE__);
+        rot_debug(RIG_DEBUG_TRACE, "%s:%d\n", __func__, __LINE__);
     }
     else if (rot->caps->rot_model == ROT_MODEL_GRBLTRK_NET)
     {
-        rot_debug(RIG_DEBUG_ERR, "%s:%d\n", __func__, __LINE__);
+        rot_debug(RIG_DEBUG_TRACE, "%s:%d\n", __func__, __LINE__);
         grbl_net_close(rot);
     }
 
-    rot_debug(RIG_DEBUG_ERR, "%s:%d\n", __func__, __LINE__);
+    rot_debug(RIG_DEBUG_TRACE, "%s:%d\n", __func__, __LINE__);
 
     return r;
 }
@@ -611,9 +609,7 @@ const struct rot_caps grbltrk_net_rot_caps =
 
 DECLARE_INITROT_BACKEND(grbltrk)
 {
-    rig_debug(RIG_DEBUG_VERBOSE, "%s: _init called\n", __func__);
-
-    //rot_debug(RIG_DEBUG_ERR, "%s: _init called\n", __func__);
+    rot_debug(RIG_DEBUG_TRACE, "%s: _init called\n", __func__);
 
     rot_register(&grbltrk_serial_rot_caps);
 

--- a/rotators/grbltrk/grbltrk.c
+++ b/rotators/grbltrk/grbltrk.c
@@ -125,9 +125,9 @@ grbl_request(ROT *rot, char *request, uint32_t req_size, char *response,
         if ((retval = write_block(rotp, (unsigned char *)request,
                                   req_size)) != RIG_OK)
         {
-            rot_debug(RIG_DEBUG_ERR, "%s write_block fail!\n", __func__);
-            //exit(-1);
             fail_count++;
+            rot_debug(RIG_DEBUG_ERR, "%s write_block fail! (%d) fail_count %d\n", __func__, retval, fail_count);
+            //exit(-1);
             //return -RIG_EIO;
         }
         else
@@ -142,9 +142,9 @@ grbl_request(ROT *rot, char *request, uint32_t req_size, char *response,
         if ((retval = read_string(rotp, (unsigned char *)response, 1024,
                                   "\n", 1, 0, 1)) < 0)
         {
-            rot_debug(RIG_DEBUG_ERR, "%s read_string fail! (%d) \n", __func__, retval);
-            //exit(-1);
             fail_count++;
+            rot_debug(RIG_DEBUG_ERR, "%s read_string fail! (%d) fail_count %d\n", __func__, retval, fail_count);
+            //exit(-1);
             //return -RIG_EIO;
         }
         else

--- a/rotators/grbltrk/grbltrk.c
+++ b/rotators/grbltrk/grbltrk.c
@@ -116,8 +116,6 @@ grbl_request(ROT *rot, char *request, uint32_t req_size, char *response,
     static int fail_count = 0;
     hamlib_port_t *rotp = ROTPORT(rot);
 
-    rot_debug(RIG_DEBUG_ERR, "req: [%s][%d]\n", request, fail_count);
-
     if (rot->caps->rot_model == ROT_MODEL_GRBLTRK_SER
             || rot->caps->rot_model == ROT_MODEL_GRBLTRK_NET)
     {
@@ -162,11 +160,7 @@ grbl_request(ROT *rot, char *request, uint32_t req_size, char *response,
 
         rig_flush(rotp);
 
-        rot_debug(RIG_DEBUG_ERR, "rsp: [%s]\n", response);
-        //fprintf(stderr, "rsp: [%s]\n", response);
-
         *resp_size = retval;
-
     }
 
     return RIG_OK;
@@ -194,7 +188,7 @@ grbl_init(ROT *rot)
     for (i = 0; i < init_count; i++)
     {
         int retval;
-        rot_debug(RIG_DEBUG_ERR, "grbl_request [%s] ", grbl_init_list[i]);
+
         retval = grbl_request(rot, grbl_init_list[i], strlen(grbl_init_list[i]), rsp,
                               &resp_size);
 


### PR DESCRIPTION
The main goal of this PR was detecting errors during the initialization, to get there I modified `rotator/grbltrk.c` to set the TRACE debug level to the lines that don't show errors and to remove the functions that only printed debug messages (this deletes some messages).

Closes issue #1759.

The ports are opened and closed by the main library so the code doesn't need to open them.
I deleted `grbl_net_open()` because is unneeded and that function was doing nothing anyway.
I deleted `grbltrk_rot_init()` because was doing nothing, in fact the initialization is the only thing remaining in `grbltrk_rot_open()`, the rest were debug  messages.

The last 2 commits propagate the error code (it was issue #1759).

I don't own the hardware, but the goal were the errors during the initialization, so my tests were limited to launching `rotclt` and trying to cause an error, which I was able to cause only with the networked model 2402.

I tested with a serial port with nothing attached (less debug messages, but mostly the same):
* [grbltrk-2401-before.txt](https://github.com/user-attachments/files/21951689/grbltrk-2401-before.txt) [grbltrk-2401
* after.txt](https://github.com/user-attachments/files/21951690/grbltrk-2401-after.txt)

and with `nc -l 4500` (less debug messages and manually killing nc at the right moment an IO error, that ironically is was was hardcoded before i changed the code to propagate the error):
* [grbltrk-2402-before.txt](https://github.com/user-attachments/files/21951687/grbltrk-2402-before.txt)
* [grbltrk-2402-after.txt](https://github.com/user-attachments/files/21951688/grbltrk-2402-after.txt)

I thought the `rotctl` would always get an error and exit, but the error is returned and propagated only if `fail_count >= 10`, so I was able to trigger that condition killing nc early enough
`grbl_request read_string fail! (-6) fail_count 11`

The code to fail at the first error was commented out and I didn't change it.