### PR TITLE
Finish converting Icom clock routines

### DIFF
--- a/rigs/icom/ic7600.c
+++ b/rigs/icom/ic7600.c
@@ -127,7 +127,7 @@
          { 241, 25.0f } \
     } }
 
-struct cmdparams ic7600_extcmds[] =
+static struct cmdparams ic7600_extcmds[] =
 {
     { {.s = RIG_PARM_BEEP}, CMD_PARAM_TYPE_PARM, C_CTL_MEM, S_MEM_PARM, SC_MOD_RW, 2, {0x00, 0x59}, CMD_DAT_BOL, 1 },
     { {.s = RIG_PARM_BACKLIGHT}, CMD_PARAM_TYPE_PARM, C_CTL_MEM, S_MEM_PARM, SC_MOD_RW, 2, {0x00, 0x38}, CMD_DAT_LVL, 2 },
@@ -137,9 +137,14 @@ struct cmdparams ic7600_extcmds[] =
     { { 0 } }
 };
 
-int ic7600_ext_tokens[] =
+static int ic7600_ext_tokens[] =
 {
     TOK_DRIVE_GAIN, TOK_BACKEND_NONE
+};
+
+static const struct icom_clock_cmds ic7600_clock_cmds =
+{
+    .date_cmds = { 0x00, 0x53 }, .time_cmds = { 0x00, 0x54 }, .offset_cmds = { 0x00, 0x56 }
 };
 
 /*
@@ -167,121 +172,9 @@ static const struct icom_priv_caps ic7600_priv_caps =
     .x1cx03_possibly = 1,
     .x1ax03_supported = 1,
     .mode_with_filter = 1,
-    .data_mode_supported = 1
+    .data_mode_supported = 1,
+    .clock_cmds = &ic7600_clock_cmds
 };
-
-
-// if hour < 0 then only date will be set
-static int ic7600_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
-                     int sec, double msec, int utc_offset)
-{
-    int cmd = 0x1a;
-    int subcmd =  0x05;
-    int retval = RIG_OK;
-    unsigned char prmbuf[MAXFRAMELEN];
-
-    if (year >= 0)
-    {
-        prmbuf[0] = 0x00;
-        prmbuf[1] = 0x53;
-        to_bcd(&prmbuf[2], year / 100, 2);
-        to_bcd(&prmbuf[3], year % 100, 2);
-        to_bcd(&prmbuf[4], month, 2);
-        to_bcd(&prmbuf[5], day, 2);
-        retval = icom_transaction(rig, cmd, subcmd, prmbuf, 6, NULL, NULL);
-
-        if (retval != RIG_OK)
-        {
-            rig_debug(RIG_DEBUG_ERR, "%s(%d): %s\b", __func__, __LINE__, rigerror(retval));
-        }
-    }
-
-    if (hour >= 0)
-    {
-        prmbuf[0] = 0x00;
-        prmbuf[1] = 0x54;
-        to_bcd(&prmbuf[2], hour, 2);
-        to_bcd(&prmbuf[3], min, 2);
-        retval = icom_transaction(rig, cmd, subcmd, prmbuf, 4, NULL, NULL);
-
-        if (retval != RIG_OK)
-        {
-            rig_debug(RIG_DEBUG_ERR, "%s(%d): %s\b", __func__, __LINE__, rigerror(retval));
-        }
-
-        prmbuf[0] = 0x00;
-        prmbuf[1] = 0x56;
-        rig_debug(RIG_DEBUG_ERR, "%s: utc_offset=%d\n", __func__, utc_offset);
-        to_bcd(&prmbuf[2], abs(utc_offset) / 100, 2);
-        to_bcd(&prmbuf[3], abs(utc_offset) % 100, 2);
-        to_bcd(&prmbuf[4], utc_offset >= 0 ? 0 : 1, 2);
-        retval = icom_transaction(rig, cmd, subcmd, prmbuf, 5, NULL, NULL);
-
-        if (retval != RIG_OK)
-        {
-            rig_debug(RIG_DEBUG_ERR, "%s(%d): %s\b", __func__, __LINE__, rigerror(retval));
-        }
-    }
-
-    return retval;
-}
-
-static int ic7600_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
-                     int *min, int *sec, double *msec, int *utc_offset)
-{
-    int cmd = 0x1a;
-    int subcmd =  0x05;
-    int retval = RIG_OK;
-    int resplen;
-    unsigned char prmbuf[MAXFRAMELEN];
-    unsigned char respbuf[MAXFRAMELEN];
-
-    prmbuf[0] = 0x00;
-    prmbuf[1] = 0x53;
-    resplen = sizeof(respbuf);
-    retval = icom_transaction(rig, cmd, subcmd, prmbuf, 2, respbuf, &resplen);
-    *year = from_bcd(&respbuf[4], 2) * 100 + from_bcd(&respbuf[5], 2);
-    *month = from_bcd(&respbuf[6], 2);
-    *day = from_bcd(&respbuf[7], 2);
-
-    if (hour != NULL)
-    {
-        prmbuf[0] = 0x00;
-        prmbuf[1] = 0x54;
-        retval = icom_transaction(rig, cmd, subcmd, prmbuf, 2, respbuf, &resplen);
-
-        if (retval != RIG_OK)
-        {
-            return retval;
-        }
-
-        *hour = from_bcd(&respbuf[4], 2);
-        *min = from_bcd(&respbuf[5], 2);
-        *sec = 0;
-        *msec = 0;
-
-        prmbuf[0] = 0x00;
-        prmbuf[1] = 0x56;
-        retval = icom_transaction(rig, cmd, subcmd, prmbuf, 2, respbuf, &resplen);
-
-        if (retval != RIG_OK)
-        {
-            return retval;
-        }
-
-        *utc_offset = from_bcd(&respbuf[4], 2) * 100;
-        *utc_offset += from_bcd(&respbuf[5], 2);
-
-        if (respbuf[6] != 0x00) { *utc_offset *= -1; }
-
-        //rig_debug(RIG_DEBUG_VERBOSE,
-        //          "%s: %02d-%02d-%02dT%02d:%02d:%06.3lf%s%04d\n'",
-        //          __func__, *year, *month, *day, *hour, *min, *sec + *msec / 1000,
-        //          *utc_offset >= 0 ? "+" : "-", (unsigned)abs(*utc_offset));
-    }
-
-    return retval;
-}
 
 struct rig_caps ic7600_caps =
 {
@@ -478,7 +371,7 @@ struct rig_caps ic7600_caps =
     .get_powerstat = icom_get_powerstat,
     .send_morse = icom_send_morse,
     .wait_morse =  rig_wait_morse,
-    .set_clock = ic7600_set_clock,
-    .get_clock = ic7600_get_clock,
+    .set_clock = icom_set_clock,
+    .get_clock = icom_get_clock,
     .hamlib_check_rig_caps = HAMLIB_CHECK_RIG_CAPS
 };

--- a/rigs/icom/ic7610.c
+++ b/rigs/icom/ic7610.c
@@ -150,7 +150,7 @@ static int ic7610_ext_tokens[] =
 
 static const struct icom_clock_cmds ic7610_clock_cmds =
 {
-  .date_cmds = { 0x00, 0x58 }, .time_cmds = { 0x00, 0x59 }, .offset_cmds = { 0x00, 0x62 }
+    .date_cmds = { 0x01, 0x58 }, .time_cmds = { 0x01, 0x59 }, .offset_cmds = { 0x01, 0x62 }
 };
 
 /*

--- a/rigs/icom/ic7610.c
+++ b/rigs/icom/ic7610.c
@@ -128,7 +128,7 @@
          { 241, 30.0f } \
     } }
 
-struct cmdparams ic7610_extcmds[] =
+static struct cmdparams ic7610_extcmds[] =
 {
     { {.s = RIG_PARM_BEEP}, CMD_PARAM_TYPE_PARM, C_CTL_MEM, S_MEM_PARM, SC_MOD_RW, 2, {0x00, 0x24}, CMD_DAT_BOL, 1 },
     { {.s = RIG_PARM_BACKLIGHT}, CMD_PARAM_TYPE_PARM, C_CTL_MEM, S_MEM_PARM, SC_MOD_RW, 2, {0x01, 0x41}, CMD_DAT_LVL, 2 },
@@ -141,11 +141,16 @@ struct cmdparams ic7610_extcmds[] =
     { { 0 } }
 };
 
-int ic7610_ext_tokens[] =
+static int ic7610_ext_tokens[] =
 {
     TOK_DRIVE_GAIN, TOK_DIGI_SEL_FUNC, TOK_DIGI_SEL_LEVEL,
     TOK_SCOPE_MSS, TOK_SCOPE_SDS, TOK_SCOPE_STX, TOK_SCOPE_CFQ, TOK_SCOPE_EDG, TOK_SCOPE_VBW, TOK_SCOPE_RBW, TOK_SCOPE_MKP, TOK_IPP_FUNC, TOK_TX_INHIBIT_FUNC, TOK_DPP_FUNC, TOK_ICPW2_FUNC,
     TOK_BACKEND_NONE
+};
+
+static const struct icom_clock_cmds ic7610_clock_cmds =
+{
+  .date_cmds = { 0x00, 0x58 }, .time_cmds = { 0x00, 0x59 }, .offset_cmds = { 0x00, 0x62 }
 };
 
 /*
@@ -248,121 +253,9 @@ static const struct icom_priv_caps ic7610_priv_caps =
     .x1cx03_possibly = 1,
     .x1ax03_supported = 1,
     .mode_with_filter = 1,
-    .data_mode_supported = 1
+    .data_mode_supported = 1,
+    .clock_cmds = &ic7610_clock_cmds
 };
-
-
-// if hour < 0 then only date will be set
-static int ic7610_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
-                     int sec, double msec, int utc_offset)
-{
-    int cmd = 0x1a;
-    int subcmd =  0x05;
-    int retval = RIG_OK;
-    unsigned char prmbuf[MAXFRAMELEN];
-
-    if (year >= 0)
-    {
-        prmbuf[0] = 0x00;
-        prmbuf[1] = 0x58;
-        to_bcd(&prmbuf[2], year / 100, 2);
-        to_bcd(&prmbuf[3], year % 100, 2);
-        to_bcd(&prmbuf[4], month, 2);
-        to_bcd(&prmbuf[5], day, 2);
-        retval = icom_transaction(rig, cmd, subcmd, prmbuf, 6, NULL, NULL);
-
-        if (retval != RIG_OK)
-        {
-            rig_debug(RIG_DEBUG_ERR, "%s(%d): %s\b", __func__, __LINE__, rigerror(retval));
-        }
-    }
-
-    if (hour >= 0)
-    {
-        prmbuf[0] = 0x00;
-        prmbuf[1] = 0x59;
-        to_bcd(&prmbuf[2], hour, 2);
-        to_bcd(&prmbuf[3], min, 2);
-        retval = icom_transaction(rig, cmd, subcmd, prmbuf, 4, NULL, NULL);
-
-        if (retval != RIG_OK)
-        {
-            rig_debug(RIG_DEBUG_ERR, "%s(%d): %s\b", __func__, __LINE__, rigerror(retval));
-        }
-
-        prmbuf[0] = 0x00;
-        prmbuf[1] = 0x62;
-        rig_debug(RIG_DEBUG_ERR, "%s: utc_offset=%d\n", __func__, utc_offset);
-        to_bcd(&prmbuf[2], abs(utc_offset) / 100, 2);
-        to_bcd(&prmbuf[3], abs(utc_offset) % 100, 2);
-        to_bcd(&prmbuf[4], utc_offset >= 0 ? 0 : 1, 2);
-        retval = icom_transaction(rig, cmd, subcmd, prmbuf, 5, NULL, NULL);
-
-        if (retval != RIG_OK)
-        {
-            rig_debug(RIG_DEBUG_ERR, "%s(%d): %s\b", __func__, __LINE__, rigerror(retval));
-        }
-    }
-
-    return retval;
-}
-
-static int ic7610_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
-                     int *min, int *sec, double *msec, int *utc_offset)
-{
-    int cmd = 0x1a;
-    int subcmd =  0x05;
-    int retval = RIG_OK;
-    int resplen;
-    unsigned char prmbuf[MAXFRAMELEN];
-    unsigned char respbuf[MAXFRAMELEN];
-
-    prmbuf[0] = 0x00;
-    prmbuf[1] = 0x58;
-    resplen = sizeof(respbuf);
-    retval = icom_transaction(rig, cmd, subcmd, prmbuf, 2, respbuf, &resplen);
-    *year = from_bcd(&respbuf[4], 2) * 100 + from_bcd(&respbuf[5], 2);
-    *month = from_bcd(&respbuf[6], 2);
-    *day = from_bcd(&respbuf[7], 2);
-
-    if (hour != NULL)
-    {
-        prmbuf[0] = 0x00;
-        prmbuf[1] = 0x59;
-        retval = icom_transaction(rig, cmd, subcmd, prmbuf, 2, respbuf, &resplen);
-
-        if (retval != RIG_OK)
-        {
-            return retval;
-        }
-
-        *hour = from_bcd(&respbuf[4], 2);
-        *min = from_bcd(&respbuf[5], 2);
-        *sec = 0;
-        *msec = 0;
-
-        prmbuf[0] = 0x00;
-        prmbuf[1] = 0x62;
-        retval = icom_transaction(rig, cmd, subcmd, prmbuf, 2, respbuf, &resplen);
-
-        if (retval != RIG_OK)
-        {
-            return retval;
-        }
-
-        *utc_offset = from_bcd(&respbuf[4], 2) * 100;
-        *utc_offset += from_bcd(&respbuf[5], 2);
-
-        if (respbuf[6] != 0x00) { *utc_offset *= -1; }
-
-        //rig_debug(RIG_DEBUG_VERBOSE,
-        //          "%s: %02d-%02d-%02dT%02d:%02d:%06.3lf%s%04d\n'",
-        //          __func__, *year, *month, *day, *hour, *min, *sec + *msec / 1000,
-        //          *utc_offset >= 0 ? "+" : "-", (unsigned)abs(*utc_offset));
-    }
-
-    return retval;
-}
 
 struct rig_caps ic7610_caps =
 {
@@ -619,7 +512,7 @@ struct rig_caps ic7610_caps =
     .wait_morse = rig_wait_morse,
     .send_voice_mem = icom_send_voice_mem,
     .stop_voice_mem = icom_stop_voice_mem,
-    .set_clock = ic7610_set_clock,
-    .get_clock = ic7610_get_clock,
+    .set_clock = icom_set_clock,
+    .get_clock = icom_get_clock,
     .hamlib_check_rig_caps = HAMLIB_CHECK_RIG_CAPS
 };

--- a/rigs/icom/ic7700.c
+++ b/rigs/icom/ic7700.c
@@ -103,15 +103,20 @@
          { 241, 15.0f } \
     } }
 
-struct cmdparams ic7700_extcmds[] =
+static struct cmdparams ic7700_extcmds[] =
 {
     { {.s = RIG_LEVEL_VOXDELAY}, CMD_PARAM_TYPE_LEVEL, C_CTL_MEM, S_MEM_PARM, SC_MOD_RW, 2, {0x01, 0x82}, CMD_DAT_INT, 1 },
     { { 0 } }
 };
 
-int ic7700_ext_tokens[] =
+static int ic7700_ext_tokens[] =
 {
     TOK_DRIVE_GAIN, TOK_DIGI_SEL_FUNC, TOK_DIGI_SEL_LEVEL, TOK_BACKEND_NONE
+};
+
+static const struct icom_clock_cmds ic7700_clock_cmds =
+{
+    .date_cmds = { 0x00, 0x58 }, .time_cmds = { 0x00, 0x59 }, .offset_cmds = { 0x00, 0x61 }
 };
 
 /*
@@ -140,120 +145,10 @@ static const struct icom_priv_caps ic7700_priv_caps =
     .x1cx03_possibly = 1,
     .x1ax03_supported = 1,
     .mode_with_filter = 1,
-    .data_mode_supported = 1
+    .data_mode_supported = 1,
+    .clock_cmds = &ic7700_clock_cmds
 };
 
-// if hour < 0 then only date will be set
-static int ic7700_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
-                     int sec, double msec, int utc_offset)
-{
-    int cmd = 0x1a;
-    int subcmd =  0x05;
-    int retval = RIG_OK;
-    unsigned char prmbuf[MAXFRAMELEN];
-
-    if (year >= 0)
-    {
-        prmbuf[0] = 0x00;
-        prmbuf[1] = 0x58;
-        to_bcd(&prmbuf[2], year / 100, 2);
-        to_bcd(&prmbuf[3], year % 100, 2);
-        to_bcd(&prmbuf[4], month, 2);
-        to_bcd(&prmbuf[5], day, 2);
-        retval = icom_transaction(rig, cmd, subcmd, prmbuf, 6, NULL, NULL);
-
-        if (retval != RIG_OK)
-        {
-            rig_debug(RIG_DEBUG_ERR, "%s(%d): %s\b", __func__, __LINE__, rigerror(retval));
-        }
-    }
-
-    if (hour >= 0)
-    {
-        prmbuf[0] = 0x00;
-        prmbuf[1] = 0x59;
-        to_bcd(&prmbuf[2], hour, 2);
-        to_bcd(&prmbuf[3], min, 2);
-        retval = icom_transaction(rig, cmd, subcmd, prmbuf, 4, NULL, NULL);
-
-        if (retval != RIG_OK)
-        {
-            rig_debug(RIG_DEBUG_ERR, "%s(%d): %s\b", __func__, __LINE__, rigerror(retval));
-        }
-
-        prmbuf[0] = 0x00;
-        prmbuf[1] = 0x61;
-        rig_debug(RIG_DEBUG_ERR, "%s: utc_offset=%d\n", __func__, utc_offset);
-        to_bcd(&prmbuf[2], abs(utc_offset) / 100, 2);
-        to_bcd(&prmbuf[3], abs(utc_offset) % 100, 2);
-        to_bcd(&prmbuf[4], utc_offset >= 0 ? 0 : 1, 2);
-        retval = icom_transaction(rig, cmd, subcmd, prmbuf, 5, NULL, NULL);
-
-        if (retval != RIG_OK)
-        {
-            rig_debug(RIG_DEBUG_ERR, "%s(%d): %s\b", __func__, __LINE__, rigerror(retval));
-        }
-    }
-
-    return retval;
-}
-
-static int ic7700_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
-                     int *min, int *sec, double *msec, int *utc_offset)
-{
-    int cmd = 0x1a;
-    int subcmd =  0x05;
-    int retval = RIG_OK;
-    int resplen;
-    unsigned char prmbuf[MAXFRAMELEN];
-    unsigned char respbuf[MAXFRAMELEN];
-
-    prmbuf[0] = 0x00;
-    prmbuf[1] = 0x58;
-    resplen = sizeof(respbuf);
-    retval = icom_transaction(rig, cmd, subcmd, prmbuf, 2, respbuf, &resplen);
-    *year = from_bcd(&respbuf[4], 2) * 100 + from_bcd(&respbuf[5], 2);
-    *month = from_bcd(&respbuf[6], 2);
-    *day = from_bcd(&respbuf[7], 2);
-
-    if (hour != NULL)
-    {
-        prmbuf[0] = 0x00;
-        prmbuf[1] = 0x59;
-        retval = icom_transaction(rig, cmd, subcmd, prmbuf, 2, respbuf, &resplen);
-
-        if (retval != RIG_OK)
-        {
-            return retval;
-        }
-
-        *hour = from_bcd(&respbuf[4], 2);
-        *min = from_bcd(&respbuf[5], 2);
-        *sec = 0;
-        *msec = 0;
-
-        prmbuf[0] = 0x00;
-        prmbuf[1] = 0x61;
-        retval = icom_transaction(rig, cmd, subcmd, prmbuf, 2, respbuf, &resplen);
-
-        if (retval != RIG_OK)
-        {
-            return retval;
-        }
-
-        *utc_offset = from_bcd(&respbuf[4], 2) * 100;
-        *utc_offset += from_bcd(&respbuf[5], 2);
-
-        if (respbuf[6] != 0x00) { *utc_offset *= -1; }
-
-        //rig_debug(RIG_DEBUG_VERBOSE,
-        //          "%s: %02d-%02d-%02dT%02d:%02d:%06.3lf%s%04d\n'",
-        //          __func__, *year, *month, *day, *hour, *min, *sec + *msec / 1000,
-        //          *utc_offset >= 0 ? "+" : "-", (unsigned)abs(*utc_offset));
-    }
-
-    return retval;
-}
 
 static int ic7700_rig_open(RIG *rig)
 {
@@ -453,7 +348,7 @@ struct rig_caps ic7700_caps =
     .send_morse = icom_send_morse,
     .stop_morse = icom_stop_morse,
     .wait_morse = rig_wait_morse,
-    .set_clock = ic7700_set_clock,
-    .get_clock = ic7700_get_clock,
+    .set_clock = icom_set_clock,
+    .get_clock = icom_get_clock,
     .hamlib_check_rig_caps = HAMLIB_CHECK_RIG_CAPS
 };

--- a/rigs/icom/ic7760.c
+++ b/rigs/icom/ic7760.c
@@ -102,15 +102,20 @@
          { 241, 15.0f } \
     } }
 
-struct cmdparams ic7760_extcmds[] =
+static struct cmdparams ic7760_extcmds[] =
 {
     { {.s = RIG_LEVEL_VOXDELAY}, CMD_PARAM_TYPE_LEVEL, C_CTL_MEM, S_MEM_PARM, SC_MOD_RW, 2, {0x01, 0x82}, CMD_DAT_INT, 1 },
     { { 0 } }
 };
 
-int ic7760_ext_tokens[] =
+static int ic7760_ext_tokens[] =
 {
     TOK_DRIVE_GAIN, TOK_DIGI_SEL_FUNC, TOK_DIGI_SEL_LEVEL, TOK_BACKEND_NONE
+};
+
+static const struct icom_clock_cmds ic7760_clock_cmds =
+{
+    .date_cmds = { 0x02, 0x00 }, .time_cmds = { 0x02, 0x01 }, .offset_cmds = { 0x02, 0x04 }
 };
 
 /*
@@ -139,120 +144,10 @@ static const struct icom_priv_caps ic7760_priv_caps =
     .x1cx03_possibly = 1,
     .x1ax03_supported = 1,
     .mode_with_filter = 1,
-    .data_mode_supported = 1
+    .data_mode_supported = 1,
+    .clock_cmds = &ic7760_clock_cmds
 };
 
-// if hour < 0 then only date will be set
-static int ic7760_set_clock(RIG *rig, int year, int month, int day, int hour, int min,
-                     int sec, double msec, int utc_offset)
-{
-    int cmd = 0x1a;
-    int subcmd =  0x05;
-    int retval = RIG_OK;
-    unsigned char prmbuf[MAXFRAMELEN];
-
-    if (year >= 0)
-    {
-        prmbuf[0] = 0x02;
-        prmbuf[1] = 0x05;
-        to_bcd(&prmbuf[2], year / 100, 2);
-        to_bcd(&prmbuf[3], year % 100, 2);
-        to_bcd(&prmbuf[4], month, 2);
-        to_bcd(&prmbuf[5], day, 2);
-        retval = icom_transaction(rig, cmd, subcmd, prmbuf, 6, NULL, NULL);
-
-        if (retval != RIG_OK)
-        {
-            rig_debug(RIG_DEBUG_ERR, "%s(%d): %s\b", __func__, __LINE__, rigerror(retval));
-        }
-    }
-
-    if (hour >= 0)
-    {
-        prmbuf[0] = 0x02;
-        prmbuf[1] = 0x06;
-        to_bcd(&prmbuf[2], hour, 2);
-        to_bcd(&prmbuf[3], min, 2);
-        retval = icom_transaction(rig, cmd, subcmd, prmbuf, 4, NULL, NULL);
-
-        if (retval != RIG_OK)
-        {
-            rig_debug(RIG_DEBUG_ERR, "%s(%d): %s\b", __func__, __LINE__, rigerror(retval));
-        }
-
-        prmbuf[0] = 0x02;
-        prmbuf[1] = 0x04;
-        rig_debug(RIG_DEBUG_ERR, "%s: utc_offset=%d\n", __func__, utc_offset);
-        to_bcd(&prmbuf[2], abs(utc_offset) / 100, 2);
-        to_bcd(&prmbuf[3], abs(utc_offset) % 100, 2);
-        to_bcd(&prmbuf[4], utc_offset >= 0 ? 0 : 1, 2);
-        retval = icom_transaction(rig, cmd, subcmd, prmbuf, 5, NULL, NULL);
-
-        if (retval != RIG_OK)
-        {
-            rig_debug(RIG_DEBUG_ERR, "%s(%d): %s\b", __func__, __LINE__, rigerror(retval));
-        }
-    }
-
-    return retval;
-}
-
-static int ic7760_get_clock(RIG *rig, int *year, int *month, int *day, int *hour,
-                     int *min, int *sec, double *msec, int *utc_offset)
-{
-    int cmd = 0x1a;
-    int subcmd =  0x05;
-    int retval = RIG_OK;
-    int resplen;
-    unsigned char prmbuf[MAXFRAMELEN];
-    unsigned char respbuf[MAXFRAMELEN];
-
-    prmbuf[0] = 0x00;
-    prmbuf[1] = 0x58;
-    resplen = sizeof(respbuf);
-    retval = icom_transaction(rig, cmd, subcmd, prmbuf, 2, respbuf, &resplen);
-    *year = from_bcd(&respbuf[4], 2) * 100 + from_bcd(&respbuf[5], 2);
-    *month = from_bcd(&respbuf[6], 2);
-    *day = from_bcd(&respbuf[7], 2);
-
-    if (hour != NULL)
-    {
-        prmbuf[0] = 0x00;
-        prmbuf[1] = 0x59;
-        retval = icom_transaction(rig, cmd, subcmd, prmbuf, 2, respbuf, &resplen);
-
-        if (retval != RIG_OK)
-        {
-            return retval;
-        }
-
-        *hour = from_bcd(&respbuf[4], 2);
-        *min = from_bcd(&respbuf[5], 2);
-        *sec = 0;
-        *msec = 0;
-
-        prmbuf[0] = 0x00;
-        prmbuf[1] = 0x61;
-        retval = icom_transaction(rig, cmd, subcmd, prmbuf, 2, respbuf, &resplen);
-
-        if (retval != RIG_OK)
-        {
-            return retval;
-        }
-
-        *utc_offset = from_bcd(&respbuf[4], 2) * 100;
-        *utc_offset += from_bcd(&respbuf[5], 2);
-
-        if (respbuf[6] != 0x00) { *utc_offset *= -1; }
-
-        //rig_debug(RIG_DEBUG_VERBOSE,
-        //          "%s: %02d-%02d-%02dT%02d:%02d:%06.3lf%s%04d\n'",
-        //          __func__, *year, *month, *day, *hour, *min, *sec + *msec / 1000,
-        //          *utc_offset >= 0 ? "+" : "-", (unsigned)abs(*utc_offset));
-    }
-
-    return retval;
-}
 
 static int ic7760_rig_open(RIG *rig)
 {
@@ -450,7 +345,7 @@ struct rig_caps ic7760_caps =
     .send_morse = icom_send_morse,
     .stop_morse = icom_stop_morse,
     .wait_morse = rig_wait_morse,
-    .set_clock = ic7760_set_clock,
-    .get_clock = ic7760_get_clock,
+    .set_clock = icom_set_clock,
+    .get_clock = icom_get_clock,
     .hamlib_check_rig_caps = HAMLIB_CHECK_RIG_CAPS
 };


### PR DESCRIPTION
Update the last four rigs.

Fix the commands for the IC-7160 - incorrect values.

For both master and 4.7 branches
