### PR TITLE
Direct usage text to stderr or stdout depending on context

### DIFF
--- a/tests/ampctl.c
+++ b/tests/ampctl.c
@@ -70,7 +70,7 @@ extern int read_history();
 /*
  * Prototypes
  */
-void usage();
+void usage(FILE *fout);
 
 /*
  * Reminder: when adding long options,
@@ -153,7 +153,7 @@ int main(int argc, char *argv[])
         switch (c)
         {
         case 'h':
-            usage();
+            usage(stdout);
             exit(0);
 
         case 'V':
@@ -237,7 +237,7 @@ int main(int argc, char *argv[])
             break;
 
         default:
-            usage();    /* unknown option? */
+            usage(stderr);    /* unknown option? */
             exit(1);
         }
     }
@@ -438,12 +438,12 @@ int main(int argc, char *argv[])
 }
 
 
-void usage()
+void usage(FILE *fout)
 {
-    printf("Usage: ampctl [OPTION]... [COMMAND]...\n"
+    fprintf(fout, "Usage: ampctl [OPTION]... [COMMAND]...\n"
            "Send COMMANDs to a connected amplifier.\n\n");
 
-    printf(
+    fprintf(fout,
         "  -m, --model=ID                select amplifier model number. See model list (-l)\n"
         "  -r, --amp-file=DEVICE         set device of the amplifier to operate on\n"
         "  -s, --serial-speed=BAUD       set serial speed of the serial port\n"
@@ -464,5 +464,5 @@ void usage()
         "\n"
     );
 
-    usage_amp(stdout);
+    usage_amp(fout);
 }

--- a/tests/ampctld.c
+++ b/tests/ampctld.c
@@ -72,7 +72,7 @@ struct handle_data
 
 void *handle_socket(void *arg);
 
-void usage();
+void usage(FILE *fout);
 
 /*
  * Reminder: when adding long options,
@@ -192,7 +192,7 @@ int main(int argc, char *argv[])
         switch (c)
         {
         case 'h':
-            usage();
+            usage(stdout);
             exit(0);
 
         case 'V':
@@ -262,7 +262,7 @@ int main(int argc, char *argv[])
             break;
 
         default:
-            usage();    /* unknown option? */
+            usage(stderr);    /* unknown option? */
             exit(1);
         }
     }
@@ -673,12 +673,12 @@ handle_exit:
 }
 
 
-void usage()
+void usage(FILE *fout)
 {
-    printf("Usage: ampctld [OPTION]... [COMMAND]...\n"
+    fprintf(fout, "Usage: ampctld [OPTION]... [COMMAND]...\n"
            "Daemon serving COMMANDs to a connected amplifier.\n\n");
 
-    printf(
+    fprintf(fout,
         "  -m, --model=ID                select amplifier model number. See model list (-l)\n"
         "  -r, --amp-file=DEVICE         set device of the amplifier to operate on\n"
         "  -s, --serial-speed=BAUD       set serial speed of the serial port\n"
@@ -694,5 +694,5 @@ void usage()
         "  -V, --version                 output version information and exit\n\n",
         portno);
 
-    usage_amp(stdout);
+    usage_amp(fout);
 }

--- a/tests/rigctl.c
+++ b/tests/rigctl.c
@@ -74,7 +74,7 @@ extern int read_history();
 #define MAXNBOPT 100    /* max number of different options */
 
 
-static void usage(void);
+static void usage(FILE *fout);
 
 /*
  * Reminder: when adding long options,
@@ -269,7 +269,7 @@ int main(int argc, char *argv[])
             break;
 
         case 'h':
-            usage();
+            usage(stdout);
             exit(0);
 
         case 'V':
@@ -463,7 +463,7 @@ int main(int argc, char *argv[])
             break;
 
         default:
-            usage();    /* unknown option? */
+            usage(stderr);    /* unknown option? */
             exit(1);
         }
     }
