### PR TITLE
Remove unused includes

### DIFF
--- a/simulators/sim.h
+++ b/simulators/sim.h
@@ -1,6 +1,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include "../src/misc.h"
 

--- a/simulators/simeasycomm.c
+++ b/simulators/simeasycomm.c
@@ -6,7 +6,6 @@
 #include <unistd.h>
 #include <pthread.h>
 
-#include "hamlib/rig.h"
 #include "misc.h"
 
 #define BUFSIZE 256

--- a/simulators/simelecraft.c
+++ b/simulators/simelecraft.c
@@ -4,7 +4,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #include "hamlib/rig.h"
 #include "sim.h"

--- a/simulators/simelecraftk4.c
+++ b/simulators/simelecraftk4.c
@@ -3,7 +3,6 @@
 // since we are POSIX here we need this
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
 
 #include "hamlib/rig.h"
 #include "sim.h"

--- a/simulators/simft1000.c
+++ b/simulators/simft1000.c
@@ -2,8 +2,6 @@
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #include <stdio.h>
-#include <string.h>
-#include <unistd.h>
 
 #include "sim.h"
 

--- a/simulators/simft736.c
+++ b/simulators/simft736.c
@@ -2,8 +2,6 @@
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #include <stdio.h>
-#include <string.h>
-#include <unistd.h>
 
 #include "sim.h"
 

--- a/simulators/simft747gx.c
+++ b/simulators/simft747gx.c
@@ -2,9 +2,6 @@
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #include <stdio.h>
-#include <stdlib.h>
-#include <fcntl.h>
-#include <string.h>
 #include <unistd.h>
 
 #include "sim.h"

--- a/simulators/simft817.c
+++ b/simulators/simft817.c
@@ -2,7 +2,6 @@
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #include <stdio.h>
-#include <string.h>
 #include <unistd.h>
 
 #include "sim.h"

--- a/simulators/simft847.c
+++ b/simulators/simft847.c
@@ -2,7 +2,6 @@
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #include <stdio.h>
-#include <string.h>
 #include <unistd.h>
 //#include "hamlib/rig.h"
 

--- a/simulators/simft897.c
+++ b/simulators/simft897.c
@@ -2,11 +2,7 @@
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #include <stdio.h>
-#include <stdlib.h>
-#include <fcntl.h>
-#include <string.h>
 #include <unistd.h>
-#include "hamlib/rig.h"
 
 #include "sim.h"
 

--- a/simulators/simjupiter.c
+++ b/simulators/simjupiter.c
@@ -2,8 +2,6 @@
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #include <stdio.h>
-#include <string.h>
-#include <unistd.h>
 
 #include "sim.h"
 

--- a/simulators/simrotorez.c
+++ b/simulators/simrotorez.c
@@ -6,7 +6,6 @@
 #include <unistd.h>
 #include <pthread.h>
 
-#include "hamlib/rig.h"
 #include "misc.h"
 
 #define BUFSIZE 256

--- a/simulators/simspid.c
+++ b/simulators/simspid.c
@@ -2,8 +2,6 @@
 #define _XOPEN_SOURCE 700
 // since we are POSIX here we need this
 #include <stdio.h>
-#include <string.h>
-#include <unistd.h>
 
 #include "sim.h"
 

--- a/simulators/simtrusdx.c
+++ b/simulators/simtrusdx.c
@@ -3,7 +3,6 @@
 // since we are POSIX here we need this
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
 #include <sys/types.h>
 
 #include "hamlib/rig.h"

--- a/simulators/simts450.c
+++ b/simulators/simts450.c
@@ -3,7 +3,6 @@
 // since we are POSIX here we need this
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
 #include <sys/types.h>
 
 #include "hamlib/rig.h"

--- a/simulators/simts890.c
+++ b/simulators/simts890.c
@@ -34,7 +34,6 @@
 #include <ctype.h>
 #include <time.h>
 
-#include "config.h"
 //#include "hamlib/rig.h"
 
 /* Definitions */

--- a/src/amp_conf.c
+++ b/src/amp_conf.c
@@ -37,7 +37,6 @@
 #include <string.h>  /* String function definitions */
 
 #include "hamlib/amplifier.h"
-#include "hamlib/port.h"
 #include "hamlib/amp_state.h"
 
 #include "amp_conf.h"

--- a/src/amp_reg.c
+++ b/src/amp_reg.c
@@ -29,7 +29,6 @@
 
 #include "hamlib/config.h"
 
-#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/src/amp_reg.c
+++ b/src/amp_reg.c
@@ -388,7 +388,7 @@ int HAMLIB_API amp_load_backend(const char *be_name)
             if (be_init == NULL)
             {
                 printf("Null\n");
-                return -EINVAL;
+                return -RIG_EINVAL;
             }
 
             status = (*be_init)(NULL);
