### PR TITLE
ftx1: wire SH bandwidth command into set_mode/get_mode (#2027)

### DIFF
--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -9413,6 +9413,107 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
             RETURNFUNC(RIG_OK);
         }
     } // end is_ftdx101d || is_ftdx101mp || is_ftdx10 || is_ft710
+    else if (is_ftx1)
+    {
+        // Bandwidth table per FTX-1 CAT Operation Reference Manual Table 5
+        // (doc 2508-C). Differs from the FT-710/FTDX10 table at SSB codes
+        // 12/13/14 (2250/2400/2450 Hz vs 2200/2300/2400), so do not merge.
+        switch (mode)
+        {
+        case RIG_MODE_PKTUSB:
+        case RIG_MODE_PKTLSB:
+        case RIG_MODE_RTTY:
+        case RIG_MODE_RTTYR:
+        case RIG_MODE_CW:
+        case RIG_MODE_CWR:
+        case RIG_MODE_PSK:
+            if (width == RIG_PASSBAND_NORMAL) { w = 0; }
+            else if (width <= 50) { w = 1; }
+            else if (width <= 100) { w = 2; }
+            else if (width <= 150) { w = 3; }
+            else if (width <= 200) { w = 4; }
+            else if (width <= 250) { w = 5; }
+            else if (width <= 300) { w = 6; }
+            else if (width <= 350) { w = 7; }
+            else if (width <= 400) { w = 8; }
+            else if (width <= 450) { w = 9; }
+            else if (width <= 500) { w = 10; }
+            else if (width <= 600) { w = 11; }
+            else if (width <= 800) { w = 12; }
+            else if (width <= 1200) { w = 13; }
+            else if (width <= 1400) { w = 14; }
+            else if (width <= 1700) { w = 15; }
+            else if (width <= 2000) { w = 16; }
+            else if (width <= 2400) { w = 17; }
+            else if (width <= 3000) { w = 18; }
+            else if (width <= 3200) { w = 19; }
+            else if (width <= 3500) { w = 20; }
+            else { w = 21; } // 4000 Hz
+
+            break;
+
+        case RIG_MODE_LSB:
+        case RIG_MODE_USB:
+            if (width == RIG_PASSBAND_NORMAL) { w = 0; }
+            else if (width <= 300) {  w = 1; }
+            else if (width <= 400) {  w = 2; }
+            else if (width <= 600) {  w = 3; }
+            else if (width <= 850) {  w = 4; }
+            else if (width <= 1100) {  w = 5; }
+            else if (width <= 1200) {  w = 6; }
+            else if (width <= 1500) {  w = 7; }
+            else if (width <= 1650) {  w = 8; }
+            else if (width <= 1800) {  w = 9; }
+            else if (width <= 1950) {  w = 10; }
+            else if (width <= 2100) {  w = 11; }
+            else if (width <= 2250) {  w = 12; }
+            else if (width <= 2400) {  w = 13; }
+            else if (width <= 2450) {  w = 14; }
+            else if (width <= 2500) {  w = 15; }
+            else if (width <= 2600) {  w = 16; }
+            else if (width <= 2700) {  w = 17; }
+            else if (width <= 2800) {  w = 18; }
+            else if (width <= 2900) {  w = 19; }
+            else if (width <= 3000) {  w = 20; }
+            else if (width <= 3200) {  w = 21; }
+            else if (width <= 3500) {  w = 22; }
+            else { w = 23; } // 4000 Hz
+
+            break;
+
+        case RIG_MODE_AM:
+        case RIG_MODE_AMN:
+        case RIG_MODE_FM:
+        case RIG_MODE_PKTFM:
+        case RIG_MODE_FMN:
+            // Fixed-width per Table 5; handled by narrow-mode toggle below.
+            break;
+
+        default:
+            RETURNFUNC(-RIG_EINVAL);
+        } // end switch(mode)
+
+        switch (mode)
+        {
+        case RIG_MODE_AM:
+        case RIG_MODE_FM:
+        case RIG_MODE_PKTFM:
+            if (width > 0 && width < rig_passband_normal(rig, mode))
+            {
+                err = newcat_set_narrow(rig, vfo,  TRUE);
+            }
+            else
+            {
+                err = newcat_set_narrow(rig, vfo, FALSE);
+            }
+
+            RETURNFUNC(err);
+
+        case RIG_MODE_AMN:
+        case RIG_MODE_FMN:
+            RETURNFUNC(RIG_OK);
+        }
+    } // end is_ftx1
     else if (is_ft2000)
     {
         // We need details on the widths here, manuals lack information.
@@ -9567,7 +9668,7 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     {
         SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "SH0%02d;", w);
     }
