### PR TITLE
Handle --amp-file and --rotfile for pytests

### DIFF
--- a/bindings/python/conftest.py
+++ b/bindings/python/conftest.py
@@ -10,7 +10,7 @@ def pytest_addoption(parser):
                         metavar='ID', help='select amplifier model number')
         parser.addoption('--amp-file', default=None,
                         metavar='DEVICE', help='set device of the amplifier to operate on')
-    if sys.argv[1].endswith("rig.py"):
+    elif sys.argv[1].endswith("rig.py"):
         parser.addoption('--model', type=int, default=1,
                         metavar='ID', help='select radio model number')
         parser.addoption('--rig-file', default=None,

--- a/bindings/python/conftest.py
+++ b/bindings/python/conftest.py
@@ -44,6 +44,10 @@ def rig_file(request):
     return request.config.getoption("--rig-file")
 
 @pytest.fixture
+def rot_file(request):
+    return request.config.getoption("--rot-file")
+
+@pytest.fixture
 def serial_speed(request):
     return request.config.getoption("--serial-speed")
 

--- a/bindings/python/conftest.py
+++ b/bindings/python/conftest.py
@@ -36,6 +36,10 @@ def model(request):
     return request.config.getoption("--model")
 
 @pytest.fixture
+def amp_file(request):
+    return request.config.getoption("--amp-file")
+
+@pytest.fixture
 def rig_file(request):
     return request.config.getoption("--rig-file")
 

--- a/bindings/python/test_rot.py
+++ b/bindings/python/test_rot.py
@@ -5,6 +5,7 @@ Running this script directly will use the installed bindings.
 For an in-tree run use "make check", or set PYTHONPATH to point to
 the directories containing Hamlib.py and _Hamlib.so.
 """
+import pytest
 from pytest import raises
 
 import Hamlib
@@ -49,12 +50,18 @@ class TestClass:
         assert rot.token_lookup("") is None
 
 
-    def test_with_open(self, model):
+    @pytest.mark.skipif('config.getoption("model") != Hamlib.ROT_MODEL_DUMMY')
+    def test_with_open(self, model, rot_file, serial_speed):
         """Call all the methods that depend on open()"""
         rot = Hamlib.Rot(model)
         assert rot is not None
 
         assert rot.state.comm_state == 0
+        # first try a known string because rot_file is None during "make check"
+        assert rot.set_conf("rot_pathname", "foo") is None
+        assert rot.get_conf("rot_pathname") == "foo"
+        assert rot.set_conf("rot_pathname", rot_file) is None
+        assert rot.set_conf("serial_speed", str(serial_speed)) is None
         assert rot.open() is None
         assert rot.state.comm_state == 1
         info = rot.get_info()
@@ -108,6 +115,7 @@ class TestClass:
         assert info is None
 
 
+    @pytest.mark.skipif('config.getoption("model") != Hamlib.ROT_MODEL_DUMMY')
     def test_object_creation(self, model):
         """Create all objects available"""
         rot = Hamlib.Rig(model)

--- a/src/amp_conf.c
+++ b/src/amp_conf.c
@@ -683,7 +683,7 @@ int HAMLIB_API amp_set_conf(AMP *amp, hamlib_token_t token, const char *val)
 {
     amp_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    if (!amp || !amp->caps)
+    if (!amp || !amp->caps || !val)
     {
         return -RIG_EINVAL;
     }

--- a/src/rot_conf.c
+++ b/src/rot_conf.c
@@ -748,7 +748,7 @@ int HAMLIB_API rot_set_conf(ROT *rot, hamlib_token_t token, const char *val)
 {
     rot_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    if (!rot || !rot->caps)
+    if (!rot || !rot->caps || !val)
     {
         return -RIG_EINVAL;
     }


### PR DESCRIPTION
This PR allows to run some tests with different drivers using the well-known `--model` argument.

Examples:
```
PYTHONPATH=bindings/:bindings/.libs bindings/python/test_amp.py --model 2
PYTHONPATH=bindings/:bindings/.libs bindings/python/test_rot.py --model 2
```
As for the rigs, at this time only the simpler tests that do not open the device are enabled for all models; the tests that open the device are enabled only for the dummy model number 1 for two reasons: they would probably fail because some arguments aren't meaningful for actual devices and there is also the risk of activating functions that the user didn't want.