### PR TITLE
lib/precise_time.c: Remove dead code

### DIFF
--- a/lib/precise_time.c
+++ b/lib/precise_time.c
@@ -53,15 +53,8 @@ double monotonic_seconds()
 
 #include <time.h>
 
-static int showme = 0;
-
 double monotonic_seconds()
 {
-    if (showme)
-    {
-        showme = 0;
-    }
-
     struct timespec time;
 
     // Note: Make sure to link with -lrt to define clock_gettime.
@@ -170,11 +163,6 @@ static void __attribute__((constructor)) init_rdtsc_per_sec()
 
 double monotonic_seconds()
 {
-    if (showme)
-    {
-        showme = false;
-    }
-
     return (double) rdtsc() / (double) rdtsc_per_sec;
 }
 


### PR DESCRIPTION
The last branch of `#if _POSIX_TIMERS` was missing a declaration of "showme". Since that variable is not used anywhere, just drop it.

Discovered because the hurd-i386 Debian build was failing: https://buildd.debian.org/status/fetch.php?pkg=hamlib&arch=hurd-i386&ver=4.6.5-1&stamp=1757241757&raw=0