### PR TITLE
Initialize motors of Skywatcher mount

### DIFF
--- a/rotators/skywatcher/skywatcher.c
+++ b/rotators/skywatcher/skywatcher.c
@@ -284,6 +284,16 @@ static int skywatcher_cleanup(ROT *rot)
     return RIG_OK;
 }
 
+static int skywatcher_open(ROT *rot)
+{
+    char str[16];
+
+    ERROR_CHECK(skywatcher_cmd(rot, ":F1\r", str, sizeof(str)));
+    ERROR_CHECK(skywatcher_cmd(rot, ":F2\r", str, sizeof(str)));
+
+    return RIG_OK;
+}
+
 /* ************************************************************************* */
 /*
  * Protocol documentation:
@@ -317,6 +327,7 @@ const struct rot_caps skywatcher_rot_caps =
 
     .rot_init     = skywatcher_init,
     .rot_cleanup  = skywatcher_cleanup,
+    .rot_open     = skywatcher_open,
     .get_position = skywatcher_get_position,
     .set_position = skywatcher_set_position,
     .stop         = skywatcher_stop,


### PR DESCRIPTION
To use the Skywatcher rotator, both motors have to by initialized. When using the direct mode of the mounts hand control unit, this initialization is performed by the hand control. We just need to set the position.

When using the motor driver directly with a simple USB-RS232-adapter, this init command must be sent before we are able to steer the mount. This allows us to use the mount without cabeling up the whole hand control unit.