### PR TITLE
Give newcat.c some needed TLC

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,8 @@ Version 5.x -- future
         * Change FT1000MP Mark V model names to align with FT1000MP
         * Internal data structures moved out of rig_struct to individual
           heap buffers - Github issues #487 & #1445 (n3gb)
+        * Update bandwidth handling in rigs/yaesu/newcat.c to use data in
+          priv_caps. Moves lots of hard-coded data into tables.  (n3gb)
 
 Version 4.7.0
         * 2026-02-15

--- a/ReleaseNotes_5.0.md
+++ b/ReleaseNotes_5.0.md
@@ -12,6 +12,9 @@ changes to the Application Binary Interface(ABI).
 - shortfreq_t changed to int32? (may not happen)
 - Functions rig_get_conf(), rot_get_conf() and amp_get_conf() have been removed.
   See [issue #924](https://github.com/Hamlib/Hamlib/issues/924).
+- Clean up bandwidth handling in newcat.c.  Move data from code to priv_caps.
+- Convert ncboolean (in newcat.h) to real `bool` typedef. Clean up previous
+  pseudo-boolean code.
 
 ## Build changes
 - C compiler needs at least c11 capability.

--- a/rigs/yaesu/ft1200.c
+++ b/rigs/yaesu/ft1200.c
@@ -33,6 +33,20 @@
 #include "ft1200.h"
 #include "tones.h"
 
+// Shared with FTDX-3000/FTDX-3000dm
+const struct newcat_width_info ftdx1200_cw_widths =
+{
+    .count = 17,
+    .widths = { 0, 50, 100, 150, 200, 250, 300, 350, 400, 450, 500, 800, 1200, 1400,
+		1700, 2000, 2400 }
+};
+const struct newcat_width_info ftdx1200_ssb_widths =
+{
+    .count = 26,
+    .widths = { 0, 200, 400, 600, 850, 1100, 1350, 1500, 1650, 1800, 1950, 2100, 2200, 2300,
+		2400, 2500, 2600, 2700, 2800, 2900, 3000, 3200, 3400, 3600, 3800, 4000 }
+};
+
 const struct newcat_priv_caps ftdx1200_priv_caps =
 {
     .roofing_filter_count = 7,
@@ -46,7 +60,9 @@ const struct newcat_priv_caps ftdx1200_priv_caps =
         { .index = 4, .set_value = 0, .get_value = '4', .width = 15000, .optional = 0 },
         { .index = 5, .set_value = 0, .get_value = '5', .width = 6000, .optional = 0 },
         { .index = 6, .set_value = 0, .get_value = '6', .width = 3000, .optional = 0 },
-    }
+    },
+    .cw_widths = &ftdx1200_cw_widths,
+    .ssb_widths = &ftdx1200_ssb_widths
 };
 
 const struct confparams ftdx1200_ext_levels[] =

--- a/rigs/yaesu/ft3000.c
+++ b/rigs/yaesu/ft3000.c
@@ -53,7 +53,9 @@ const struct newcat_priv_caps ftdx3000_priv_caps =
         { .index = 8, .set_value = 0, .get_value = '6', .width = 3000, .optional = 0 },
         { .index = 9, .set_value = 0, .get_value = '9', .width = 600, .optional = 0 },
         { .index = 10, .set_value = 0, .get_value = 'A', .width = 300, .optional = 0 },
-    }
+    },
+    .cw_widths = &ftdx1200_cw_widths,
+    .ssb_widths = &ftdx1200_ssb_widths
 };
 
 const struct confparams ftdx3000_ext_levels[] =

--- a/rigs/yaesu/ft5000.c
+++ b/rigs/yaesu/ft5000.c
@@ -32,6 +32,14 @@
 #include "ft5000.h"
 #include "tones.h"
 
+/* FTDX-5000 CAT Operation Reference says index 14 not defined - 2400 duplicated as filler */
+static const struct newcat_width_info ftdx5000_ssb_widths =
+{
+    .count = 26,
+    .widths = { 0, 200, 400, 600, 850, 1100, 1350, 1500, 1650, 1800, 1950, 2100, 2250, 2400,
+                2400, 2500, 2600, 2700, 2800, 2900, 3000, 3200, 3400, 3600, 3800, 4000 }
+};
+
 const struct newcat_priv_caps ftdx5000_priv_caps =
 {
     .roofing_filter_count = 11,
@@ -50,6 +58,8 @@ const struct newcat_priv_caps ftdx5000_priv_caps =
         { .index = 9, .set_value = 0, .get_value = '9', .width = 600, .optional = 0 },
         { .index = 10, .set_value = 0, .get_value = 'A', .width = 300, .optional = 0 },
     },
+    .cw_widths = &ftdx1200_cw_widths,
+    .ssb_widths = &ftdx5000_ssb_widths,
 };
 
 const struct confparams ftdx5000_ext_levels[] =

--- a/rigs/yaesu/ft710.c
+++ b/rigs/yaesu/ft710.c
@@ -38,7 +38,9 @@
 const struct newcat_priv_caps ft710_priv_caps =
 {
     .roofing_filter_count = 0,
-    .roofing_filters = {}
+    .roofing_filters = {},
+    .cw_widths = &ftdx101_cw_widths,
+    .ssb_widths = &ftdx101_ssb_widths
 };
 
 const struct confparams ft710_ext_levels[] =

--- a/rigs/yaesu/ft891.c
+++ b/rigs/yaesu/ft891.c
@@ -123,6 +123,12 @@ int ft891_ext_tokens[] =
     TOK_BACKEND_NONE
 };
 
+static const struct newcat_priv_caps ft891_priv_caps =
+{
+    .cw_widths = &ft991_cw_widths,
+    .ssb_widths = &ft991_ssb_widths
+};
+
 /*
  * FT-891 rig capabilities
  */
@@ -286,7 +292,7 @@ struct rig_caps ft891_caps =
     .ext_tokens =         ft891_ext_tokens,
     .extlevels =          ft891_ext_levels,
 
-    .priv =               NULL,           /* private data FIXME: */
+    .priv =               &ft891_priv_caps,
 
     .rig_init =           ft891_init,
     .rig_cleanup =        newcat_cleanup,

--- a/rigs/yaesu/ft950.c
+++ b/rigs/yaesu/ft950.c
@@ -31,6 +31,19 @@
 #include "newcat.h"
 #include "ft950.h"
 
+static const struct newcat_width_info ft950_cw_widths =
+{
+  .count = 14,
+  .widths = { 0, 0, 0, 100, 200, 300, 400, 500, 800, 1200, 1400, 1700, 2000, 2400}
+};
+
+static const struct newcat_width_info ft950_ssb_widths =
+{
+  .count = 21,
+  .widths = { 0, 200, 400, 600, 850, 1100, 1350, 1500, 1650, 1800, 1950, 2100, 2250, 2400,
+	      2450, 2500, 2600, 2700, 2800, 2900, 3000}
+};
+
 const struct newcat_priv_caps ft950_priv_caps =
 {
     .roofing_filter_count = 7,
@@ -44,7 +57,9 @@ const struct newcat_priv_caps ft950_priv_caps =
         { .index = 4, .set_value = 0, .get_value = '4', .width = 15000, .optional = 0 },
         { .index = 5, .set_value = 0, .get_value = '5', .width = 6000, .optional = 0 },
         { .index = 6, .set_value = 0, .get_value = '6', .width = 3000, .optional = 0 },
-    }
+    },
+    .cw_widths = &ft950_cw_widths,
+    .ssb_widths = &ft950_ssb_widths
 };
 
 const struct confparams ft950_ext_levels[] =

--- a/rigs/yaesu/ft991.c
+++ b/rigs/yaesu/ft991.c
@@ -170,6 +170,25 @@ int ft991_ext_tokens[] =
 };
 
 /*
+ * Rig unique data
+ */
+static const struct newcat_width_info ft991_cw_widths = {
+    .count = 18,
+    .widths = { 0, 50, 100, 150, 200, 250, 300, 350, 400, 450, 500, 800, 1200, 1400, 1700,
+                2000, 2400, 3000 }
+};
+static const struct newcat_width_info ft991_ssb_widths = {
+    .count = 22,
+    .widths = { 0, 200, 400, 600, 850, 1100, 1350, 1500, 1650, 1800, 1950, 2100, 2200, 2300,
+                2400, 2500, 2600, 2700, 2800, 2900, 3000, 3200 }
+};
+
+static const struct newcat_priv_caps ft991_priv_caps = {
+    .cw_widths = &ft991_cw_widths,
+    .ssb_widths = &ft991_ssb_widths
+};
+
+/*
  * FT-991 rig capabilities
  */
 struct rig_caps ft991_caps =
@@ -347,7 +366,7 @@ struct rig_caps ft991_caps =
     .ext_tokens =         ft991_ext_tokens,
     .extlevels =          ft991_ext_levels,
 
-    .priv =               NULL,           /* private data FIXME: */
+    .priv =               &ft991_priv_caps,
 
     .rig_init =           ft991_init,
     .rig_cleanup =        newcat_cleanup,

--- a/rigs/yaesu/ft991.c
+++ b/rigs/yaesu/ft991.c
@@ -169,15 +169,13 @@ int ft991_ext_tokens[] =
     TOK_BACKEND_NONE
 };
 
-/*
- * Rig unique data
- */
-static const struct newcat_width_info ft991_cw_widths = {
+// Shared with FT-891
+const struct newcat_width_info ft991_cw_widths = {
     .count = 18,
     .widths = { 0, 50, 100, 150, 200, 250, 300, 350, 400, 450, 500, 800, 1200, 1400, 1700,
                 2000, 2400, 3000 }
 };
-static const struct newcat_width_info ft991_ssb_widths = {
+const struct newcat_width_info ft991_ssb_widths = {
     .count = 22,
     .widths = { 0, 200, 400, 600, 850, 1100, 1350, 1500, 1650, 1800, 1950, 2100, 2200, 2300,
                 2400, 2500, 2600, 2700, 2800, 2900, 3000, 3200 }

--- a/rigs/yaesu/ftdx10.c
+++ b/rigs/yaesu/ftdx10.c
@@ -45,7 +45,9 @@ const struct newcat_priv_caps ftdx10_priv_caps =
 //        { .index = 3, .set_value = '3', .get_value = '8', .width = 1200, .optional = 1 },
         { .index = 4, .set_value = '4', .get_value = '9', .width = 500, .optional = 0 },
         { .index = 5, .set_value = '5', .get_value = 'A', .width = 300, .optional = 0 },
-    }
+    },
+    .cw_widths = &ftdx101_cw_widths,
+    .ssb_widths = &ftdx101_ssb_widths
 };
 
 const struct confparams ftdx10_ext_levels[] =

--- a/rigs/yaesu/ftdx101.c
+++ b/rigs/yaesu/ftdx101.c
@@ -33,6 +33,20 @@
 #include "yaesu.h"
 #include "ftdx101.h"
 
+// Shared with FTDX-101mp, FTDX-10, FT-710
+const struct newcat_width_info ftdx101_cw_widths =
+{
+    .count = 22,
+    .widths = { 0, 50, 100, 150, 200, 250, 300, 350, 400, 450, 500, 600, 800, 1200, 1400, 1700,
+                2000, 2400, 3000, 3200, 3500, 4000 }
+};
+const struct newcat_width_info ftdx101_ssb_widths =
+{
+    .count = 24,
+    .widths = { 0, 300, 400, 600, 850, 1100, 1200, 1500, 1650, 1800, 1950, 2100, 2200, 2300, 2400,
+		2500, 2600, 2700, 2800, 2900, 3000, 3200, 3500, 4000 }
+};
+
 const struct newcat_priv_caps ftdx101d_priv_caps =
 {
     .roofing_filter_count = 6,
@@ -45,7 +59,9 @@ const struct newcat_priv_caps ftdx101d_priv_caps =
         { .index = 3, .set_value = '3', .get_value = '8', .width = 1200, .optional = 1 },
         { .index = 4, .set_value = '4', .get_value = '9', .width = 600, .optional = 0 },
         { .index = 5, .set_value = '5', .get_value = 'A', .width = 300, .optional = 1 },
-    }
+    },
+    .cw_widths = &ftdx101_cw_widths,
+    .ssb_widths = &ftdx101_ssb_widths
 };
 
 const struct confparams ftdx101d_ext_levels[] =

--- a/rigs/yaesu/ftdx101mp.c
+++ b/rigs/yaesu/ftdx101mp.c
@@ -46,7 +46,9 @@ const struct newcat_priv_caps ftdx101mp_priv_caps =
         { .index = 3, .set_value = '3', .get_value = '8', .width = 1200, .optional = 1 },
         { .index = 4, .set_value = '4', .get_value = '9', .width = 600, .optional = 0 },
         { .index = 5, .set_value = '5', .get_value = 'A', .width = 300, .optional = 1 },
-    }
+    },
+    .cw_widths = &ftdx101_cw_widths,
+    .ssb_widths = &ftdx101_ssb_widths
 };
 
 const struct confparams ftdx101mp_ext_levels[] =

--- a/rigs/yaesu/ftx1/ftx1.c
+++ b/rigs/yaesu/ftx1/ftx1.c
@@ -51,8 +51,20 @@
 #include "ftx1_menu.h"
 
 /* Private caps for newcat framework */
+static const struct newcat_width_info ftx1_ssb_widths =
+{
+    // Bandwidth table per FTX-1 CAT Operation Reference Manual Table 5
+    // (doc 2508-C). Differs from the FT-710/FTDX10 table at SSB codes
+    // 12/13/14 (2250/2400/2450 Hz vs 2200/2300/2400), so do not merge.
+    .count = 24,
+    .widths = { 0, 300, 400, 600, 850, 1100, 1200, 1500, 1650, 1800, 1950, 2100, 2250,
+		2400, 2450, 2500, 2600, 2700, 2800, 2900, 3000, 3200, 3500, 4000 }
+};
+
 static const struct newcat_priv_caps ftx1_priv_caps = {
     .roofing_filter_count = 0,
+    .cw_widths = &ftdx101_cw_widths,
+    .ssb_widths = &ftx1_ssb_widths,
 };
 
 /* Extern declarations for group-specific functions (add more as groups are implemented) */

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -9034,23 +9034,8 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
                 RETURNFUNC(err);
             }
 
-            if (width == RIG_PASSBAND_NORMAL) { w = 0; }
-            else if (width <= 50) { w = 1; }
-            else if (width <= 100) { w = 2; }
-            else if (width <= 150) { w = 3; }
-            else if (width <= 200) { w = 4; }
-            else if (width <= 250) { w = 5; }
-            else if (width <= 300) { w = 6; }
-            else if (width <= 350) { w = 7; }
-            else if (width <= 400) { w = 8; }
-            else if (width <= 450) { w = 9; }
-            else if (width <= 500) { w = 10; }
-            else if (width <= 800) { w = 11; }
-            else if (width <= 1200) { w = 12; }
-            else if (width <= 1400) { w = 13; }
-            else if (width <= 1700) { w = 14; }
-            else if (width <= 2000) { w = 15; }
-            else { w = 16; } // 2400 Hz
+            w = newcat_get_index_from_width(width, priv_caps->cw_widths);
+            if (w < 0) { RETURNFUNC(w); }
 
             break;
 
@@ -9064,31 +9049,8 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
                 RETURNFUNC(err);
             }
 
-            if (width == RIG_PASSBAND_NORMAL) { w = 0; }
-            else if (width <= 200) {  w = 1; }
-            else if (width <= 400) {  w = 2; }
-            else if (width <= 600) {  w = 3; }
-            else if (width <= 850) {  w = 4; }
-            else if (width <= 1100) {  w = 5; }
-            else if (width <= 1350) {  w = 6; }
-            else if (width <= 1500) {  w = 7; }
-            else if (width <= 1650) {  w = 8; }
-            else if (width <= 1800) {  w = 9; }
-            else if (width <= 1950) {  w = 10; }
-            else if (width <= 2100) {  w = 11; }
-            else if (width <= 2250) {  w = 12; }
-            else if (width <= 2400) {  w = 13; }
-            else if (width <= 2500) {  w = 15; }
-            else if (width <= 2600) {  w = 16; }
-            else if (width <= 2700) {  w = 17; }
-            else if (width <= 2800) {  w = 18; }
-            else if (width <= 2900) {  w = 19; }
-            else if (width <= 3000) {  w = 20; }
-            else if (width <= 3200) {  w = 21; }
-            else if (width <= 3400) {  w = 22; }
-            else if (width <= 3600) {  w = 23; }
-            else if (width <= 3800) {  w = 24; }
-            else { w = 25; } // 4000 Hz
+            w = newcat_get_index_from_width(width, priv_caps->ssb_widths);
+            if (w < 0) { RETURNFUNC(w); }
 
             break;
 
