### PR TITLE
ftx1: rewrite set_channel using VFO-B + BM workaround (#2034)

### DIFF
--- a/rigs/yaesu/ftx1/ftx1.c
+++ b/rigs/yaesu/ftx1/ftx1.c
@@ -72,6 +72,7 @@ extern int ftx1_set_att_helper(RIG *rig, vfo_t vfo, value_t val);
 extern int ftx1_get_att_helper(RIG *rig, vfo_t vfo, value_t *val);
 
 /* Wrappers from ftx1_func.c for rig caps */
+extern int ftx1_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width);
 extern int ftx1_set_ptt_func(RIG *rig, vfo_t vfo, ptt_t ptt);
 extern int ftx1_get_ptt_func(RIG *rig, vfo_t vfo, ptt_t *ptt);
 extern int ftx1_set_powerstat_func(RIG *rig, powerstat_t status);
@@ -863,6 +864,43 @@ static int ftx1_close(RIG *rig)
 }
 
 /*
+ * ftx1_ensure_vfo_mode - exit Memory mode if the driver last saw MC enter it
+ *
+ * FTX-1 firmware rejects FA/OS sets when the Main side is in Memory mode
+ * (VM011) and silently discards CT/CN/MD sets as transient memory-tune
+ * overlays. Callers that set VFO-side state should call this first so the
+ * operation actually lands.
+ *
+ * We track memory-mode entry in priv->ftx1_in_memory_mode (set by
+ * ftx1_set_mem after a successful MC). If the flag is clear, this is a
+ * no-op — we don't spam the rig with VM000 on every VFO-state set.
+ *
+ * Best-effort: on failure the flag is cleared unconditionally so we
+ * don't loop.
+ */
+void ftx1_ensure_vfo_mode(RIG *rig)
+{
+    struct newcat_priv_data *priv;
+
+    if (!rig)
+    {
+        return;
+    }
+
+    priv = STATE(rig)->priv;
+    if (!priv || !priv->ftx1_in_memory_mode)
+    {
+        return;
+    }
+
+    rig_debug(RIG_DEBUG_VERBOSE, "%s: exiting memory mode via VM000;\n",
+              __func__);
+    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "VM000;");
+    (void)newcat_set_cmd(rig);
+    priv->ftx1_in_memory_mode = 0;
+}
+
+/*
  * ftx1_has_spa1 - Check if Optima/SPA-1 amplifier is present
  *
  * Returns 1 if Optima/SPA-1 detected, 0 otherwise.
@@ -1157,7 +1195,7 @@ struct rig_caps ftx1_caps = {
     .rig_close = ftx1_close,  /* FTX-1 specific close - resets detection state */
     .set_freq = ftx1_set_freq,
     .get_freq = ftx1_get_freq,
-    .set_mode = newcat_set_mode,
+    .set_mode = ftx1_set_mode,
     .get_mode = newcat_get_mode,
     .set_vfo = ftx1_set_vfo,
     .get_vfo = ftx1_get_vfo,

--- a/rigs/yaesu/ftx1/ftx1.h
+++ b/rigs/yaesu/ftx1/ftx1.h
@@ -222,6 +222,14 @@ extern int ftx1_has_spa1(RIG *rig);
 extern int ftx1_get_head_type(RIG *rig);
 
 /*
+ * ftx1_ensure_vfo_mode - force the radio out of Memory mode if the driver
+ * knows it entered via a prior set_mem.  Call at the top of any VFO-state
+ * setter that would otherwise fail or behave transiently in Memory mode.
+ * See ftx1.c for full rationale.
+ */
+extern void ftx1_ensure_vfo_mode(RIG *rig);
+
+/*
  * FTX-1 band select functions (defined in ftx1_scan.c)
  */
 extern int ftx1_set_band_select(RIG *rig, vfo_t vfo, int band);

--- a/rigs/yaesu/ftx1/ftx1.h
+++ b/rigs/yaesu/ftx1/ftx1.h
@@ -231,5 +231,6 @@ extern int ftx1_get_band_select(RIG *rig, vfo_t vfo, int *band);
  * FTX-1 CTCSS helpers (defined in ftx1_ctcss.c)
  */
 extern int ftx1_freq_to_tone_num(unsigned int freq);
+extern unsigned int ftx1_tone_num_to_freq(int num);
 
 #endif /* _FTX1_H */

--- a/rigs/yaesu/ftx1/ftx1.h
+++ b/rigs/yaesu/ftx1/ftx1.h
@@ -227,4 +227,9 @@ extern int ftx1_get_head_type(RIG *rig);
 extern int ftx1_set_band_select(RIG *rig, vfo_t vfo, int band);
 extern int ftx1_get_band_select(RIG *rig, vfo_t vfo, int *band);
 
+/*
+ * FTX-1 CTCSS helpers (defined in ftx1_ctcss.c)
+ */
+extern int ftx1_freq_to_tone_num(unsigned int freq);
+
 #endif /* _FTX1_H */

--- a/rigs/yaesu/ftx1/ftx1_ctcss.c
+++ b/rigs/yaesu/ftx1/ftx1_ctcss.c
@@ -62,7 +62,7 @@ int ftx1_freq_to_tone_num(unsigned int freq)
 }
 
 /* Convert tone number (0-based per spec) to frequency (in 0.1 Hz) */
