### PR TITLE
Initialize rp->timeout in rig_init

### DIFF
--- a/src/rig.c
+++ b/src/rig.c
@@ -776,11 +776,12 @@ RIG *HAMLIB_API rig_init(rig_model_t rig_model)
 
     rp->write_delay = caps->write_delay;
     rp->post_write_delay = caps->post_write_delay;
+    rp->timeout = caps->timeout;
 
     // since we do two timeouts now we can cut the timeout in half for serial
     if (caps->port_type == RIG_PORT_SERIAL && caps->timeout_retry >= 0)
     {
-        rp->timeout = caps->timeout / 2;
+        rp->timeout /= 2;
     }
 
     rp->retry = caps->retry;
@@ -1273,7 +1274,6 @@ int HAMLIB_API rig_open(RIG *rig)
         }
     }
 
-    rp->timeout = caps->timeout;
     status = port_open(rp);
 
     if (status < 0)


### PR DESCRIPTION
Timeout setting, e.g. provided by rig_set_conf(), is not effective.
It gets set in rig_open(), overwriting any value set from config, as well as the caps->timeout/2 logic in rig_init().

This change may cause issues for users, that have unreasonable timeouts configured, which did not take effect, but would now.