@@ -10027,109 +9989,34 @@ int newcat_get_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t *width)
         case RIG_MODE_RTTYR:
         case RIG_MODE_CW:
         case RIG_MODE_CWR:
-            switch (w)
+            if (w > 0 && w < priv_caps->cw_widths->count)
             {
-            case 0:
+                *width = priv_caps->cw_widths->widths[w];
+            }
+            else if (w == 0)
+            {
                 *width = narrow ? 500 : 2400;
-                break;
-
-            case 1: *width = 50; break;
-
-            case 2: *width = 100; break;
-
-            case 3: *width = 150; break;
-
-            case 4: *width = 200; break;
-
-            case 5: *width = 250; break;
-
-            case 6: *width = 300; break;
-
-            case 7: *width = 350; break;
-
-            case 8: *width = 400; break;
-
-            case 9: *width = 450; break;
-
-            case 10: *width = 500; break;
-
-            case 11: *width = 800; break;
-
-            case 12: *width = 1200; break;
-
-            case 13: *width = 1400; break;
-
-            case 14: *width = 1700; break;
-
-            case 15: *width = 2000; break;
-
-            case 16: *width = 2400; break;
-
-            default: RETURNFUNC(-RIG_EINVAL);
+            }
+            else
+            {
+                RETURNFUNC(-RIG_EINVAL);
             }
 
             break;
 
         case RIG_MODE_LSB:
         case RIG_MODE_USB:
-            switch (w)
+            if (w > 0 && w < priv_caps->ssb_widths->count)
             {
-            case 0:
+                *width = priv_caps->ssb_widths->widths[w];
+            }
+            else if (w == 0)
+            {
                 *width = narrow ? 1500 : 2400;
-                break;
-
-            case  1: *width =  200; break;
-
-            case  2: *width =  400; break;
-
-            case  3: *width =  600; break;
-
-            case  4: *width =  850; break;
-
-            case  5: *width = 1100; break;
-
-            case  6: *width = 1350; break;
-
-            case  7: *width = 1500; break;
-
-            case  8: *width = 1650; break;
-
-            case  9: *width = 1800; break;
-
-            case 10: *width = 1950; break;
-
-            case 11: *width = 2100; break;
-
-            case 12: *width = 2250; break;
-
-            case 13: *width = 2400; break;
-
-            // 14 is not defined for FTDX 5000, but leaving here for completeness
-            case 14: *width = 2400; break;
-
-            case 15: *width = 2500; break;
-
-            case 16: *width = 2600; break;
-
-            case 17: *width = 2700; break;
-
-            case 18: *width = 2800; break;
-
-            case 19: *width = 2900; break;
-
-            case 20: *width = 3000; break;
-
-            case 21: *width = 3200; break;
-
-            case 22: *width = 3400; break;
-
-            case 23: *width = 3600; break;
-
-            case 24: *width = 3800; break;
-
-            case 25: *width = 4000; break;
-
-            default: RETURNFUNC(-RIG_EINVAL);
+            }
+            else
+            {
+                RETURNFUNC(-RIG_EINVAL);
             }
 
             break;

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -27,6 +27,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include <stdlib.h>
 #include <string.h>  /* String function definitions */
@@ -643,6 +644,7 @@ static int newcat_set_contour_level(RIG *rig, vfo_t vfo, int level);
 static int newcat_get_contour_level(RIG *rig, vfo_t vfo, int *level);
 static int newcat_set_contour_width(RIG *rig, vfo_t vfo, int width);
 static int newcat_get_contour_width(RIG *rig, vfo_t vfo, int *width);
+static int newcat_get_index_from_width(pbwidth_t width, const struct newcat_width_info * info);
 static ncboolean newcat_valid_command(RIG *rig, char const *const command);
 
 /*
@@ -682,6 +684,28 @@ static int newcat_band_index(freq_t freq)
 
     rig_debug(RIG_DEBUG_TRACE, "%s: freq=%g, band=%d\n", __func__, freq, band);
     return (band);
+}
+
+/*
+ *  Get the width index(SH value) given the requested passband width
+ *    and the widths the rig supports
+ */
+static int newcat_get_index_from_width(pbwidth_t width, const struct newcat_width_info *info)
+{
+    if (width == RIG_PASSBAND_NORMAL)
+    {
+        return 0;  // Rig default
+    }
+
+    for (int i = 1; i < info->count - 2; i++)
+    {
+        if (width <= info->widths[i])
+        {
+            return i;
+        }
+    }
+
+    return info->count - 1; // Not found, use the maximum
 }
 
 /*
@@ -8677,6 +8701,7 @@ static int get_narrow(RIG *rig, vfo_t vfo)
 int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 {
     struct newcat_priv_data *priv = (struct newcat_priv_data *)STATE(rig)->priv;
+    struct newcat_priv_caps *priv_caps = (struct newcat_priv_caps *)rig->caps->priv;
     int err;
     int w = 0;
     char main_sub_vfo = '0';
@@ -8723,6 +8748,8 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
                 RETURNFUNC(err);
             }
 
+            w = newcat_get_index_from_width(width, priv_caps->cw_widths);
+//---Start cut here            // Remove this if() when the above routine works
             if (width == RIG_PASSBAND_NORMAL) { w = 0; }
             else if (width <= 100) { w = 3; }
             else if (width <= 200) { w = 4; }
@@ -8735,6 +8762,7 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
             else if (width <= 1700) { w = 11; }
             else if (width <= 2000) { w = 12; }
             else { w = 13; } // 2400 Hz
+//---End cut here---
 
             break;
 
@@ -8748,6 +8776,8 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
                 RETURNFUNC(err);
             }
 
+            w = newcat_get_index_from_width(width, priv_caps->ssb_widths);
+//---Start cut here---            // Remove when above is tested
             if (width == RIG_PASSBAND_NORMAL) { w = 0; }
             else if (width <= 200) { w = 1; }
             else if (width <= 400) { w = 2; }
@@ -8769,6 +8799,7 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
             else if (width <= 2800) { w = 18; }
             else if (width <= 2900) { w = 19; }
             else { w = 20; } // 3000 Hz
+//---End cut here---
 
             break;
 
@@ -9764,6 +9795,7 @@ static int get_roofing_filter(RIG *rig, vfo_t vfo,
 int newcat_get_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t *width)
 {
     struct newcat_priv_data *priv = (struct newcat_priv_data *)STATE(rig)->priv;
+    struct newcat_priv_caps *priv_caps = (struct newcat_priv_caps *)rig->caps->priv;
     int err;
     int w;
     int sh_command_valid = 1;
@@ -9895,6 +9927,12 @@ int newcat_get_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t *width)
         case RIG_MODE_RTTYR:
         case RIG_MODE_CW:
         case RIG_MODE_CWR:
+            if (w >= 0 && w < priv_caps->cw_widths->count)
+            {
+                *width = priv_caps->cw_widths->widths[w];
+            }
+            else {RETURNFUNC(-RIG_EINVAL);}
+//---Start cut here---
             switch (w)
             {
             case 0:
@@ -9925,6 +9963,7 @@ int newcat_get_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t *width)
 
             default: RETURNFUNC(-RIG_EINVAL);
             }
+//---End cut here---
 
             break;
 

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -8934,24 +8934,8 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
                 RETURNFUNC(err);
             }
 
-            if (width == RIG_PASSBAND_NORMAL) { w = 0; }
-            else if (width <= 50) { w = 1; }
-            else if (width <= 100) { w = 2; }
-            else if (width <= 150) { w = 3; }
-            else if (width <= 200) { w = 4; }
-            else if (width <= 250) { w = 5; }
-            else if (width <= 300) { w = 6; }
-            else if (width <= 350) { w = 7; }
-            else if (width <= 400) { w = 8; }
-            else if (width <= 450) { w = 9; }
-            else if (width <= 500) { w = 10; }
-            else if (width <= 800) { w = 11; }
-            else if (width <= 1200) { w = 12; }
-            else if (width <= 1400) { w = 13; }
-            else if (width <= 1700) { w = 14; }
-            else if (width <= 2000) { w = 15; }
-            else if (width <= 2400) { w = 16; }
-            else { w = 17; } // 3000 Hz
+            w = newcat_get_index_from_width(width, priv_caps->cw_widths);
+            if (w < 0) { RETURNFUNC(w); }
 
             break;
 
@@ -8965,28 +8949,8 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
                 RETURNFUNC(err);
             }
 
-            if (width == RIG_PASSBAND_NORMAL) { w = 0; }
-            else if (width <= 200) { w = 1; }
-            else if (width <= 400) { w = 2; }
-            else if (width <= 600) { w = 3; }
-            else if (width <= 850) { w = 4; }
-            else if (width <= 1100) { w = 5; }
-            else if (width <= 1350) { w = 6; }
-            else if (width <= 1500) { w = 7; }
-            else if (width <= 1650) { w = 8; }
-            else if (width <= 1800) { w = 9; }
-            else if (width <= 1950) { w = 10; }
-            else if (width <= 2100) { w = 11; }
-            else if (width <= 2200) { w = 12; }
-            else if (width <= 2300) { w = 13; }
-            else if (width <= 2400) { w = 14; }
-            else if (width <= 2500) { w = 15; }
-            else if (width <= 2600) { w = 16; }
-            else if (width <= 2700) { w = 17; }
-            else if (width <= 2800) { w = 18; }
-            else if (width <= 2900) { w = 19; }
-            else if (width <= 3000) { w = 20; }
-            else { w = 21; } // 3200 Hz
+            w = newcat_get_index_from_width(width, priv_caps->ssb_widths);
+            if (w < 0) { RETURNFUNC(w); }
 
             break;
 
@@ -9877,34 +9841,34 @@ int newcat_get_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t *width)
         case RIG_MODE_RTTYR:
         case RIG_MODE_CW:
         case RIG_MODE_CWR:
-            if (w == 0)
+            if (w > 0 && w < priv_caps->cw_widths->count)
+            {
+                *width = priv_caps->cw_widths->widths[w];
+            }
+            else if (w == 0)
             {
                 *width = narrow ? 300 : 500;
             }
-            else if (w < 0 || w >= priv_caps->cw_widths->count)
-            {
-                RETURNFUNC(-RIG_EINVAL);
-            }
             else
             {
-                *width = priv_caps->cw_widths->widths[w];
+                RETURNFUNC(-RIG_EINVAL);
             }
 
             break;
 
         case RIG_MODE_LSB:
         case RIG_MODE_USB:
-            if (w == 0)
+            if (w > 0 && w < priv_caps->ssb_widths->count)
+            {
+                *width = priv_caps->ssb_widths->widths[w];
+            }
+            else if (w == 0)
             {
                 *width = narrow ? 1800 : 2400;
             }
-            else if (w < 0 || w >= priv_caps->ssb_widths->count)
-            {
-                RETURNFUNC(-RIG_EINVAL);
-            }
             else
             {
-                *width = priv_caps->ssb_widths->widths[w];
+                RETURNFUNC(-RIG_EINVAL);
             }
 
             break;
@@ -10093,9 +10057,13 @@ int newcat_get_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t *width)
         case RIG_MODE_RTTYR:
         case RIG_MODE_CW:
         case RIG_MODE_CWR:
-            switch (w)
+            if (w > 0 && w < priv_caps->cw_widths->count)
             {
-            case 0:
+                *width = priv_caps->cw_widths->widths[w];
+            }
+            else if (w == 0)
+            {
+                // This seems weird but it's what the manual says
                 if (mode == RIG_MODE_CW || mode == RIG_MODE_CWR)
                 {
                     *width = narrow ? 500 : 2400;
@@ -10104,97 +10072,26 @@ int newcat_get_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t *width)
                 {
                     *width = narrow ? 300 : 500;
                 }
-
-                break;
-
-            case 1: *width = 50; break;
-
-            case 2: *width = 100; break;
-
-            case 3: *width = 150; break;
-
-            case 4: *width = 200; break;
-
-            case 5: *width = 250; break;
-
-            case 6: *width = 300; break;
-
-            case 7: *width = 350; break;
-
-            case 8: *width = 400; break;
-
-            case 9: *width = 450; break;
-
-            case 10: *width = 500; break;
-
-            case 11: *width = 800; break;
-
-            case 12: *width = 1200; break;
-
-            case 13: *width = 1400; break;
-
-            case 14: *width = 1700; break;
-
-            case 15: *width = 2000; break;
-
-            case 16: *width = 2400; break;
-
-            case 17: *width = 3000; break;
-
-            default: RETURNFUNC(-RIG_EINVAL);
             }
-
+            else
+            {
+                 RETURNFUNC(-RIG_EPROTO);
+            }
             break;
 
         case RIG_MODE_LSB:
         case RIG_MODE_USB:
-            switch (w)
+            if (w > 0 && w < priv_caps->ssb_widths->count)
             {
-            case 0: *width = narrow ? 1500 : 2400; break;
-
-            case  1: *width =  200; break;
-
-            case  2: *width =  400; break;
-
-            case  3: *width =  600; break;
-
-            case  4: *width =  850; break;
-
-            case  5: *width = 1100; break;
-
-            case  6: *width = 1350; break;
-
-            case  7: *width = 1500; break;
-
-            case  8: *width = 1650; break;
-
-            case  9: *width = 1800; break;
-
-            case 10: *width = 1950; break;
-
-            case 11: *width = 2100; break;
-
-            case 12: *width = 2200; break;
-
-            case 13: *width = 2300; break;
-
-            case 14: *width = 2400; break;
-
-            case 15: *width = 2500; break;
-
-            case 16: *width = 2600; break;
-
-            case 17: *width = 2700; break;
-
-            case 18: *width = 2800; break;
-
-            case 19: *width = 2900; break;
-
-            case 20: *width = 3000; break;
-
-            case 21: *width = 3200; break;
-
-            default: RETURNFUNC(-RIG_EINVAL);
+                *width = priv_caps->ssb_widths->widths[w];
+            }
+            else if (w == 0)
+            {
+                *width = narrow ? 1500 : 2400; break;
+            }
+            else
+            {
+                RETURNFUNC(-RIG_EPROTO);
             }
 
             break;
@@ -10534,24 +10431,30 @@ int newcat_get_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t *width)
         case RIG_MODE_RTTYR:
         case RIG_MODE_CW:
         case RIG_MODE_CWR:
-            if (w == 0) { break; }  // use the roofing/default width
-            else if (w < 0 || w >= priv_caps->cw_widths->count)
+            if (w > 0 && w < priv_caps->cw_widths->count)
             {
-                RETURNFUNC(-RIG_EPROTO);  // Should not happen
+                *width = priv_caps->cw_widths->widths[w];
             }
+            else if (w == 0)
+            {
+                break;   // use the roofing/default width
+            }
+            else {RETURNFUNC(-RIG_EPROTO);}  // Should not happen
 
-            *width = priv_caps->cw_widths->widths[w];
             break;
 
         case RIG_MODE_LSB:
         case RIG_MODE_USB:
-            if (w == 0) { break; } // Use the roofing/default value
-            else if (w < 0 || w >= priv_caps->ssb_widths->count)
+            if (w > 0 && w < priv_caps->ssb_widths->count)
             {
-                RETURNFUNC(-RIG_EPROTO);
+                *width = priv_caps->ssb_widths->widths[w];
             }
+            else if (w == 0)
+            {
+                break;  // Use the roofing/default value
+            }
+            else {RETURNFUNC(-RIG_EPROTO);}
 
-            *width = priv_caps->ssb_widths->widths[w];
             break;
 
         case RIG_MODE_AM:

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -430,6 +430,7 @@ const cal_table_float_t yaesu_default_id_meter_cal =
     }
 };
 
+#if 0 // This cannot handle multiple rigs! (Think SO2R)
 // Easy reference to rig model -- it is set in newcat_valid_command
 static ncboolean is_ft450;
 static ncboolean is_ft710;
@@ -449,6 +450,28 @@ static ncboolean is_ftdx101mp;
 static ncboolean is_ftdx10;
 static ncboolean is_ftx1;
 static ncboolean is_ftdx9000Old;
+#else
+// These assume there is a 'rig' in scope
+#define is_ft450 (RIG_MODEL_FT450==rig->caps->rig_model || RIG_MODEL_FT450D==rig->caps->rig_model)
+#define is_ft710 (RIG_MODEL_FT710==rig->caps->rig_model)
+#define is_ft891 (RIG_MODEL_FT891==rig->caps->rig_model)
+#define is_ft897 (RIG_MODEL_FT897==rig->caps->rig_model)
+#define is_ft897d (RIG_MODEL_FT897D==rig->caps->rig_model)
+#define is_ft950 (RIG_MODEL_FT950==rig->caps->rig_model)
+#define is_ft991 (RIG_MODEL_FT991==rig->caps->rig_model)
+#define is_ft2000 (RIG_MODEL_FT2000==rig->caps->rig_model)
+#define is_ftdx10 (RIG_MODEL_FTDX10==rig->caps->rig_model)
+#define is_ftdx101d (RIG_MODEL_FTDX101D==rig->caps->rig_model)
+#define is_ftdx101mp (RIG_MODEL_FTDX101MP==rig->caps->rig_model)
+#define is_ftdx1200 (RIG_MODEL_FTDX1200==rig->caps->rig_model)
+#define is_ftdx3000 (RIG_MODEL_FTDX3000==rig->caps->rig_model)
+// Only needed to distinguish between versions of the same model
+#define is_ftdx3000dm (NC_RIGID_FTDX3000DM==((struct newcat_priv_data *)(STATE(rig)->priv))->rig_id)
+#define is_ftdx5000 (RIG_MODEL_FTDX5000==rig->caps->rig_model)
+#define is_ftdx9000 (RIG_MODEL_FT9000==rig->caps->rig_model)
+#define is_ftdx9000Old (RIG_MODEL_FTD000OLD==rig->caps->rig_model)
+#define is_ftx1 (RIG_MODEL_FTX1==rig->caps->rig_model)
+#endif
 
 /*
  * Even though this table does make a handy reference, it could be deprecated as it is not really needed.
@@ -603,7 +626,9 @@ int valid_commands_count = sizeof(valid_commands) / sizeof(
 const struct confparams newcat_cfg_params[] =
 {
     {
-        TOK_FAST_SET_CMD, "fast_commands_token", "High throughput of commands", "Enabled high throughput of >200 messages/sec by not waiting for ACK/NAK of messages", "0", RIG_CONF_NUMERIC, { .n = { 0, 1, 1 } }
+        TOK_FAST_SET_CMD, "fast_commands_token", "High throughput of commands",
+        "Enabled high throughput of >200 messages/sec by not waiting for ACK/NAK of messages",
+        "0", RIG_CONF_NUMERIC, { .n = { 0, 1, 1 } }
     },
     { RIG_CONF_END, NULL, }
 };
@@ -651,7 +676,7 @@ static ncboolean newcat_valid_command(RIG *rig, char const *const command);
  * The BS command needs to know what band we're on so we can restore band info
  * So this converts freq to band index
  */
