### PR TITLE
Use rig_debug() instead of sending error messages to stdout

### DIFF
--- a/tests/ampctl_parse.c
+++ b/tests/ampctl_parse.c
@@ -1584,7 +1584,7 @@ void list_models()
 
     if (status != RIG_OK)
     {
-        printf("amp_list_foreach: error = %s \n", rigerror(status));
+        rig_debug(RIG_DEBUG_ERR, "amp_list_foreach: error = %s \n", rigerror(status));
         exit(2);
     }
 

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -2154,7 +2154,7 @@ void list_models()
 
     if (status != RIG_OK)
     {
-        printf("rig_list_foreach: error = %s \n", rigerror(status));
+        rig_debug(RIG_DEBUG_ERR, "rig_list_foreach: error = %s \n", rigerror(status));
         exit(2);
     }
 

--- a/tests/rotctl_parse.c
+++ b/tests/rotctl_parse.c
@@ -1667,7 +1667,7 @@ void list_models()
 
     if (status != RIG_OK)
     {
-        printf("rot_list_foreach: error = %s \n", rigerror(status));
+        rig_debug(RIG_DEBUG_ERR, "rot_list_foreach: error = %s \n", rigerror(status));
         exit(2);
     }
 


### PR DESCRIPTION
This PR replaces `printf()` with `rig_debug()` in 3 lines.