### PR TITLE
Fix include config.h

### DIFF
--- a/lib/precise_time.c
+++ b/lib/precise_time.c
@@ -20,7 +20,7 @@
 // along with fldigi.  If not, see <http://www.gnu.org/licenses/>.
 // ---------------------------------------------------------------------
 
-#include "config.h"
+#include "hamlib/config.h"
 #include <errno.h>
 #include <time.h>
 #include <sys/time.h>

--- a/rigs/anytone/anytone.c
+++ b/rigs/anytone/anytone.c
@@ -34,7 +34,7 @@
 //    HAMLIB INCLUDES
 // ---------------------------------------------------------------------------
 
-#include "config.h"
+#include "hamlib/config.h"
 #include "hamlib/rig.h"
 #include "serial.h"
 #include "misc.h"

--- a/rigs/barrett/barrett.c
+++ b/rigs/barrett/barrett.c
@@ -19,7 +19,7 @@
  *
  */
 
-#include "config.h"
+#include "hamlib/config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/rigs/dummy/dummy.c
+++ b/rigs/dummy/dummy.c
@@ -20,7 +20,7 @@
  *
  */
 
-#include "config.h"
+#include "hamlib/config.h"
 // cppcheck-suppress *
 #include <stdint.h>
 // cppcheck-suppress *

--- a/rigs/dummy/flrig.c
+++ b/rigs/dummy/flrig.c
@@ -20,7 +20,7 @@
 *
 */
 
-#include "config.h"
+#include "hamlib/config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>             /* String function definitions */

--- a/rigs/dummy/netrigctl.c
+++ b/rigs/dummy/netrigctl.c
@@ -19,7 +19,7 @@
  *
  */
 
-#include "config.h"
+#include "hamlib/config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */

--- a/rigs/dummy/quisk.c
+++ b/rigs/dummy/quisk.c
@@ -19,7 +19,7 @@
  *
  */
 
-#include "config.h"
+#include "hamlib/config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */

--- a/rigs/dummy/tci1x.c
+++ b/rigs/dummy/tci1x.c
@@ -19,7 +19,7 @@
 *
 */
 
-#include "config.h"
+#include "hamlib/config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>             /* String function definitions */

--- a/rigs/dummy/trxmanager.c
+++ b/rigs/dummy/trxmanager.c
@@ -20,7 +20,7 @@
  *
  */
 
-#include "config.h"
+#include "hamlib/config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>             /* String function definitions */

--- a/rigs/kit/usrp_impl.cc
+++ b/rigs/kit/usrp_impl.cc
@@ -19,7 +19,7 @@
  *
  */
 
-#include <hamlib/config.h>
+#include "hamlib/config.h"
 
 /*
  * Compile only this model if usrp is available

--- a/rigs/winradio/g313-posix.c
+++ b/rigs/winradio/g313-posix.c
@@ -23,7 +23,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "config.h"
+#include "hamlib/config.h"
 
 #ifdef HAVE_DLFCN_H
 #  include <dlfcn.h>

--- a/rigs/winradio/linradio/wrg313api.c
+++ b/rigs/winradio/linradio/wrg313api.c
@@ -2,7 +2,7 @@
 
 #include <stdio.h>
 
-#include "config.h"
+#include "hamlib/config.h"
 
 #ifdef  HAVE_DLFCN_H
 #  include <dlfcn.h>

--- a/rotators/androidsensor/androidsensor.cpp
+++ b/rotators/androidsensor/androidsensor.cpp
@@ -21,7 +21,7 @@
  *
  */
 
-#include <hamlib/config.h>
+#include "hamlib/config.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/rotators/grbltrk/grbltrk.c
+++ b/rotators/grbltrk/grbltrk.c
@@ -20,7 +20,7 @@
  */
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include "hamlib/config.h"
 #endif
 
 #include <stdint.h>

--- a/security/AESStringCrypt.c
+++ b/security/AESStringCrypt.c
@@ -28,7 +28,7 @@
  * BUT NOT LIMITED TO, LOSS OF DATA OR DATA BEING RENDERED INACCURATE.
  */
 
-#include "config.h"
+#include "hamlib/config.h"
 #include <stdio.h>
 #include <string.h>
 

--- a/src/fifo.c
+++ b/src/fifo.c
@@ -1,8 +1,10 @@
-#include "hamlib/rig.h"
+#include "hamlib/config.h"
+
 #include <stdio.h>
 #include <ctype.h>
+
+#include "hamlib/rig.h"
 #include "fifo.h"
-#include "config.h"
 
 void initFIFO(FIFO_RIG *fifo)
 {

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -23,7 +23,7 @@
 #ifndef _PARALLEL_H
 #define _PARALLEL_H 1
 
-#include "config.h"
+#include "hamlib/config.h"
 #include "hamlib/rig.h"
 
 #ifdef HAVE_PARALLEL

--- a/tests/rigtestlibusb.c
+++ b/tests/rigtestlibusb.c
@@ -25,7 +25,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include "config.h"
+#include <hamlib/config.h>
 #if defined(HAVE_LIBUSB_H)
 #include <libusb.h>
 #elif defined(HAVE_LIBUSB_1_0_LIBUSB_H)

--- a/tests/rigtestmcastrx.c
+++ b/tests/rigtestmcastrx.c
@@ -1,4 +1,4 @@
-#include "config.h"
+#include <hamlib/config.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/testnet.c
+++ b/tests/testnet.c
@@ -9,7 +9,7 @@
 #include <sys/types.h>
 #include <signal.h>
 
-#include "config.h"
+#include <hamlib/config.h>
 
 #ifdef HAVE_NETINET_IN_H
 #  include <netinet/in.h>


### PR DESCRIPTION
Fix unlikely ambiguity on which `config.h` should be included. There are 2 `config.h` but only the one under `include/` :

```
find -name config.h
./android/config.h
./include/hamlib/config.h
```

before:
```
grep -hEro 'include .(hamlib/)?config.h.' | sort | uniq -c
     19 include "config.h"
      1 include <config.h>
     82 include "hamlib/config.h"
      8 include <hamlib/config.h>
```

after:
```
grep -hEro 'include .(hamlib/)?config.h.' --exclude=*.txt | sort | uniq -c
      1 include "config.h"
      1 include <config.h>
     99 include "hamlib/config.h"
      9 include <hamlib/config.h>
```

The `1 include "config.h"` is in `simts890.c` and will be removed by PR #1872 because it is unused.
The `1 include <config.h>` is in `version_dll.rc` and I'm not sure which separator should be used `\` or `/`.
The `9 include <hamlib/config.h>` are in `bindings/` and `tests/`.