@@ -871,13 +871,12 @@ int main(int argc, char *argv[])
 }
 
 
-void usage(void)
+void usage(FILE *fout)
 {
-    printf("Usage: rigctl [OPTION]... [COMMAND]...\n"
+    fprintf(fout, "Usage: rigctl [OPTION]... [COMMAND]...\n"
            "Send COMMANDs to a connected radio transceiver or receiver.\n\n");
 
-
-    printf(
+    fprintf(fout,
         "  -m, --model=ID                select radio model number. See model list (-l)\n"
         "  -r, --rig-file=DEVICE         set device of the radio to operate on\n"
         "  -p, --ptt-file=DEVICE         set device of the PTT device to operate on\n"
@@ -908,5 +907,5 @@ void usage(void)
         "\n"
     );
 
-    usage_rig(stdout);
+    usage_rig(fout);
 }

--- a/tests/rigctlcom.c
+++ b/tests/rigctlcom.c
@@ -114,7 +114,7 @@ static struct option long_options[] =
     {0, 0, 0, 0}
 };
 
-void usage();
+void usage(FILE *fout);
 static int handle_ts2000(void *arg);
 
 static RIG *my_rig;             /* handle to rig */
@@ -248,7 +248,7 @@ int main(int argc, char *argv[])
         switch (c)
         {
         case 'h':
-            usage();
+            usage(stdout);
             exit(0);
 
         case 'V':
@@ -400,7 +400,7 @@ int main(int argc, char *argv[])
             break;
 
         default:
-            usage();            /* unknown option? */
+            usage(stderr);            /* unknown option? */
             exit(1);
         }
     }
@@ -411,7 +411,7 @@ int main(int argc, char *argv[])
 
     if (argc == 1)
     {
-        usage();
+        usage(stderr);
         exit(1);
     }
 
@@ -1690,20 +1690,21 @@ static int handle_ts2000(void *arg)
 }
 
 
-void usage()
+void usage(FILE *fout)
 {
     char *name = "rigctlcom";
-    printf("Usage: %s -m rignumber -r comport -s baud -R comport [OPTIONS]...\n\n"
+
+    fprintf(fout, "Usage: %s -m rignumber -r comport -s baud -R comport [OPTIONS]...\n\n"
            "A TS-2000 emulator for rig sharing with programs that don't support Hamlib or FLRig to be able\n"
            "to use a connected radio transceiver or receiver with FLRig or rigctld via Hamlib.\n\n",
            name);
 
-    printf("Example: Using FLRig with virtual COM5/COM6 and other program:\n");
-    printf("\t%s -m 4 -R COM5 -S 115200\n\n", name);
-    printf("Other program would connect to COM6 and use TS-2000 115200 8N1\n\n");
-    printf("See the %s.1 manual page for complete details.\n\n", name);
+    fprintf(fout, "Example: Using FLRig with virtual COM5/COM6 and other program:\n");
+    fprintf(fout, "\t%s -m 4 -R COM5 -S 115200\n\n", name);
+    fprintf(fout, "Other program would connect to COM6 and use TS-2000 115200 8N1\n\n");
+    fprintf(fout, "See the %s.1 manual page for complete details.\n\n", name);
 
-    printf(
+    fprintf(fout,
         "  -m, --model=ID                select radio model number. See model list (-l)\n"
         "  -r, --rig-file=DEVICE         set device of the radio to operate on\n"
         "  -R, --rig-file2=DEVICE        set device of the virtual com port to operate on\n"
@@ -1725,6 +1726,5 @@ void usage()
         "  -V, --version                 output version information and exit\n\n"
     );
 
-    printf("\nReport bugs to <hamlib-developer@lists.sourceforge.net>.\n");
-
+    fprintf(fout, "\nReport bugs to <hamlib-developer@lists.sourceforge.net>.\n");
 }

--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -124,7 +124,7 @@ struct handle_data
 
 
 void *handle_socket(void *arg);
-void usage(void);
+void usage(FILE *fout);
 
 
 static unsigned client_count;
@@ -301,7 +301,7 @@ int main(int argc, char *argv[])
         switch (c)
         {
         case 'h':
-            usage();
+            usage(stdout);
             exit(0);
 
         case 'V':
@@ -524,7 +524,7 @@ int main(int argc, char *argv[])
             break;
 
         default:
-            usage();    /* unknown option? */
+            usage(stderr);    /* unknown option? */
             exit(1);
         }
     }
@@ -1363,13 +1363,13 @@ handle_exit:
 }
 
 