-static int newcat_band_index(freq_t freq)
+static int newcat_band_index(RIG *rig, freq_t freq)
 {
     int band = 11; // general
 
@@ -751,6 +776,7 @@ int newcat_init(RIG *rig)
      * FT-9000 variants.
      */
 
+#if 0
     is_ft450 = newcat_is_rig(rig, RIG_MODEL_FT450);
     is_ft450 |= newcat_is_rig(rig, RIG_MODEL_FT450D);
     is_ft891 = newcat_is_rig(rig, RIG_MODEL_FT891);
@@ -770,6 +796,7 @@ int newcat_init(RIG *rig)
     is_ftdx10 = newcat_is_rig(rig, RIG_MODEL_FTDX10);
     is_ft710 = newcat_is_rig(rig, RIG_MODEL_FT710);
     is_ftx1 = newcat_is_rig(rig, RIG_MODEL_FTX1);
+#endif
 
     RETURNFUNC(RIG_OK);
 }
@@ -1392,7 +1419,7 @@ int newcat_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
         rig_debug(RIG_DEBUG_TRACE, "%s(%d)%s: checking VFOA for band change \n",
                   __FILE__, __LINE__, __func__);
 
-        changing = newcat_band_index(freq) != newcat_band_index(freqA);
+        changing = newcat_band_index(rig, freq) != newcat_band_index(rig, freqA);
         rig_debug(RIG_DEBUG_TRACE, "%s: VFO_A band changing=%d\n", __func__, changing);
     }
     else
@@ -1402,7 +1429,7 @@ int newcat_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
         rig_debug(RIG_DEBUG_TRACE, "%s(%d)%s: checking VFOB for band change \n",
                   __FILE__, __LINE__, __func__);
 
-        changing = newcat_band_index(freq) != newcat_band_index(freqB);
+        changing = newcat_band_index(rig, freq) != newcat_band_index(rig, freqB);
         rig_debug(RIG_DEBUG_TRACE, "%s: VFO_B band changing=%d\n", __func__, changing);
     }
 
@@ -1413,9 +1440,9 @@ int newcat_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
             // seems some rigs are problematic
             // && !(is_ftdx3000 || is_ftdx3000dm)
             // some rigs can't do BS command on 60M
-            // && !(is_ftdx3000 || is_ftdx3000dm && newcat_band_index(freq) == 2)
-            && !(is_ft2000 && newcat_band_index(freq) == 2)
-            && !(is_ftdx1200 && newcat_band_index(freq) == 2)
+            // && !(is_ftdx3000 || is_ftdx3000dm && newcat_band_index(rig, freq) == 2)
+            && !(is_ft2000 && newcat_band_index(rig, freq) == 2)
+            && !(is_ftdx1200 && newcat_band_index(rig, freq) == 2)
             && !is_ft891 // 891 does not remember bandwidth so don't do this
             && !is_ft991 // 991 does not behave well with bandstack changes
             && rig->caps->get_vfo != NULL
@@ -1436,12 +1463,12 @@ int newcat_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
             if (is_ft991 == FALSE && is_ft891 == FALSE && newcat_valid_command(rig, "VS"))
             {
                 SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "VS%d;BS%02d%c",
-                         vfo1, newcat_band_index(freq), cat_term);
+                         vfo1, newcat_band_index(rig, freq), cat_term);
             }
             else
             {
                 SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "BS%02d%c",
-                         newcat_band_index(freq), cat_term);
+                         newcat_band_index(rig, freq), cat_term);
             }
 
 
@@ -1467,7 +1494,7 @@ int newcat_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
         else
         {
             SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "BS%02d%c",
-                     newcat_band_index(freq), cat_term);
+                     newcat_band_index(rig, freq), cat_term);
 
             if (RIG_OK != (err = newcat_set_cmd(rig)))
             {
@@ -1509,11 +1536,11 @@ int newcat_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
             // If the BS works on both VFOs then VFOB will have the band select answer
             // so now change needed
             // If the BS is by VFO then we'll need to do BS for the other VFO too
-            if (newcat_band_index(freqtmp) != newcat_band_index(freq))
+            if (newcat_band_index(rig, freqtmp) != newcat_band_index(rig, freq))
             {
 
                 SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "BS%02d%c",
-                         newcat_band_index(freq), cat_term);
+                         newcat_band_index(rig, freq), cat_term);
 
                 if (RIG_OK != (err = newcat_set_cmd(rig)))
                 {
@@ -1596,26 +1623,26 @@ int newcat_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     rig_debug(RIG_DEBUG_VERBOSE, "%s: is_ft991=%d, CACHE(rig)->split=%d, vfo=%s\n",
               __func__, is_ft991, cachep->split, rig_strvfo(vfo));
 
-    if (priv->band_index < 0) { priv->band_index = newcat_band_index(freq); }
+    if (priv->band_index < 0) { priv->band_index = newcat_band_index(rig, freq); }
 
     // only use bandstack method when actually changing bands
     // there are multiple bandstacks so we just use the 1st one
-    if (is_ft991 && vfo == RIG_VFO_A && priv->band_index != newcat_band_index(freq))
+    if (is_ft991 && vfo == RIG_VFO_A && priv->band_index != newcat_band_index(rig, freq))
     {
         if (cachep->split)
         {
             // FT991/991A bandstack does not work in split mode
             // so for a VFOA change we stop split, change bands, change freq, enable split
             SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "FT2;BS%02d;FA%09.0f;FT3;",
-                     newcat_band_index(freq), freq);
+                     newcat_band_index(rig, freq), freq);
         }
         else  // in non-split us BS to get bandstack info
         {
             SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "BS%02d;FA%09.0f;",
-                     newcat_band_index(freq), freq);
+                     newcat_band_index(rig, freq), freq);
         }
 
-        priv->band_index = newcat_band_index(freq);
+        priv->band_index = newcat_band_index(rig, freq);
     }
 
     else if (RIG_MODEL_FT450 == caps->rig_model)
@@ -1648,7 +1675,7 @@ int newcat_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     }
 
     rig_debug(RIG_DEBUG_TRACE, "%s: band changing? old=%d, new=%d\n", __func__,
-              newcat_band_index(freq), newcat_band_index(rig_s->current_freq));
+              newcat_band_index(rig, freq), newcat_band_index(rig, rig_s->current_freq));
 
     if (RIG_MODEL_FT450 == caps->rig_model && priv->ret_data[2] != target_vfo)
     {
@@ -8154,8 +8181,7 @@ ncboolean newcat_valid_command(RIG *rig, char const *const command)
             else if (is_ftdx5000) { retval = valid_commands[search_index].ft5000; }
             else if (is_ftdx9000) { retval = valid_commands[search_index].ft9000; }
             else if (is_ftdx1200) { retval = valid_commands[search_index].ft1200; }
-            else if (is_ftdx3000) { retval = valid_commands[search_index].ft3000; }
-            else if (is_ftdx3000dm) { retval = valid_commands[search_index].ft3000; }
+            else if (is_ftdx3000 || is_ftdx3000dm) { retval = valid_commands[search_index].ft3000; }
             else if (is_ftdx101d) { retval = valid_commands[search_index].ft101d; }
             else if (is_ftdx101mp) { retval = valid_commands[search_index].ft101mp; }
             else if (is_ftdx10) { retval = valid_commands[search_index].ftdx10; }
@@ -11178,7 +11204,7 @@ int newcat_get_rigid(RIG *rig)
             s += 2;     /* ID0310, jump past ID */
             priv->rig_id = atoi(s);
 
-            is_ftdx3000dm = priv->rig_id == NC_RIGID_FTDX3000DM;
+            //is_ftdx3000dm = priv->rig_id == NC_RIGID_FTDX3000DM;
         }
 
         rig_debug(RIG_DEBUG_TRACE, "rig_id = %d, idstr = %s\n", priv->rig_id,

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -759,8 +759,7 @@ int newcat_init(RIG *rig)
     STATE(rig)->priv = (struct newcat_priv_data *) calloc(1,
                        sizeof(struct newcat_priv_data));
 
-    if (!STATE(
-                rig)->priv)                                  /* whoops! memory shortage! */
+    if (!STATE(rig)->priv)                                  /* whoops! memory shortage! */
     {
         RETURNFUNC(-RIG_ENOMEM);
     }
@@ -773,34 +772,6 @@ int newcat_init(RIG *rig)
     priv->rig_id = NC_RIGID_NONE;
     priv->current_mem = NC_MEM_CHANNEL_NONE;
     priv->fast_set_commands = FALSE;
-
-    /*
-     * Determine the type of rig from the model number.  Note it is
-     * possible for several model variants to exist; i.e., all the
-     * FT-9000 variants.
-     */
-
-#if 0
-    is_ft450 = newcat_is_rig(rig, RIG_MODEL_FT450);
-    is_ft450 |= newcat_is_rig(rig, RIG_MODEL_FT450D);
-    is_ft891 = newcat_is_rig(rig, RIG_MODEL_FT891);
-    is_ft897 = newcat_is_rig(rig, RIG_MODEL_FT897);
-    is_ft897d = newcat_is_rig(rig, RIG_MODEL_FT897D);
-    is_ft950 = newcat_is_rig(rig, RIG_MODEL_FT950);
-    is_ft991 = newcat_is_rig(rig, RIG_MODEL_FT991);
-    is_ft2000 = newcat_is_rig(rig, RIG_MODEL_FT2000);
-    is_ftdx9000 = newcat_is_rig(rig, RIG_MODEL_FT9000);
-    is_ftdx9000Old = newcat_is_rig(rig, RIG_MODEL_FT9000OLD);
-    is_ftdx5000 = newcat_is_rig(rig, RIG_MODEL_FTDX5000);
-    is_ftdx1200 = newcat_is_rig(rig, RIG_MODEL_FTDX1200);
-    is_ftdx3000 = newcat_is_rig(rig, RIG_MODEL_FTDX3000);
-    is_ftdx3000dm = FALSE; // Detected dynamically
-    is_ftdx101d = newcat_is_rig(rig, RIG_MODEL_FTDX101D);
-    is_ftdx101mp = newcat_is_rig(rig, RIG_MODEL_FTDX101MP);
-    is_ftdx10 = newcat_is_rig(rig, RIG_MODEL_FTDX10);
-    is_ft710 = newcat_is_rig(rig, RIG_MODEL_FT710);
-    is_ftx1 = newcat_is_rig(rig, RIG_MODEL_FTX1);
-#endif
 
     RETURNFUNC(RIG_OK);
 }
@@ -8845,24 +8816,8 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
                 RETURNFUNC(err);
             }
 
-            if (width == RIG_PASSBAND_NORMAL) { w = 0; }
-            else if (width <= 50) { w = 1; }
-            else if (width <= 100) { w = 2; }
-            else if (width <= 150) { w = 3; }
-            else if (width <= 200) { w = 4; }
-            else if (width <= 250) { w = 5; }
-            else if (width <= 300) { w = 6; }
-            else if (width <= 350) { w = 7; }
-            else if (width <= 400) { w = 8; }
-            else if (width <= 450) { w = 9; }
-            else if (width <= 500) { w = 10; }
-            else if (width <= 800) { w = 11; }
-            else if (width <= 1200) { w = 12; }
-            else if (width <= 1400) { w = 13; }
-            else if (width <= 1700) { w = 14; }
-            else if (width <= 2000) { w = 15; }
-            else if (width <= 2400) { w = 16; }
-            else { w = 17; } // 3000 Hz
+            w = newcat_get_index_from_width(width, priv_caps->cw_widths);
+            if (w < 0) { RETURNFUNC(w); }
 
             break;
 
@@ -8876,28 +8831,8 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
                 RETURNFUNC(err);
             }
 
-            if (width == RIG_PASSBAND_NORMAL) { w = 0; }
-            else if (width <= 200) { w = 1; }
-            else if (width <= 400) { w = 2; }
-            else if (width <= 600) { w = 3; }
-            else if (width <= 850) { w = 4; }
-            else if (width <= 1100) { w = 5; }
-            else if (width <= 1350) { w = 6; }
-            else if (width <= 1500) { w = 7; }
-            else if (width <= 1650) { w = 8; }
-            else if (width <= 1800) { w = 9; }
-            else if (width <= 1950) { w = 10; }
-            else if (width <= 2100) { w = 11; }
-            else if (width <= 2200) { w = 12; }
-            else if (width <= 2300) { w = 13; }
-            else if (width <= 2400) { w = 14; }
-            else if (width <= 2500) { w = 15; }
-            else if (width <= 2600) { w = 16; }
-            else if (width <= 2700) { w = 17; }
-            else if (width <= 2800) { w = 18; }
-            else if (width <= 2900) { w = 19; }
-            else if (width <= 3000) { w = 20; }
-            else { w = 21; } // 3000 Hz
+            w = newcat_get_index_from_width(width, priv_caps->ssb_widths);
+            if (w < 0) { RETURNFUNC(w); }
 
             break;
 
@@ -9908,9 +9843,12 @@ int newcat_get_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t *width)
         case RIG_MODE_RTTYR:
         case RIG_MODE_CW:
         case RIG_MODE_CWR:
