### PR TITLE
Remove misleading duplicated error message

### DIFF
--- a/tests/rigmem.c
+++ b/tests/rigmem.c
@@ -187,7 +187,6 @@ int main(int argc, char *argv[])
             break;
 
         default:
-            fprintf(stderr, "Unknown option '%c'\n", c);
             usage();    /* unknown option? */
             exit(1);
         }


### PR DESCRIPTION
This PR avoids printing `Unknown option '?'`

The correct error message has been printed by getopt_long() before returning.

Test cases:

before
```
$ rigmem -Q
rigmem: invalid option -- 'Q'
Unknown option '?'
Usage: rigmem [OPTION]... COMMAND... FILE
...

$ rigmem --foo
rigmem: unrecognized option '--foo'
Unknown option '?'
Usage: rigmem [OPTION]... COMMAND... FILE
...
```

after
```
$ rigmem -Q
rigmem: invalid option -- 'Q'
Usage: rigmem [OPTION]... COMMAND... FILE
...
$ rigmem --foo
rigmem: unrecognized option '--foo'
Usage: rigmem [OPTION]... COMMAND... FILE
...
```