@@ -396,7 +396,7 @@ int HAMLIB_API amp_load_backend(const char *be_name)
         }
     }
 
-    return -EINVAL;
+    return -RIG_EINVAL;
 
 }
 //! @endcond

--- a/src/amplifier.c
+++ b/src/amplifier.c
@@ -58,13 +58,11 @@
 #include <fcntl.h>
 
 #include "hamlib/amplifier.h"
-#include "hamlib/port.h"
 #include "hamlib/amp_state.h"
 #include "serial.h"
 #include "parallel.h"
 #include "usb_port.h"
 #include "network.h"
-#include "token.h"
 
 //! @cond Doxygen_Suppress
 #define CHECK_AMP_ARG(r) (!(r) || !(r)->caps || !AMPSTATE(r)->comm_state)

--- a/src/cm108.c
+++ b/src/cm108.c
@@ -45,10 +45,6 @@
 #  include <sys/ioctl.h>
 #endif
 
-#ifdef HAVE_SYS_PARAM_H
-#  include <sys/param.h>
-#endif
-
 #ifdef HAVE_WINDOWS_H
 #  include <windows.h>
 #  include "par_nt.h"
@@ -67,8 +63,6 @@
 #endif
 
 #include "cm108.h"
-
-#include <stdio.h>
 
 const char *get_usb_device_class_string(int device_class)
 {

--- a/src/cm108.h
+++ b/src/cm108.h
@@ -24,7 +24,6 @@
 #define _CM108_H 1
 
 #include "hamlib/rig.h"
-#include "iofunc.h"
 
 
 __BEGIN_DECLS

--- a/src/conf.c
+++ b/src/conf.c
@@ -38,7 +38,6 @@
 #include <strings.h>
 
 #include "hamlib/rig.h"
-#include "hamlib/port.h"
 #include "hamlib/rig_state.h"
 #include "token.h"
 

--- a/src/extamp.c
+++ b/src/extamp.c
@@ -47,9 +47,6 @@
 
 #include "hamlib/amplifier.h"
 
-#include "token.h"
-
-
 /**
  * \brief Executes \a cfunc on all the elements stored in the amp_caps::extlevels
  * extension levels table.

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -22,11 +22,9 @@
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
-#include <sys/stat.h>
 #include <fcntl.h>
 
 #include "gpio.h"
-#include "hamlib/port.h"
 
 
 int gpio_open(hamlib_port_t *port, int output, int on_value)

--- a/src/iofunc.c
+++ b/src/iofunc.c
@@ -41,7 +41,6 @@
 #include <sys/time.h>
 #include <sys/types.h>
 
-#include "hamlib/port.h"
 #include "iofunc.h"
 #include "misc.h"
 

--- a/src/mem.c
+++ b/src/mem.c
@@ -37,7 +37,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#include <sys/stat.h>
 
 #include "hamlib/rig.h"
 #include "hamlib/rig_state.h"

--- a/src/network.c
+++ b/src/network.c
@@ -74,7 +74,6 @@
 #endif
 
 #include "hamlib/rig.h"
-#include "hamlib/port.h"
 #include "hamlib/rig_state.h"
 #include "network.h"
 #include "misc.h"

--- a/src/parallel.c
+++ b/src/parallel.c
@@ -40,10 +40,6 @@
 #  include <sys/ioctl.h>
 #endif
 
-#ifdef HAVE_SYS_PARAM_H
-#  include <sys/param.h>
-#endif
-
 #ifdef HAVE_WINDOWS_H
 #  include <windows.h>
 #  include "par_nt.h"
@@ -57,7 +53,6 @@
 #  include <winbase.h>
 #endif
 
-#include "hamlib/port.h"
 #include "parallel.h"
 
 #ifdef HAVE_LINUX_PPDEV_H

--- a/src/register.c
+++ b/src/register.c
@@ -35,7 +35,6 @@
 #include "register.h"
 
 #include "hamlib/rig.h"
-#include "misc.h"
 
 //! @cond Doxygen_Suppress
 #ifndef PATH_MAX

--- a/src/register.h
+++ b/src/register.h
@@ -23,8 +23,6 @@
 
 
 #include "hamlib/rig.h"
-#include "hamlib/rotator.h"
-#include "hamlib/amplifier.h"
 #include "hamlib/config.h"
 
 #ifdef __cplusplus

--- a/src/rig.c
+++ b/src/rig.c
@@ -52,7 +52,6 @@
 
 #include "hamlib/config.h"
 #include "hamlib/rig.h"
-#include "hamlib/port.h"
 #include "hamlib/rig_state.h"
 #include "fifo.h"
 

--- a/src/rot_conf.c
+++ b/src/rot_conf.c
@@ -38,7 +38,6 @@
 #include <string.h>  /* String function definitions */
 
 #include "hamlib/rotator.h"
-#include "hamlib/port.h"
 #include "hamlib/rot_state.h"
 
 #include "rot_conf.h"

--- a/src/rot_reg.c
+++ b/src/rot_reg.c
@@ -29,7 +29,6 @@
 
 #include "hamlib/config.h"
 
-#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/src/rot_reg.c
+++ b/src/rot_reg.c
@@ -445,7 +445,7 @@ int HAMLIB_API rot_load_backend(const char *be_name)
             if (be_init == NULL)
             {
                 printf("Null\n");
-                return -EINVAL;
+                return -RIG_EINVAL;
             }
 
             status = (*be_init)(NULL);
@@ -453,7 +453,7 @@ int HAMLIB_API rot_load_backend(const char *be_name)
         }
     }
 