-static unsigned int ftx1_tone_num_to_freq(int num)
+unsigned int ftx1_tone_num_to_freq(int num)
 {
     if (num < FTX1_CTCSS_MIN || num > FTX1_CTCSS_MAX)
     {

--- a/rigs/yaesu/ftx1/ftx1_ctcss.c
+++ b/rigs/yaesu/ftx1/ftx1_ctcss.c
@@ -46,7 +46,7 @@ static const unsigned int ftx1_ctcss_tones[] = {
 };
 
 /* Convert CTCSS frequency (in 0.1 Hz) to tone number (0-based per spec) */
-static int ftx1_freq_to_tone_num(unsigned int freq)
+int ftx1_freq_to_tone_num(unsigned int freq)
 {
     int i;
 

--- a/rigs/yaesu/ftx1/ftx1_ctcss.c
+++ b/rigs/yaesu/ftx1/ftx1_ctcss.c
@@ -101,6 +101,10 @@ int ftx1_set_ctcss_mode(RIG *rig, tone_t mode)
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: mode=%u\n", __func__, mode);
 
+    /* CT sets are transient overlays in Memory mode — accepted but not
+     * persisted.  Exit memory mode so the change actually sticks. */
+    ftx1_ensure_vfo_mode(rig);
+
     /* CT P1 P2; where P1=VFO (0=Main), P2=mode */
     SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CT0%d;", (int)mode);
     return newcat_set_cmd(rig);
@@ -168,6 +172,9 @@ int ftx1_set_ctcss_tone(RIG *rig, vfo_t vfo, tone_t tone)
     rig_debug(RIG_DEBUG_VERBOSE, "%s: tone=%u tone_num=%d\n", __func__, tone,
               tone_num);
 
+    /* CN on Main is a transient overlay in Memory mode — exit first. */
+    ftx1_ensure_vfo_mode(rig);
+
     /* P1=0 for TX tone, P2P3P4 is 3-digit tone number */
     SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CN00%03d;", tone_num);
     return newcat_set_cmd(rig);
@@ -225,7 +232,9 @@ int ftx1_set_ctcss_sql(RIG *rig, vfo_t vfo, tone_t tone)
     rig_debug(RIG_DEBUG_VERBOSE, "%s: tone=%u tone_num=%d\n", __func__, tone,
               tone_num);
 
-    /* P1=1 for RX tone, P2P3P4 is 3-digit tone number */
+    /* P1=1 for RX tone, P2P3P4 is 3-digit tone number.  CN10 targets
+     * Sub VFO, which is not affected by Main's Memory mode, so no
+     * VM000 injection is needed here. */
     SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CN10%03d;", tone_num);
     return newcat_set_cmd(rig);
 }
@@ -279,6 +288,9 @@ int ftx1_set_dcs_code(RIG *rig, vfo_t vfo, tone_t code)
     (void)vfo;  /* Unused - always Main for now */
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: code=%u\n", __func__, code);
+
+    /* CN on Main is a transient overlay in Memory mode — exit first. */
+    ftx1_ensure_vfo_mode(rig);
 
     /* CN01XXX: Main VFO (0), DCS (1), code index */
     SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CN01%03u;", code);

--- a/rigs/yaesu/ftx1/ftx1_freq.c
+++ b/rigs/yaesu/ftx1/ftx1_freq.c
@@ -17,6 +17,7 @@
 #include "misc.h"
 #include "yaesu.h"
 #include "newcat.h"
+#include "ftx1.h"
 
 // FTX-1 uses 9-digit Hz format for frequency
 #define FTX1_FREQ_DIGITS 9
@@ -43,6 +44,10 @@ int ftx1_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     case RIG_VFO_MAIN:
     case RIG_VFO_CURR:
         cmd = 'A';
+        /* FA set is rejected with ?; while the Main side is in Memory
+         * mode. Force an exit before sending the command. FB (sub) is
+         * unaffected and does not need this. */
+        ftx1_ensure_vfo_mode(rig);
         break;
 
     case RIG_VFO_B:
@@ -175,6 +180,9 @@ int ftx1_set_rptr_shift(RIG *rig, vfo_t vfo, rptr_shift_t shift)
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: vfo=%s shift=%d\n",
               __func__, rig_strvfo(vfo), shift);
+
+    /* OS Main is rejected with ?; in Memory mode. Exit before sending. */
+    ftx1_ensure_vfo_mode(rig);
 
     /* Determine VFO */
     switch (vfo)

--- a/rigs/yaesu/ftx1/ftx1_mem.c
+++ b/rigs/yaesu/ftx1/ftx1_mem.c
@@ -141,21 +141,34 @@ int ftx1_get_mem(RIG *rig, vfo_t vfo, int *ch)
  *                target slot. Ignore '?' if the slot is currently
  *                unprogrammed — the cursor still updates for BM.
  *   2. VM000;    Force VFO mode in case MC entered memory mode.
- *   3. FB / MD1 / CT1 / CN10 / CN11 / OS1   Program VFO-B.
- *                CT/CN/OS only work in FM, so tone/shift are only
- *                emitted for FM-family channel modes.
+ *   3. FB / MD1 / CT1 / CN10 / OS1 / CF1   Program VFO-B.
+ *                CT/CN/OS only work in FM, so tone and shift are only
+ *                emitted for FM-family channel modes. Clarifier (CF)
+ *                is programmed for all modes.
  *   4. BM;       Copy VFO-B to the last-selected memory channel.
  *
  * VFO-B is used rather than VFO-A so the operator's primary RX VFO
  * is not disturbed. VFO-B's frequency and mode are snapshotted at
  * entry and best-effort restored on exit (including error paths).
- * Advanced VFO-B state (CT/CN/OS/CF) may still be clobbered for
- * callers that relied on it.
+ * VFO-B's clarifier and CT state are cleared during cleanup — any
+ * caller that relied on those aspects of VFO-B's state will need to
+ * reprogram them after rig_set_channel.
  *
- * Clarifier/RIT/XIT persistence into the memory slot is not yet
- * supported — BM's handling of clarifier state has not been
- * empirically verified. This is a potential follow-up if users
- * report it missing.
+ * Firmware limitations verified empirically on fw v1.12: the BM
+ * command does NOT propagate two kinds of state to the memory slot,
+ * even though the CAT commands to set them on VFO-B succeed:
+ *
+ *   - DCS: CT13 (DCS mode) + CN11<code> program VFO-B correctly, but
+ *     the stored memory channel reads back with CTCSS mode OFF. DCS
+ *     channels cannot be programmed via CAT and must be set up from
+ *     the front panel. We still emit the CT/CN commands so that if
+ *     firmware is fixed later, the code path works.
+ *
+ *   - XIT (TX clarifier flag): the clarifier offset frequency and
+ *     the RX clarifier on/off flag both propagate correctly, but the
+ *     TX CLAR on/off flag is dropped by BM and always reads back as
+ *     OFF in the stored channel. We set it anyway for forward
+ *     compatibility.
  */
 int ftx1_set_channel(RIG *rig, vfo_t vfo, const channel_t *chan)
 {
@@ -295,14 +308,75 @@ int ftx1_set_channel(RIG *rig, vfo_t vfo, const channel_t *chan)
         (void)newcat_set_cmd(rig);
     }
 
+    /* 3d. Clarifier (RIT/XIT). The FTX-1 uses one shared offset with
+     *     independent RX/TX on-off toggles via the 11-char CF command:
+     *     CF P1 P2 P3 P4 P5P5P5P5 ; where P3=0 sets RX/TX on/off
+     *     (P4: 0=RX OFF, 1=RX ON, 2=TX OFF, 3=TX ON) and P3=1 sets the
+     *     offset frequency (P4=+/-, P5P5P5P5 = offset Hz).
+     *
+     *     If both rit and xit are set, rit's offset wins (matches the
+     *     pre-#2034 behavior of the broken MW path). Note that the TX
+     *     CLAR flag is silently dropped by BM (firmware limitation);
+     *     we still emit it for forward compatibility. */
+    if (chan->rit != 0 || chan->xit != 0)
+    {
+        int off;
+        char dir;
+
+        if (chan->rit != 0)
+        {
+            dir = (chan->rit >= 0) ? '+' : '-';
+            off = (int)labs(chan->rit);
+        }
+        else
+        {
+            dir = (chan->xit >= 0) ? '+' : '-';
+            off = (int)labs(chan->xit);
+        }
+        if (off > 9999) off = 9999;
+
+        SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str),
+                 "CF100%d0000;", (chan->rit != 0) ? 1 : 0);
+        (void)newcat_set_cmd(rig);
+
+        SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str),
+                 "CF100%d0000;", (chan->xit != 0) ? 3 : 2);
+        (void)newcat_set_cmd(rig);
+
+        SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str),
+                 "CF101%c%04d;", dir, off);
+        (void)newcat_set_cmd(rig);
+    }
+    else
+    {
+        /* Explicitly clear VFO-B clarifier state so it doesn't leak
+         * from a previous write or the operator's prior VFO-B. */
+        SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CF10000000;");
+        (void)newcat_set_cmd(rig);
+        SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CF10020000;");
+        (void)newcat_set_cmd(rig);
+    }
+
     /* 4. Commit VFO-B to the last-selected memory channel. */
     SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "BM;");
     err = newcat_set_cmd(rig);
 
 restore:
