### PR TITLE
Fix get set conf

### DIFF
--- a/rigs/dummy/dummy.c
+++ b/rigs/dummy/dummy.c
@@ -430,6 +430,10 @@ static int dummy_get_conf(RIG *rig, hamlib_token_t token, char *val)
         strcpy(val, priv->magic_conf);
         break;
 
+    case TOK_CFG_STATIC_DATA:
+        SNPRINTF(val, 128, "%d", priv->static_data);
+        break;
+
     default:
         RETURNFUNC(-RIG_EINVAL);
     }

--- a/src/conf.c
+++ b/src/conf.c
@@ -1221,6 +1221,14 @@ static int frontend_get_conf2(RIG *rig, hamlib_token_t token, char *val,
         SNPRINTF(val, val_len, "%g", rs->lo_freq);
         break;
 
+    case TOK_RANGE_SELECTED:
+        SNPRINTF(val, val_len, "%d", 0); // FIXME
+        break;
+
+    case TOK_RANGE_NAME:
+        SNPRINTF(val, val_len, "%s", ""); // FIXME
+        break;
+
     case TOK_CACHE_TIMEOUT:
         SNPRINTF(val, val_len, "%d", rig_get_cache_timeout_ms(rig, HAMLIB_CACHE_ALL));
         break;
@@ -1257,8 +1265,20 @@ static int frontend_get_conf2(RIG *rig, hamlib_token_t token, char *val,
         SNPRINTF(val, val_len, "%d", rs->twiddle_rit);
         break;
 
+    case TOK_OFFSET_VFOA:
+        SNPRINTF(val, val_len, "%g", rs->offset_vfoa);
+        break;
+
+    case TOK_OFFSET_VFOB:
+        SNPRINTF(val, val_len, "%g", rs->offset_vfob);
+        break;
+
     case TOK_ASYNC:
         SNPRINTF(val, val_len, "%d", rs->async_data_enabled);
+        break;
+
+    case TOK_TUNER_CONTROL_PATHNAME:
+        SNPRINTF(val, val_len, "%s", rs->tuner_control_pathname);
         break;
 
     case TOK_TIMEOUT_RETRY:
@@ -1279,6 +1299,10 @@ static int frontend_get_conf2(RIG *rig, hamlib_token_t token, char *val,
 
     case TOK_MULTICAST_CMD_PORT:
         SNPRINTF(val, val_len, "%d", rs->multicast_cmd_port);
+        break;
+
+    case TOK_FREQ_SKIP:
+        SNPRINTF(val, val_len, "%d", rs->freq_skip);
         break;
 
     default:

--- a/src/conf.c
+++ b/src/conf.c
@@ -81,13 +81,13 @@ static const struct confparams frontend_cfg_params[] =
         "1", RIG_CONF_NUMERIC, { .n = { 0, 100, 1 } }
     },
     {
-        TOK_RANGE_SELECTED, "Selected range list", "Range list#",
-        "The tx/rx range list in use",
+        TOK_RANGE_SELECTED, "range_list_number", "Range list number",
+        "The tx/rx range list number in use",
         "0", RIG_CONF_NUMERIC, { .n = { 1, 5, 1 } }
     },
     {
-        TOK_RANGE_NAME, "Selected range list", "Range list name",
-        "The tx/rx range list name",
+        TOK_RANGE_NAME, "range_list_name", "Range list name",
+        "The tx/rx range list name in use",
         "Default", RIG_CONF_STRING
     },
     {

--- a/src/conf.c
+++ b/src/conf.c
@@ -1222,12 +1222,10 @@ static int frontend_get_conf2(RIG *rig, hamlib_token_t token, char *val,
         break;
 
     case TOK_RANGE_SELECTED:
-        SNPRINTF(val, val_len, "%d", 0); // FIXME
-        break;
+        return -RIG_ENAVAIL;
 
     case TOK_RANGE_NAME:
-        SNPRINTF(val, val_len, "%s", ""); // FIXME
-        break;
+        return -RIG_ENAVAIL;
 
     case TOK_CACHE_TIMEOUT:
         SNPRINTF(val, val_len, "%d", rig_get_cache_timeout_ms(rig, HAMLIB_CACHE_ALL));

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -6048,7 +6048,7 @@ declare_proto_rig(get_conf)
 
     if (arg1 == NULL || arg1[0] == '?')
     {
-        dumpconf_list(rig, stdout);
+        dumpconf_list(rig, fout);
         debugmsgsave[0] = 0;
         debugmsgsave2[0] = 0;
         return RIG_OK;


### PR DESCRIPTION
This PR:
* add support for reading the following tokens (they could only be written)
   * `freq_skip`
   * `offset_vfoa`
   * `offset_vfob`
   * `tuner_control_pathname`
* adds some preliminary support for reading the following tokens (they can only be written)
   * `range_list_name`
   * `range_list_number`

Initially I made `range_list_name` always return an empty string and `range_list_number` always returns 0, then I changed both to return `-RIG_ENAVAIL` because the value passed to `set_conf` isn't stored anywhere so it can't be read back.

The tokens that return an error when using `get_conf` with the dummy driver are:
* `MGC`
* `MGF`
* `MGL`
* `MGO`
* `range_list_name`
* `range_list_number`
 
I'm going to open an issue because this affects also other drivers.

Test case for `get_conf` (see [output-get_conf.txt](https://github.com/user-attachments/files/22125525/output-get_conf.txt)):
```
tests/rigctl \
 get_conf async \
 get_conf auto_disable_screensaver \
 get_conf auto_power_off \
 get_conf auto_power_on \
 get_conf cache_timeout \
 get_conf client \
 get_conf dcd_pathname \
 get_conf dcd_type \
 get_conf device_id \
 get_conf disable_yaesu_bandselect \
 get_conf flushx \
 get_conf freq_skip \
 get_conf lo_freq \
 get_conf mcfg \
 get_conf MGC \
 get_conf MGF \
 get_conf MGL \
 get_conf MGO \
 get_conf multicast_cmd_addr \
 get_conf multicast_cmd_port \
 get_conf multicast_data_addr \
 get_conf multicast_data_port \
 get_conf offset_vfoa \
 get_conf offset_vfob \
 get_conf poll_interval \
 get_conf post_ptt_delay \
 get_conf post_write_delay \
 get_conf ptt_bitnum \
 get_conf ptt_pathname \
 get_conf ptt_share \
 get_conf ptt_type \
 get_conf retry \
 get_conf rig_pathname \
 get_conf static_data \
 get_conf timeout \
 get_conf timeout_retry \
 get_conf tuner_control_pathname \
 get_conf twiddle_rit \
 get_conf twiddle_timeout \
 get_conf vfo_comp \
 get_conf write_delay \
 > output-get_conf.txt
 ```
Test case for `set_conf` (see [output-set_conf.txt](https://github.com/user-attachments/files/22125534/output-set_conf.txt))
```

tests/rigctl \
 set_conf async 0 \
 set_conf auto_disable_screensaver 0 \
 set_conf auto_power_off 0 \
 set_conf auto_power_on 0 \
 set_conf cache_timeout 0 \
 set_conf client 0 \
 set_conf dcd_pathname 0 \
 set_conf dcd_type None \
 set_conf device_id 0 \
 set_conf disable_yaesu_bandselect 0 \
 set_conf flushx 0 \
 set_conf freq_skip 0 \
 set_conf lo_freq 0 \
 set_conf mcfg 0 \
 set_conf MGC 0 \
 set_conf MGF 0 \
 set_conf MGL 0 \
 set_conf MGO 0 \
 set_conf multicast_cmd_addr 0 \
 set_conf multicast_cmd_port 0 \
 set_conf multicast_data_addr 0 \
 set_conf multicast_data_port 0 \
 set_conf offset_vfoa 0 \
 set_conf offset_vfob 0 \
 set_conf poll_interval 0 \
 set_conf post_ptt_delay 0 \
 set_conf post_write_delay 0 \
 set_conf ptt_bitnum 0 \
 set_conf ptt_pathname 0 \
 set_conf ptt_share 0 \
 set_conf ptt_type None \
 set_conf range_list_name 0 \
 set_conf range_list_number 0 \
 set_conf retry 0 \
 set_conf rig_pathname 0 \
 set_conf static_data 0 \
 set_conf timeout 0 \
 set_conf timeout_retry 0 \
 set_conf tuner_control_pathname 0 \
 set_conf twiddle_rit 0 \
 set_conf twiddle_timeout 0 \
 set_conf vfo_comp 0 \
 set_conf write_delay 0 \
 > output-set_conf.txt
```