### PR TITLE
Fix definition of twiddle_timeout in struct confparam

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -175,7 +175,7 @@ static const struct confparams frontend_cfg_params[] =
     {
         TOK_TWIDDLE_TIMEOUT, "twiddle_timeout", "Timeout(secs) to resume VFO polling when twiddling VFO",
         "For satellite ops when VFOB is twiddled will pause VFOB commands until timeout",
-        "Unset", RIG_CONF_COMBO, { .c = {{ "Unset", "ON", "OFF", NULL }} }
+        "0", RIG_CONF_NUMERIC, { .n = { 0, 100, 1 } }
     },
     {
         TOK_TWIDDLE_RIT, "twiddle_rit", "RIT twiddle",

--- a/src/rig.c
+++ b/src/rig.c
@@ -1918,7 +1918,6 @@ int HAMLIB_API rig_cleanup(RIG *rig)
  * \param seconds    The timeout to set to
  *
  * timeout seconds to stop rigctld when VFO is manually changed
- * turns on/off the radio.
  *
  * \return RIG_OK if the operation has been successful, otherwise
  * a negative value if an error occurred (in which case, cause is


### PR DESCRIPTION
Fixes the definition of config parameter `twiddle_timeout` and the description of `rig_set_twiddle()`.

This sets the maximum value to 10 seconds, however `rigctl` doesn't check the range so it can be set higher.

The value is in seconds with a minimum of 1, I wonder if a lower value would be better if this gets set by software; issue #662 says that `twiddle_timeout` needs to be completed so perhaps this can be changed to be milliseconds. How to test it?