-void usage(void)
+void usage(FILE *fout)
 {
-    printf("Usage: rigctld [OPTION]...\n"
+    fprintf(fout, "Usage: rigctld [OPTION]...\n"
            "Daemon serving COMMANDs to a connected radio transceiver or receiver.\n\n");
 
 
-    printf(
+    fprintf(fout,
         "  -m, --model=ID                select radio model number. See model list (-l)\n"
         "  -r, --rig-file=DEVICE         set device of the radio to operate on\n"
         "  -p, --ptt-file=DEVICE         set device of the PTT device to operate on\n"
@@ -1398,5 +1398,5 @@ void usage(void)
         "  -V, --version                 output version information and exit\n\n",
         portno);
 
-    usage_rig(stdout);
+    usage_rig(fout);
 }

--- a/tests/rigctlsync.c
+++ b/tests/rigctlsync.c
@@ -105,7 +105,7 @@ static struct option long_options[] =
     {0, 0, 0, 0}
 };
 
-void usage();
+void usage(FILE *fout);
 static RIG *my_rig;             /* handle to rig */
 static RIG
 *my_rig_sync;        /* rig the gets synchronized -- freq only for now */
@@ -236,7 +236,7 @@ int main(int argc, char *argv[])
         switch (c)
         {
         case 'h':
-            usage();
+            usage(stdout);
             exit(0);
 
         case 'V':
@@ -409,7 +409,7 @@ int main(int argc, char *argv[])
             break;
 
         default:
-            usage();            /* unknown option? */
+            usage(stderr);            /* unknown option? */
             exit(1);
         }
     }
@@ -420,7 +420,7 @@ int main(int argc, char *argv[])
 
     if (argc < 3)
     {
-        usage();
+        usage(stderr);
         exit(1);
     }
 
@@ -591,19 +591,20 @@ int main(int argc, char *argv[])
     return 0;
 }
 
-void usage()
+void usage(FILE *fout)
 {
     const char *name = "rigctlsync";
-    printf("Usage: %s -m rignumber -r comport -s baud -M rignumber -R comport [OPTIONS]...\n\n"
+
+    fprintf(fout, "Usage: %s -m rignumber -r comport -s baud -M rignumber -R comport [OPTIONS]...\n\n"
            "Will copy frequency from -m rig to -M rig\n"
            "e.g. will keep SDR# synchronized to a rig.\n\n",
            name);
 
-    printf("Example: Sync freq from rigctld to SDR#\n");
-    printf("\t%s -m 2 -M 9 -R 127.0.0.1:4532\n\n", name);
-    printf("See the %s.1 manual page for complete details.\n\n", name);
+    fprintf(fout, "Example: Sync freq from rigctld to SDR#\n");
+    fprintf(fout, "\t%s -m 2 -M 9 -R 127.0.0.1:4532\n\n", name);
+    fprintf(fout, "See the %s.1 manual page for complete details.\n\n", name);
 
-    printf(
+    fprintf(fout,
         "  -m, --model=ID                select radio model number. See model list (-l)\n"
         "  -r, --rig-file=DEVICE         set device of the radio to operate on\n"
         "  -R, --rig-file2=DEVICE        set device of the virtual com port to operate on\n"
@@ -620,6 +621,5 @@ void usage()
         "  -V, --version                 output version information and exit\n\n"
     );
 
-    printf("\nReport bugs to <hamlib-developer@lists.sourceforge.net>.\n");
-
+    fprintf(fout, "\nReport bugs to <hamlib-developer@lists.sourceforge.net>.\n");
 }

--- a/tests/rigctltcp.c
+++ b/tests/rigctltcp.c
@@ -128,7 +128,7 @@ struct handle_data
 
 
 void *handle_socket(void *arg);
-void usage(void);
+void usage(FILE *fout);
 
 static unsigned client_count;
 
@@ -301,7 +301,7 @@ int main(int argc, char *argv[])
         switch (c)
         {
         case 'h':
-            usage();
+            usage(stdout);
             exit(0);
 
         case 'V':
@@ -525,7 +525,7 @@ int main(int argc, char *argv[])
             break;
 
         default:
-            usage();    /* unknown option? */
+            usage(stderr);    /* unknown option? */
             exit(1);
         }
     }
@@ -1364,13 +1364,12 @@ handle_exit:
 }
 
 
