### PR TITLE
Various fixes, mostly for error handling

### DIFF
--- a/amplifiers/elecraft/kpa.c
+++ b/amplifiers/elecraft/kpa.c
@@ -574,7 +574,7 @@ int kpa_set_powerstat(AMP *amp, powerstat_t status)
 
     switch (status)
     {
-    case RIG_POWER_UNKNOWN: break;
+    //case RIG_POWER_UNKNOWN: break;
 
     case RIG_POWER_OFF: cmd = "^ON0;"; break;
 
@@ -584,17 +584,15 @@ int kpa_set_powerstat(AMP *amp, powerstat_t status)
 
     case RIG_POWER_STANDBY: cmd = "^OS0;"; break;
 
-
     default:
         rig_debug(RIG_DEBUG_ERR, "%s invalid status=%d\n", __func__, status);
+	return -RIG_EINVAL;
 
     }
 
     retval = kpa_transaction(amp, cmd, NULL, 0);
 
-    if (retval != RIG_OK) { return retval; }
-
-    return RIG_OK;
+    return retval;
 }
 
 int kpa_reset(AMP *amp, amp_reset_t reset)

--- a/amplifiers/gemini/gemini.c
+++ b/amplifiers/gemini/gemini.c
@@ -348,7 +348,7 @@ int gemini_set_powerstat(AMP *amp, powerstat_t status)
 
     switch (status)
     {
-    case RIG_POWER_UNKNOWN: break;
+    //case RIG_POWER_UNKNOWN: break;
 
     case RIG_POWER_OFF: cmd = "R0\n"; break;
 
@@ -358,17 +358,15 @@ int gemini_set_powerstat(AMP *amp, powerstat_t status)
 
     case RIG_POWER_STANDBY: cmd = "R0\n"; break;
 
-
     default:
         rig_debug(RIG_DEBUG_ERR, "%s invalid status=%d\n", __func__, status);
+        return -RIG_EINVAL;
 
     }
 
     retval = gemini_transaction(amp, cmd, NULL, 0);
 
-    if (retval != RIG_OK) { return retval; }
-
-    return RIG_OK;
+    return retval;
 }
 
 int gemini_reset(AMP *amp, amp_reset_t reset)

--- a/rigs/dummy/rot_pstrotator.c
+++ b/rigs/dummy/rot_pstrotator.c
@@ -18,12 +18,13 @@
  *
  */
 
+#include "hamlib/config.h"
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
 #include <sys/time.h>
 #include <errno.h>
+#include <unistd.h>
 
-#include "hamlib/config.h"
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
@@ -277,6 +278,7 @@ static int pstrotator_rot_init(ROT *rot)
     priv->az = priv->el = 0;
 
     priv->target_az = priv->target_el = 0;
+    priv->sockfd2 = -1;
 
     strcpy(ROTPORT(rot)->pathname, "192.168.56.1:12000");
 
@@ -335,6 +337,7 @@ static int pstrotator_rot_open(ROT *rot)
     if (bind(sockfd, (const struct sockaddr *)&clientAddr, sizeof(clientAddr)) < 0)
     {
         rig_debug(RIG_DEBUG_ERR, "%s: bind failed: %s\n", __func__, strerror(errno));
+	close(sockfd);
         return -RIG_EINTERNAL;
     }
 
@@ -370,6 +373,11 @@ static int pstrotator_rot_close(ROT *rot)
     rig_debug(RIG_DEBUG_VERBOSE, "%s: thread stopped\n", __func__);
     priv->threadid = 0;
 
+    if (priv->sockfd2 != -1)
+    {
+        close(priv->sockfd2);
+        priv->sockfd2 = -1;
+    }
     return RIG_OK;
 }
 

--- a/rigs/dummy/trxmanager.c
+++ b/rigs/dummy/trxmanager.c
@@ -1165,11 +1165,7 @@ static int trxmanager_set_split_freq_mode(RIG *rig, vfo_t vfo, freq_t freq,
 
     if (strlen(response) != 16 || strstr(response, cmd) == NULL)
     {
-        FILE *fp;
         rig_debug(RIG_DEBUG_ERR, "%s invalid response='%s'\n", __func__, response);
-        fp = fopen("debug.txt", "w+");
-        fprintf(fp, "XT response=%s\n", response);
-        fclose(fp);
         return -RIG_EPROTO;
     }
 

--- a/rigs/kenwood/k3.c
+++ b/rigs/kenwood/k3.c
@@ -2996,12 +2996,6 @@ static int k3_send_voice_mem(RIG *rig, vfo_t vfo, int ch)
     const char *cmd;
     int retval;
 
-    if (ch < 1 || ch > 4)
-    {
-        rig_debug(RIG_DEBUG_ERR, "%s: expected 1<=ch<=4, got %d\n", __func__, ch);
-        return (-RIG_EINVAL);
-    }
-
     switch (ch)
     {
     case 1: cmd = "SWT21;"; break;
@@ -3011,6 +3005,10 @@ static int k3_send_voice_mem(RIG *rig, vfo_t vfo, int ch)
     case 3: cmd = "SWT35;"; break;
 
     case 4: cmd = "SWT39;"; break;
+
+    default:      
+        rig_debug(RIG_DEBUG_ERR, "%s: expected 1<=ch<=4, got %d\n", __func__, ch);
+        return (-RIG_EINVAL);
     }
 
     retval = kenwood_transaction(rig, cmd, NULL, 0);

--- a/tests/rigctltcp.c
+++ b/tests/rigctltcp.c
@@ -1121,7 +1121,7 @@ void *handle_socket(void *arg)
             powerstat_t powerstat;
             unsigned char cmd[64];
             unsigned char reply[64];
-            unsigned char *term = (unsigned char *)";";
+            unsigned char term[2] = ";";
             rig_debug(RIG_DEBUG_TRACE, "%s: doing rigctl_parse vfo_mode=%d, secure=%d\n",
                       __func__,
                       handle_data_arg->vfo_mode, handle_data_arg->use_password);


### PR DESCRIPTION
Don't let one error lead to others - don't call routine on uninitialized buffer, don't go on if we get bad input, don't forget to clean up if we're exiting early, yada, yada.

Fix bad use of string literal.
