### PR TITLE
Fix setting the variable HAVE_LIBUSB for makefiles by adding a missing AC_SUBST

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -357,7 +357,6 @@ AC_ARG_WITH([libusb],
     )
 
 AC_MSG_RESULT([$cf_with_libusb])
-AM_CONDITIONAL([HAVE_LIBUSB], [test x"${cf_with_libusb}" = "xyes"])
 
 LIBUSB=""
 AC_ARG_VAR([LIBUSB_CFLAGS], [C compiler flags for libusb, overriding configure defaults])
@@ -376,6 +375,9 @@ AS_IF([test x"${cf_with_libusb}" = "xyes"], [
 		   [1],
 		   [Define if libusb-1.0 is available])
 	LIBUSB="libusb-1.0"])])
+
+AM_CONDITIONAL([HAVE_LIBUSB], [test x"${cf_with_libusb}" = "xyes"])
+AC_SUBST([HAVE_LIBUSB])
 
 # Only used in hamlib.pc.in
 AC_SUBST([LIBUSB])

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,8 +4,6 @@
 # AUTOMAKE_OPTIONS = dejagnu
 # DEJATOOL = testfreq testbcd testloc rigctl
 
-# For some reason this "if" is not working -- rigtestlibusb is still being included
-# Fix for now is to change rigtestlibusb.c instead
 if HAVE_LIBUSB
     TESTLIBUSB = rigtestlibusb
 else


### PR DESCRIPTION
This fixes a build failure when running `./configure --with-libusb' (which is the default when no libusb argument is given) and the needed files weren't found.

The relevant fragment of `configure` output looks like this:
```
checking whether to build USB dependent backends... yes
checking for libusb-1.0... yes
checking for libusb.h... no
checking for libusb-1.0/libusb.h... no
```