-void usage(void)
+void usage(FILE *fout)
 {
-    printf("Usage: rigctltcp [OPTION]...\n"
+    fprintf(fout, "Usage: rigctltcp [OPTION]...\n"
            "Daemon serving COMMANDs to a connected radio transceiver or receiver.\n\n");
 
-
-    printf(
+    fprintf(fout,
         "  -m, --model=ID                select radio model number. See model list (-l)\n"
         "  -r, --rig-file=DEVICE         set device of the radio to operate on\n"
         "  -p, --ptt-file=DEVICE         set device of the PTT device to operate on\n"
@@ -1400,5 +1399,5 @@ void usage(void)
         "  -V, --version                 output version information and exit\n\n",
         portno);
 
-    usage_rig(stdout);
+    usage_rig(fout);
 }

--- a/tests/rigmem.c
+++ b/tests/rigmem.c
@@ -54,7 +54,7 @@ extern int csv_parm_load(RIG *rig, const char *infilename);
 /*
  * Prototypes
  */
-void usage();
+void usage(FILE *fout);
 void version();
 static int set_conf(RIG *rig, char *conf_parms);
 
@@ -122,7 +122,7 @@ int main(int argc, char *argv[])
         switch (c)
         {
         case 'h':
-            usage();
+            usage(stdout);
             exit(0);
 
         case 'V':
@@ -187,7 +187,7 @@ int main(int argc, char *argv[])
             break;
 
         default:
-            usage();    /* unknown option? */
+            usage(stderr);    /* unknown option? */
             exit(1);
         }
     }
@@ -201,7 +201,7 @@ int main(int argc, char *argv[])
 
     if (optind + 1 >= argc)
     {
-        usage();
+        usage(stderr);
         exit(1);
     }
 
@@ -348,7 +348,7 @@ int main(int argc, char *argv[])
     }
     else
     {
-        usage();
+        usage(stderr);
         exit(1);
     }
 
@@ -372,13 +372,13 @@ void version()
 }
 
 