-    else if (is_ftdx10 || is_ft710)
+    else if (is_ftdx10 || is_ft710 || is_ftx1)
     {
         SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "SH00%02d;", w);
     }
@@ -10729,6 +10830,160 @@ int newcat_get_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t *width)
 
         rig_debug(RIG_DEBUG_TRACE, "%s: end if FTDX101D\n", __func__);
     } /* end if is_ftdx101d || is_ftdx101mp || is_ftdx10 || is_ft710 */
+    else if (is_ftx1)
+    {
+        // Bandwidth table per FTX-1 CAT Operation Reference Manual Table 5
+        // (doc 2508-C). Differs from FT-710/FTDX10 at SSB codes 12/13/14.
+        rig_debug(RIG_DEBUG_TRACE, "%s: is_ftx1 w=%d, mode=%s\n", __func__, w,
+                  rig_strrmode(mode));
+
+        if (w == 0) // default: fall back to the mode's normal passband
+        {
+            *width = rig_passband_normal(rig, mode);
+        }
+
+        switch (mode)
+        {
+        case RIG_MODE_PKTUSB:
+        case RIG_MODE_PKTLSB:
+        case RIG_MODE_RTTY:
+        case RIG_MODE_RTTYR:
+        case RIG_MODE_CW:
+        case RIG_MODE_CWR:
+        case RIG_MODE_PSK:
+            switch (w)
+            {
+            case 0: break; /* default */
+
+            case 1: *width = 50; break;
+
+            case 2: *width = 100; break;
+
+            case 3: *width = 150; break;
+
+            case 4: *width = 200; break;
+
+            case 5: *width = 250; break;
+
+            case 6: *width = 300; break;
+
+            case 7: *width = 350; break;
+
+            case 8: *width = 400; break;
+
+            case 9: *width = 450;  break;
+
+            case 10: *width = 500;  break;
+
+            case 11: *width = 600;  break;
+
+            case 12: *width = 800;  break;
+
+            case 13: *width = 1200;  break;
+
+            case 14: *width = 1400;  break;
+
+            case 15: *width = 1700;  break;
+
+            case 16: *width = 2000;  break;
+
+            case 17: *width = 2400;  break;
+
+            case 18: *width = 3000;  break;
+
+            case 19: *width = 3200;  break;
+
+            case 20: *width = 3500;  break;
+
+            case 21: *width = 4000;  break;
+
+            default:
+                RETURNFUNC(-RIG_EINVAL);
+            }
+
+            break;
+
+        case RIG_MODE_LSB:
+        case RIG_MODE_USB:
+            switch (w)
+            {
+            case 0: break; /* default */
+
+            case 1: *width = 300; break;
+
+            case 2: *width = 400; break;
+
+            case 3: *width = 600; break;
+
+            case 4: *width = 850; break;
+
+            case 5: *width = 1100; break;
+
+            case 6: *width = 1200; break;
+
+            case 7: *width = 1500; break;
+
+            case 8: *width = 1650; break;
+
+            case 9: *width = 1800; break;
+
+            case 10: *width = 1950;  break;
+
+            case 11: *width = 2100;  break;
+
+            case 12: *width = 2250;  break;
+
+            case 13: *width = 2400;  break;
+
+            case 14: *width = 2450;  break;
+
+            case 15: *width = 2500;  break;
+
+            case 16: *width = 2600;  break;
+
+            case 17: *width = 2700;  break;
+
+            case 18: *width = 2800;  break;
+
+            case 19: *width = 2900;  break;
+
+            case 20: *width = 3000;  break;
+
+            case 21: *width = 3200;  break;
+
+            case 22: *width = 3500;  break;
+
+            case 23: *width = 4000;  break;
+
+            default:
+                rig_debug(RIG_DEBUG_ERR, "%s: unknown width=%d\n", __func__, w);
+                RETURNFUNC(-RIG_EINVAL);
+            }
+
+            break;
+
+        case RIG_MODE_AM:
+        case RIG_MODE_FMN:
+        case RIG_MODE_PKTFMN:
+            *width = 9000;
+            break;
+
+        case RIG_MODE_AMN:
+            *width = 6000;
+            break;
+
+        case RIG_MODE_FM:
+        case RIG_MODE_PKTFM:
+            *width = 16000;
+            break;
+
+        default:
+            rig_debug(RIG_DEBUG_TRACE, "%s: bad mode\n", __func__);
+            RETURNFUNC(-RIG_EINVAL);
+        }   /* end switch(mode) */
+
+        rig_debug(RIG_DEBUG_TRACE, "%s: end if is_ftx1\n", __func__);
+    } /* end if is_ftx1 */
     else if (is_ft2000)
     {
         if ((narrow = get_narrow(rig, RIG_VFO_MAIN)) < 0)


### PR DESCRIPTION
## Summary

Fixes #2027 — FTX-1 `get_mode` always returned `passband=0` and `set_mode` silently dropped the width argument, because the driver delegates to `newcat_set_mode` / `newcat_get_mode` and those helpers had no FTX-1 branch.

This adds dedicated `is_ftx1` branches to `newcat_set_rx_bandwidth` and `newcat_get_rx_bandwidth`, and extends the SH command-string builder at line 9671 to emit the 7-char `SH00NN;` form for FTX-1. Follows the reviewer guidance on the issue (N0NB: "test for `RIG_MODEL_FTX1` and do what is needed in `newcat.c` to support SH") and structures the gating so a future Yaesu model sharing this MD/SH pattern is a one-line extension.

## Why a dedicated branch instead of piggybacking on FT-710

The FTX-1 bandwidth table is per the FTX-1 CAT Operation Reference Manual Table 5 (doc 2508-C, firmware v1.08+). CW/DATA/RTTY/PSK codes 01–21 are identical to the FT-710 table, but the **SSB column diverges at codes 12/13/14**:

| Code | FT-710 (existing) | FTX-1 (spec) |
|------|-------------------|--------------|
| 12   | 2200 Hz           | **2250 Hz**  |
| 13   | 2300 Hz           | **2400 Hz**  |
| 14   | 2400 Hz           | **2450 Hz**  |

Sharing the branch would silently misreport 2400 Hz on the FTX-1 — exactly the canonical SSB filter width — because the radio would return `w=13` (= 2400 Hz on FTX-1) but the FT-710 decoder would translate that to 2300 Hz. PSK is also included in the CW/DATA/RTTY case group because Table 5 groups it there, and live probing confirmed PSK mode defaults to SH code 19 (the DATA default).

## Verification

Built clean against current master on macOS (Apple Silicon). Verified end-to-end against a live **FTX-1 field, firmware v1.12**, at 115200 bps through rigctl:

```
M USB 2400  → m → USB 2400   (was broken: returned 0)
M USB 2700  → m → USB 2700   (was broken: returned 0)
M USB 2250  → m → USB 2250   (corrected code 12)
M USB 2450  → m → USB 2450   (corrected code 14)
M USB 3000  → m → USB 3000
M CW 500    → m → CW 500     (was broken: returned 0)
M CW 2400   → m → CW 2400
M PKTUSB 3000 → m → PKTUSB 3000
M AM 9000   → m → AM 9000
M FM 16000  → m → FM 16000
```

Cross-checked raw-CAT afterwards to confirm the radio received the *corrected* SH codes on the wire (not the stale FT-710 codes):

```
USB 2250 Hz → SH0012;
USB 2400 Hz → SH0013;   ← proof the corrected branch is in effect
USB 2450 Hz → SH0014;
```

## Firmware note

The existing `newcat_get_rx_bandwidth` 7-byte response parser at line 9922 (`SH%*1d%1d%3d`) already handles the FTX-1 `SH00NN;` response shape unchanged. The read-command builder at line 9908 (`SH%c;`) also already produces the correct query form. Only the decode tables and SET branch needed new code.

SH set was empirically confirmed to work and persist in-session on firmware v1.12 across 16 sweep writes in LSB and CW-U, plus the full rigctl test above.

## Test plan

- [x] Build clean on macOS ARM
- [x] `rigctl -m 1051` set/get round-trip for SSB, CW, DATA, AM, FM
- [x] Raw-CAT confirmation of corrected SH code mapping
- [x] Out-of-range behavior: firmware silently clamps (CW code 22 → 21), hamlib pre-clamps per mode
- [ ] Regression on FT-710 / FTDX10 (no hardware available; existing branch is untouched, `is_ftx1` false path)