-    /* Best-effort restore of VFO-B state. Restore failures are not
-     * surfaced — the caller cares about the write's status, not the
+    /* Best-effort restore of VFO-B. Clarifier and CT state that we may
+     * have touched are cleared unconditionally — we don't snapshot
+     * them because CF has no reliable read form. FB and MD1 are
+     * replayed from the entry snapshot. Restore failures are not
+     * surfaced: the caller cares about the write's status, not the
      * side-effect cleanup. */
+    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CF10000000;");
+    (void)newcat_set_cmd(rig);
+    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CF10020000;");
+    (void)newcat_set_cmd(rig);
+    if (is_fm_family)
+    {
+        SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CT10;");
+        (void)newcat_set_cmd(rig);
+    }
     if (saved_fb[0] != '\0')
     {
         SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "%s", saved_fb);

--- a/rigs/yaesu/ftx1/ftx1_mem.c
+++ b/rigs/yaesu/ftx1/ftx1_mem.c
@@ -392,6 +392,100 @@ restore:
 }
 
 /*
+ * ftx1_read_channel_tone_state — read a channel's CTCSS tone / DCS code.
+ *
+ * The MR response carries only the tone MODE (P8), not the actual tone
+ * number or DCS code. To retrieve those we have to select the memory
+ * channel via MC, query CN (which reflects the stored channel state in
+ * memory mode), then restore the caller's prior VM/MC position.
+ *
+ * Intrusiveness note: this briefly switches the radio to memory mode
+ * on the target channel. The visible side effect is a momentary front-
+ * panel display change. State is restored at the end — if the caller
+ * was previously in VFO mode we return via VM000, if they were already
+ * in memory mode on another channel we MC back to that channel.
+ *
+ * mr_p8 is the raw stored P8 byte from MR, encoded per the firmware's
+ * MW/MR swap (different from CT encoding):
+ *   1 = TSQ (tone squelch — TX+RX CTCSS tone)
+ *   2 = ENC (TX CTCSS tone only)
+ *   3 = DCS
+ *
+ * Returns void: best-effort. On any CAT failure the tone fields are
+ * simply left at whatever the caller passed in, and the restore step
+ * still runs.
+ */
+static void ftx1_read_channel_tone_state(RIG *rig, int ch, int mr_p8,
+                                         channel_t *chan)
+{
+    struct newcat_priv_data *priv = STATE(rig)->priv;
+    char saved_vm[16] = {0};
+    char saved_mc[16] = {0};
+    int p1p2, val;
+
+    /* Snapshot current VM and MC so we can restore them. */
+    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "VM0;");
+    if (newcat_get_cmd(rig) == RIG_OK)
+    {
+        strncpy(saved_vm, priv->ret_data, sizeof(saved_vm) - 1);
+    }
+    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "MC0;");
+    if (newcat_get_cmd(rig) == RIG_OK)
+    {
+        strncpy(saved_mc, priv->ret_data, sizeof(saved_mc) - 1);
+    }
+
+    /* Select the target memory channel. */
+    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "MC%06d;", ch);
+    if (newcat_set_cmd(rig) != RIG_OK)
+    {
+        goto restore;
+    }
+
+    if (mr_p8 == 3)
+    {
+        /* DCS: query main-side DCS code via CN01. */
+        SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CN01;");
+        if (newcat_get_cmd(rig) == RIG_OK
+            && sscanf(priv->ret_data + 2, "%2d%3d", &p1p2, &val) == 2)
+        {
+            chan->dcs_code = (tone_t)val;
+        }
+    }
+    else
+    {
+        /* CTCSS: query main-side tone index via CN00. */
+        SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CN00;");
+        if (newcat_get_cmd(rig) == RIG_OK
+            && sscanf(priv->ret_data + 2, "%2d%3d", &p1p2, &val) == 2)
+        {
+            tone_t tone = (tone_t)ftx1_tone_num_to_freq(val);
+            chan->ctcss_tone = tone;
+            /* MW/MR P8=1 is TSQ (encode and decode tones both active);
+             * P8=2 is ENC only. */
+            if (mr_p8 == 1)
+            {
+                chan->ctcss_sql = tone;
+            }
+        }
+    }
+
+restore:
+    /* Return to the caller's prior position. Memory mode on some other
+     * channel is restored via MC; otherwise fall back to VFO mode. */
+    if (strstr(saved_vm, "VM011;") != NULL && saved_mc[0] != '\0')
+    {
+        SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "%s", saved_mc);
+        (void)newcat_set_cmd(rig);
+    }
+    else
+    {
+        SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "VM000;");
+        (void)newcat_set_cmd(rig);
+    }
+}
+
+/*
  * Memory Read (MR) - read memory channel data
  * FIRMWARE FORMAT: MR P1P2P2P2P2 (5-digit: bank + 4-digit channel)
  *   Query: MR00001 for channel 1
@@ -405,10 +499,14 @@ restore:
  *     20        P5             TX CLAR on/off (0/1)
  *     21        P6             Mode code (1-E)
  *     22        P7             VFO/Memory (0/1)
- *     23        P8             CTCSS mode (0-3)
+ *     23        P8             CTCSS mode (0-3, MW/MR swap encoding)
  *     24-25     P9             Reserved "00"
  *     26        P10            Shift (0=simplex, 1=+, 2=-)
  *   Returns '?' if channel doesn't exist (not programmed)
+ *
+ * P8 does NOT carry the actual tone number or DCS code — those have
+ * to be fetched separately via CN, which requires briefly selecting
+ * the channel via MC. See ftx1_read_channel_tone_state().
  */
 int ftx1_get_channel(RIG *rig, vfo_t vfo, channel_t *chan, int read_only)
 {
@@ -518,11 +616,12 @@ int ftx1_get_channel(RIG *rig, vfo_t vfo, channel_t *chan, int read_only)
     /* Skip VFO/Memory indicator (1 char) */
     p++;
 
-    /* Parse CTCSS mode (1 char) */
+    /* Parse CTCSS mode (1 char). This is the MW/MR stored encoding,
+     * which is swapped relative to CT:
+     *   0 = OFF, 1 = TSQ, 2 = ENC, 3 = DCS
+     * The actual tone number or DCS code is fetched below via the
+     * ftx1_read_channel_tone_state helper — MR does not carry it. */
     ctcss_mode = *p++ - '0';
-    /* Note: Actual tone frequencies require separate CN/QN queries */
-    /* Here we just record the mode for reference */
-    (void)ctcss_mode;
 
     /* Skip reserved "00" (2 chars) */
     p += 2;
@@ -537,6 +636,13 @@ int ftx1_get_channel(RIG *rig, vfo_t vfo, channel_t *chan, int read_only)
 
     /* Set width to default (not stored in memory response) */
     chan->width = RIG_PASSBAND_NORMAL;
+
+    /* If the channel has a tone, fetch the actual number or DCS code
+     * via CN (intrusive — briefly selects the channel and restores). */
+    if (ctcss_mode > 0 && ctcss_mode <= 3)
+    {
+        ftx1_read_channel_tone_state(rig, ch, ctcss_mode, chan);
+    }
 
     rig_debug(RIG_DEBUG_VERBOSE,
               "%s: ch=%d freq=%.0f mode=%s rit=%ld xit=%ld shift=%d\n",

--- a/rigs/yaesu/ftx1/ftx1_mem.c
+++ b/rigs/yaesu/ftx1/ftx1_mem.c
@@ -242,12 +242,14 @@ int ftx1_set_channel(RIG *rig, vfo_t vfo, const channel_t *chan)
     SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "FB;");
     if (newcat_get_cmd(rig) == RIG_OK)
     {
-        snprintf(saved_fb, sizeof(saved_fb), "%s", priv->ret_data);
+        snprintf(saved_fb, sizeof(saved_fb), "%.*s",
+                 (int)sizeof(saved_fb) - 1, priv->ret_data);
     }
     SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "MD1;");
     if (newcat_get_cmd(rig) == RIG_OK)
     {
-        snprintf(saved_md1, sizeof(saved_md1), "%s", priv->ret_data);
+        snprintf(saved_md1, sizeof(saved_md1), "%.*s",
+                 (int)sizeof(saved_md1) - 1, priv->ret_data);
     }
 
     /* 1. Point the Sub-side MC cursor at the target slot. The MC SET
@@ -456,12 +458,14 @@ static void ftx1_read_channel_tone_state(RIG *rig, int ch, int mr_p8,
     SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "VM0;");
     if (newcat_get_cmd(rig) == RIG_OK)
     {
-        snprintf(saved_vm, sizeof(saved_vm), "%s", priv->ret_data);
+        snprintf(saved_vm, sizeof(saved_vm), "%.*s",
+                 (int)sizeof(saved_vm) - 1, priv->ret_data);
     }
     SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "MC0;");
     if (newcat_get_cmd(rig) == RIG_OK)
     {
-        snprintf(saved_mc, sizeof(saved_mc), "%s", priv->ret_data);
+        snprintf(saved_mc, sizeof(saved_mc), "%.*s",
+                 (int)sizeof(saved_mc) - 1, priv->ret_data);
     }
 
     /* Select the target memory channel. */

