### PR TITLE
First cut at separating CIs with Ubuntu latest

### DIFF
--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -1,0 +1,84 @@
+name: C/C++ CI on Ubuntu latest
+
+on:
+  push:
+    branches: [ master, feature/* ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        configure_args:
+          - >-
+            --enable-html-matrix=no
+            --enable-parallel=no
+            --enable-pytest=no
+            --enable-shared=yes
+            --enable-silent-rules
+            --enable-static=yes
+            --enable-usrp=no
+            --enable-winradio=no
+            --with-cxx-binding=no
+            --with-indi=no
+            --with-libusb=no
+            --with-lua-binding=no
+            --with-perl-binding=no
+            --with-python-binding=no
+            --with-readline=no
+            --with-tcl-binding=no
+            --with-xml-support=no
+          - >-
+            --enable-html-matrix=yes
+            --enable-parallel=yes
+            --enable-pytest=yes
+            --enable-shared=yes
+            --enable-silent-rules
+            --enable-static=yes
+            --enable-usrp=no
+            --enable-winradio=yes
+            --with-cxx-binding=yes
+            --with-indi=yes
+            --with-libusb=yes
+            --with-lua-binding=yes
+            --with-perl-binding=yes
+            --with-python-binding=yes
+            --with-readline=yes
+            --with-tcl-binding=yes
+            --with-xml-support=yes
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies on Ubuntu latest
+      run: |
+        sudo apt update
+        sudo apt install libusb-1.0-0-dev
+        sudo apt install libgd-dev
+        sudo apt install libgpiod-dev
+        sudo apt install libindi-dev libnova-dev
+        sudo apt install grep
+        sudo apt install python3-dev python3-pytest
+        sudo apt install lua5.4 liblua5.4-dev libperl-dev tcl-dev
+    - name: bootstrap
+      run: |
+        pwd
+        ./bootstrap
+    - name: README Debug
+      run: grep README Makefile.am
+    - name: configure
+      run: ./configure ${{ matrix.configure_args }}
+    - name: make
+      run: make -j 4 V=0 --no-print-directory
+    - name: make distcheck
+      run: make distcheck V=0 --no-print-directory AM_DISTCHECK_CONFIGURE_FLAGS="${{ matrix.configure_args }} --without-perl-binding"
+    - name: 'Tar files'
+      run: tar -cvf hamlib_artifacts /home/runner/work/Hamlib/Hamlib
+    - name: 'Upload Build Artifacts'
+      uses: actions/upload-artifact@v4.6.2
+      with:
+        name: 'Hamlib build artifacts'
+      path: hamlib_artifacts
+


### PR DESCRIPTION
Includes runs without and with language bindings.

Should create a build artifact tar file.

References GitHub issue #1870.