### PR TITLE
Fix build

### DIFF
--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -16,4 +16,7 @@ TESTS = $(check_PROGRAMS)
 $(top_builddir)/src/libhamlib.la:
 	$(MAKE) -C $(top_builddir)/src/ libhamlib.la
 
+$(top_builddir)/lib/libmisc.la:
+	$(MAKE) -C $(top_builddir)/lib/ libmisc.la
+
 endif

--- a/simulators/Makefile.am
+++ b/simulators/Makefile.am
@@ -101,3 +101,6 @@ EXTRA_DIST = sim.h simft990.dat
 
 $(top_builddir)/src/libhamlib.la:
 	$(MAKE) -C $(top_builddir)/src/ libhamlib.la
+
+$(top_builddir)/lib/libmisc.la:
+	$(MAKE) -C $(top_builddir)/lib/ libmisc.la

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -127,6 +127,9 @@ TESTS = $(check_SCRIPTS)
 $(top_builddir)/src/libhamlib.la:
 	$(MAKE) -C $(top_builddir)/src/ libhamlib.la
 
+$(top_builddir)/lib/libmisc.la:
+	$(MAKE) -C $(top_builddir)/lib/ libmisc.la
+
 testrig.sh:
 	echo 'LD_LIBRARY_PATH=$(top_builddir)/src/.libs:$(top_builddir)/dummy/.libs ./testrig 1' > testrig.sh
 	chmod +x ./testrig.sh


### PR DESCRIPTION
This PR fixes build errors when running `make` from inside the `simulators/` or `tests/` directories.
In my tests running `make` inside the `c++/` never failed, however the rule for build `libmisc.la` was missing, so I'm adding it there too.