### PR TITLE
Revert updating FLRig model name

### DIFF
--- a/rigs/dummy/flrig.c
+++ b/rigs/dummy/flrig.c
@@ -145,7 +145,7 @@ struct rig_caps flrig_caps =
     RIG_MODEL(RIG_MODEL_FLRIG),
     .model_name = "FLRig",
     .mfg_name = "FLRig",
-    .version = "20250107.2",
+    .version = "20260130.0",
     .copyright = "LGPL",
     .status = RIG_STATUS_STABLE,
     .rig_type = RIG_TYPE_TRANSCEIVER,
@@ -869,10 +869,6 @@ static int flrig_open(RIG *rig)
 
     strncpy(priv->info, value, sizeof(priv->info));
     rig_debug(RIG_DEBUG_VERBOSE, "Transceiver=%s\n", value);
-    char model_name[256];
-    snprintf(model_name,sizeof(model_name), "%.248s(%s)", value, "FLRig");
-    rig->caps->model_name = strdup(model_name);
-    STATE(rig)->model_name = strdup(model_name);
 
     /* see if get_pwrmeter_scale is available */
     retval = flrig_transaction(rig, "rig.get_pwrmeter_scale", NULL, value,


### PR DESCRIPTION
Per discussion on the mailing list:
https://sourceforge.net/p/hamlib/mailman/message/59275001/

The additions in commit c22392e5cd are causing issues for users of mutliple radios when using the FLrig interface.  This commit reverts c22392e5cd and partially reverts commit 11acef5d3b as it applies to flrig.c

Thanks to Peter Sumner, VK5PJ, and Philip Rose, GM3ZZA, for working this out.