### PR TITLE
Fix ambiguous syntax of includes

### DIFF
--- a/rigs/dummy/gqrx.c
+++ b/rigs/dummy/gqrx.c
@@ -26,10 +26,10 @@
 #include <math.h>
 #include <stdbool.h>
 
-#include <hamlib/rig.h>
-#include <serial.h>
-#include <misc.h>
-#include <cal.h>
+#include "hamlib/rig.h"
+#include "serial.h"
+#include "misc.h"
+#include "cal.h"
 #include "idx_builtin.h"
 
 #define BACKEND_VER "20250718.2"

--- a/rigs/harris/harris.h
+++ b/rigs/harris/harris.h
@@ -27,7 +27,7 @@
 #ifndef _HARRIS_H
 #define _HARRIS_H
 
-#include <hamlib/rig.h>
+#include "hamlib/rig.h"
 
 struct harris_priv_data {
     freq_t current_freq;

--- a/rigs/harris/prc138.h
+++ b/rigs/harris/prc138.h
@@ -27,7 +27,7 @@
 #ifndef _PRC138_H
 #define _PRC138_H
 
-#include <hamlib/rig.h>
+#include "hamlib/rig.h"
 
 #define PRC138_MODES (RIG_MODE_USB | RIG_MODE_LSB | RIG_MODE_CW | RIG_MODE_AM)
 #define PRC138_VFO   (RIG_VFO_A)

--- a/rigs/icom/ic736.c
+++ b/rigs/icom/ic736.c
@@ -22,7 +22,7 @@
 #include <stdlib.h>
 
 #include "hamlib/rig.h"
-#include <bandplan.h>
+#include "bandplan.h"
 #include "icom.h"
 
 

--- a/rigs/icom/ic737.c
+++ b/rigs/icom/ic737.c
@@ -22,7 +22,7 @@
 #include <stdlib.h>
 
 #include "hamlib/rig.h"
-#include <bandplan.h>
+#include "bandplan.h"
 #include "icom.h"
 
 

--- a/rigs/icom/ic738.c
+++ b/rigs/icom/ic738.c
@@ -22,7 +22,7 @@
 #include <stdlib.h>
 
 #include "hamlib/rig.h"
-#include <bandplan.h>
+#include "bandplan.h"
 #include "icom.h"
 
 

--- a/rigs/kenwood/ts930.c
+++ b/rigs/kenwood/ts930.c
@@ -20,7 +20,7 @@
  */
 
 #include "hamlib/rig.h"
-#include <bandplan.h>
+#include "bandplan.h"
 #include "kenwood.h"
 
 


### PR DESCRIPTION
This PR replaces the angled brackets < > with double quotes " " for private includes.

Fixed by hand in gqrx.c and with:
perl -pe 's/<bandplan.h>/"bandplan.h"/' -i rigs/*/*.c perl -pe 's/<serial.h>/"serial.h"/' -i rigs/*/*.c
perl -pe 's,<hamlib/rig.h>,"hamlib/rig.h",' -i rigs/*/*.h