-    return -EINVAL;
+    return -RIG_EINVAL;
 
 }
 //! @endcond

--- a/src/rot_settings.c
+++ b/src/rot_settings.c
@@ -38,7 +38,6 @@
 #include "hamlib/config.h"
 
 #include <stdio.h>
-#include <sys/stat.h>
 
 #include "hamlib/rig.h"
 #include "hamlib/rotator.h"

--- a/src/rotator.c
+++ b/src/rotator.c
@@ -53,11 +53,9 @@
 #include <string.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/stat.h>
 #include <fcntl.h>
 
 #include "hamlib/rotator.h"
-#include "hamlib/port.h"
 #include "hamlib/rot_state.h"
 #include "serial.h"
 #include "parallel.h"
@@ -65,9 +63,6 @@
 #include "usb_port.h"
 #endif
 #include "network.h"
-#include "rot_conf.h"
-#include "token.h"
-#include "iofunc.h"
 
 
 #ifndef DOC_HIDDEN

--- a/src/serial.c
+++ b/src/serial.c
@@ -46,10 +46,6 @@
 #  include <sys/ioctl.h>
 #endif
 
-#ifdef HAVE_SYS_PARAM_H
-#  include <sys/param.h>
-#endif
-
 #ifdef HAVE_TERMIOS_H
 #  include <termios.h> /* POSIX terminal control definitions */
 #else
@@ -63,7 +59,6 @@
 #endif
 
 #include "hamlib/rig.h"
-#include "hamlib/port.h"
 
 //! @cond Doxygen_Suppress
 #if defined(WIN32) && !defined(HAVE_TERMIOS_H)

--- a/src/settings.c
+++ b/src/settings.c
@@ -999,7 +999,6 @@ int HAMLIB_API rig_setting2idx(setting_t s)
     return 0;
 }
 
-#include <unistd.h>  /* UNIX standard function definitions */
 
 #if 0
 #include "hamlib/config.h"

--- a/src/snapshot_data.c
+++ b/src/snapshot_data.c
@@ -2,7 +2,6 @@
 #include <unistd.h>
 #include "hamlib/config.h"
 #include "hamlib/rig.h"
-#include "hamlib/port.h"
 #include "hamlib/rig_state.h"
 #include "misc.h"
 #include "cache.h"

--- a/src/sprintflst.c
+++ b/src/sprintflst.c
@@ -22,7 +22,6 @@
 
 #include "hamlib/config.h"
 
-#include <stdlib.h>
 #include <stdio.h>   /* Standard input/output definitions */
 #include <string.h>  /* String function definitions */
 

--- a/src/usb_port.c
+++ b/src/usb_port.c
@@ -39,7 +39,6 @@
 #include <strings.h>
 
 #include "hamlib/rig.h"
-#include "hamlib/port.h"
 
 #ifdef HAVE_LIBUSB_H
 #  include <libusb.h>

--- a/src/usb_port.h
+++ b/src/usb_port.h
@@ -23,7 +23,6 @@
 #define _USB_PORT_H 1
 
 #include "hamlib/rig.h"
-#include "iofunc.h"
 
 __BEGIN_DECLS
 


### PR DESCRIPTION
This PR removes some of the includes that according to `iwyu` aren't used, but not all. It keeps `config.h` `rig_state.h` and some that are conditionally included (eg. on Windows), since `iwyu` replaces the compiler, it gets the preprocessed sources so I'm not sure if it can handle these cases right.

OTH `iwyu` removed some includes from simulators without adding `unistd.h` to `sim.h`, which made the build fail because `write()` wasn't defined.

I built this on linux and cross-built on mingw.