### PR TITLE
Potential fix for incorrect return-value check for a 'scanf'-like function

### DIFF
--- a/rigs/codan/codan.c
+++ b/rigs/codan/codan.c
@@ -384,17 +384,18 @@ int codan_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
     }
 
     retval = sscanf(response, "FREQ: %lg", freq);
-
-    if (retval == 0)
-    retval = sscanf(response, "CHAN: %lg", freq);
-
-    *freq *= 1000; // returned freq is in kHz
+    if (retval != 1)
+    {
+        retval = sscanf(response, "CHAN: %lg", freq);
+    }
 
     if (retval != 1)
     {
         rig_debug(RIG_DEBUG_ERR, "%s: Unable to parse response\n", __func__);
         return -RIG_EPROTO;
     }
+
+    *freq *= 1000; // returned freq is in kHz
 
     return RIG_OK;
 }


### PR DESCRIPTION
**CodeQL in my branch detected a potential issue with the sscanf starting on line 386 in rigs/codan/codan.c,  Here is the analysis**:

In general, code using scanf-like functions should compare the return value to the exact number of expected successful conversions (here, 1) and treat any other value (including 0 and EOF) as an error. Chaining multiple parse attempts should be done by explicitly checking for success (retval == 1) and only then using the parsed values.

For this specific code in rigs/codan/codan.c, we should change the logic so that:

    We first try to parse "FREQ: %lg".
    If that fails (i.e., retval != 1), we then try "CHAN: %lg".
    Only if one of those calls returns 1 do we scale *freq by 1000 and return RIG_OK.
    If both fail (including EOF), we log an error and return -RIG_EPROTO.

This can be implemented by replacing the current pattern:

retval = sscanf(response, "FREQ: %lg", freq);

if (retval == 0)
    retval = sscanf(response, "CHAN: %lg", freq);

*freq *= 1000; // returned freq is in kHz

if (retval != 1)
{
    ...
    return -RIG_EPROTO;
}

with logic that:

    Only tries the "CHAN: %lg" parse if the first did not succeed (retval != 1).
    Only multiplies *freq after confirming retval == 1.

No new functions or headers are required; we only adjust the control flow in codan_get_freq around the sscanf calls.