-void usage()
+void usage(FILE *fout)
 {
-    printf("Usage: rigmem [OPTION]... COMMAND... FILE\n"
+    fprintf(fout, "Usage: rigmem [OPTION]... COMMAND... FILE\n"
            "Backup/restore COMMANDs to a connected radio transceiver or receiver.\n\n");
 
 
-    printf(
+    fprintf(fout,
         "  -m, --model=ID                select radio model number. See model list (rigctl -l)\n"
         "  -r, --rig-file=DEVICE         set device of the radio to operate on\n"
         "  -s, --serial-speed=BAUD       set serial speed of the serial port\n"
@@ -394,7 +394,7 @@ void usage()
         "  -V, --version                 output version information and exit\n\n"
     );
 
-    printf(
+    fprintf(fout,
         "COMMANDs:\n"
         "  load\n"
         "  save\n"
@@ -403,8 +403,7 @@ void usage()
         "  clear\n\n"
     );
 
-    printf("\nReport bugs to <hamlib-developer@lists.sourceforge.net>.\n");
-
+    fprintf(fout, "\nReport bugs to <hamlib-developer@lists.sourceforge.net>.\n");
 }
 
 

--- a/tests/rigsmtr.c
+++ b/tests/rigsmtr.c
@@ -36,7 +36,7 @@
 /*
  * Prototypes
  */
-static void usage();
+static void usage(FILE *fout);
 static void version();
 static int set_conf_rig(RIG *rig, char *conf_parms);
 static int set_conf_rot(ROT *rot, char *conf_parms);
@@ -106,7 +106,7 @@ int main(int argc, char *argv[])
         switch (c)
         {
         case 'h':
-            usage();
+            usage(stdout);
             exit(0);
 
         case 'V':
@@ -177,7 +177,7 @@ int main(int argc, char *argv[])
             break;
 
         default:
-            usage();    /* unknown option? */
+            usage(stderr);    /* unknown option? */
             exit(1);
         }
     }
@@ -356,12 +356,12 @@ void version()
 }
 
 
-void usage()
+void usage(FILE *fout)
 {
-    printf("Usage: rigsmtr [OPTION]... [time]\n"
+    fprintf(fout, "Usage: rigsmtr [OPTION]... [time]\n"
            "Input S-Meter vs Azimuth.\n\n");
 
-    printf(
+    fprintf(fout,
         "  -m, --model=ID                select radio model number. See model list (rigctl -l)\n"
         "  -r, --rig-file=DEVICE         set device of the radio to operate on\n"
         "  -s, --serial-speed=BAUD       set serial speed of the serial port\n"
@@ -376,8 +376,7 @@ void usage()
         "  -V, --version                 output version information and exit\n\n"
     );
 
-    printf("\nReport bugs to <hamlib-developer@lists.sourceforge.net>.\n");
-
+    fprintf(fout, "\nReport bugs to <hamlib-developer@lists.sourceforge.net>.\n");
 }
 
 

--- a/tests/rigswr.c
+++ b/tests/rigswr.c
@@ -34,7 +34,7 @@
 /*
  * Prototypes
  */
-static void usage();
+static void usage(FILE *fout);
 static void version();
 static int set_conf(RIG *rig, char *conf_parms);
 
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
         switch (c)
         {
         case 'h':
-            usage();
+            usage(stdout);
             exit(0);
 
         case 'V':
@@ -178,7 +178,7 @@ int main(int argc, char *argv[])
             break;
 
         default:
-            usage();    /* unknown option? */
+            usage(stderr);    /* unknown option? */
             exit(1);
         }
     }
@@ -191,7 +191,7 @@ int main(int argc, char *argv[])
 
     if (optind + 1 >= argc)
     {
-        usage();
+        usage(stderr);
         exit(1);
     }
 
@@ -310,13 +310,13 @@ void version()
 }
 
 
-void usage()
+void usage(FILE *fout)
 {
-    printf("Usage: rigswr [OPTION]... start_freq stop_freq [freq_step]\n"
+    fprintf(fout, "Usage: rigswr [OPTION]... start_freq stop_freq [freq_step]\n"
            "Output SWR vs Frequency.\n\n");
 
 
-    printf(
+    fprintf(fout,
         "  -m, --model=ID                select radio model number. See model list (rigctl -l)\n"
         "  -r, --rig-file=DEVICE         set device of the radio to operate on\n"
         "  -s, --serial-speed=BAUD       set serial speed of the serial port\n"
@@ -329,8 +329,7 @@ void usage()
         "  -V, --version                 output version information and exit\n\n"
     );
 
-    printf("\nReport bugs to <hamlib-developer@lists.sourceforge.net>.\n");
-
+    fprintf(fout, "\nReport bugs to <hamlib-developer@lists.sourceforge.net>.\n");
 }
 
 

--- a/tests/rotctl.c
+++ b/tests/rotctl.c
@@ -70,7 +70,7 @@ extern int read_history();
 /*
  * Prototypes
  */
-void usage();
+void usage(FILE *fout);
 
 /*
  * Reminder: when adding long options,
@@ -161,7 +161,7 @@ int main(int argc, char *argv[])
         switch (c)
         {
         case 'h':
-            usage();
+            usage(stdout);
             exit(0);
 
         case 'V':
@@ -258,7 +258,7 @@ int main(int argc, char *argv[])
             break;
 
         default:
-            usage();    /* unknown option? */
+            usage(stderr);    /* unknown option? */
             exit(1);
         }
     }
@@ -478,12 +478,12 @@ int main(int argc, char *argv[])
 }
 
 