-            switch (w)
+            if (w > 0 && w < priv_caps->cw_widths->count)
             {
-            case 0:
+                *width = priv_caps->cw_widths->widths[w];
+            }
+            else if (w == 0)
+            {
                 if (mode == RIG_MODE_CW || mode == RIG_MODE_CWR)
                 {
                     *width = narrow ? 500 : 2400;
@@ -9919,44 +9857,9 @@ int newcat_get_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t *width)
                 {
                     *width = narrow ? 300 : 500;
                 }
-
-                break;
-
-            case 1: *width = 50; break;
-
-            case 2: *width = 100; break;
-
-            case 3: *width = 150; break;
-
-            case 4: *width = 200; break;
-
-            case 5: *width = 250; break;
-
-            case 6: *width = 300; break;
-
-            case 7: *width = 350; break;
-
-            case 8: *width = 400; break;
-
-            case 9: *width = 450; break;
-
-            case 10: *width = 500; break;
-
-            case 11: *width = 800; break;
-
-            case 12: *width = 1200; break;
-
-            case 13: *width = 1400; break;
-
-            case 14: *width = 1700; break;
-
-            case 15: *width = 2000; break;
-
-            case 16: *width = 2400; break;
-
-            case 17: *width = 3000; break;
-
-            default:
+            }
+            else
+            {
                 rig_debug(RIG_DEBUG_ERR, "%s: unknown w=%d\n", __func__, w);
                 RETURNFUNC(-RIG_EINVAL);
             }
@@ -9965,53 +9868,16 @@ int newcat_get_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t *width)
 
         case RIG_MODE_LSB:
         case RIG_MODE_USB:
-            switch (w)
+            if (w > 0 && w < priv_caps->ssb_widths->count)
             {
-            case 0: *width = narrow ? 1500 : 2400; break;
-
-            case  1: *width =  200; break;
-
-            case  2: *width =  400; break;
-
-            case  3: *width =  600; break;
-
-            case  4: *width =  850; break;
-
-            case  5: *width = 1100; break;
-
-            case  6: *width = 1350; break;
-
-            case  7: *width = 1500; break;
-
-            case  8: *width = 1650; break;
-
-            case  9: *width = 1800; break;
-
-            case 10: *width = 1950; break;
-
-            case 11: *width = 2100; break;
-
-            case 12: *width = 2200; break;
-
-            case 13: *width = 2300; break;
-
-            case 14: *width = 2400; break;
-
-            case 15: *width = 2500; break;
-
-            case 16: *width = 2600; break;
-
-            case 17: *width = 2700; break;
-
-            case 18: *width = 2800; break;
-
-            case 19: *width = 2900; break;
-
-            case 20: *width = 3000; break;
-
-            case 21: *width = 3200; break;
-
-            default:
+                *width = priv_caps->ssb_widths->widths[w];
+            }
+            else if (w == 0)
+            {
+                *width = narrow ? 1500 : 2400;
+            }
+            else
+            {
                 rig_debug(RIG_DEBUG_ERR, "%s: unknown mode=%s\n", __func__, rig_strrmode(mode));
                 RETURNFUNC(-RIG_EINVAL);
             }
@@ -10087,7 +9953,7 @@ int newcat_get_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t *width)
             }
             else if (w == 0)
             {
-                *width = narrow ? 1500 : 2400; break;
+                *width = narrow ? 1500 : 2400;
             }
             else
             {

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -1332,7 +1332,7 @@ int newcat_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
         if (vfo != rig_s->tx_vfo) { RETURNFUNC(-RIG_ENTARGET); }
     }
 