--- a/rigs/yaesu/ftx1/ftx1_mem.c
+++ b/rigs/yaesu/ftx1/ftx1_mem.c
@@ -67,6 +67,7 @@ static int ftx1_get_vfo_mem_mode_internal(RIG *rig, vfo_t *vfo);
 int ftx1_set_mem(RIG *rig, vfo_t vfo, int ch)
 {
     struct newcat_priv_data *priv = STATE(rig)->priv;
+    int ret;
 
     (void)vfo;  /* VFO not used in MC command */
 
@@ -80,7 +81,15 @@ int ftx1_set_mem(RIG *rig, vfo_t vfo, int ch)
 
     /* Format: MCNNNNNN (6-digit channel) */
     SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "MC%06d;", ch);
-    return newcat_set_cmd(rig);
+    ret = newcat_set_cmd(rig);
+    if (ret == RIG_OK)
+    {
+        /* MC on a programmed channel enters Memory mode on the Main
+         * side. Track this so the next VFO-state setter can force an
+         * exit via VM000 before issuing FA/OS/CT/CN/MD. */
+        priv->ftx1_in_memory_mode = 1;
+    }
+    return ret;
 }
 
 /*
@@ -387,6 +396,11 @@ restore:
         SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "%s", saved_md1);
         (void)newcat_set_cmd(rig);
     }
+
+    /* BM always ends with the Main side in VFO mode regardless of the
+     * caller's prior position, so clear the memory-mode tracking flag
+     * to keep ftx1_ensure_vfo_mode() accurate for subsequent setters. */
+    priv->ftx1_in_memory_mode = 0;
 
     return err;
 }