-void usage()
+void usage(FILE *fout)
 {
-    printf("Usage: rotctl [OPTION]... [COMMAND]...\n"
+    fprintf(fout, "Usage: rotctl [OPTION]... [COMMAND]...\n"
            "Send COMMANDs to a connected antenna rotator.\n\n");
 
-    printf(
+    fprintf(fout,
         "  -m, --model=ID                select rotator model number. See model list (-l)\n"
         "  -r, --rot-file=DEVICE         set device of the rotator to operate on\n"
         "  -R, --rot-file2=DEVICE        set device of the 2nd rotator controller to operate on\n"
@@ -507,5 +507,5 @@ void usage()
         "\n"
     );
 
-    usage_rot(stdout);
+    usage_rot(fout);
 }

--- a/tests/rotctld.c
+++ b/tests/rotctld.c
@@ -69,7 +69,7 @@ struct handle_data
 
 void *handle_socket(void *arg);
 
-void usage();
+void usage(FILE *fout);
 
 /*
  * Reminder: when adding long options,
@@ -185,7 +185,7 @@ int main(int argc, char *argv[])
         switch (c)
         {
         case 'h':
-            usage();
+            usage(stdout);
             exit(0);
 
         case 'V':
@@ -267,7 +267,7 @@ int main(int argc, char *argv[])
             break;
 
         default:
-            usage();    /* unknown option? */
+            usage(stderr);    /* unknown option? */
             exit(1);
         }
     }
@@ -697,12 +697,12 @@ handle_exit:
 }
 
 
-void usage()
+void usage(FILE *fout)
 {
-    printf("Usage: rotctld [OPTION]... [COMMAND]...\n"
+    fprintf(fout, "Usage: rotctld [OPTION]... [COMMAND]...\n"
            "Daemon serving COMMANDs to a connected antenna rotator.\n\n");
 
-    printf(
+    fprintf(fout,
         "  -m, --model=ID                select rotator model number. See model list (-l)\n"
         "  -r, --rot-file=DEVICE         set device of the rotator to operate on\n"
         "  -R, --rot-file2=DEVICE        set device of the 2nd rotator controller to operate on\n"
@@ -721,5 +721,5 @@ void usage()
         "  -V, --version                 output version information and exit\n\n",
         portno);
 
-    usage_rot(stdout);
+    usage_rot(fout);
 }


### PR DESCRIPTION
Prints usage text to stdout when requested with -h/--help or to stderr otherwise.

This was part of a big PR that I split and I'm sending as draft because I'm not convinced that the long text to `stderr` is too useful because the error message has scrolled away by about 100 lines, so an alternate change could be print a shorter usage text to `stderr` in case of error, but I can't think of what should contain (all the short and long options? only some of them?).

The idea was that if the  user passed the `--help` argument then the text is printed to `stdout` like now, otherwise if the program prints the usage text after an error then the text goes to `stderr`; in other words, the patterns are:
```
            usage(stdout);
            exit(0);
```
and:
```
            usage(stderr);
            exit(1);
```
