### PR TITLE
Fix misc.c

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -2233,7 +2233,7 @@ int HAMLIB_API parse_hoststr(char *hoststr, int hoststr_len, char host[256],
 
     if (n >= 1 && strlen(dummy) == 0) { return RIG_OK; }
 
-    printf("Unhandled host=%s\n", hoststr);
+    rig_debug(RIG_DEBUG_BUG, "%s: Unhandled host=%s\n", __func__, hoststr);
 
     return -1;
 }

--- a/src/misc.c
+++ b/src/misc.c
@@ -2131,14 +2131,14 @@ int HAMLIB_API parse_hoststr(char *hoststr, int hoststr_len, char host[256],
 
     // Exclude any names that aren't a host:port format
     // Handle device names 1st
-    if (strstr(hoststr, "/dev")) { return -1; }
+    if (strstr(hoststr, "/dev")) { return -RIG_EINVAL; }
 
-    if (strstr(hoststr, "/")) { return -1; } // probably a path so not a hoststr
+    if (strstr(hoststr, "/")) { return -RIG_EINVAL; } // probably a path so not a hoststr
 
-    if (strncasecmp(hoststr, "com", 3) == 0) { return -1; }
+    if (strncasecmp(hoststr, "com", 3) == 0) { return -RIG_EINVAL; }
 
     // escaped COM port like \\.\COM3 or \.\COM3
-    if (strstr(hoststr, "\\.\\")) { return -1; }
+    if (strstr(hoststr, "\\.\\")) { return -RIG_EINVAL; }
 
     // Now let's try and parse a host:port thing
     // bracketed IPV6 with optional port
@@ -2235,7 +2235,7 @@ int HAMLIB_API parse_hoststr(char *hoststr, int hoststr_len, char host[256],
 
     rig_debug(RIG_DEBUG_BUG, "%s: Unhandled host=%s\n", __func__, hoststr);
 
-    return -1;
+    return -RIG_EINVAL;
 }
 
 


### PR DESCRIPTION
This PR:
* replaces a literal `-1` with `-RIG_EINVAL` which has the same numeric value
* prints an error message to `stderr` instead of `stdout` (this means that the message isn't visible unless using `-v`, just like other BUG messages)

I'm using `RIG_DEBUG_BUG` because the function is about to return an error with a "Unhandled host" message that is too generic.
One way to trigger that error is adding trailing garbage to a host:port string:
`tests/rigctl -r "invalid:123:port" -m 2`
`tests/rigctl -r "invalid:123xyz" -m 2`
