### PR TITLE
Fix FT-710 VFO swap after cross-band tune

### DIFF
--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -1561,7 +1561,14 @@ int newcat_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
         }
 
         rig_get_mode(rig, RIG_VFO_MAIN, &tmp_mode, &tmp_width);
-        rig_get_mode(rig, RIG_VFO_SUB, &tmp_mode, &tmp_width);
+        // FT-710 does not advertise RIG_TARGETABLE_MODE, so reading mode
+        // on the non-current VFO forces a physical VFO swap (rig.c).
+        // Skip the post-BS cache refresh unless we are in split mode, where
+        // VFO_SUB is the TX VFO.
+        if (!is_ft710 || cachep->split)
+        {
+            rig_get_mode(rig, RIG_VFO_SUB, &tmp_mode, &tmp_width);
+        }
 
         if ((target_vfo == 0 && tmp_freqA == freq)
                 || (target_vfo == 1 && tmp_freqB == freq))


### PR DESCRIPTION
Avoid re-reading the sub-VFO mode after band change on the FT-710 unless we are operating in split mode.

---

This might be too specific of a fix, but I cannot verify the change on any other device.

Perhaps gating this behind `RIG_TARGETABLE_MODE` would be more appropriate?

```c
!(caps->targetable_vfo & RIG_TARGETABLE_MODE) || cachep->split
```

trace after fix [rigctld-trace-fix.log](https://github.com/user-attachments/files/27810196/rigctld-trace-fix.log)

Fixes #2055 