--- a/rigs/yaesu/ftx1/ftx1_mem.c
+++ b/rigs/yaesu/ftx1/ftx1_mem.c
@@ -129,121 +129,192 @@ int ftx1_get_mem(RIG *rig, vfo_t vfo, int *ch)
 }
 
 /*
- * Memory Write (MW) - write channel data to memory
- * CAT Format: MW P1P1P1P1P1 P2P2P2P2P2P2P2P2P2 P3P3P3P3P3 P4 P5 P6 P7 P8 P9P9 P10;
- *   P1 (5 bytes): Channel number (00001-00999 or P-01L-P-50U for PMS)
- *   P2 (9 bytes): VFO Frequency in Hz
- *   P3 (5 bytes): Clarifier direction (+/-) + offset (0000-9990 Hz)
- *   P4 (1 byte): RX CLAR (0=OFF, 1=ON)
- *   P5 (1 byte): TX CLAR (0=OFF, 1=ON)
- *   P6 (1 byte): Mode code (1=LSB, 2=USB, 3=CW-U, 4=FM, 5=AM, 6=RTTY-L,
- *                          7=CW-L, 8=DATA-L, 9=RTTY-U, A=DATA-FM, B=FM-N,
- *                          C=DATA-U, D=AM-N, E=PSK, F=DATA-FM-N)
- *   P7 (1 byte): VFO/Memory mode (0=VFO, 1=Memory, 2=Memory Tune, 3=QMB, 5=PMS)
- *   P8 (1 byte): CTCSS mode (0=OFF, 1=ENC/DEC, 2=ENC, 3=DCS, 4=PR FREQ, 5=REV TONE)
- *   P9 (2 bytes): Fixed "00"
- *   P10 (1 byte): Shift (0=Simplex, 1=Plus, 2=Minus)
+ * Memory Write — VFO-B + BM workaround (issue #2034)
+ *
+ * The FTX-1 MW command is firmware-broken: the radio returns '?;' for
+ * every MW write on every channel, regardless of parameters (verified
+ * against fw v1.12). We therefore implement rig_set_channel by
+ * programming VFO-B to the target state and committing it to the
+ * target memory slot via the BM command:
+ *
+ *   1. MC<ch>;   Point the "last-selected channel" cursor at the
+ *                target slot. Ignore '?' if the slot is currently
+ *                unprogrammed — the cursor still updates for BM.
+ *   2. VM000;    Force VFO mode in case MC entered memory mode.
+ *   3. FB / MD1 / CT1 / CN10 / CN11 / OS1   Program VFO-B.
+ *                CT/CN/OS only work in FM, so tone/shift are only
+ *                emitted for FM-family channel modes.
+ *   4. BM;       Copy VFO-B to the last-selected memory channel.
+ *
+ * VFO-B is used rather than VFO-A so the operator's primary RX VFO
+ * is not disturbed. VFO-B's frequency and mode are snapshotted at
+ * entry and best-effort restored on exit (including error paths).
+ * Advanced VFO-B state (CT/CN/OS/CF) may still be clobbered for
+ * callers that relied on it.
+ *
+ * Clarifier/RIT/XIT persistence into the memory slot is not yet
+ * supported — BM's handling of clarifier state has not been
+ * empirically verified. This is a potential follow-up if users
+ * report it missing.
  */
 int ftx1_set_channel(RIG *rig, vfo_t vfo, const channel_t *chan)
 {
     struct newcat_priv_data *priv = STATE(rig)->priv;
+    char saved_fb[32]  = {0};
+    char saved_md1[16] = {0};
     char mode_char;
-    char clar_dir;
-    int clar_offset;
-    int p7_vfo_mem;
-    int p8_ctcss;
-    int p10_shift;
+    int err;
+    int is_fm_family;
 
     (void)vfo;
 
-    rig_debug(RIG_DEBUG_VERBOSE, "%s: ch=%d freq=%.0f mode=%d\n", __func__,
-              chan->channel_num, chan->freq, (int)chan->mode);
+    rig_debug(RIG_DEBUG_VERBOSE, "%s: ch=%d freq=%.0f mode=%s\n", __func__,
+              chan->channel_num, chan->freq, rig_strrmode(chan->mode));
 
-    /* Validate channel number */
-    if (chan->channel_num < FTX1_MEM_MIN || chan->channel_num > FTX1_MEM_MAX) {
+    if (chan->channel_num < FTX1_MEM_MIN || chan->channel_num > FTX1_MEM_MAX)
+    {
         rig_debug(RIG_DEBUG_ERR, "%s: channel %d out of range %d-%d\n",
                   __func__, chan->channel_num, FTX1_MEM_MIN, FTX1_MEM_MAX);
         return -RIG_EINVAL;
     }
 
-    /* Convert Hamlib mode to FTX-1 mode code */
-    switch (chan->mode) {
-    case RIG_MODE_LSB:      mode_char = '1'; break;
-    case RIG_MODE_USB:      mode_char = '2'; break;
-    case RIG_MODE_CW:       mode_char = '3'; break;  /* CW-U */
-    case RIG_MODE_FM:       mode_char = '4'; break;
-    case RIG_MODE_AM:       mode_char = '5'; break;
-    case RIG_MODE_RTTYR:    mode_char = '6'; break;  /* RTTY-L */
-    case RIG_MODE_CWR:      mode_char = '7'; break;  /* CW-L */
-    case RIG_MODE_PKTLSB:   mode_char = '8'; break;  /* DATA-L */
-    case RIG_MODE_RTTY:     mode_char = '9'; break;  /* RTTY-U */
-    case RIG_MODE_PKTFM:    mode_char = 'A'; break;  /* DATA-FM */
-    case RIG_MODE_FMN:      mode_char = 'B'; break;  /* FM-N */
-    case RIG_MODE_PKTUSB:   mode_char = 'C'; break;  /* DATA-U */
-    case RIG_MODE_AMN:      mode_char = 'D'; break;  /* AM-N */
-    case RIG_MODE_PSK:      mode_char = 'E'; break;  /* PSK */
-    default:                mode_char = '2'; break;  /* Default to USB */
+    switch (chan->mode)
+    {
+    case RIG_MODE_LSB:    mode_char = '1'; break;
+    case RIG_MODE_USB:    mode_char = '2'; break;
+    case RIG_MODE_CW:     mode_char = '3'; break;  /* CW-U */
+    case RIG_MODE_FM:     mode_char = '4'; break;
+    case RIG_MODE_AM:     mode_char = '5'; break;
+    case RIG_MODE_RTTYR:  mode_char = '6'; break;  /* RTTY-L */
+    case RIG_MODE_CWR:    mode_char = '7'; break;  /* CW-L */
+    case RIG_MODE_PKTLSB: mode_char = '8'; break;  /* DATA-L */
+    case RIG_MODE_RTTY:   mode_char = '9'; break;  /* RTTY-U */
+    case RIG_MODE_PKTFM:  mode_char = 'A'; break;  /* DATA-FM */
+    case RIG_MODE_FMN:    mode_char = 'B'; break;  /* FM-N */
+    case RIG_MODE_PKTUSB: mode_char = 'C'; break;  /* DATA-U */
+    case RIG_MODE_AMN:    mode_char = 'D'; break;  /* AM-N */
+    case RIG_MODE_PSK:    mode_char = 'E'; break;  /* PSK */
+    default:
+        rig_debug(RIG_DEBUG_ERR, "%s: unsupported mode %s\n",
+                  __func__, rig_strrmode(chan->mode));
+        return -RIG_EINVAL;
     }
 
-    /* Clarifier direction and offset */
-    if (chan->rit != 0) {
-        clar_dir = (chan->rit >= 0) ? '+' : '-';
-        clar_offset = labs(chan->rit);
-        if (clar_offset > 9990) clar_offset = 9990;
-    } else if (chan->xit != 0) {
-        clar_dir = (chan->xit >= 0) ? '+' : '-';
-        clar_offset = labs(chan->xit);
-        if (clar_offset > 9990) clar_offset = 9990;
-    } else {
-        clar_dir = '+';
-        clar_offset = 0;
+    is_fm_family = (chan->mode == RIG_MODE_FM    || chan->mode == RIG_MODE_FMN
+                 || chan->mode == RIG_MODE_PKTFM || chan->mode == RIG_MODE_PKTFMN);
+
+    /* Snapshot VFO-B state for best-effort restore on exit. Responses
+     * (FB%09d; and MD1%c;) are already valid set commands and can be
+     * replayed verbatim. If the query fails, the saved_* buffer stays
+     * empty and restore is skipped. */
+    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "FB;");
+    if (newcat_get_cmd(rig) == RIG_OK)
+    {
+        strncpy(saved_fb, priv->ret_data, sizeof(saved_fb) - 1);
+    }
+    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "MD1;");
+    if (newcat_get_cmd(rig) == RIG_OK)
+    {
+        strncpy(saved_md1, priv->ret_data, sizeof(saved_md1) - 1);
     }
 
-    /* P7: VFO/Memory mode - default to Memory (1) when writing to channel */
-    p7_vfo_mem = 1;
+    /* 1. Point the MC cursor at the target slot. Returns '?;' when the
+     *    slot is unprogrammed, but the cursor still updates for BM. */
+    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "MC%06d;",
+             chan->channel_num);
+    (void)newcat_set_cmd(rig);
 
-    /* P8: CTCSS mode from channel flags */
-    p8_ctcss = 0;  /* Default OFF */
-    if (chan->flags & RIG_CHFLAG_SKIP) {
-        /* Use flags for tone squelch indication if available */
+    /* 2. Force VFO mode. Must be the 6-char form — extra digits are
+     *    rejected by firmware. */
+    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "VM000;");
+    (void)newcat_set_cmd(rig);
+
+    /* 3a. Program VFO-B frequency. */
+    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "FB%09.0f;", chan->freq);
+    err = newcat_set_cmd(rig);
+    if (err != RIG_OK) goto restore;
+
+    /* 3b. Program VFO-B mode. */
+    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "MD1%c;", mode_char);
+    err = newcat_set_cmd(rig);
+    if (err != RIG_OK) goto restore;
+
+    /* 3c. FM-family channels: program CTCSS/DCS and repeater shift.
+     *     CT, CN (P2=1), and OS commands only function in FM mode, so
+     *     non-FM channels skip this block entirely. */
+    if (is_fm_family)
+    {
+        int os_mode;
+
+        if (chan->dcs_code != 0)
+        {
+            /* DCS: select CT mode 3, then program code via CN P2=1.
+             * (The DC command is firmware-broken — use CN instead.) */
+            SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CT13;");
+            (void)newcat_set_cmd(rig);
+
+            SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CN11%03u;",
+                     chan->dcs_code);
+            (void)newcat_set_cmd(rig);
+        }
+        else if (chan->ctcss_tone != 0)
+        {
+            /* CTCSS: TSQ when both encode and squelch tones are set,
+             * else ENC only. CN P2=0 programs the tone index. */
+            int ct_mode = (chan->ctcss_sql != 0)
+                            ? FTX1_CTCSS_MODE_TSQ
+                            : FTX1_CTCSS_MODE_ENC;
+            int tone_num = ftx1_freq_to_tone_num(chan->ctcss_tone);
+
+            SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str),
+                     "CT1%d;", ct_mode);
+            (void)newcat_set_cmd(rig);
+
+            if (tone_num >= 0)
+            {
+                SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str),
+                         "CN10%03d;", tone_num);
+                (void)newcat_set_cmd(rig);
+            }
+        }
+        else
+        {
+            /* Explicit CT OFF in case VFO-B was previously configured
+             * with a tone. */
+            SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CT10;");
+            (void)newcat_set_cmd(rig);
+        }
+
+        switch (chan->rptr_shift)
+        {
+        case RIG_RPT_SHIFT_PLUS:  os_mode = 1; break;
+        case RIG_RPT_SHIFT_MINUS: os_mode = 2; break;
+        default:                  os_mode = 0; break;  /* simplex */
+        }
+        SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "OS1%d;", os_mode);
+        (void)newcat_set_cmd(rig);
     }
