### PR TITLE
Fix various unknown type compilation errors

### DIFF
--- a/rigs/jrc/jst145.c
+++ b/rigs/jrc/jst145.c
@@ -66,7 +66,7 @@ struct jst145_priv_data
 {
     ptt_t ptt;
     freq_t freqA, freqB;
-    mode_t mode;
+    rmode_t mode;
 };
 
 

--- a/rigs/yaesu/ft847.c
+++ b/rigs/yaesu/ft847.c
@@ -216,7 +216,7 @@ struct ft847_priv_data
     /* for early ft847's we keep our own memory items */
     /* Early rigs are one-way com to the rig */
     freq_t freqA, freqB;
-    mode_t mode;
+    rmode_t mode;
     pbwidth_t width;
     ptt_t ptt;
 };

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -1061,7 +1061,7 @@ int newcat_get_conf2(RIG *rig, hamlib_token_t token, char *val, int val_len)
 static int freq_60m[] = { 5332000, 5348000, 5358500, 5373000, 5405000 };
 
 /* returns 0 if no exception or 1 if rig needs special handling */
-int newcat_60m_exception(RIG *rig, freq_t freq, mode_t mode)
+int newcat_60m_exception(RIG *rig, freq_t freq, rmode_t mode)
 {
     struct newcat_priv_data *priv = (struct newcat_priv_data *)STATE(rig)->priv;
     int err;


### PR DESCRIPTION
When compiling Hamlib 4.7 on Alpine Linux, the build fails due to several unknown type errors with the following message:

    error: unknown type name 'mode_t'; did you mean 'rmode_t'?

This commit adjusts the usage of mode_t to rmode_t to fix these compilation errors. With these changes, Hamlib 4.7 builds on Alpine Linux 3.21.6.

See PR #1642 for additional context.