-    if (is_ftdx3000 || is_ftdx3000dm || is_ftdx5000 || is_ftdx1200)
+    if (is_ftdx3000 || is_ftdx5000 || is_ftdx1200)
     {
         // we have a few rigs that can't set freq while PTT_ON
         // so we'll try a few times to see if we just need to wait a bit
@@ -1438,9 +1438,9 @@ int newcat_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
             // remove the split check here -- hopefully works OK
             //&& !cachep->split
             // seems some rigs are problematic
-            // && !(is_ftdx3000 || is_ftdx3000dm)
+            // && !(is_ftdx3000)
             // some rigs can't do BS command on 60M
-            // && !(is_ftdx3000 || is_ftdx3000dm && newcat_band_index(rig, freq) == 2)
+            // && !(is_ftdx3000 && newcat_band_index(rig, freq) == 2)
             && !(is_ft2000 && newcat_band_index(rig, freq) == 2)
             && !(is_ftdx1200 && newcat_band_index(rig, freq) == 2)
             && !is_ft891 // 891 does not remember bandwidth so don't do this
@@ -2277,7 +2277,7 @@ int newcat_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
         if (STATE(rig)->current_mode != RIG_MODE_CW
                 && STATE(rig)->current_mode != RIG_MODE_CWR
                 && STATE(rig)->current_mode != RIG_MODE_CWN
-                && (is_ftdx3000 || is_ftdx3000dm)
+                && (is_ftdx3000)
            )
         {
             // DX3000 with separate rx/tx antennas was failing frequency change
@@ -4235,7 +4235,7 @@ int newcat_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
             RETURNFUNC(-RIG_ENAVAIL);
         }
 
-        if (is_ft991 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000 || is_ftdx101d
+        if (is_ft991 || is_ftdx3000 || is_ftdx5000 || is_ftdx101d
                 || is_ftdx101mp)
         {
             newcat_get_mode(rig, vfo, &mode, &width);
@@ -4284,7 +4284,7 @@ int newcat_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
         }
 
         // Some Yaesu rigs reject this command in AM/FM modes
-        if (is_ft991 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000 || is_ftdx101d
+        if (is_ft991 || is_ftdx3000 || is_ftdx5000 || is_ftdx101d
                 || is_ftdx101mp)
         {
             if (mode & RIG_MODE_AM || mode & RIG_MODE_FM || mode & RIG_MODE_AMN
@@ -4346,7 +4346,7 @@ int newcat_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
         }
 
 
-        if (is_ft991 || is_ft710 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000
+        if (is_ft991 || is_ft710 || is_ftdx3000 || is_ftdx5000
                 || is_ftdx101d
                 || is_ftdx101mp)
         {
@@ -4358,7 +4358,7 @@ int newcat_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
         SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "MG%03d%c", fpf, cat_term);
 
         // Some Yaesu rigs reject this command in RTTY modes
-        if (is_ft991 || is_ft710 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000
+        if (is_ft991 || is_ft710 || is_ftdx3000 || is_ftdx5000
                 || is_ftdx101d
                 || is_ftdx101mp)
         {
@@ -4642,7 +4642,7 @@ int newcat_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
             SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "SD%04d%c", millis, cat_term);
         }
         else if (is_ft950 || is_ft450 || is_ft891 || is_ft991 || is_ftdx1200
-                 || is_ftdx3000 || is_ftdx3000dm)
+                 || is_ftdx3000)
         {
             if (millis < 30)
             {
@@ -5071,7 +5071,7 @@ int newcat_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
             RETURNFUNC(-RIG_ENAVAIL);
         }
 
-        if (is_ft991 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000 || is_ftdx101d
+        if (is_ft991 || is_ftdx3000 || is_ftdx5000 || is_ftdx101d
                 || is_ftdx101mp)
         {
             newcat_get_mode(rig, vfo, &mode, &width);
@@ -5087,7 +5087,7 @@ int newcat_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         }
 
         // Some Yaesu rigs reject this command in AM/FM modes
-        if (is_ft991 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000 || is_ftdx101d
+        if (is_ft991 || is_ftdx3000 || is_ftdx5000 || is_ftdx101d
                 || is_ftdx101mp)
         {
             if (mode & RIG_MODE_AM || mode & RIG_MODE_FM || mode & RIG_MODE_AMN
@@ -5139,7 +5139,7 @@ int newcat_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
             RETURNFUNC(RIG_OK);
         }
 
-        if (is_ft991 || is_ft710 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000
+        if (is_ft991 || is_ft710 || is_ftdx3000 || is_ftdx5000
                 || is_ftdx101d
                 || is_ftdx101mp)
         {
@@ -5149,7 +5149,7 @@ int newcat_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "MG%c", cat_term);
 
         // Some Yaesu rigs reject this command in RTTY modes
-        if (is_ft991 || is_ft710 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000
+        if (is_ft991 || is_ft710 || is_ftdx3000 || is_ftdx5000
                 || is_ftdx101d
                 || is_ftdx101mp)
         {
@@ -5309,7 +5309,7 @@ int newcat_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         {
             SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "RM09%c", cat_term);
         }
-        else if (is_ftdx3000 || is_ftdx3000dm || is_ftdx5000)
+        else if (is_ftdx3000 || is_ftdx5000)
         {
             // The 3000 has to use the meter read for SWR when the tuner is on
             // We'll assume the 5000 is the same way for now
@@ -5805,7 +5805,7 @@ int newcat_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
             break;
         }
 
-        if (is_ftdx1200 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000 || is_ft891
+        if (is_ftdx1200 || is_ftdx3000 || is_ftdx5000 || is_ft891
                 || is_ft991
                 || is_ftdx101d || is_ftdx101mp || is_ftdx10)
         {
@@ -6075,7 +6075,7 @@ int newcat_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
             RETURNFUNC(-RIG_ENAVAIL);
         }
 
-        if (is_ft991 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000 || is_ftdx101d
+        if (is_ft991 || is_ftdx3000 || is_ftdx5000 || is_ftdx101d
                 || is_ftdx101mp)
         {
             err = newcat_get_mode(rig, vfo, &mode, &width);
@@ -6095,7 +6095,7 @@ int newcat_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
         }
 
         // Some Yaesu rigs reject this command in FM mode
-        if (is_ft991 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000 || is_ftdx101d
+        if (is_ft991 || is_ftdx3000 || is_ftdx5000 || is_ftdx101d
                 || is_ftdx101mp)
         {
             if (mode & RIG_MODE_FM || mode & RIG_MODE_FMN)
@@ -6117,7 +6117,7 @@ int newcat_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
             RETURNFUNC(-RIG_ENAVAIL);
         }
 
-        if (is_ft991 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000 || is_ftdx101d
+        if (is_ft991 || is_ftdx3000 || is_ftdx5000 || is_ftdx101d
                 || is_ftdx101mp)
         {
             err = newcat_get_mode(rig, vfo, &mode, &width);
@@ -6137,7 +6137,7 @@ int newcat_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
         }
 
         // Some Yaesu rigs reject this command in FM mode
-        if (is_ft991 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000 || is_ftdx101d
+        if (is_ft991 || is_ftdx3000 || is_ftdx5000 || is_ftdx101d
                 || is_ftdx101mp)
         {
             if (mode & RIG_MODE_FM || mode & RIG_MODE_FMN)
@@ -6213,7 +6213,7 @@ int newcat_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
             RETURNFUNC(-RIG_ENAVAIL);
         }
 
-        if (is_ftdx1200 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000 || is_ftdx101d
+        if (is_ftdx1200 || is_ftdx3000 || is_ftdx5000 || is_ftdx101d
                 || is_ftdx101mp)
         {
             // These rigs can lock Main/Sub VFO dials individually
@@ -6280,7 +6280,7 @@ int newcat_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
             RETURNFUNC(-RIG_ENAVAIL);
         }
 
-        if (is_ft991 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000 || is_ftdx101d
+        if (is_ft991 || is_ftdx3000 || is_ftdx5000 || is_ftdx101d
                 || is_ftdx101mp)
         {
             err = newcat_get_mode(rig, vfo, &mode, &width);
@@ -6300,7 +6300,7 @@ int newcat_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
         }
 
         // Some Yaesu rigs reject this command in FM mode
-        if (is_ft991 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000 || is_ftdx101d
+        if (is_ft991 || is_ftdx3000 || is_ftdx5000 || is_ftdx101d
                 || is_ftdx101mp)
         {
             if (mode & RIG_MODE_FM || mode & RIG_MODE_FMN)
@@ -6322,7 +6322,7 @@ int newcat_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
             RETURNFUNC(-RIG_ENAVAIL);
         }
 
-        if (is_ft991 || is_ft710 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000
+        if (is_ft991 || is_ft710 || is_ftdx3000 || is_ftdx5000
                 || is_ftdx101d
                 || is_ftdx101mp)
         {
@@ -6335,7 +6335,6 @@ int newcat_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
         }
 
         if (is_ft891 || is_ft991 || is_ft710 || is_ftdx1200 || is_ftdx3000
-                || is_ftdx3000dm
                 || is_ftdx101d
                 || is_ftdx101mp)
         {
@@ -6350,7 +6349,7 @@ int newcat_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
         }
 
         // Some Yaesu rigs reject this command in AM/FM/RTTY modes
-        if (is_ft991 || is_ft710 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000
+        if (is_ft991 || is_ft710 || is_ftdx3000 || is_ftdx5000
                 || is_ftdx101d
                 || is_ftdx101mp)
         {
@@ -6444,7 +6443,7 @@ int newcat_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
             SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CO%c0%02d%c", main_sub_vfo,
                      status ? 2 : 0, cat_term);
         }
-        else if (is_ftdx3000 || is_ftdx3000dm || is_ftdx1200 || is_ft2000)
+        else if (is_ftdx3000 || is_ftdx1200 || is_ft2000)
         {
             SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CO00%02d%c", status ? 2 : 0,
                      cat_term);
@@ -6509,7 +6508,7 @@ int newcat_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
             RETURNFUNC(-RIG_ENAVAIL);
         }
 
-        if (is_ft991 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000 || is_ftdx101d
+        if (is_ft991 || is_ftdx3000 || is_ftdx5000 || is_ftdx101d
                 || is_ftdx101mp)
         {
             err = newcat_get_mode(rig, vfo, &mode, &width);
@@ -6528,7 +6527,7 @@ int newcat_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
         }
 
         // Some Yaesu rigs reject this command in FM mode
-        if (is_ft991 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000 || is_ftdx101d
+        if (is_ft991 || is_ftdx3000 || is_ftdx5000 || is_ftdx101d
                 || is_ftdx101mp)
         {
             if (mode & RIG_MODE_FM || mode & RIG_MODE_FMN)
@@ -6664,7 +6663,7 @@ int newcat_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
             RETURNFUNC(-RIG_ENAVAIL);
         }
 
-        if (is_ftdx1200 || is_ftdx3000 || is_ftdx3000dm || is_ft891 || is_ft991
+        if (is_ftdx1200 || is_ftdx3000 || is_ft891 || is_ft991
                 || is_ft710
                 || is_ftdx101d
                 || is_ftdx101mp)
@@ -6750,7 +6749,7 @@ int newcat_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
             SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CO%c0%c", main_sub_vfo,
                      cat_term);
         }
-        else if (is_ftdx3000 || is_ftdx3000dm || is_ftdx1200 || is_ft2000)
+        else if (is_ftdx3000 || is_ftdx1200 || is_ft2000)
         {
             SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CO00%c", cat_term);
         }
@@ -6811,7 +6810,7 @@ int newcat_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
         break;
 
     case RIG_FUNC_LOCK:
-        if (is_ftdx1200 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000 || is_ftdx101d
+        if (is_ftdx1200 || is_ftdx3000 || is_ftdx5000 || is_ftdx101d
                 || is_ftdx101mp)
         {
             // These rigs can lock Main/Sub VFO dials individually
@@ -6873,7 +6872,7 @@ int newcat_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
         {
             *status = (retfunc[last_char_index] == '2') ? 1 : 0;
         }
-        else if (is_ftdx3000 || is_ftdx3000dm || is_ftdx1200 || is_ft2000)
+        else if (is_ftdx3000 || is_ftdx1200 || is_ft2000)
         {
             *status = (retfunc[last_char_index] == '2') ? 1 : 0;
         }
@@ -8181,7 +8180,7 @@ ncboolean newcat_valid_command(RIG *rig, char const *const command)
             else if (is_ftdx5000) { retval = valid_commands[search_index].ft5000; }
             else if (is_ftdx9000) { retval = valid_commands[search_index].ft9000; }
             else if (is_ftdx1200) { retval = valid_commands[search_index].ft1200; }
-            else if (is_ftdx3000 || is_ftdx3000dm) { retval = valid_commands[search_index].ft3000; }
+            else if (is_ftdx3000) { retval = valid_commands[search_index].ft3000; }
             else if (is_ftdx101d) { retval = valid_commands[search_index].ft101d; }
             else if (is_ftdx101mp) { retval = valid_commands[search_index].ft101mp; }
             else if (is_ftdx10) { retval = valid_commands[search_index].ftdx10; }
@@ -8267,7 +8266,7 @@ int newcat_set_tx_vfo(RIG *rig, vfo_t tx_vfo)
     }
 
     // NOTE: FT-450 only has toggle command so not sure how to definitively set the TX VFO (VS; doesn't seem to help either)
-    if (is_ft950 || is_ft2000 || is_ftdx3000 || is_ftdx3000dm || is_ftdx5000
+    if (is_ft950 || is_ft2000 || is_ftdx3000 || is_ftdx5000
             || is_ftdx1200 || is_ft991 ||
             is_ftdx10 || is_ftdx101d || is_ftdx101mp)
     {

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -8117,75 +8117,33 @@ ncboolean newcat_valid_command(RIG *rig, char const *const command)
         }
         else
         {
+            ncboolean retval = FALSE;
             /*
              * The command is valid.  Now make sure it is supported by the rig.
              */
-            if (is_ft450 && valid_commands[search_index].ft450)
-            {
-                RETURNFUNC2(TRUE);
-            }
-            else if (is_ft891 && valid_commands[search_index].ft891)
-            {
-                RETURNFUNC2(TRUE);
-            }
-            else if (is_ft950 && valid_commands[search_index].ft950)
-            {
-                RETURNFUNC2(TRUE);
-            }
-            else if (is_ft991 && valid_commands[search_index].ft991)
-            {
-                RETURNFUNC2(TRUE);
-            }
-            else if (is_ft2000 && valid_commands[search_index].ft2000)
-            {
-                RETURNFUNC2(TRUE);
-            }
-            else if (is_ftdx5000 && valid_commands[search_index].ft5000)
-            {
-                RETURNFUNC2(TRUE);
-            }
-            else if (is_ftdx9000 && valid_commands[search_index].ft9000)
-            {
-                RETURNFUNC2(TRUE);
-            }
-            else if (is_ftdx1200 && valid_commands[search_index].ft1200)
-            {
-                RETURNFUNC2(TRUE);
-            }
-            else if (is_ftdx3000 && valid_commands[search_index].ft3000)
-            {
-                RETURNFUNC2(TRUE);
-            }
-            else if (is_ftdx3000dm && valid_commands[search_index].ft3000)
-            {
-                RETURNFUNC2(TRUE);
-            }
-            else if (is_ftdx101d && valid_commands[search_index].ft101d)
-            {
-                RETURNFUNC2(TRUE);
-            }
-            else if (is_ftdx101mp && valid_commands[search_index].ft101mp)
-            {
-                RETURNFUNC2(TRUE);
-            }
-            else if (is_ftdx10 && valid_commands[search_index].ftdx10)
-            {
-                RETURNFUNC2(TRUE);
-            }
-            else if (is_ft710 && valid_commands[search_index].ft710)
-            {
-                RETURNFUNC2(TRUE);
-            }
-            else if (is_ftx1 && valid_commands[search_index].ftx1)
-            {
-                RETURNFUNC2(TRUE);
-            }
-            else
+            // Until valid_commands gets a second index
+            if (is_ft450) { retval = valid_commands[search_index].ft450; }
+            else if (is_ft891) { retval = valid_commands[search_index].ft891; }
+            else if (is_ft950) { retval = valid_commands[search_index].ft950; }
+            else if (is_ft991) { retval = valid_commands[search_index].ft991; }
+            else if (is_ft2000) { retval =  valid_commands[search_index].ft2000; }
+            else if (is_ftdx5000) { retval = valid_commands[search_index].ft5000; }
+            else if (is_ftdx9000) { retval = valid_commands[search_index].ft9000; }
+            else if (is_ftdx1200) { retval = valid_commands[search_index].ft1200; }
+            else if (is_ftdx3000) { retval = valid_commands[search_index].ft3000; }
+            else if (is_ftdx3000dm) { retval = valid_commands[search_index].ft3000; }
+            else if (is_ftdx101d) { retval = valid_commands[search_index].ft101d; }
+            else if (is_ftdx101mp) { retval = valid_commands[search_index].ft101mp; }
+            else if (is_ftdx10) { retval = valid_commands[search_index].ftdx10; }
+            else if (is_ft710) { retval = valid_commands[search_index].ft710; }
+            else if (is_ftx1) { retval = valid_commands[search_index].ftx1; }
+
+            if (!retval)
             {
                 rig_debug(RIG_DEBUG_TRACE, "%s: '%s' command '%s' not supported\n",
                           __func__, caps->model_name, command);
-                RETURNFUNC2(FALSE);
             }
+            RETURNFUNC2(retval);
         }
     }
 

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -8601,7 +8601,7 @@ int newcat_set_narrow(RIG *rig, vfo_t vfo, ncboolean narrow)
         main_sub_vfo = (RIG_VFO_B == vfo || RIG_VFO_SUB == vfo) ? '1' : '0';
     }
 
-    if (narrow == TRUE)
+    if (narrow)
     {
         c = '1';
     }
@@ -8966,23 +8966,8 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
                 RETURNFUNC(err);
             }
 
-            if (width == RIG_PASSBAND_NORMAL) { w = 0; }
-            else if (width <= 50) { w = 1; }
-            else if (width <= 100) { w = 2; }
-            else if (width <= 150) { w = 3; }
-            else if (width <= 200) { w = 4; }
-            else if (width <= 250) { w = 5; }
-            else if (width <= 300) { w = 6; }
-            else if (width <= 350) { w = 7; }
-            else if (width <= 400) { w = 8; }
-            else if (width <= 450) { w = 9; }
-            else if (width <= 500) { w = 10; }
-            else if (width <= 800) { w = 11; }
-            else if (width <= 1200) { w = 12; }
-            else if (width <= 1400) { w = 13; }
-            else if (width <= 1700) { w = 14; }
-            else if (width <= 2000) { w = 15; }
-            else { w = 16; } // 2400 Hz
+            w = newcat_get_index_from_width(width, priv_caps->cw_widths);
+            if (w < 0) { RETURNFUNC(w); }
 
             break;
 
@@ -8996,32 +8981,8 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
                 RETURNFUNC(err);
             }
 
-            if (width == RIG_PASSBAND_NORMAL) { w = 0; }
-            else if (width <= 200) {  w = 1; }
-            else if (width <= 400) {  w = 2; }
-            else if (width <= 600) {  w = 3; }
-            else if (width <= 850) {  w = 4; }
-            else if (width <= 1100) {  w = 5; }
-            else if (width <= 1350) {  w = 6; }
-            else if (width <= 1500) {  w = 7; }
-            else if (width <= 1650) {  w = 8; }
-            else if (width <= 1800) {  w = 9; }
-            else if (width <= 1950) {  w = 10; }
-            else if (width <= 2100) {  w = 11; }
-            else if (width <= 2200) {  w = 12; }
-            else if (width <= 2300) {  w = 13; }
-            else if (width <= 2400) {  w = 14; }
-            else if (width <= 2500) {  w = 15; }
-            else if (width <= 2600) {  w = 16; }
-            else if (width <= 2700) {  w = 17; }
-            else if (width <= 2800) {  w = 18; }
-            else if (width <= 2900) {  w = 19; }
-            else if (width <= 3000) {  w = 20; }
-            else if (width <= 3200) {  w = 21; }
-            else if (width <= 3400) {  w = 22; }
-            else if (width <= 3600) {  w = 23; }
-            else if (width <= 3800) {  w = 24; }
-            else { w = 25; } // 4000 Hz
+            w = newcat_get_index_from_width(width, priv_caps->ssb_widths);
+            if (w < 0) { RETURNFUNC(w); }
 
             break;
 
@@ -9193,7 +9154,7 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
             RETURNFUNC(-RIG_EINVAL);
         } // end switch(mode)
 
-        if (((struct newcat_priv_caps *)rig->caps->priv)->roofing_filter_count > 0)
+        if (priv_caps->roofing_filter_count > 0)
         {
             if ((err = set_roofing_filter_for_width(rig, vfo, width)) != RIG_OK)
             {
@@ -9997,108 +9958,34 @@ int newcat_get_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t *width)
         case RIG_MODE_RTTYR:
         case RIG_MODE_CW:
         case RIG_MODE_CWR:
-            switch (w)
+            if (w > 0 && w < priv_caps->cw_widths->count)
             {
-            case 0:
+                *width = priv_caps->cw_widths->widths[w];
+            }
+            else if (w == 0)
+            {
                 *width = narrow ? 500 : 2400;
-                break;
-
-            case 1: *width = 50; break;
-
-            case 2: *width = 100; break;
-
-            case 3: *width = 150; break;
-
-            case 4: *width = 200; break;
-
-            case 5: *width = 250; break;
-
-            case 6: *width = 300; break;
-
-            case 7: *width = 350; break;
-
-            case 8: *width = 400; break;
-
-            case 9: *width = 450; break;
-
-            case 10: *width = 500; break;
-
-            case 11: *width = 800; break;
-
-            case 12: *width = 1200; break;
-
-            case 13: *width = 1400; break;
-
-            case 14: *width = 1700; break;
-
-            case 15: *width = 2000; break;
-
-            case 16: *width = 2400; break;
-
-            default: RETURNFUNC(-RIG_EINVAL);
+            }
+            else
+            {
+                RETURNFUNC(-RIG_EPROTO);
             }
 
             break;
 
         case RIG_MODE_LSB:
         case RIG_MODE_USB:
-            switch (w)
+            if (w > 0 && w < priv_caps->ssb_widths->count)
             {
-            case 0:
+                *width = priv_caps->ssb_widths->widths[w];
+            }
+            else if (w == 0)
+            {
                 *width = narrow ? 1500 : 2400;
-                break;
-
-            case  1: *width =  200; break;
-
-            case  2: *width =  400; break;
-
-            case  3: *width =  600; break;
-
-            case  4: *width =  850; break;
-
-            case  5: *width = 1100; break;
-
-            case  6: *width = 1350; break;
-
-            case  7: *width = 1500; break;
-
-            case  8: *width = 1650; break;
-
-            case  9: *width = 1800; break;
-
-            case 10: *width = 1950; break;
-
-            case 11: *width = 2100; break;
-
-            case 12: *width = 2250; break;
-
-            case 13: *width = 2400; break;
-
-            case 14: *width = 2450; break;
-
-            case 15: *width = 2500; break;
-
-            case 16: *width = 2600; break;
-
-            case 17: *width = 2700; break;
-
-            case 18: *width = 2800; break;
-
-            case 19: *width = 2900; break;
-
-            case 20: *width = 3000; break;
-
-            case 21: *width = 3200; break;
-
-            case 22: *width = 3400; break;
-
-            case 23: *width = 3600; break;
-
-            case 24: *width = 3800; break;
-
-            case 25: *width = 4000; break;
-
-            default: RETURNFUNC(-RIG_EINVAL);
+            }
+            else
+            {
+                RETURNFUNC(-RIG_EPROTO);
             }
 
             break;

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -714,6 +714,7 @@ static int newcat_band_index(RIG *rig, freq_t freq)
 /*
  *  Get the width index(SH value) given the requested passband width
  *    and the widths the rig supports
+ *  Negative return is -rig_errcode_e
  */
 static int newcat_get_index_from_width(pbwidth_t width, const struct newcat_width_info *info)
 {
@@ -721,8 +722,9 @@ static int newcat_get_index_from_width(pbwidth_t width, const struct newcat_widt
     {
         return 0;  // Rig default
     }
+    if (width <  0) { return -RIG_EINVAL; }
 
-    for (int i = 1; i < info->count - 2; i++)
+    for (int i = 1; i < info->count; i++)
     {
         if (width <= info->widths[i])
         {
@@ -730,6 +732,8 @@ static int newcat_get_index_from_width(pbwidth_t width, const struct newcat_widt
         }
     }
 
+    /* Which is correct?  If width is too big, do we return max width or error? */
+    //return -RIG_EINVAL; // Not found, return error
     return info->count - 1; // Not found, use the maximum
 }
 
@@ -8774,20 +8778,7 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
             }
 
             w = newcat_get_index_from_width(width, priv_caps->cw_widths);
-//---Start cut here            // Remove this if() when the above routine works
-            if (width == RIG_PASSBAND_NORMAL) { w = 0; }
-            else if (width <= 100) { w = 3; }
-            else if (width <= 200) { w = 4; }
-            else if (width <= 300) { w = 5; }
-            else if (width <= 400) { w = 6; }
-            else if (width <= 500) { w = 7; }
-            else if (width <= 800) { w = 8; }
-            else if (width <= 1200) { w = 9; }
-            else if (width <= 1400) { w = 10; }
-            else if (width <= 1700) { w = 11; }
-            else if (width <= 2000) { w = 12; }
-            else { w = 13; } // 2400 Hz
-//---End cut here---
+            if (w < 0) { RETURNFUNC(w); }
 
             break;
 
@@ -8802,29 +8793,7 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
             }
 
             w = newcat_get_index_from_width(width, priv_caps->ssb_widths);
-//---Start cut here---            // Remove when above is tested
-            if (width == RIG_PASSBAND_NORMAL) { w = 0; }
-            else if (width <= 200) { w = 1; }
-            else if (width <= 400) { w = 2; }
-            else if (width <= 600) { w = 3; }
-            else if (width <= 850) { w = 4; }
-            else if (width <= 1100) { w = 5; }
-            else if (width <= 1350) { w = 6; }
-            else if (width <= 1500) { w = 7; }
-            else if (width <= 1650) { w = 8; }
-            else if (width <= 1800) { w = 9; }
-            else if (width <= 1950) { w = 10; }
-            else if (width <= 2100) { w = 11; }
-            else if (width <= 2250) { w = 12; }
-            else if (width <= 2400) { w = 13; }
-            else if (width <= 2450) { w = 14; }
-            else if (width <= 2500) { w = 15; }
-            else if (width <= 2600) { w = 16; }
-            else if (width <= 2700) { w = 17; }
-            else if (width <= 2800) { w = 18; }
-            else if (width <= 2900) { w = 19; }
-            else { w = 20; } // 3000 Hz
-//---End cut here---
+            if (w < 0) { RETURNFUNC(w); }
 
             break;
 
@@ -9303,58 +9272,14 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         case RIG_MODE_RTTYR:
         case RIG_MODE_CW:
         case RIG_MODE_CWR:
-            if (width == RIG_PASSBAND_NORMAL) { w = 0; }
-            else if (width <= 50) { w = 1; }
-            else if (width <= 100) { w = 2; }
-            else if (width <= 150) { w = 3; }
-            else if (width <= 200) { w = 4; }
-            else if (width <= 250) { w = 5; }
-            else if (width <= 300) { w = 6; }
-            else if (width <= 350) { w = 7; }
-            else if (width <= 400) { w = 8; }
-            else if (width <= 450) { w = 9; }
-            else if (width <= 500) { w = 10; }
-            else if (width <= 600) { w = 11; }
-            else if (width <= 800) { w = 12; }
-            else if (width <= 1200) { w = 13; }
-            else if (width <= 1400) { w = 14; }
-            else if (width <= 1700) { w = 15; }
-            else if (width <= 2000) { w = 16; }
-            else if (width <= 2400) { w = 17; }
-            else if (width <= 3000) { w = 18; }
-            else if (width <= 3200) { w = 19; }
-            else if (width <= 3500) { w = 20; }
-            else { w = 21; } // 4000 Hz
-
+            w = newcat_get_index_from_width(width, priv_caps->cw_widths);
+            if (w < 0) { RETURNFUNC(w); } // Out of bounds
             break;
 
         case RIG_MODE_LSB:
         case RIG_MODE_USB:
-            if (width == RIG_PASSBAND_NORMAL) { w = 0; }
-            else if (width <= 300) {  w = 1; }
-            else if (width <= 400) {  w = 2; }
-            else if (width <= 600) {  w = 3; }
-            else if (width <= 850) {  w = 4; }
-            else if (width <= 1100) {  w = 5; }
-            else if (width <= 1200) {  w = 6; }
-            else if (width <= 1500) {  w = 7; }
-            else if (width <= 1650) {  w = 8; }
-            else if (width <= 1800) {  w = 9; }
-            else if (width <= 1950) {  w = 10; }
-            else if (width <= 2100) {  w = 11; }
-            else if (width <= 2200) {  w = 12; }
-            else if (width <= 2300) {  w = 13; }
-            else if (width <= 2400) {  w = 14; }
-            else if (width <= 2500) {  w = 15; }
-            else if (width <= 2600) {  w = 16; }
-            else if (width <= 2700) {  w = 17; }
-            else if (width <= 2800) {  w = 18; }
-            else if (width <= 2900) {  w = 19; }
-            else if (width <= 3000) {  w = 20; }
-            else if (width <= 3200) {  w = 21; }
-            else if (width <= 3500) {  w = 22; }
-            else { w = 23; } // 4000 Hz
-
+            w = newcat_get_index_from_width(width, priv_caps->ssb_widths);
+            if (w < 0) { RETURNFUNC(w); }
             break;
 
         case RIG_MODE_AM:
@@ -9823,10 +9748,10 @@ int newcat_get_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t *width)
     struct newcat_priv_caps *priv_caps = (struct newcat_priv_caps *)rig->caps->priv;
     int err;
     int w;
-    int sh_command_valid = 1;
     int narrow = 0;
     char cmd[] = "SH";
     char main_sub_vfo = '0';
+    ncboolean sh_command_valid = TRUE;
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s vfo=%s, mode=%s\n", __func__,
@@ -9855,7 +9780,7 @@ int newcat_get_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t *width)
         case RIG_MODE_AM:
         case RIG_MODE_AMN:
         case RIG_MODE_PKTAM:
-            sh_command_valid = 0;
+            sh_command_valid = FALSE;
             break;
         }
     }
@@ -9952,96 +9877,34 @@ int newcat_get_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t *width)
         case RIG_MODE_RTTYR:
         case RIG_MODE_CW:
         case RIG_MODE_CWR:
-            if (w >= 0 && w < priv_caps->cw_widths->count)
+            if (w == 0)
+            {
+                *width = narrow ? 300 : 500;
+            }
+            else if (w < 0 || w >= priv_caps->cw_widths->count)
+            {
+                RETURNFUNC(-RIG_EINVAL);
+            }
+            else
             {
                 *width = priv_caps->cw_widths->widths[w];
             }
-            else {RETURNFUNC(-RIG_EINVAL);}
-//---Start cut here---
-            switch (w)
-            {
-            case 0:
-                *width = narrow ? 300 : 500;
-                break;
-
-            case 3: *width = 100; break;
-
-            case 4: *width = 200; break;
-
-            case 5: *width = 300; break;
-
-            case 6: *width = 400; break;
-
-            case 7: *width = 500; break;
-
-            case 8: *width = 800; break;
-
-            case 9: *width = 1200; break;
-
-            case 10: *width = 1400; break;
-
-            case 11: *width = 1700; break;
-
-            case 12: *width = 2000; break;
-
-            case 13: *width = 2400; break;
-
-            default: RETURNFUNC(-RIG_EINVAL);
-            }
-//---End cut here---
 
             break;
 
         case RIG_MODE_LSB:
         case RIG_MODE_USB:
-            switch (w)
+            if (w == 0)
             {
-            case 0:
                 *width = narrow ? 1800 : 2400;
-                break;
-
-            case  1: *width =  200; break;
-
-            case  2: *width =  400; break;
-
-            case  3: *width =  600; break;
-
-            case  4: *width =  850; break;
-
-            case  5: *width = 1100; break;
-
-            case  6: *width = 1350; break;
-
-            case  7: *width = 1500; break;
-
-            case  8: *width = 1650; break;
-
-            case  9: *width = 1800; break;
-
-            case 10: *width = 1950; break;
-
-            case 11: *width = 2100; break;
-
-            case 12: *width = 2250; break;
-
-            case 13: *width = 2400; break;
-
-            case 14: *width = 2450; break;
-
-            case 15: *width = 2500; break;
-
-            case 16: *width = 2600; break;
-
-            case 17: *width = 2700; break;
-
-            case 18: *width = 2800; break;
-
-            case 19: *width = 2900; break;
-
-            case 20: *width = 3000; break;
-
-            default:
+            }
+            else if (w < 0 || w >= priv_caps->ssb_widths->count)
+            {
                 RETURNFUNC(-RIG_EINVAL);
+            }
+            else
+            {
+                *width = priv_caps->ssb_widths->widths[w];
             }
 
             break;
@@ -10671,116 +10534,24 @@ int newcat_get_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t *width)
         case RIG_MODE_RTTYR:
         case RIG_MODE_CW:
         case RIG_MODE_CWR:
-            switch (w)
+            if (w == 0) { break; }  // use the roofing/default width
+            else if (w < 0 || w >= priv_caps->cw_widths->count)
             {
-            case 0: break; /* use roofing filter width */
-
-            case 1: *width = 50; break;
-
-            case 2: *width = 100; break;
-
-            case 3: *width = 150; break;
-
-            case 4: *width = 200; break;
-
-            case 5: *width = 250; break;
-
-            case 6: *width = 300; break;
-
-            case 7: *width = 350; break;
-
-            case 8: *width = 400; break;
-
-            case 9: *width = 450;  break;
-
-            case 10: *width = 500;  break;
-
-            case 11: *width = 600;  break;
-
-            case 12: *width = 800;  break;
-
-            case 13: *width = 1200;  break;
-
-            case 14: *width = 1400;  break;
-
-            case 15: *width = 1700;  break;
-
-            case 16: *width = 2000;  break;
-
-            case 17: *width = 2400;  break;
-
-            case 18: *width = 3000;  break;
-
-            case 19: *width = 3200;  break;
-
-            case 20: *width = 3500;  break;
-
-            case 21: *width = 4000;  break;
-
-            default:
-
-                RETURNFUNC(-RIG_EINVAL);
+                RETURNFUNC(-RIG_EPROTO);  // Should not happen
             }
 
+            *width = priv_caps->cw_widths->widths[w];
             break;
 
         case RIG_MODE_LSB:
         case RIG_MODE_USB:
-            switch (w)
+            if (w == 0) { break; } // Use the roofing/default value
+            else if (w < 0 || w >= priv_caps->ssb_widths->count)
             {
-            case 0: break; /* use roofing filter width */
-
-            case 1: *width = 300; break;
-
-            case 2: *width = 400; break;
-
-            case 3: *width = 600; break;
-
-            case 4: *width = 850; break;
-
-            case 5: *width = 1100; break;
-
-            case 6: *width = 1200; break;
-
-            case 7: *width = 1500; break;
-
-            case 8: *width = 1650; break;
-
-            case 9: *width = 1800; break;
-
-            case 10: *width = 1950;  break;
-
-            case 11: *width = 2100;  break;
-
-            case 12: *width = 2200;  break;
-
-            case 13: *width = 2300;  break;
-
-            case 14: *width = 2400;  break;
-
-            case 15: *width = 2500;  break;
-
-            case 16: *width = 2600;  break;
-
-            case 17: *width = 2700;  break;
-
-            case 18: *width = 2800;  break;
-
-            case 19: *width = 2900;  break;
-
-            case 20: *width = 3000;  break;
-
-            case 21: *width = 3200;  break;
-
-            case 22: *width = 3500;  break;
-
-            case 23: *width = 4000;  break;
-
-            default:
-                rig_debug(RIG_DEBUG_ERR, "%s: unknown width=%d\n", __func__, w);
-                RETURNFUNC(-RIG_EINVAL);
+                RETURNFUNC(-RIG_EPROTO);
             }
 
+            *width = priv_caps->ssb_widths->widths[w];
             break;
 
         case RIG_MODE_AM:

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -8159,7 +8159,7 @@ ncboolean newcat_is_rig(RIG *rig, rig_model_t model)
 
     //a bit too verbose so disable this unless needed
     //rig_debug(RIG_DEBUG_TRACE, "%s(%d):%s called\n", __FILE__, __LINE__, __func__);
-    is_rig = (model == rig->caps->rig_model) ? TRUE : FALSE;
+    is_rig = model == rig->caps->rig_model;
 
     return (is_rig); // RETURN is too verbose here
 }
@@ -8716,7 +8716,7 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         case RIG_MODE_CW:
         case RIG_MODE_CWR:
             // Narrow mode must be chosen correctly before filter width
-            err = newcat_set_narrow(rig, vfo, width <= 500 ? TRUE : FALSE);
+            err = newcat_set_narrow(rig, vfo, width <= 500);
 
             if (err != RIG_OK)
             {
@@ -8741,7 +8741,7 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         case RIG_MODE_LSB:
         case RIG_MODE_USB:
             // Narrow mode must be chosen correctly before filter width
-            err = newcat_set_narrow(rig, vfo, width <= 1800 ? TRUE : FALSE);
+            err = newcat_set_narrow(rig, vfo, width <= 1800);
 
             if (err != RIG_OK)
             {
@@ -8813,7 +8813,7 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         case RIG_MODE_CW:
         case RIG_MODE_CWR:
             // Narrow mode must be chosen correctly before filter width
-            err = newcat_set_narrow(rig, vfo, width <= 500 ? TRUE : FALSE);
+            err = newcat_set_narrow(rig, vfo, width <= 500);
 
             if (err != RIG_OK)
             {
@@ -8844,7 +8844,7 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         case RIG_MODE_LSB:
         case RIG_MODE_USB:
             // Narrow mode must be chosen correctly before filter width
-            err = newcat_set_narrow(rig, vfo, width <= 1800 ? TRUE : FALSE);
+            err = newcat_set_narrow(rig, vfo, width <= 1800);
 
             if (err != RIG_OK)
             {
@@ -8902,7 +8902,7 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         case RIG_MODE_CW:
         case RIG_MODE_CWR:
             // Narrow mode must be chosen correctly before filter width
-            err = newcat_set_narrow(rig, vfo, width <= 500 ? TRUE : FALSE);
+            err = newcat_set_narrow(rig, vfo, width <= 500);
 
             if (err != RIG_OK)
             {
@@ -8933,7 +8933,7 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         case RIG_MODE_LSB:
         case RIG_MODE_USB:
             // Narrow mode must be chosen correctly before filter width
-            err = newcat_set_narrow(rig, vfo, width <= 1800 ? TRUE : FALSE);
+            err = newcat_set_narrow(rig, vfo, width <= 1800);
 
             if (err != RIG_OK)
             {
@@ -9035,7 +9035,7 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         case RIG_MODE_CW:
         case RIG_MODE_CWR:
             // Narrow mode must be chosen correctly before filter width
-            err = newcat_set_narrow(rig, vfo, width <= 500 ? TRUE : FALSE);
+            err = newcat_set_narrow(rig, vfo, width <= 500);
 
             if (err != RIG_OK)
             {
@@ -9065,7 +9065,7 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         case RIG_MODE_LSB:
         case RIG_MODE_USB:
             // Narrow mode must be chosen correctly before filter width
-            err = newcat_set_narrow(rig, vfo, width <= 1800 ? TRUE : FALSE);
+            err = newcat_set_narrow(rig, vfo, width <= 1800);
 
             if (err != RIG_OK)
             {
@@ -9142,7 +9142,7 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         case RIG_MODE_CW:
         case RIG_MODE_CWR:
             // Narrow mode must be chosen correctly before filter width
-            err = newcat_set_narrow(rig, vfo, width <= 500 ? TRUE : FALSE);
+            err = newcat_set_narrow(rig, vfo, width <= 500 );
 
             if (err != RIG_OK)
             {
@@ -9172,7 +9172,7 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         case RIG_MODE_LSB:
         case RIG_MODE_USB:
             // Narrow mode must be chosen correctly before filter width
-            err = newcat_set_narrow(rig, vfo, width <= 1800 ? TRUE : FALSE);
+            err = newcat_set_narrow(rig, vfo, width <= 1800);
 
             if (err != RIG_OK)
             {

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -8680,6 +8680,7 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     int err;
     int w = 0;
     char main_sub_vfo = '0';
+    ncboolean is_narrow;
 
     ENTERFUNC;
     rig_debug(RIG_DEBUG_TRACE, "%s vfo=%s, mode=%s, width=%d\n", __func__,
@@ -8792,14 +8793,8 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         case RIG_MODE_AM:
         case RIG_MODE_FM:
         case RIG_MODE_PKTFM:
-            if (width > 0 && width < rig_passband_normal(rig, mode))
-            {
-                err = newcat_set_narrow(rig, vfo,  TRUE);
-            }
-            else
-            {
-                err = newcat_set_narrow(rig, vfo, FALSE);
-            }
+            is_narrow = width > 0 && width < rig_passband_normal(rig, mode);
+            err = newcat_set_narrow(rig, vfo, is_narrow);
 
             RETURNFUNC(err);
 
@@ -8884,14 +8879,8 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         case RIG_MODE_AM:
         case RIG_MODE_FM:
         case RIG_MODE_PKTFM:
-            if (width > 0 && width < rig_passband_normal(rig, mode))
-            {
-                err = newcat_set_narrow(rig, vfo,  TRUE);
-            }
-            else
-            {
-                err = newcat_set_narrow(rig, vfo, FALSE);
-            }
+            is_narrow = width > 0 && width < rig_passband_normal(rig, mode);
+            err = newcat_set_narrow(rig, vfo, is_narrow);
 
             RETURNFUNC(err);
 
@@ -9025,14 +9014,8 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
             RETURNFUNC(err);
 
         case RIG_MODE_PKTFM:
-            if (width > 0 && width < rig_passband_normal(rig, mode))
-            {
-                err = newcat_set_narrow(rig, vfo,  TRUE);
-            }
-            else
-            {
-                err = newcat_set_narrow(rig, vfo, FALSE);
-            }
+            is_narrow = width > 0 && width < rig_passband_normal(rig, mode);
+            err = newcat_set_narrow(rig, vfo, is_narrow);
 
             RETURNFUNC(err);
 
@@ -9142,14 +9125,8 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         case RIG_MODE_FM:
         case RIG_MODE_PKTFM:
         case RIG_MODE_FMN:
-            if (width > 0 && width < rig_passband_normal(rig, mode))
-            {
-                err = newcat_set_narrow(rig, vfo,  TRUE);
-            }
-            else
-            {
-                err = newcat_set_narrow(rig, vfo, FALSE);
-            }
+            is_narrow = width > 0 && width < rig_passband_normal(rig, mode);
+            err = newcat_set_narrow(rig, vfo, is_narrow);
 
             RETURNFUNC(err);
         }
@@ -9254,14 +9231,8 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         case RIG_MODE_FM:
         case RIG_MODE_PKTFM:
         case RIG_MODE_FMN:
-            if (width > 0 && width < rig_passband_normal(rig, mode))
-            {
-                err = newcat_set_narrow(rig, vfo,  TRUE);
-            }
-            else
-            {
-                err = newcat_set_narrow(rig, vfo, FALSE);
-            }
+            is_narrow = width > 0 && width < rig_passband_normal(rig, mode);
+            err = newcat_set_narrow(rig, vfo, is_narrow);
 
             RETURNFUNC(err);
         }
@@ -9355,14 +9326,8 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         case RIG_MODE_AM:
         case RIG_MODE_FM:
         case RIG_MODE_PKTFM:
-            if (width > 0 && width < rig_passband_normal(rig, mode))
-            {
-                err = newcat_set_narrow(rig, vfo,  TRUE);
-            }
-            else
-            {
-                err = newcat_set_narrow(rig, vfo, FALSE);
-            }
+            is_narrow = width > 0 && width < rig_passband_normal(rig, mode);
+            err = newcat_set_narrow(rig, vfo, is_narrow);
 
             RETURNFUNC(err);
 
@@ -9552,14 +9517,8 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         case RIG_MODE_FM:
         case RIG_MODE_PKTFM:
         case RIG_MODE_FMN:
-            if (width > 0 && width < rig_passband_normal(rig, mode))
-            {
-                err = newcat_set_narrow(rig, vfo,  TRUE);
-            }
-            else
-            {
-                err = newcat_set_narrow(rig, vfo, FALSE);
-            }
+            is_narrow = width > 0 && width < rig_passband_normal(rig, mode);
+            err = newcat_set_narrow(rig, vfo, is_narrow);
 
             RETURNFUNC(err);
         }
@@ -9595,14 +9554,8 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         case RIG_MODE_AM:
         case RIG_MODE_FM:
         case RIG_MODE_PKTFM:
-            if (width > 0 && width < rig_passband_normal(rig, mode))
-            {
-                err = newcat_set_narrow(rig, vfo,  TRUE);
-            }
-            else
-            {
-                err = newcat_set_narrow(rig, vfo, FALSE);
-            }
+            is_narrow = width > 0 && width < rig_passband_normal(rig, mode);
+            err = newcat_set_narrow(rig, vfo, is_narrow);
 
             RETURNFUNC(err);
 

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -9141,9 +9141,6 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     } // end is_ftdx101d || is_ftdx101mp || is_ftdx10 || is_ft710
     else if (is_ftx1)
     {
-        // Bandwidth table per FTX-1 CAT Operation Reference Manual Table 5
-        // (doc 2508-C). Differs from the FT-710/FTDX10 table at SSB codes
-        // 12/13/14 (2250/2400/2450 Hz vs 2200/2300/2400), so do not merge.
         switch (mode)
         {
         case RIG_MODE_PKTUSB:
@@ -9153,58 +9150,14 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         case RIG_MODE_CW:
         case RIG_MODE_CWR:
         case RIG_MODE_PSK:
-            if (width == RIG_PASSBAND_NORMAL) { w = 0; }
-            else if (width <= 50) { w = 1; }
-            else if (width <= 100) { w = 2; }
-            else if (width <= 150) { w = 3; }
-            else if (width <= 200) { w = 4; }
-            else if (width <= 250) { w = 5; }
-            else if (width <= 300) { w = 6; }
-            else if (width <= 350) { w = 7; }
-            else if (width <= 400) { w = 8; }
-            else if (width <= 450) { w = 9; }
-            else if (width <= 500) { w = 10; }
-            else if (width <= 600) { w = 11; }
-            else if (width <= 800) { w = 12; }
-            else if (width <= 1200) { w = 13; }
-            else if (width <= 1400) { w = 14; }
-            else if (width <= 1700) { w = 15; }
-            else if (width <= 2000) { w = 16; }
-            else if (width <= 2400) { w = 17; }
-            else if (width <= 3000) { w = 18; }
-            else if (width <= 3200) { w = 19; }
-            else if (width <= 3500) { w = 20; }
-            else { w = 21; } // 4000 Hz
-
+            w = newcat_get_index_from_width(width, priv_caps->cw_widths);
+            if (w < 0) { RETURNFUNC(w); } // Out of bounds
             break;
 
         case RIG_MODE_LSB:
         case RIG_MODE_USB:
-            if (width == RIG_PASSBAND_NORMAL) { w = 0; }
-            else if (width <= 300) {  w = 1; }
-            else if (width <= 400) {  w = 2; }
-            else if (width <= 600) {  w = 3; }
-            else if (width <= 850) {  w = 4; }
-            else if (width <= 1100) {  w = 5; }
-            else if (width <= 1200) {  w = 6; }
-            else if (width <= 1500) {  w = 7; }
-            else if (width <= 1650) {  w = 8; }
-            else if (width <= 1800) {  w = 9; }
-            else if (width <= 1950) {  w = 10; }
-            else if (width <= 2100) {  w = 11; }
-            else if (width <= 2250) {  w = 12; }
-            else if (width <= 2400) {  w = 13; }
-            else if (width <= 2450) {  w = 14; }
-            else if (width <= 2500) {  w = 15; }
-            else if (width <= 2600) {  w = 16; }
-            else if (width <= 2700) {  w = 17; }
-            else if (width <= 2800) {  w = 18; }
-            else if (width <= 2900) {  w = 19; }
-            else if (width <= 3000) {  w = 20; }
-            else if (width <= 3200) {  w = 21; }
-            else if (width <= 3500) {  w = 22; }
-            else { w = 23; } // 4000 Hz
-
+            w = newcat_get_index_from_width(width, priv_caps->ssb_widths);
+            if (w < 0) { RETURNFUNC(w); }
             break;
 
         case RIG_MODE_AM:
@@ -9224,14 +9177,8 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         case RIG_MODE_AM:
         case RIG_MODE_FM:
         case RIG_MODE_PKTFM:
-            if (width > 0 && width < rig_passband_normal(rig, mode))
-            {
-                err = newcat_set_narrow(rig, vfo,  TRUE);
-            }
-            else
-            {
-                err = newcat_set_narrow(rig, vfo, FALSE);
-            }
+            is_narrow = width > 0 && width < rig_passband_normal(rig, mode);
+            err = newcat_set_narrow(rig, vfo, is_narrow);
 
             RETURNFUNC(err);
 
@@ -10121,8 +10068,6 @@ int newcat_get_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t *width)
     } /* end if is_ftdx101d || is_ftdx101mp || is_ftdx10 || is_ft710 */
     else if (is_ftx1)
     {
-        // Bandwidth table per FTX-1 CAT Operation Reference Manual Table 5
-        // (doc 2508-C). Differs from FT-710/FTDX10 at SSB codes 12/13/14.
         rig_debug(RIG_DEBUG_TRACE, "%s: is_ftx1 w=%d, mode=%s\n", __func__, w,
                   rig_strrmode(mode));
 
@@ -10140,114 +10085,29 @@ int newcat_get_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t *width)
         case RIG_MODE_CW:
         case RIG_MODE_CWR:
         case RIG_MODE_PSK:
-            switch (w)
+            if (w > 0 && w < priv_caps->cw_widths->count)
             {
-            case 0: break; /* default */
-
-            case 1: *width = 50; break;
-
-            case 2: *width = 100; break;
-
-            case 3: *width = 150; break;
-
-            case 4: *width = 200; break;
-
-            case 5: *width = 250; break;
-
-            case 6: *width = 300; break;
-
-            case 7: *width = 350; break;
-
-            case 8: *width = 400; break;
-
-            case 9: *width = 450;  break;
-
-            case 10: *width = 500;  break;
-
-            case 11: *width = 600;  break;
-
-            case 12: *width = 800;  break;
-
-            case 13: *width = 1200;  break;
-
-            case 14: *width = 1400;  break;
-
-            case 15: *width = 1700;  break;
-
-            case 16: *width = 2000;  break;
-
-            case 17: *width = 2400;  break;
-
-            case 18: *width = 3000;  break;
-
-            case 19: *width = 3200;  break;
-
-            case 20: *width = 3500;  break;
-
-            case 21: *width = 4000;  break;
-
-            default:
-                RETURNFUNC(-RIG_EINVAL);
+                *width = priv_caps->cw_widths->widths[w];
             }
+            else if (w == 0)
+            {
+                break;   // use the roofing/default width
+            }
+            else {RETURNFUNC(-RIG_EPROTO);}  // Should not happen
 
             break;
 
         case RIG_MODE_LSB:
         case RIG_MODE_USB:
-            switch (w)
+            if (w > 0 && w < priv_caps->ssb_widths->count)
             {
-            case 0: break; /* default */
-
-            case 1: *width = 300; break;
-
-            case 2: *width = 400; break;
-
-            case 3: *width = 600; break;
-
-            case 4: *width = 850; break;
-
-            case 5: *width = 1100; break;
-
-            case 6: *width = 1200; break;
-
-            case 7: *width = 1500; break;
-
-            case 8: *width = 1650; break;
-
-            case 9: *width = 1800; break;
-
-            case 10: *width = 1950;  break;
-
-            case 11: *width = 2100;  break;
-
-            case 12: *width = 2250;  break;
-
-            case 13: *width = 2400;  break;
-
-            case 14: *width = 2450;  break;
-
-            case 15: *width = 2500;  break;
-
-            case 16: *width = 2600;  break;
-
-            case 17: *width = 2700;  break;
-
-            case 18: *width = 2800;  break;
-
-            case 19: *width = 2900;  break;
-
-            case 20: *width = 3000;  break;
-
-            case 21: *width = 3200;  break;
-
-            case 22: *width = 3500;  break;
-
-            case 23: *width = 4000;  break;
-
-            default:
-                rig_debug(RIG_DEBUG_ERR, "%s: unknown width=%d\n", __func__, w);
-                RETURNFUNC(-RIG_EINVAL);
+                *width = priv_caps->ssb_widths->widths[w];
             }
+            else if (w == 0)
+            {
+                break;  // Use the roofing/default value
+            }
+            else {RETURNFUNC(-RIG_EPROTO);}
 
             break;
 

--- a/rigs/yaesu/newcat.h
+++ b/rigs/yaesu/newcat.h
@@ -274,6 +274,7 @@ int newcat_scan(RIG *rig, vfo_t vfo, scan_t scan, int ch);
  */
 extern const struct newcat_width_info ft991_cw_widths, ft991_ssb_widths;
 extern const struct newcat_width_info ftdx101_cw_widths, ftdx101_ssb_widths;
+extern const struct newcat_width_info ftdx1200_cw_widths, ftdx1200_ssb_widths;
 
 #define TOKEN_BACKEND(t) (t)
 

--- a/rigs/yaesu/newcat.h
+++ b/rigs/yaesu/newcat.h
@@ -269,6 +269,11 @@ int newcat_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
                      int *min, int *sec, double *msec, int *utc_offset);
 int newcat_scan(RIG *rig, vfo_t vfo, scan_t scan, int ch);
 
+/*
+ * Shared data structures
+ */
+extern const struct newcat_width_info ftdx101_cw_widths, ftdx101_ssb_widths;
+
 #define TOKEN_BACKEND(t) (t)
 
 #define TOK_ROOFING_FILTER TOKEN_BACKEND(100)

--- a/rigs/yaesu/newcat.h
+++ b/rigs/yaesu/newcat.h
@@ -272,6 +272,7 @@ int newcat_scan(RIG *rig, vfo_t vfo, scan_t scan, int ch);
 /*
  * Shared data structures
  */
+extern const struct newcat_width_info ft991_cw_widths, ft991_ssb_widths;
 extern const struct newcat_width_info ftdx101_cw_widths, ftdx101_ssb_widths;
 
 #define TOKEN_BACKEND(t) (t)

--- a/rigs/yaesu/newcat.h
+++ b/rigs/yaesu/newcat.h
@@ -54,7 +54,7 @@
 typedef bool ncboolean;
 
 /* shared function version */
-#define NEWCAT_VER "20241118"
+#define NEWCAT_VER "20260419"
 
 /* Hopefully large enough for future use, 128 chars plus '\0' */
 #define NEWCAT_DATA_LEN                 129
@@ -109,8 +109,9 @@ struct newcat_roofing_filter
 
 struct newcat_width_info
 {
+    // New entries should go here
     short count;       // Max value + 1
-    uint16_t widths[]; // Must have values for all indices from 0 to max
+    uint16_t widths[]; // Must have values for all indices from 0 to max and must be last in struct
 };
 
 struct newcat_priv_caps

--- a/rigs/yaesu/newcat.h
+++ b/rigs/yaesu/newcat.h
@@ -33,6 +33,8 @@
 #ifndef _NEWCAT_H
 #define _NEWCAT_H 1
 
+#include <stdbool.h>
+
 #include "tones.h"
 #include "token.h"
 
@@ -47,7 +49,7 @@
 #endif
 #define OFF FALSE
 
-typedef char ncboolean;
+typedef bool ncboolean;
 
 /* shared function version */
 #define NEWCAT_VER "20241118"

--- a/rigs/yaesu/newcat.h
+++ b/rigs/yaesu/newcat.h
@@ -28,11 +28,13 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 
 #ifndef _NEWCAT_H
 #define _NEWCAT_H 1
 
+#include <stdint.h>
 #include <stdbool.h>
 
 #include "tones.h"
@@ -105,10 +107,18 @@ struct newcat_roofing_filter
     int optional;
 };
 
+struct newcat_width_info
+{
+    short count;       // Max value + 1
+    uint16_t widths[]; // Must have values for all indices from 0 to max
+};
+
 struct newcat_priv_caps
 {
     int roofing_filter_count;
     struct newcat_roofing_filter roofing_filters[NEWCAT_ROOFING_FILTER_COUNT];
+    const struct newcat_width_info *ssb_widths;
+    const struct newcat_width_info *cw_widths;
 };
 
 /*

--- a/simulators/simft991.c
+++ b/simulators/simft991.c
@@ -5,19 +5,22 @@
 #include <string.h>
 #include <unistd.h>
 
+#if 0
 #include "hamlib/rig.h"
 #include "misc.h"
-
+#else
+int hl_usleep(unsigned long usec);
+#endif
 
 float freqA = 14074000;
 float freqB = 14074500;
 char tx_vfo = '1';
 char rx_vfo = '1';
-char modeA = '0';
-char modeB = '0';
+char modeA = 'C';
+char modeB = 'C';
 int keyspd = 20;
 int bandselect = 5;
-int  width = 21;
+int  width = 17;
 int narrow = 0;
 int vd = 0;
 int sm0 = 0;
@@ -26,6 +29,8 @@ int sm1 = 0;
 
 #include "sim.h"
 
+//#define ID NC_RIGID_FT991
+#define ID NC_RIGID_FT991A
 
 int main(int argc, char *argv[])
 {
@@ -88,7 +93,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "FA;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "FA%09.0f;", freqA);
+            snprintf(buf, sizeof(buf), "FA%09.0f;", freqA);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "FA", 2) == 0)
@@ -97,7 +102,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "FB;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "FB%09.0f;", freqB);
+            snprintf(buf, sizeof(buf), "FB%09.0f;", freqB);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "FB", 2) == 0)
@@ -108,8 +113,8 @@ int main(int argc, char *argv[])
         {
             printf("%s\n", buf);
             hl_usleep(50 * 1000);
-            int id = NC_RIGID_FTDX3000;
-            SNPRINTF(buf, sizeof(buf), "ID%03d;", id);
+            int id = ID;
+            snprintf(buf, sizeof(buf), "ID%04d;", id);
             n = write(fd, buf, strlen(buf));
             printf("n=%d\n", n);
 
@@ -117,14 +122,14 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "PS;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "PS1;");
+            snprintf(buf, sizeof(buf), "PS1;");
             n = write(fd, buf, strlen(buf));
         }
         else if (strcmp(buf, "AI;") == 0)
         {
             printf("%s\n", buf);
             hl_usleep(50 * 1000);
-            SNPRINTF(buf, sizeof(buf), "AI0;");
+            snprintf(buf, sizeof(buf), "AI0;");
             n = write(fd, buf, strlen(buf));
             printf("n=%d\n", n);
 
@@ -137,7 +142,7 @@ int main(int argc, char *argv[])
         else if (strcmp(buf, "FT;") == 0)
         {
             hl_usleep(50 * 1000);
-            SNPRINTF(buf, sizeof(buf), "FT%c;", tx_vfo);
+            snprintf(buf, sizeof(buf), "FT%c;", tx_vfo);
             printf(" FT response#1=%s, tx_vfo=%c\n", buf, tx_vfo);
             n = write(fd, buf, strlen(buf));
             printf(" FT response#2=%s\n", buf);
@@ -155,7 +160,7 @@ int main(int argc, char *argv[])
         else if (strcmp(buf, "MD0;") == 0)
         {
             hl_usleep(50 * 1000);
-            SNPRINTF(buf, sizeof(buf), "MD0%c;", modeA);
+            snprintf(buf, sizeof(buf), "MD0%c;", modeA);
             n = write(fd, buf, strlen(buf));
 
             if (n < 0) { perror("MD0;"); }
@@ -167,7 +172,7 @@ int main(int argc, char *argv[])
         else if (strcmp(buf, "MD1;") == 0)
         {
             hl_usleep(50 * 1000);
-            SNPRINTF(buf, sizeof(buf), "MD1%c;", modeB);
+            snprintf(buf, sizeof(buf), "MD1%c;", modeB);
             n = write(fd, buf, strlen(buf));
 
             if (n < 0) { perror("MD0;"); }
@@ -210,7 +215,7 @@ int main(int argc, char *argv[])
             ant = (ant + 1) % 3;
             printf("%s\n", buf);
             hl_usleep(50 * 1000);
-            SNPRINTF(buf, sizeof(buf), "EX032%1d;", ant);
+            snprintf(buf, sizeof(buf), "EX032%1d;", ant);
             n = write(fd, buf, strlen(buf));
             printf("n=%d\n", n);
 

--- a/simulators/simftdx101.c
+++ b/simulators/simftdx101.c
@@ -5,9 +5,12 @@
 #include <string.h>
 #include <unistd.h>
 
+#if 0
 #include "hamlib/rig.h"
 #include "misc.h"
-
+#else
+int hl_usleep(unsigned long usec);
+#endif
 
 float freqA = 14074000;
 float freqB = 14074500;
@@ -29,11 +32,14 @@ int rport_gain_am = 50;
 int rport_gain_fm = 50;
 int rport_gain_psk = 50;
 int syncvfo = 0;
+int submain = 0;    // Dummy for now
 int ant = 1;
 
 
 #include "sim.h"
 
+#define ID NC_RIGID_FTDX101D
+//#define ID NC_RIGID_FTDX101MP
 
 int main(int argc, char *argv[])
 {
@@ -64,7 +70,7 @@ int main(int argc, char *argv[])
         if (strcmp(buf, "AN0;") == 0)
         {
             hl_usleep(50 * 1000);
-            SNPRINTF(buf, sizeof(buf), "AN0%d;", ant);
+            snprintf(buf, sizeof(buf), "AN0%d;", ant);
             n = write(fd, buf, strlen(buf));
 
             if (n <= 0) { perror("AN"); }
@@ -88,8 +94,8 @@ int main(int argc, char *argv[])
         {
             printf("%s\n", buf);
             hl_usleep(50 * 1000);
-            int id = NC_RIGID_FTDX3000;
-            SNPRINTF(buf, sizeof(buf), "ID%03d;", id);
+            int id = ID;
+            snprintf(buf, sizeof(buf), "ID%03d;", id);
             n = write(fd, buf, strlen(buf));
             printf("n=%d\n", n);
 
@@ -116,7 +122,7 @@ int main(int argc, char *argv[])
             ant = (ant + 1) % 3;
             printf("%s\n", buf);
             hl_usleep(50 * 1000);
-            SNPRINTF(buf, sizeof(buf), "EX032%1d;", ant);
+            snprintf(buf, sizeof(buf), "EX032%1d;", ant);
             n = write(fd, buf, strlen(buf));
             printf("n=%d\n", n);
 
@@ -125,7 +131,7 @@ int main(int argc, char *argv[])
 
         else if (strcmp(buf, "FA;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "FA%08.0f;", freqA);
+            snprintf(buf, sizeof(buf), "FA%08.0f;", freqA);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "FA", 2) == 0)
@@ -134,7 +140,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "FB;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "FB%08.0f;", freqB);
+            snprintf(buf, sizeof(buf), "FB%08.0f;", freqB);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "FB", 2) == 0)
@@ -143,12 +149,12 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "FT;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "FT%d;", ft);
+            snprintf(buf, sizeof(buf), "FT%d;", ft);
             n = write(fd, buf, strlen(buf));
         }
         else if (strcmp(buf, "MD0;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "MD0%X;", modeA);
+            snprintf(buf, sizeof(buf), "MD0%X;", modeA);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "MD0", 3) == 0)
@@ -157,7 +163,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "MD1;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "MD1%X;", modeB);
+            snprintf(buf, sizeof(buf), "MD1%X;", modeB);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "MD1", 3) == 0)
@@ -166,7 +172,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "VS;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "VS%d;", vs);
+            snprintf(buf, sizeof(buf), "VS%d;", vs);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "VS", 2) == 0)
@@ -175,7 +181,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "TX;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "TX%d;", tx);
+            snprintf(buf, sizeof(buf), "TX%d;", tx);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "TX", 2) == 0)
@@ -184,7 +190,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "AI;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "AI%d;", ai);
+            snprintf(buf, sizeof(buf), "AI%d;", ai);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "AI", 2) == 0)
@@ -193,7 +199,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "PC;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "PC%d;", power);
+            snprintf(buf, sizeof(buf), "PC%d;", power);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "PC", 2) == 0)
@@ -202,16 +208,17 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "SH0;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "SH0%d;", sh);
+            snprintf(buf, sizeof(buf), "SH0%1d%2d;", vfo, sh);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "SH0", 3) == 0)
         {
-            sscanf(buf, "SH0%d", &sh);
+            sscanf(buf, "SH0%1d%02d", &submain, &sh);
+	    printf("submain=%d, sh=%d\n", submain, sh);
         }
         else if (strcmp(buf, "NA0;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "NA0%d;", na);
+            snprintf(buf, sizeof(buf), "NA0%d;", na);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "NA0", 3) == 0)
@@ -220,7 +227,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "EX039;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "EX039%d;", ex039);
+            snprintf(buf, sizeof(buf), "EX039%d;", ex039);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "EX039", 5) == 0)
@@ -229,7 +236,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "PS;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "PS1;");
+            snprintf(buf, sizeof(buf), "PS1;");
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "KS;", 3) == 0)

--- a/simulators/simftdx1200.c
+++ b/simulators/simftdx1200.c
@@ -5,9 +5,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "hamlib/rig.h"
-#include "misc.h"
-
+int hl_usleep(unsigned long usec);
 
 float freqA = 14074000;
 float freqB = 14074500;
@@ -22,9 +20,9 @@ int na = 0;
 int ex039 = 0;
 int keyspd = 20;
 
-
 #include "sim.h"
 
+#define ID NC_RIGID_FTDX1200
 
 int main(int argc, char *argv[])
 {
@@ -74,10 +72,8 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "ID;") == 0)
         {
-            printf("%s\n", buf);
             hl_usleep(50 * 1000);
-            int id = NC_RIGID_FTDX3000;
-            SNPRINTF(buf, sizeof(buf), "ID%03d;", id);
+            snprintf(buf, sizeof(buf), "ID%04d;", ID);
             n = write(fd, buf, strlen(buf));
             printf("n=%d\n", n);
 
@@ -105,7 +101,7 @@ int main(int argc, char *argv[])
             ant = (ant + 1) % 3;
             printf("%s\n", buf);
             hl_usleep(50 * 1000);
-            SNPRINTF(buf, sizeof(buf), "EX032%1d;", ant);
+            snprintf(buf, sizeof(buf), "EX032%1d;", ant);
             n = write(fd, buf, strlen(buf));
             printf("n=%d\n", n);
 
@@ -114,7 +110,7 @@ int main(int argc, char *argv[])
 
         else if (strcmp(buf, "FA;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "FA%08.0f;", freqA);
+            snprintf(buf, sizeof(buf), "FA%08.0f;", freqA);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "FA", 2) == 0)
@@ -123,7 +119,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "FB;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "FB%08.0f;", freqB);
+            snprintf(buf, sizeof(buf), "FB%08.0f;", freqB);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "FB", 2) == 0)
@@ -132,17 +128,21 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "FT;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "FT%d;", ft);
+            snprintf(buf, sizeof(buf), "FT%d;", ft);
             n = write(fd, buf, strlen(buf));
         }
         else if (strcmp(buf, "MD0;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "MD0%d;", md);
+            snprintf(buf, sizeof(buf), "MD0%d;", md);
             n = write(fd, buf, strlen(buf));
+        }
+        else if (strncmp(buf, "MD0", 3) == 0)
+        {
+            sscanf(buf, "MD0%d", &md);
         }
         else if (strcmp(buf, "VS;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "VS%c;", vfo == 0 ? '0' : '1');
+            snprintf(buf, sizeof(buf), "VS%c;", vfo == 0 ? '0' : '1');
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "VS", 2) == 0)
@@ -151,7 +151,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "TX;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "TX%d;", tx);
+            snprintf(buf, sizeof(buf), "TX%d;", tx);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "TX", 2) == 0)
@@ -160,7 +160,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "AI;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "AI%d;", ai);
+            snprintf(buf, sizeof(buf), "AI%d;", ai);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "AI", 2) == 0)
@@ -169,7 +169,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "SH0;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "SH0%d;", sh);
+            snprintf(buf, sizeof(buf), "SH0%02d;", sh);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "SH0", 3) == 0)
@@ -178,7 +178,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "NA0;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "NA0%d;", na);
+            snprintf(buf, sizeof(buf), "NA0%d;", na);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "NA0", 3) == 0)
@@ -187,7 +187,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "EX039;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "EX039%d;", ex039);
+            snprintf(buf, sizeof(buf), "EX039%d;", ex039);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "EX039", 5) == 0)
@@ -196,7 +196,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "PS;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "PS1;");
+            snprintf(buf, sizeof(buf), "PS1;");
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "KS;", 3) == 0)

--- a/simulators/simftdx3000.c
+++ b/simulators/simftdx3000.c
@@ -5,9 +5,12 @@
 #include <string.h>
 #include <unistd.h>
 
+#if 0
 #include "hamlib/rig.h"
 #include "misc.h"
-
+#else
+int hl_usleep(unsigned long usec);
+#endif
 
 float freqA = 14074000;
 float freqB = 14074500;
@@ -20,10 +23,13 @@ int ai = 0;
 int sh = 25;
 int na = 0;
 int ex039 = 0;
+int keyspd = 24;
 
 
 #include "sim.h"
 
+#define ID NC_RIGID_FTDX3000
+//#define ID NC_RIGID_FTDX3000DM
 
 int main(int argc, char *argv[])
 {
@@ -75,8 +81,7 @@ int main(int argc, char *argv[])
         {
             printf("%s\n", buf);
             hl_usleep(50 * 1000);
-            int id = NC_RIGID_FTDX3000;
-            SNPRINTF(buf, sizeof(buf), "ID%03d;", id);
+            snprintf(buf, sizeof(buf), "ID%04d;", ID);
             n = write(fd, buf, strlen(buf));
             printf("n=%d\n", n);
 
@@ -89,7 +94,7 @@ int main(int argc, char *argv[])
             ant = (ant + 1) % 3;
             printf("%s\n", buf);
             hl_usleep(50 * 1000);
-            SNPRINTF(buf, sizeof(buf), "EX032%1d;", ant);
+            snprintf(buf, sizeof(buf), "EX032%1d;", ant);
             n = write(fd, buf, strlen(buf));
             printf("n=%d\n", n);
 
@@ -98,7 +103,7 @@ int main(int argc, char *argv[])
 
         else if (strcmp(buf, "FA;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "FA%08.0f;", freqA);
+            snprintf(buf, sizeof(buf), "FA%08.0f;", freqA);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "FA", 2) == 0)
@@ -107,7 +112,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "FB;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "FB%08.0f;", freqB);
+            snprintf(buf, sizeof(buf), "FB%08.0f;", freqB);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "FB", 2) == 0)
@@ -121,7 +126,7 @@ int main(int argc, char *argv[])
             if (ft == 2) { val = 0; }
             else if (ft == 3) { val = 1; }
 
-            SNPRINTF(buf, sizeof(buf), "FT%d;", val);
+            snprintf(buf, sizeof(buf), "FT%d;", val);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "FT", 2) == 0)
@@ -130,7 +135,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "MD0;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "MD0%d;", md);
+            snprintf(buf, sizeof(buf), "MD0%d;", md);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "MD0", 3) == 0)
@@ -139,12 +144,12 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "PS;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "PS1;");
+            snprintf(buf, sizeof(buf), "PS1;");
             n = write(fd, buf, strlen(buf));
         }
         else if (strcmp(buf, "VS;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "VS%d;", vs);
+            snprintf(buf, sizeof(buf), "VS%d;", vs);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "VS", 2) == 0)
@@ -153,7 +158,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "TX;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "TX%d;", tx);
+            snprintf(buf, sizeof(buf), "TX%d;", tx);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "TX", 2) == 0)
@@ -162,7 +167,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "AI;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "AI%d;", ai);
+            snprintf(buf, sizeof(buf), "AI%d;", ai);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "AI", 2) == 0)
@@ -171,7 +176,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "SH0;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "SH0%d;", sh);
+            snprintf(buf, sizeof(buf), "SH0%02d;", sh);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "SH0", 3) == 0)
@@ -180,7 +185,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "NA0;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "NA0%d;", na);
+            snprintf(buf, sizeof(buf), "NA0%d;", na);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "NA0", 3) == 0)
@@ -189,12 +194,21 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "EX039;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "EX039%d;", ex039);
+            snprintf(buf, sizeof(buf), "EX039%d;", ex039);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "EX039", 5) == 0)
         {
             sscanf(buf, "EX039%d", &ex039);
+        }
+        else if (strncmp(buf, "KS;", 3) == 0)
+        {
+            sprintf(buf, "KS%d;", keyspd);
+            n = write(fd, buf, strlen(buf));
+        }
+        else if (strncmp(buf, "KS", 2) == 0)
+        {
+            sscanf(buf, "KS%03d", &keyspd);
         }
         else if (strlen(buf) > 0)
         {

--- a/simulators/simftdx5000.c
+++ b/simulators/simftdx5000.c
@@ -5,9 +5,8 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "hamlib/rig.h"
-#include "misc.h"
-
+// Borrowed from misc.h
+int hl_usleep(unsigned long usec);
 
 float freqA = 14074000;
 float freqB = 14074500;
@@ -26,6 +25,7 @@ int ex103 = 0;
 
 #include "sim.h"
 
+#define ID NC_RIGID_FTDX5000
 
 int main(int argc, char *argv[])
 {
@@ -77,8 +77,7 @@ int main(int argc, char *argv[])
         {
             printf("%s\n", buf);
             hl_usleep(50 * 1000);
-            int id = NC_RIGID_FTDX3000;
-            SNPRINTF(buf, sizeof(buf), "ID%03d;", id);
+            snprintf(buf, sizeof(buf), "ID%04d;", ID);
             n = write(fd, buf, strlen(buf));
             printf("n=%d\n", n);
 
@@ -90,7 +89,7 @@ int main(int argc, char *argv[])
             ant = (ant + 1) % 3;
             printf("%s\n", buf);
             hl_usleep(50 * 1000);
-            SNPRINTF(buf, sizeof(buf), "EX032%1d;", ant);
+            snprintf(buf, sizeof(buf), "EX032%1d;", ant);
             n = write(fd, buf, strlen(buf));
             printf("n=%d\n", n);
 
@@ -99,7 +98,7 @@ int main(int argc, char *argv[])
 
         else if (strcmp(buf, "FA;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "FA%08.0f;", freqA);
+            snprintf(buf, sizeof(buf), "FA%08.0f;", freqA);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "FA", 2) == 0)
@@ -108,7 +107,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "FB;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "FB%08.0f;", freqB);
+            snprintf(buf, sizeof(buf), "FB%08.0f;", freqB);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "FB", 2) == 0)
@@ -117,7 +116,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "FT;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "FT%d;", ft);
+            snprintf(buf, sizeof(buf), "FT%d;", ft);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "FT", 2) == 0)
@@ -131,7 +130,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "MD0;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "MD0%d;", md0);
+            snprintf(buf, sizeof(buf), "MD0%d;", md0);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "MD0", 2) == 0)
@@ -140,7 +139,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "MD1;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "MD1%d;", md1);
+            snprintf(buf, sizeof(buf), "MD1%d;", md1);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "MD1", 2) == 0)
@@ -149,7 +148,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "VS;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "VS%d;", vs);
+            snprintf(buf, sizeof(buf), "VS%d;", vs);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "VS", 2) == 0)
@@ -158,7 +157,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "TX;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "TX%d;", tx);
+            snprintf(buf, sizeof(buf), "TX%d;", tx);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "TX", 2) == 0)
@@ -167,7 +166,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "AI;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "AI%d;", ai);
+            snprintf(buf, sizeof(buf), "AI%d;", ai);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "AI", 2) == 0)
@@ -176,7 +175,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "SH0;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "SH0%d;", sh);
+            snprintf(buf, sizeof(buf), "SH0%02d;", sh);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "SH0", 3) == 0)
@@ -185,7 +184,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "NA0;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "NA0%d;", na);
+            snprintf(buf, sizeof(buf), "NA0%d;", na);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "NA0", 3) == 0)
@@ -194,7 +193,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "EX039;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "EX039%d;", ex039);
+            snprintf(buf, sizeof(buf), "EX039%d;", ex039);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "EX039", 5) == 0)
@@ -203,7 +202,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "EX103;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "EX103%d;", ex103);
+            snprintf(buf, sizeof(buf), "EX103%d;", ex103);
             n = write(fd, buf, strlen(buf));
         }
         else if (strncmp(buf, "EX103", 3) == 0)
@@ -212,7 +211,7 @@ int main(int argc, char *argv[])
         }
         else if (strcmp(buf, "PS;") == 0)
         {
-            SNPRINTF(buf, sizeof(buf), "PS1;");
+            snprintf(buf, sizeof(buf), "PS1;");
             n = write(fd, buf, strlen(buf));
         }
         else if (strlen(buf) > 0)


### PR DESCRIPTION
Apply some modern techniques to handling of Yaesu rigs.

- Make `ncboolean` a `bool` typedef.  Use real boolean operations, parameters, and values with the compiler knowing the right way to handle them all.
- Remove the static flags for the rig type(i.e., is_ft710, etc.)  Replace them with macros that use the rig_model to give the same results.  Allows more than one Yaesu radio to be controlled by a single computer(think SO2R).
- Move many of the hard-coded constants used in bandwidth control out of the code and into structures attached to the rig; all in one place.  Makes the code much easier to handle, and allows for much more commonality between the many different feature sets.
- Fix some of the missing parts and incorrect behavior of the simulators - still a long way to go.

This PR does not address two issues in the original code:

1. What to do if a width request is larger that the rig can handle?  The current code is divided between returning an error and using the max width the rig is capable of. This now goes for using the max, but can be changed by swapping two lines.
2. Would the real FTDX-3000 please stand up.  The ftdx3000 and ftdx3000dm use the same rig_model, and supposedly differ by the results of the 'ID' command.  But I found that the FTDX-3000 Series CAT manual says that we're using the wrong ID.  I'll send a query to Yaesu tech support to see if they can sort it out.

For master only