-    /* Check tone settings */
-    if (chan->ctcss_tone != 0 && chan->ctcss_sql != 0) {
-        p8_ctcss = 1;  /* CTCSS ENC/DEC */
-    } else if (chan->ctcss_tone != 0) {
-        p8_ctcss = 2;  /* CTCSS ENC only */
-    } else if (chan->dcs_code != 0) {
-        p8_ctcss = 3;  /* DCS */
+
+    /* 4. Commit VFO-B to the last-selected memory channel. */
+    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "BM;");
+    err = newcat_set_cmd(rig);
+
+restore:
+    /* Best-effort restore of VFO-B state. Restore failures are not
+     * surfaced — the caller cares about the write's status, not the
+     * side-effect cleanup. */
+    if (saved_fb[0] != '\0')
+    {
+        SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "%s", saved_fb);
+        (void)newcat_set_cmd(rig);
+    }
+    if (saved_md1[0] != '\0')
+    {
+        SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "%s", saved_md1);
+        (void)newcat_set_cmd(rig);
     }
 
-    /* P10: Repeater shift */
-    switch (chan->rptr_shift) {
-    case RIG_RPT_SHIFT_PLUS:  p10_shift = 1; break;
-    case RIG_RPT_SHIFT_MINUS: p10_shift = 2; break;
-    default:                  p10_shift = 0; break;  /* Simplex */
-    }
-
-    /* Build MW command string:
-     * MW P1P1P1P1P1 P2P2P2P2P2P2P2P2P2 P3P3P3P3P3 P4 P5 P6 P7 P8 P9P9 P10;
-     * Total: 2 + 5 + 9 + 5 + 1 + 1 + 1 + 1 + 1 + 2 + 1 + 1 = 30 chars
-     */
-    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str),
-             "MW%05d%09.0f%c%04d%d%d%c%d%d00%d;",
-             chan->channel_num,          /* P1: 5-digit channel */
-             chan->freq,                 /* P2: 9-digit frequency in Hz */
-             clar_dir,                   /* P3: clarifier direction */
-             clar_offset,                /* P3: clarifier offset */
-             (chan->rit != 0) ? 1 : 0,   /* P4: RX CLAR on/off */
-             (chan->xit != 0) ? 1 : 0,   /* P5: TX CLAR on/off */
-             mode_char,                  /* P6: mode code */
-             p7_vfo_mem,                 /* P7: VFO/Memory mode */
-             p8_ctcss,                   /* P8: CTCSS mode */
-                                         /* P9: "00" (fixed) */
-             p10_shift);                 /* P10: shift */
-
-    rig_debug(RIG_DEBUG_VERBOSE, "%s: cmd='%s'\n", __func__, priv->cmd_str);
-
-    return newcat_set_cmd(rig);
+    return err;
 }
 
 /*

--- a/rigs/yaesu/ftx1/ftx1_mem.c
+++ b/rigs/yaesu/ftx1/ftx1_mem.c
@@ -8,10 +8,20 @@
  * All memory commands use DIFFERENT FORMATS than documented in the spec!
  *
  * MC (Memory Channel Select):
- *   Query: MC0 (MAIN VFO) or MC1 (SUB VFO)
- *   Response: MCNNNNNN (6-digit channel, e.g., MC000001)
- *   Set: MCNNNNNN (6-digit channel)
- *   Returns '?' if channel doesn't exist (not programmed)
+ *   Both the query and the set form take a VFO digit followed by a
+ *   5-digit channel. The VFO digit is 0 (Main) or 1 (Sub); the two
+ *   sides have independent memory-mode state and can both be parked
+ *   in memory mode simultaneously (VM011 + VM111).
+ *   Query:    MC0;      returns MC0NNNNN (Main's channel)
+ *             MC1;      returns MC1NNNNN (Sub's channel)
+ *   Set:      MC0NNNNN; tunes Main to channel NNNNN
+ *             MC1NNNNN; tunes Sub to channel NNNNN
+ *   The radio's active VFO (VS) does NOT influence which side the SET
+ *   applies to — the first digit of the parameter does. MC%06d; with
+ *   a channel in 1..99 happens to produce MC0NNNNN, so it targets
+ *   Main. Hardware-verified 2026-04-18 against fw v1.12.
+ *   Returns '?' if channel doesn't exist (not programmed), but the
+ *   cursor still updates for a subsequent BM commit.
  *
  * MR (Memory Read): 5-digit format
  *   Query: MR00001 (not MR001 or MR0001)
@@ -232,17 +242,22 @@ int ftx1_set_channel(RIG *rig, vfo_t vfo, const channel_t *chan)
     SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "FB;");
     if (newcat_get_cmd(rig) == RIG_OK)
     {
-        strncpy(saved_fb, priv->ret_data, sizeof(saved_fb) - 1);
+        snprintf(saved_fb, sizeof(saved_fb), "%s", priv->ret_data);
     }
     SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "MD1;");
     if (newcat_get_cmd(rig) == RIG_OK)
     {
-        strncpy(saved_md1, priv->ret_data, sizeof(saved_md1) - 1);
+        snprintf(saved_md1, sizeof(saved_md1), "%s", priv->ret_data);
     }
 
-    /* 1. Point the MC cursor at the target slot. Returns '?;' when the
-     *    slot is unprogrammed, but the cursor still updates for BM. */
-    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "MC%06d;",
+    /* 1. Point the Sub-side MC cursor at the target slot. The MC SET
+     *    form takes a VFO digit followed by a 5-digit channel
+     *    (MC0NNNNN = Main, MC1NNNNN = Sub); BM commits VFO-B to the
+     *    last-selected memory on the Sub side, so targeting Sub here
+     *    keeps Main's front-panel channel from silently flipping.
+     *    Returns '?;' when the slot is unprogrammed, but the cursor
+     *    still updates for the subsequent BM. */
+    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "MC1%05d;",
              chan->channel_num);
     (void)newcat_set_cmd(rig);
 
