### PR TITLE
Fix errors found by glibc 2.43

### DIFF
--- a/tests/ampctl_parse.c
+++ b/tests/ampctl_parse.c
@@ -124,14 +124,14 @@ struct test_table
                        int,
                        const struct test_table *,
                        const char *,
-                       const char *,
+                       char *,
                        const char *,
                        const char *,
                        const char *,
                        const char *);
     int flags;
     const char *arg1;
-    const char *arg2;
+    char *arg2;
     const char *arg3;
     const char *arg4;
     const char *arg5;
@@ -146,7 +146,7 @@ struct test_table
                                                     int interactive,    \
                                                     const struct test_table *cmd, \
                                                     const char *arg1,   \
-                                                    const char *arg2,   \
+                                                    char *arg2,   \
                                                     const char *arg3,   \
                                                     const char *arg4,   \
                                                     const char *arg5,   \

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -144,11 +144,11 @@ struct test_table
                        const struct test_table *,
                        vfo_t,
                        const char *,
-                       const char *,
+                       char *,
                        const char *);
     int flags;
     const char *arg1;
-    const char *arg2;
+    char *arg2;
     const char *arg3;
     const char *arg4;
     const char *arg5;
@@ -171,7 +171,7 @@ struct test_table
                                                     const struct test_table *cmd, \
                                                     vfo_t vfo,          \
                                                     const char *arg1,   \
-                                                    const char *arg2,   \
+                                                    char *arg2,   \
                                                     const char *arg3)
 
 declare_proto_rig(set_freq);
@@ -5325,7 +5325,7 @@ declare_proto_rig(send_cmd)
 
     if (strstr(arg1, ";") || arg2[0] == ';')
     {
-        char *p = strchr(arg1, ';');
+        const char *p = strchr(arg1, ';');
 
         while (p)
         {

--- a/tests/rotctl_parse.c
+++ b/tests/rotctl_parse.c
@@ -139,15 +139,15 @@ struct test_table
                        int,
                        char,
                        const struct test_table *,
-                       const char *,
-                       const char *,
+                       char *,
+                       char *,
                        const char *,
                        const char *,
                        const char *,
                        const char *);
     int flags;
-    const char *arg1;
-    const char *arg2;
+    char *arg1;
+    char *arg2;
     const char *arg3;
     const char *arg4;
     const char *arg5;
@@ -165,8 +165,8 @@ struct test_table
                                                     int ext_resp,       \
                                                     char resp_sep,      \
                                                     const struct test_table *cmd, \
-                                                    const char *arg1,   \
-                                                    const char *arg2,   \
+                                                    char *arg1,   \
+                                                    char *arg2,   \
                                                     const char *arg3,   \
                                                     const char *arg4,   \
                                                     const char *arg5,   \


### PR DESCRIPTION
glibc implements some new parts of the C23 standard: (Taken from https://download.opensuse.org/tumbleweed/iso/Changes.20260430.txt)

  * For ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the input argument is a pointer to a const-qualified type

and

  * The aforementioned change in ISO C23 of the declaration of bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr, and wmemchr as const-preserving macros can lead to compilation issues in code not set up for it

This lead to some warnings about assigning returns from strchr(const, target)
  to non-const pointers, and then discovering that Hamlib was modifying
  those const parameters.

This commit aligns the const-ness of the offending parameters. Only affects
  internal functions in ampctl_parse.c, rigctl_parse.c and rotctl_parse.c,
  so API/ABI should not change.

For both master and 4.7.x