### PR TITLE
Directly open the file descriptor from mkstemp

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -1161,9 +1161,14 @@ HAMLIB_EXPORT(int) rig_settings_save(const char *setting, void *value,
     }
 
     int fd = mkstemp(template);
-    close(fd);
-    fptmp = fopen(template, "w");
+    if (fd == -1)
+    {
+        rig_debug(RIG_DEBUG_ERR, "%s: error creating %s: %s\n", __func__,
+                  template, strerror(errno));
+        return -RIG_EIO;
+    }
 
+    fptmp = fdopen(fd, "w");
     if (fptmp == NULL)
     {
         rig_debug(RIG_DEBUG_ERR, "%s: error opening for write %s: %s\n", __func__,


### PR DESCRIPTION
Bring back the `s` in `mkstemp`: Don't close the created file descriptor before the changes are actually written.

`fclose` is documented to close the underlying file descriptor, so no additional calls are needed before return.

Amends 56efa155dc0bfdcfa042690ac5780d9c5777f67b.

Disclaimer: I cannot test at runtime at the moment.