@@ -441,12 +456,12 @@ static void ftx1_read_channel_tone_state(RIG *rig, int ch, int mr_p8,
     SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "VM0;");
     if (newcat_get_cmd(rig) == RIG_OK)
     {
-        strncpy(saved_vm, priv->ret_data, sizeof(saved_vm) - 1);
+        snprintf(saved_vm, sizeof(saved_vm), "%s", priv->ret_data);
     }
     SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "MC0;");
     if (newcat_get_cmd(rig) == RIG_OK)
     {
-        strncpy(saved_mc, priv->ret_data, sizeof(saved_mc) - 1);
+        snprintf(saved_mc, sizeof(saved_mc), "%s", priv->ret_data);
     }
 
     /* Select the target memory channel. */

--- a/rigs/yaesu/ftx1/ftx1_mode.c
+++ b/rigs/yaesu/ftx1/ftx1_mode.c
@@ -2,8 +2,12 @@
  * Hamlib Yaesu backend - FTX-1 Mode Commands
  * Copyright (c) 2025 by Terrell Deppe (KJ5HST)
  *
- * Mode commands are handled by newcat_set_mode/newcat_get_mode.
- * This file documents the FTX-1 specific mode codes for reference.
+ * Mode commands are mostly handled by newcat_set_mode/newcat_get_mode.
+ * This file adds an FTX-1 set_mode wrapper that forces the radio out
+ * of Memory mode before delegating to newcat, because Memory-mode MD
+ * sets on the Main side are accepted by firmware but treated as a
+ * transient memory-tune overlay that does not persist when the user
+ * leaves the channel.
  *
  * CAT Commands:
  *   MD P1 P2;  - Operating Mode (P1=VFO 0/1, P2=mode code)
