### PR TITLE
Partially revert "[src] Remove unused includes"

### DIFF
--- a/src/amp_conf.c
+++ b/src/amp_conf.c
@@ -37,6 +37,7 @@
 #include <string.h>  /* String function definitions */
 
 #include "hamlib/amplifier.h"
+#include "hamlib/port.h"
 #include "hamlib/amp_state.h"
 
 #include "amp_conf.h"

--- a/src/amplifier.c
+++ b/src/amplifier.c
@@ -58,6 +58,7 @@
 #include <fcntl.h>
 
 #include "hamlib/amplifier.h"
+#include "hamlib/port.h"
 #include "hamlib/amp_state.h"
 #include "serial.h"
 #include "parallel.h"

--- a/src/conf.c
+++ b/src/conf.c
@@ -38,6 +38,7 @@
 #include <strings.h>
 
 #include "hamlib/rig.h"
+#include "hamlib/port.h"
 #include "hamlib/rig_state.h"
 #include "token.h"
 

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -25,6 +25,7 @@
 #include <fcntl.h>
 
 #include "gpio.h"
+#include "hamlib/port.h"
 
 
 int gpio_open(hamlib_port_t *port, int output, int on_value)

--- a/src/iofunc.c
+++ b/src/iofunc.c
@@ -41,6 +41,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 
+#include "hamlib/port.h"
 #include "iofunc.h"
 #include "misc.h"
 

--- a/src/network.c
+++ b/src/network.c
@@ -74,6 +74,7 @@
 #endif
 
 #include "hamlib/rig.h"
+#include "hamlib/port.h"
 #include "hamlib/rig_state.h"
 #include "network.h"
 #include "misc.h"

--- a/src/parallel.c
+++ b/src/parallel.c
@@ -53,6 +53,7 @@
 #  include <winbase.h>
 #endif
 
+#include "hamlib/port.h"
 #include "parallel.h"
 
 #ifdef HAVE_LINUX_PPDEV_H

--- a/src/register.h
+++ b/src/register.h
@@ -23,6 +23,8 @@
 
 
 #include "hamlib/rig.h"
+#include "hamlib/rotator.h"
+#include "hamlib/amplifier.h"
 #include "hamlib/config.h"
 
 #ifdef __cplusplus

--- a/src/rig.c
+++ b/src/rig.c
@@ -52,6 +52,7 @@
 
 #include "hamlib/config.h"
 #include "hamlib/rig.h"
+#include "hamlib/port.h"
 #include "hamlib/rig_state.h"
 #include "fifo.h"
 

--- a/src/rot_conf.c
+++ b/src/rot_conf.c
@@ -38,6 +38,7 @@
 #include <string.h>  /* String function definitions */
 
 #include "hamlib/rotator.h"
+#include "hamlib/port.h"
 #include "hamlib/rot_state.h"
 
 #include "rot_conf.h"

--- a/src/rotator.c
+++ b/src/rotator.c
@@ -56,6 +56,7 @@
 #include <fcntl.h>
 
 #include "hamlib/rotator.h"
+#include "hamlib/port.h"
 #include "hamlib/rot_state.h"
 #include "serial.h"
 #include "parallel.h"
@@ -63,7 +64,6 @@
 #include "usb_port.h"
 #endif
 #include "network.h"
-
 
 #ifndef DOC_HIDDEN
 

--- a/src/serial.c
+++ b/src/serial.c
@@ -59,6 +59,7 @@
 #endif
 
 #include "hamlib/rig.h"
+#include "hamlib/port.h"
 
 //! @cond Doxygen_Suppress
 #if defined(WIN32) && !defined(HAVE_TERMIOS_H)

--- a/src/snapshot_data.c
+++ b/src/snapshot_data.c
@@ -2,6 +2,7 @@
 #include <unistd.h>
 #include "hamlib/config.h"
 #include "hamlib/rig.h"
+#include "hamlib/port.h"
 #include "hamlib/rig_state.h"
 #include "misc.h"
 #include "cache.h"

--- a/src/usb_port.c
+++ b/src/usb_port.c
@@ -39,6 +39,7 @@
 #include <strings.h>
 
 #include "hamlib/rig.h"
+#include "hamlib/port.h"
 
 #ifdef HAVE_LIBUSB_H
 #  include <libusb.h>


### PR DESCRIPTION
This partially reverts commit 83ed5abeb44e21c1e13a7a57e0f02eb8a1dece6e.

@GeoBaltz this PR adds all `hamlib/*` includes removed in PR #1872, is this correct?

```
      1 +#include "hamlib/amplifier.h"
     13 +#include "hamlib/port.h"
      1 +#include "hamlib/rotator.h"
```