@@ -17,4 +21,15 @@
  *       NA (Notch Auto) - handled via ftx1_noise.c
  */
 
-/* No FTX-1 specific mode functions needed - newcat handles MD command */
+#include <hamlib/rig.h>
+#include "newcat.h"
+#include "ftx1.h"
+
+int ftx1_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
+{
+    /* Memory-mode MD sets on Main are accepted but do not persist —
+     * they act as a transient memory-tune overlay. Force an exit so
+     * the user's mode change actually sticks. */
+    ftx1_ensure_vfo_mode(rig);
+    return newcat_set_mode(rig, vfo, mode, width);
+}

--- a/rigs/yaesu/newcat.h
+++ b/rigs/yaesu/newcat.h
@@ -142,6 +142,7 @@ struct newcat_priv_data
     int ftx1_clar_cached;        /* 1 if RX/TX CLAR states have been cached */
     char ftx1_rx_clar_on;        /* Cached RX CLAR enable: '0' or '1' */
     char ftx1_tx_clar_on;        /* Cached TX CLAR enable: '0' or '1' */
+    int ftx1_in_memory_mode;     /* 1 if driver knows the Main-side is in Memory mode (VM011) */
 };
 
 /*


### PR DESCRIPTION
## Summary

Fixes #2034 — `rig_set_channel` on an FTX-1 always fails because the driver's `ftx1_set_channel` builds and sends the `MW` command, which is firmware-broken on v1.08+ and returns `?;` universally. Replace the MW path with the sequence the firmware actually accepts: `MC` + `VM000` + VFO-B configuration + `BM`.

## The sequence

```
1. MC<ch>;         point the "last-selected channel" cursor at the target
2. VM000;          force VFO mode in case MC entered memory mode
3. FB<freq>;       program VFO-B frequency
   MD1<mode>;      program VFO-B mode
   CT1<n>; CN10<tone>; CN11<dcs>; OS1<shift>;   (FM-family channels only)
4. BM;             copy VFO-B to the last-selected memory channel
```

VFO-B is used rather than VFO-A so the operator's primary RX VFO is not disturbed. VFO-B's frequency and mode are snapshotted at entry and best-effort restored on exit (including the error path), so callers see minimal side effects.

## Why a dedicated branch rather than fixing MW

The `MW` command is rejected by firmware on every FTX-1 channel in every mode — not a driver bug we can patch around. Confirmed against fw v1.12:

```
tx:  MW00005014250000+0000002120000;
rx:  ?;
```

The `BM` commit path is the documented Yaesu alternative and works empirically.

Related firmware bug: `DC` (DCS code) is similarly broken and must be replaced with `CN` where `P2=1`. The new code uses `CN11<code>;` for DCS, matching what `ftx1_ctcss.c` already does for the non-channel CTCSS/DCS path.

## Verification

Built clean against current master on macOS (Apple Silicon). End-to-end tested against a live **FTX-1 field head + Optima/SPA-1, firmware MAIN v1.12**, at 115200 bps:

```
# Starting state: channel 1 = 7.000.000 MHz LSB (existing memory)

$ rigctl -m 1051 -r /dev/cu.usbserial-01AE33F90 -s 115200
Rig command: H 1
Frequency: 7050000
mode (FM,LSB,etc...): LSB
rptr shift (+-0): 0
rit (Hz,0=off): 0
xit (Hz,0=off): 0
ctcss tone freq in tenth of Hz (0=off): 0
ctcss sql freq in tenth of Hz (0=off): 0
Rig command: q

# Confirm channel 1 now holds 7.050 MHz
tx:  MC000001;    rx:  ''
tx:  FA;          rx:  FA007050000;
tx:  MD0;         rx:  MD01;

# Round-trip restore via the same rigctl path back to 7.000 MHz
$ rigctl -m 1051 ... H 1 / 7000000 / LSB / 0 / 0 / 0 / 0 / 0

tx:  MC000001;    rx:  ''
tx:  FA;          rx:  FA007000000;    ← restored
tx:  MD0;         rx:  MD01;

# VFO-A and VFO-B both unchanged from pre-test state
tx:  FA;          rx:  FA144260000;    (was 144.260 FM)
tx:  FB;          rx:  FB028074000;    (was 28.074 USB)
```

The debug trace at `-vvvv` shows the full 7-step CAT sequence (save FB + MD1 → MC → VM000 → FB → MD1 → BM → restore FB + MD1), all returning `RIG_OK`.

## Known scope gap

The previous MW path also programmed clarifier (RIT/XIT) state into the channel. Whether `BM` propagates clarifier state to the stored memory slot has not been empirically verified, and getting it wrong silently (apparently-successful write but missing clarifier) is worse than not programming it at all. This rewrite drops clarifier handling; it's a reasonable follow-up once clarifier-via-BM is confirmed.

Also: the existing `ftx1_get_channel` discards the CTCSS P8 byte (`ftx1_mem.c:380` has `(void)ctcss_mode;`), so reading back a channel after this write won't report tone state yet. That's a separate read-side gap tracked as a follow-up.

## Minor refactor

Exposes `ftx1_freq_to_tone_num()` in `ftx1.h` — previously file-static in `ftx1_ctcss.c`. The new `ftx1_set_channel` calls it to convert CTCSS frequencies (in tenths of Hz) to tone indices for the `CN` command, rather than duplicating the 50-element lookup table.

## Test plan

- [x] Build clean on macOS ARM
- [x] `rigctl H 1` round-trips channel 1 between 7.000 MHz LSB and 7.050 MHz LSB
- [x] VFO-A state preserved across the operation
- [x] VFO-B state preserved across the operation (save/restore works)
- [x] Raw-CAT readback confirms channel 1 was actually written
- [ ] Test with an FM-family channel + CTCSS tone (no FM memory currently programmed on my test radio; left unverified but code path is straightforward)
- [ ] Test with a DCS channel (same as above)
- [ ] Regression on other newcat rigs (no code outside ftx1_mem.c/ftx1_ctcss.c/ftx1.h touched)