### PR TITLE
Clutter reduction

### DIFF
--- a/amplifiers/elecraft/kpa.c
+++ b/amplifiers/elecraft/kpa.c
@@ -267,7 +267,6 @@ int kpa_get_level(AMP *amp, setting_t level, value_t *val)
     char *cmd;
     int retval;
     int fault;
-    int i;
     int nargs;
     int antenna;
     int pwrpeak;
@@ -469,7 +468,7 @@ int kpa_get_level(AMP *amp, setting_t level, value_t *val)
             return -RIG_EPROTO;
         }
 
-        for (i = 0; kpa_fault_list[i].errmsg != NULL; ++i)
+        for (int i = 0; kpa_fault_list[i].errmsg != NULL; ++i)
         {
             if (kpa_fault_list[i].code == fault)
             {

--- a/rigs/aor/aor.c
+++ b/rigs/aor/aor.c
@@ -1207,8 +1207,6 @@ static int parse_chan_line(RIG *rig, channel_t *chan, char *basep,
     /* channel desc */
     if (mem_caps->channel_desc)
     {
-        int i;
-
         tagp = strstr(basep, "TM");
 
         if (!tagp)
@@ -1222,7 +1220,7 @@ static int parse_chan_line(RIG *rig, channel_t *chan, char *basep,
         chan->channel_desc[12] = '\0';
 
         /* chop off trailing spaces */
-        for (i = 11; i > 0 && chan->channel_desc[i] == ' '; i--)
+        for (int i = 11; i > 0 && chan->channel_desc[i] == ' '; i--)
         {
             chan->channel_desc[i] = '\0';
         }
@@ -1261,9 +1259,7 @@ int aor_get_channel(RIG *rig, vfo_t vfo, channel_t *chan, int read_only)
         /*
          * find mem_caps in caps, we'll need it later
          */
-        int i;
-
-        for (i = 0; i < HAMLIB_CHANLSTSIZ && !RIG_IS_CHAN_END(chan_list[i]); i++)
+        for (int i = 0; i < HAMLIB_CHANLSTSIZ && !RIG_IS_CHAN_END(chan_list[i]); i++)
         {
             if (channel_num >= chan_list[i].startc &&
                     channel_num <= chan_list[i].endc)

--- a/rigs/drake/drake.c
+++ b/rigs/drake/drake.c
@@ -69,10 +69,9 @@ void drake_fix_string(char* inStr)
     const char* chPos;
     int   newLen;
     int   offset;
-    int   i;
     int   j;
 
-    for (i = 0; i < 3; i++)
+    for (int i = 0; i < 3; i++)
     {
         do {
             chPos = strchr(inStr, chChkAry[i]); 

--- a/rigs/dummy/aclog.c
+++ b/rigs/dummy/aclog.c
@@ -367,11 +367,9 @@ static int aclog_init(RIG *rig)
 */
 static const char *modeMapGet(rmode_t modeHamlib)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 
-    for (i = 0; modeMap[i].mode_hamlib != 0; ++i)
+    for (int i = 0; modeMap[i].mode_hamlib != 0; ++i)
     {
         if (modeMap[i].mode_aclog == NULL) { continue; }
 
@@ -399,12 +397,11 @@ static const char *modeMapGet(rmode_t modeHamlib)
 */
 static rmode_t modeMapGetHamlib(const char *modeACLog)
 {
-    int i;
     char modeCheck[64];
 
     SNPRINTF(modeCheck, sizeof(modeCheck), "|%s|", modeACLog);
 
-    for (i = 0; modeMap[i].mode_hamlib != 0; ++i)
+    for (int i = 0; modeMap[i].mode_hamlib != 0; ++i)
     {
         rig_debug(RIG_DEBUG_TRACE, "%s: find '%s' in '%s'\n", __func__,
                   modeCheck, modeMap[i].mode_aclog);
@@ -697,9 +694,7 @@ static int aclog_cleanup(RIG *rig)
     // model_aclog was not getting refilled
     // if we can figure out that one we can re-enable this
 #if 0
-    int i;
-
-    for (i = 0; modeMap[i].mode_hamlib != 0; ++i)
+    for (int i = 0; modeMap[i].mode_hamlib != 0; ++i)
     {
         if (modeMap[i].mode_aclog)
         {

--- a/rigs/dummy/dummy.c
+++ b/rigs/dummy/dummy.c
@@ -208,11 +208,10 @@ static void init_chan(RIG *rig, vfo_t vfo, channel_t *chan)
 static void copy_chan(channel_t *dest, const channel_t *src)
 {
     struct ext_list *saved_ext_levels;
-    int i;
 
     /* TODO: ext_levels[] of different sizes */
 
-    for (i = 0; !RIG_IS_EXT_END(src->ext_levels[i]) &&
+    for (int i = 0; !RIG_IS_EXT_END(src->ext_levels[i]) &&
             !RIG_IS_EXT_END(dest->ext_levels[i]); i++)
     {
         dest->ext_levels[i] = src->ext_levels[i];
@@ -226,7 +225,6 @@ static void copy_chan(channel_t *dest, const channel_t *src)
 static int dummy_init(RIG *rig)
 {
     struct dummy_priv_data *priv;
-    int i;
 
     ENTERFUNC;
     priv = (struct dummy_priv_data *)calloc(1, sizeof(struct dummy_priv_data));
@@ -250,7 +248,7 @@ static int dummy_init(RIG *rig)
 
     memset(priv->mem, 0, sizeof(priv->mem));
 
-    for (i = 0; i < NB_CHAN; i++)
+    for (int i = 0; i < NB_CHAN; i++)
     {
         priv->mem[i].channel_num = i;
         priv->mem[i].vfo = RIG_VFO_MEM;
@@ -338,11 +336,10 @@ static int dummy_cleanup(RIG *rig)
 {
     struct rig_state *rs = STATE(rig);
     struct dummy_priv_data *priv = (struct dummy_priv_data *)rs->priv;
-    int i;
 
     ENTERFUNC;
 
-    for (i = 0; i < NB_CHAN; i++)
+    for (int i = 0; i < NB_CHAN; i++)
     {
         free(priv->mem[i].ext_levels);
     }
@@ -2076,9 +2073,8 @@ static int dummy_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op)
         {
             struct ext_list *saved_ext_levels = curr->ext_levels;
             int saved_ch = curr->channel_num;
-            int i;
 
-            for (i = 0; !RIG_IS_EXT_END(curr->ext_levels[i]); i++)
+            for (int i = 0; !RIG_IS_EXT_END(curr->ext_levels[i]); i++)
             {
                 curr->ext_levels[i].val.i = 0;
             }
@@ -2092,9 +2088,8 @@ static int dummy_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op)
         {
             struct ext_list *saved_ext_levels = curr->ext_levels;
             channel_t *mem_chan = &priv->mem[curr->channel_num];
-            int i;
 
-            for (i = 0; !RIG_IS_EXT_END(mem_chan->ext_levels[i]); i++)
+            for (int i = 0; !RIG_IS_EXT_END(mem_chan->ext_levels[i]); i++)
             {
                 mem_chan->ext_levels[i].val.i = 0;
             }

--- a/rigs/dummy/dummy_common.c
+++ b/rigs/dummy/dummy_common.c
@@ -28,7 +28,7 @@
 struct ext_list *alloc_init_ext(const struct confparams *cfp)
 {
     struct ext_list *elp;
-    int i, nb_ext;
+    int nb_ext;
 
     if (cfp == NULL)
     {
@@ -45,7 +45,7 @@ struct ext_list *alloc_init_ext(const struct confparams *cfp)
         return NULL;
     }
 
-    for (i = 0; !RIG_IS_EXT_END(cfp[i]); i++)
+    for (int i = 0; !RIG_IS_EXT_END(cfp[i]); i++)
     {
         elp[i].token = cfp[i].token;
         /* value reset already by calloc */
@@ -58,14 +58,12 @@ struct ext_list *alloc_init_ext(const struct confparams *cfp)
 
 struct ext_list *find_ext(struct ext_list *elp, hamlib_token_t token)
 {
-    int i;
-
     if (elp == NULL)
     {
         return NULL;
     }
 
-    for (i = 0; elp[i].token != 0; i++)
+    for (int i = 0; elp[i].token != 0; i++)
     {
         if (elp[i].token == token)
         {

--- a/rigs/dummy/flrig.c
+++ b/rigs/dummy/flrig.c
@@ -702,11 +702,9 @@ static int flrig_init(RIG *rig)
 */
 static const char *modeMapGetFLRig(rmode_t modeHamlib)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 
-    for (i = 0; modeMap[i].mode_hamlib != 0; ++i)
+    for (int i = 0; modeMap[i].mode_hamlib != 0; ++i)
     {
         if (modeMap[i].mode_flrig == NULL) { continue; }
 
@@ -734,12 +732,11 @@ static const char *modeMapGetFLRig(rmode_t modeHamlib)
 */
 static rmode_t modeMapGetHamlib(const char *modeFLRig)
 {
-    int i;
     char modeFLRigCheck[64];
 
     SNPRINTF(modeFLRigCheck, sizeof(modeFLRigCheck), "|%s|", modeFLRig);
 
-    for (i = 0; modeMap[i].mode_hamlib != 0; ++i)
+    for (int i = 0; modeMap[i].mode_hamlib != 0; ++i)
     {
         rig_debug(RIG_DEBUG_TRACE, "%s: find '%s' in '%s'\n", __func__,
                   modeFLRigCheck, modeMap[i].mode_flrig);
@@ -763,7 +760,6 @@ static rmode_t modeMapGetHamlib(const char *modeFLRig)
 */
 static void modeMapAdd(rmode_t *modes, rmode_t mode_hamlib, char *mode_flrig, int force)
 {
-    int i;
     int len1;
 
     rig_debug(RIG_DEBUG_TRACE, "%s:mode_flrig=%s\n", __func__, mode_flrig);
@@ -777,7 +773,7 @@ static void modeMapAdd(rmode_t *modes, rmode_t mode_hamlib, char *mode_flrig, in
 
     len1 = strlen(mode_flrig) + 3; /* bytes needed for allocating */
 
-    for (i = 0; modeMap[i].mode_hamlib != 0; ++i)
+    for (int i = 0; modeMap[i].mode_hamlib != 0; ++i)
     {
         if (modeMap[i].mode_hamlib == mode_hamlib)
         {
@@ -1205,9 +1201,7 @@ static int flrig_cleanup(RIG *rig)
     // model_flrig was not getting refilled
     // if we can figure out that one we can re-enable this
 #if 0
-    int i;
-
-    for (i = 0; modeMap[i].mode_hamlib != 0; ++i)
+    for (int i = 0; modeMap[i].mode_hamlib != 0; ++i)
     {
         if (modeMap[i].mode_flrig)
         {
@@ -2315,9 +2309,7 @@ static swrpair swrtbl[] =
 // Function to interpolate SWR from MTR
 float interpolateSWR(float mtr)
 {
-    int i;
-
-    for (i = 0; i < sizeof(swrtbl) / sizeof(swrpair) - 1; i++)
+    for (int i = 0; i < sizeof(swrtbl) / sizeof(swrpair) - 1; i++)
     {
         if (mtr == swrtbl[i].mtr)
         {

--- a/rigs/dummy/gqrx.c
+++ b/rigs/dummy/gqrx.c
@@ -465,9 +465,7 @@ static int gqrx_cleanup(RIG *rig)
     // model_gqrx was not getting refilled
     // if we can figure out that one we can re-enable this
 #if 0
-    int i;
-
-    for (i = 0; modeMap[i].mode_hamlib != 0; ++i)
+    for (int i = 0; modeMap[i].mode_hamlib != 0; ++i)
     {
         if (modeMap[i].mode_gqrx)
         {

--- a/rigs/dummy/sdrsharp.c
+++ b/rigs/dummy/sdrsharp.c
@@ -428,9 +428,7 @@ static int sdrsharp_cleanup(RIG *rig)
     // model_sdrsharp was not getting refilled
     // if we can figure out that one we can re-enable this
 #if 0
-    int i;
-
-    for (i = 0; modeMap[i].mode_hamlib != 0; ++i)
+    for (int i = 0; modeMap[i].mode_hamlib != 0; ++i)
     {
         if (modeMap[i].mode_sdrsharp)
         {

--- a/rigs/dummy/tci1x.c
+++ b/rigs/dummy/tci1x.c
@@ -476,11 +476,9 @@ static int tci1x_init(RIG *rig)
 */
 static const char *modeMapGetTCI(rmode_t modeHamlib)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_TRACE, "%s: called\n", __func__);
 
-    for (i = 0; modeMap[i].mode_hamlib != 0; ++i)
+    for (int i = 0; modeMap[i].mode_hamlib != 0; ++i)
     {
         if (modeMap[i].mode_tci1x == NULL) { continue; }
 
@@ -508,12 +506,11 @@ static const char *modeMapGetTCI(rmode_t modeHamlib)
 */
 static rmode_t modeMapGetHamlib(const char *modeTCI)
 {
-    int i;
     char modeTCICheck[MAXBUFLEN + 2];
 
     SNPRINTF(modeTCICheck, sizeof(modeTCICheck), "|%s|", modeTCI);
 
-    for (i = 0; modeMap[i].mode_hamlib != 0; ++i)
+    for (int i = 0; modeMap[i].mode_hamlib != 0; ++i)
     {
         rig_debug(RIG_DEBUG_TRACE, "%s: find '%s' in '%s'\n", __func__,
                   modeTCICheck, modeMap[i].mode_tci1x);
@@ -537,7 +534,6 @@ static rmode_t modeMapGetHamlib(const char *modeTCI)
 */
 static void modeMapAdd(rmode_t *modes, rmode_t mode_hamlib, char *mode_tci1x)
 {
-    int i;
     int len1;
 
     rig_debug(RIG_DEBUG_TRACE, "%s:mode_tci1x=%s\n", __func__, mode_tci1x);
@@ -548,7 +544,7 @@ static void modeMapAdd(rmode_t *modes, rmode_t mode_hamlib, char *mode_tci1x)
 
     len1 = strlen(mode_tci1x) + 3; /* bytes needed for allocating */
 
-    for (i = 0; modeMap[i].mode_hamlib != 0; ++i)
+    for (int i = 0; modeMap[i].mode_hamlib != 0; ++i)
     {
         if (modeMap[i].mode_hamlib == mode_hamlib)
         {

--- a/rigs/flexradio/dttsp.c
+++ b/rigs/flexradio/dttsp.c
@@ -763,9 +763,7 @@ int dttsp_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 
 static enum dttsp_mode_e rmode2dttsp(rmode_t mode)
 {
-    int i;
-
-    for (i = 0; i < HAMLIB_VS_DTTSP_MODES_COUNT; i++)
+    for (int i = 0; i < HAMLIB_VS_DTTSP_MODES_COUNT; i++)
     {
         if (hamlib_vs_dttsp_modes[i].hamlib_mode == mode)
         {

--- a/rigs/flexradio/sdr1k.c
+++ b/rigs/flexradio/sdr1k.c
@@ -302,7 +302,6 @@ static int set_band(RIG *rig, freq_t freq)
 int sdr1k_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
     struct sdr1k_priv_data *priv = (struct sdr1k_priv_data *)STATE(rig)->priv;
-    int i;
     double ftw;
     double DDS_step_size;
     freq_t frqval;
@@ -347,7 +346,7 @@ int sdr1k_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     /*** */
     ftw = (double)frqval / priv->xtal ;
 
-    for (i = 0; i < 6; i++)
+    for (int i = 0; i < 6; i++)
     {
         unsigned word;
 

--- a/rigs/icom/ic7800.c
+++ b/rigs/icom/ic7800.c
@@ -370,9 +370,7 @@ int ic7800_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val)
         if (val.i != 0)
         {
             /* Convert dB to index */
-            int i;
-
-            for (i = 0; i < 7; i++)
+            for (int i = 0; i < 7; i++)
             {
                 if (val.i == STATE(rig)->attenuator[i])
                 {

--- a/rigs/icom/icom.c
+++ b/rigs/icom/icom.c
@@ -2230,7 +2230,7 @@ static int icom_get_mode_x26(RIG *rig, vfo_t vfo, int *mode_len,
     const struct icom_priv_caps *priv_caps = rig->caps->priv;
     int retval;
 
-    if (priv->x26cmdfails > 0 && priv_caps->x25x26_always == 0)
+    if (priv->x26cmdfails > 0 && !priv_caps->x25x26_always)
     {
         rig_debug(RIG_DEBUG_WARN, "%s: x26cmdfails=%d, x25x26_always=%d\n", __func__,
                   priv->x26cmdfails, priv_caps->x25x26_always);

--- a/rigs/icom/icom.c
+++ b/rigs/icom/icom.c
@@ -607,7 +607,6 @@ int icom_init(RIG *rig)
     struct icom_priv_caps *priv_caps;
     struct rig_caps *caps;
     struct rig_state *rs = STATE(rig);
-    int i;
 
     ENTERFUNC;
 
@@ -639,7 +638,7 @@ int icom_init(RIG *rig)
 
     priv->spectrum_scope_count = 0;
 
-    for (i = 0; caps->spectrum_scopes[i].name != NULL; i++)
+    for (int i = 0; caps->spectrum_scopes[i].name != NULL; i++)
     {
         priv->spectrum_scope_cache[i].spectrum_data = NULL;
 
@@ -689,13 +688,12 @@ int icom_init(RIG *rig)
 int icom_cleanup(RIG *rig)
 {
     struct icom_priv_data *priv;
-    int i;
 
     ENTERFUNC;
 
     priv = STATE(rig)->priv;
 
-    for (i = 0; rig->caps->spectrum_scopes[i].name != NULL; i++)
+    for (int i = 0; rig->caps->spectrum_scopes[i].name != NULL; i++)
     {
         if (priv->spectrum_scope_cache[i].spectrum_data)
         {
@@ -2057,9 +2055,7 @@ int icom_set_dsp_flt(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         if (!rig_get_func(rig, RIG_VFO_CURR, RIG_FUNC_RF, &rfstatus)
                 && (rfstatus))
         {
-            int i;
-
-            for (i = 0; i < RTTY_FIL_NB; i++)
+            for (int i = 0; i < RTTY_FIL_NB; i++)
             {
                 if (rtty_fil[i] == width)
                 {
@@ -3353,12 +3349,11 @@ static int icom_set_cmd(RIG *rig, vfo_t vfo, struct cmdparams *par, value_t val)
     }
 
     int wrd = val.i;
-    int i;
 
     switch (par->dattyp)
     {
     case CMD_DAT_WRD:
-        for (i = 1; i <= par->datlen; i++)
+        for (int i = 1; i <= par->datlen; i++)
         {
             cmdbuf[cmdlen + par->datlen - i] = wrd & 0xff;
             wrd >>= 8;
@@ -3431,9 +3426,8 @@ static int icom_get_cmd(RIG *rig, vfo_t vfo, struct cmdparams *par, value_t *val
     case CMD_DAT_WRD:
     {
         int wrd = 0;
-        int i;
 
-        for (i = 0; i < par->datlen; i++)
+        for (int i = 0; i < par->datlen; i++)
         {
             wrd = (wrd << 8) + resbuf[i];
         }
@@ -5036,9 +5030,8 @@ int icom_set_ext_func(RIG *rig, vfo_t vfo, hamlib_token_t token, int status)
 
     const struct confparams *cfp = rig->caps->extfuncs;
     cfp = (cfp == NULL) ? icom_ext_funcs : cfp;
-    int i;
 
-    for (i = 0; (cfp[i].token != RIG_CONF_END) || (cfp != icom_ext_funcs);)
+    for (int i = 0; (cfp[i].token != RIG_CONF_END) || (cfp != icom_ext_funcs);)
     {
         if (cfp[i].token == RIG_CONF_END)
         {
@@ -5062,9 +5055,8 @@ int icom_get_ext_func(RIG *rig, vfo_t vfo, hamlib_token_t token, int *status)
 
     const struct confparams *cfp = rig->caps->extfuncs;
     cfp = (cfp == NULL) ? icom_ext_funcs : cfp;
-    int i;
 
-    for (i = 0; (cfp[i].token != RIG_CONF_END) || (cfp != icom_ext_funcs);)
+    for (int i = 0; (cfp[i].token != RIG_CONF_END) || (cfp != icom_ext_funcs);)
     {
         if (cfp[i].token == RIG_CONF_END)
         {
@@ -5095,9 +5087,8 @@ int icom_set_ext_parm(RIG *rig, hamlib_token_t token, value_t val)
 
     const struct confparams *cfp = rig->caps->extparms;
     cfp = (cfp == NULL) ? icom_ext_parms : cfp;
-    int i;
 
-    for (i = 0; (cfp[i].token != RIG_CONF_END) || (cfp != icom_ext_parms);)
+    for (int i = 0; (cfp[i].token != RIG_CONF_END) || (cfp != icom_ext_parms);)
     {
         if (cfp[i].token == RIG_CONF_END)
         {
@@ -5120,9 +5111,8 @@ int icom_get_ext_parm(RIG *rig, hamlib_token_t token, value_t *val)
 
     const struct confparams *cfp = rig->caps->extparms;
     cfp = (cfp == NULL) ? icom_ext_parms : cfp;
-    int i;
 
-    for (i = 0; (cfp[i].token != RIG_CONF_END) || (cfp != icom_ext_parms);)
+    for (int i = 0; (cfp[i].token != RIG_CONF_END) || (cfp != icom_ext_parms);)
     {
         if (cfp[i].token == RIG_CONF_END)
         {
@@ -5141,11 +5131,9 @@ int icom_get_ext_parm(RIG *rig, hamlib_token_t token, value_t *val)
 
 int icom_get_ext_cmd(RIG *rig, vfo_t vfo, hamlib_token_t token, value_t *val)
 {
-    int i;
-
     ENTERFUNC;
 
-    for (i = 0; rig->caps->ext_tokens
+    for (int i = 0; rig->caps->ext_tokens
             && rig->caps->ext_tokens[i] != TOK_BACKEND_NONE; i++)
     {
         if (rig->caps->ext_tokens[i] == token)
@@ -7528,11 +7516,10 @@ int icom_set_parm(RIG *rig, setting_t parm, value_t val)
 {
     ENTERFUNC;
 
-    int i;
     const struct icom_priv_caps *priv = rig->caps->priv;
     const struct cmdparams *extcmds = priv->extcmds;
 
-    for (i = 0; extcmds && extcmds[i].id.s != 0; i++)
+    for (int i = 0; extcmds && extcmds[i].id.s != 0; i++)
     {
         if (extcmds[i].cmdparamtype == CMD_PARAM_TYPE_PARM && extcmds[i].id.s == parm)
         {
@@ -7606,9 +7593,8 @@ int icom_get_parm(RIG *rig, setting_t parm, value_t *val)
 
     const struct icom_priv_caps *priv = rig->caps->priv;
     const struct cmdparams *cmd = priv->extcmds;
-    int i;
 
-    for (i = 0; cmd && cmd[i].id.s != 0; i++)
+    for (int i = 0; cmd && cmd[i].id.s != 0; i++)
     {
         if (cmd[i].cmdparamtype == CMD_PARAM_TYPE_PARM && cmd[i].id.s == parm)
         {
@@ -7698,7 +7684,6 @@ int icom_get_ctcss_tone(RIG *rig, vfo_t vfo, tone_t *tone)
     const struct rig_caps *caps;
     unsigned char tonebuf[MAXFRAMELEN];
     int tone_len, retval;
-    int i;
 
     ENTERFUNC;
     caps = rig->caps;
@@ -7728,7 +7713,7 @@ int icom_get_ctcss_tone(RIG *rig, vfo_t vfo, tone_t *tone)
     }
 
     /* check this tone exists. That's better than nothing. */
-    for (i = 0; caps->ctcss_list[i] != 0; i++)
+    for (int i = 0; caps->ctcss_list[i] != 0; i++)
     {
         if (caps->ctcss_list[i] == *tone)
         {
@@ -7797,7 +7782,6 @@ int icom_get_ctcss_sql(RIG *rig, vfo_t vfo, tone_t *tone)
     const struct rig_caps *caps;
     unsigned char tonebuf[MAXFRAMELEN];
     int tone_len, retval;
-    int i;
 
     ENTERFUNC;
     caps = rig->caps;
@@ -7821,7 +7805,7 @@ int icom_get_ctcss_sql(RIG *rig, vfo_t vfo, tone_t *tone)
     *tone = from_bcd_be(tonebuf + 2, tone_len * 2);
 
     /* check this tone exists. That's better than nothing. */
-    for (i = 0; caps->ctcss_list[i] != 0; i++)
+    for (int i = 0; caps->ctcss_list[i] != 0; i++)
     {
         if (caps->ctcss_list[i] == *tone)
         {
@@ -7889,7 +7873,6 @@ int icom_get_dcs_code(RIG *rig, vfo_t vfo, tone_t *code)
     const struct rig_caps *caps;
     unsigned char codebuf[MAXFRAMELEN];
     int code_len, retval;
-    int i;
 
     ENTERFUNC;
     caps = rig->caps;
@@ -7918,7 +7901,7 @@ int icom_get_dcs_code(RIG *rig, vfo_t vfo, tone_t *code)
     *code = from_bcd_be(codebuf + 3, code_len * 2);
 
     /* check this code exists. That's better than nothing. */
-    for (i = 0; caps->dcs_list[i] != 0; i++)
+    for (int i = 0; caps->dcs_list[i] != 0; i++)
     {
         if (caps->dcs_list[i] == *code)
         {
@@ -7986,7 +7969,6 @@ int icom_get_dcs_sql(RIG *rig, vfo_t vfo, tone_t *code)
     const struct rig_caps *caps;
     unsigned char codebuf[MAXFRAMELEN];
     int code_len, retval;
-    int i;
 
     ENTERFUNC;
     caps = rig->caps;
@@ -8015,7 +7997,7 @@ int icom_get_dcs_sql(RIG *rig, vfo_t vfo, tone_t *code)
     *code = from_bcd_be(codebuf + 3, code_len * 2);
 
     /* check this code exists. That's better than nothing. */
-    for (i = 0; caps->dcs_list[i] != 0; i++)
+    for (int i = 0; caps->dcs_list[i] != 0; i++)
     {
         if (caps->dcs_list[i] == *code)
         {
@@ -9767,7 +9749,7 @@ static int icom_get_spectrum_edge_frequency_range(RIG *rig, vfo_t vfo,
     rmode_t mode;
     pbwidth_t width;
     int cache_ms_freq, cache_ms_mode, cache_ms_width;
-    int i, retval;
+    int retval;
     struct icom_priv_caps *priv_caps = (struct icom_priv_caps *) rig->caps->priv;
 
     retval = rig_get_cache(rig, vfo, &freq, &cache_ms_freq, &mode, &cache_ms_mode,
@@ -9789,7 +9771,7 @@ static int icom_get_spectrum_edge_frequency_range(RIG *rig, vfo_t vfo,
         }
     }
 
-    for (i = 0; i < ICOM_MAX_SPECTRUM_FREQ_RANGES; i++)
+    for (int i = 0; i < ICOM_MAX_SPECTRUM_FREQ_RANGES; i++)
     {
         int id = priv_caps->spectrum_edge_frequency_ranges[i].range_id;
 

--- a/rigs/icom/icom.h
+++ b/rigs/icom/icom.h
@@ -25,6 +25,7 @@
 #include "hamlib/config.h"
 
 #include <stddef.h>
+#include <stdbool.h>
 
 #include "hamlib/rig.h"
 #include "hamlib/rig_state.h"
@@ -254,14 +255,14 @@ struct icom_priv_caps
     struct icom_spectrum_scope_caps spectrum_scope_caps; /*!< Icom spectrum scope capabilities, if supported by the rig. Main/Sub scopes in Icom rigs have the same caps. */
     struct icom_spectrum_edge_frequency_range spectrum_edge_frequency_ranges[ICOM_MAX_SPECTRUM_FREQ_RANGES]; /*!< Icom spectrum scope edge frequencies, if supported by the rig. Last entry should have zeros in all fields. */
     const struct cmdparams *extcmds;  /*!< Pointer to extended operations array */
-    int dualwatch_split;        /*!< Rig supports dual watch for split ops -- e.g. ID-5100 */
-    int x25x26_always;          /*!< Rig should use 0x25 and 0x26 commands always */
-    int x25x26_possibly;        /*!< Rig might support 0x25 and 0x26 commands if the firmware is upgraded */
-    int x1cx03_always;          /*!< Rig should use 0x1C 0x03 command for getting TX frequency */
-    int x1cx03_possibly;        /*!< Rig might support 0x1C 0x03 command if the firmware is upgraded TODO: is this added by FW upgrade ever? */
-    int x1ax03_supported;       /*!< Rig supports setting/getting filter width */
-    int mode_with_filter;       /*!< Rig mode commands include filter selection */
-    int data_mode_supported;    /*!< Rig supports data mode flag */
+    bool dualwatch_split;       /*!< Rig supports dual watch for split ops -- e.g. ID-5100 */
+    bool x25x26_always;         /*!< Rig should use 0x25 and 0x26 commands always */
+    bool x25x26_possibly;       /*!< Rig might support 0x25 and 0x26 commands if the firmware is upgraded */
+    bool x1cx03_always;         /*!< Rig should use 0x1C 0x03 command for getting TX frequency */
+    bool x1cx03_possibly;       /*!< Rig might support 0x1C 0x03 command if the firmware is upgraded TODO: is this added by FW upgrade ever? */
+    bool x1ax03_supported;      /*!< Rig supports setting/getting filter width */
+    bool mode_with_filter;      /*!< Rig mode commands include filter selection */
+    bool data_mode_supported;   /*!< Rig supports data mode flag */
     int fm_filters[3];          /*!< For models with FIL1/2/3 for FM low-to-high fixed filters -- IC7300/9700 */
     const struct icom_clock_cmds *clock_cmds; /*!< Pointer to clock ops commands */
 };

--- a/rigs/kenwood/elecraft.c
+++ b/rigs/kenwood/elecraft.c
@@ -105,10 +105,10 @@ int elecraft_open(RIG *rig)
     rig_debug(RIG_DEBUG_VERBOSE, "%s called, rig version=%s\n", __func__,
               rig->caps->version);
 
-    if (rs->auto_power_on && priv->poweron == 0)
+    if (rs->auto_power_on && !priv->poweron)
     {
         rig_set_powerstat(rig, 1);
-        priv->poweron = 1;
+        priv->poweron = true;
     }
 
 
@@ -210,7 +210,7 @@ int elecraft_open(RIG *rig)
         rig_debug(RIG_DEBUG_VERBOSE, "%s: K2 level is %d, %s\n", __func__,
                   priv->k2_ext_lvl, elec_ext_id_str_lst[priv->k2_ext_lvl].id);
 
-        priv->is_k2 = 1;
+        priv->is_k2 = true;
         break;
 
     case RIG_MODEL_K3:
@@ -224,35 +224,35 @@ int elecraft_open(RIG *rig)
         if (err != RIG_OK) { return err; }
 
         rig_debug(RIG_DEBUG_TRACE, "%s: OM=%s\n", __func__, buf);
-        priv->has_kpa3 = 0;
+        priv->has_kpa3 = false;
 
         if (strstr(buf, "P")) { priv->has_kpa3 = 1; }
 
         // could also use K4; command
-        priv->is_k3 = 1;  // default to K3
+        priv->is_k3 = true;  // default to K3
 
         if (rig->caps->rig_model == RIG_MODEL_K4)
         {
-            priv->is_k3 = 0;
-            priv->is_k4 = 1;
+            priv->is_k3 = false;
+            priv->is_k4 = true;
         }
         else if (strstr(buf, "R"))
         {
-            priv->is_k3 = 0;
-            priv->is_k3s = 1;
+            priv->is_k3 = false;
+            priv->is_k3s = true;
         }
 
         // combination of OM flags determines model
         if (strstr(buf, "S") && strstr(buf, "4") && strstr(buf, "H"))
         {
             // new firmware should recognize k4hd now
-            priv->is_k4 = priv->is_k3 = 0;
-            priv->is_k4hd = 1;
+            priv->is_k4 = priv->is_k3 = false;
+            priv->is_k4hd = true;
         }
         else if (strstr(buf, "S") && strstr(buf, "4"))
         {
-            priv->is_k4 = priv->is_k3 = 0;
-            priv->is_k4d = 1;
+            priv->is_k4 = priv->is_k3 = false;
+            priv->is_k4d = true;
         }
 
         if (buf[13] == '0') // then we have a KX3 or KX2
@@ -263,15 +263,15 @@ int elecraft_open(RIG *rig)
             switch (modelnum)
             {
             case '1':
-                priv->is_k2 = 0;
+                priv->is_k2 = false;
                 model = "KX2";
-                priv->is_kx2 = 1;
+                priv->is_kx2 = true;
                 break;
 
             case '2':
                 model = "KX3";
-                priv->is_k3 = 0;
-                priv->is_kx3 = 1;
+                priv->is_k3 = false;
+                priv->is_kx3 = true;
                 break;
 
             default:

--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -241,10 +241,10 @@ struct confparams kenwood_cfg_params[] =
 // [1]: https://github.com/Hamlib/Hamlib/issues/1652
 static int remove_nonprint(char *s)
 {
-    int i, j = 0;
+    int j = 0;
     if (s == NULL) return 0;
 
-    for (i = 0; s[i] != '\0'; ++i)
+    for (int i = 0; s[i] != '\0'; ++i)
     {
         if (isprint((unsigned char)s[i]))
         {
@@ -821,9 +821,7 @@ char rmode2kenwood(rmode_t mode, const rmode_t mode_table[])
 
     if (mode != RIG_MODE_NONE)
     {
-        int i;
-
-        for (i = 0; i < KENWOOD_MODE_TABLE_MAX; i++)
+        for (int i = 0; i < KENWOOD_MODE_TABLE_MAX; i++)
         {
             if (mode_table[i] == mode)
             {
@@ -966,7 +964,7 @@ int kenwood_open(RIG *rig)
 {
     struct kenwood_priv_data *priv = STATE(rig)->priv;
     struct kenwood_priv_caps *caps = kenwood_caps(rig);
-    int err, i;
+    int err;
     char *idptr;
     char id[KENWOOD_MAX_BUF_LEN];
     int retry_save = RIGPORT(rig)->retry;
@@ -1140,7 +1138,7 @@ int kenwood_open(RIG *rig)
     }
 
     /* compare id string */
-    for (i = 0; kenwood_id_string_list[i].model != RIG_MODEL_NONE; i++)
+    for (int i = 0; kenwood_id_string_list[i].model != RIG_MODEL_NONE; i++)
     {
         //rig_debug(RIG_DEBUG_ERR, "%s: comparing '%s'=='%s'\n", __func__, kenwood_id_string_list[i].id, idptr);
         if (strcmp(kenwood_id_string_list[i].id, idptr) != 0)
@@ -2238,7 +2236,7 @@ int kenwood_get_rit_new(RIG *rig, vfo_t vfo, shortfreq_t *rit)
 int kenwood_set_rit(RIG *rig, vfo_t vfo, shortfreq_t rit)
 {
     char buf[32];
-    int retval, i;
+    int retval;
     int diff;
     int rit_enabled;
     int xit_enabled;
@@ -2319,7 +2317,7 @@ int kenwood_set_rit(RIG *rig, vfo_t vfo, shortfreq_t rit)
                   rit, curr_rit, diff);
         rig_debug(RIG_DEBUG_TRACE, "%s: rit change loop=%d\n", __func__, diff);
 
-        for (i = 0; i < diff; i++)
+        for (int i = 0; i < diff; i++)
         {
             retval = kenwood_transaction(rig, buf, NULL, 0);
         }
@@ -2431,7 +2429,6 @@ static int kenwood_set_filter_width(RIG *rig, rmode_t mode, pbwidth_t width)
     struct kenwood_priv_caps *caps = kenwood_caps(rig);
     struct kenwood_filter_width *selected_filter_width = NULL;
     char cmd[20];
-    int i;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called, width=%ld\n", __func__, width);
 
@@ -2440,7 +2437,7 @@ static int kenwood_set_filter_width(RIG *rig, rmode_t mode, pbwidth_t width)
         RETURNFUNC2(-RIG_ENAVAIL);
     }
 
-    for (i = 0; caps->filter_width[i].value >= 0; i++)
+    for (int i = 0; caps->filter_width[i].value >= 0; i++)
     {
         if (caps->filter_width[i].modes & mode)
         {
@@ -2793,7 +2790,6 @@ static int kenwood_get_filter_width(RIG *rig, rmode_t mode, pbwidth_t *width)
 {
     struct kenwood_priv_caps *caps = kenwood_caps(rig);
     char ackbuf[20];
-    int i;
     int retval;
     int filter_value;
 
@@ -2813,7 +2809,7 @@ static int kenwood_get_filter_width(RIG *rig, rmode_t mode, pbwidth_t *width)
 
     sscanf(ackbuf, "FW%d", &filter_value);
 
-    for (i = 0; caps->filter_width[i].value >= 0; i++)
+    for (int i = 0; caps->filter_width[i].value >= 0; i++)
     {
         if (caps->filter_width[i].modes & mode)
         {
@@ -3268,7 +3264,6 @@ static int kenwood_find_slope_filter_for_frequency(RIG *rig, vfo_t vfo,
         struct kenwood_slope_filter *filter, int frequency_hz, int *value)
 {
     int retval;
-    int i;
     struct kenwood_slope_filter *last_filter = NULL;
     freq_t freq;
     int cache_ms_freq;
@@ -3300,7 +3295,7 @@ static int kenwood_find_slope_filter_for_frequency(RIG *rig, vfo_t vfo,
         data_mode_filter_active = 0;
     }
 
-    for (i = 0; filter[i].value >= 0; i++)
+    for (int i = 0; filter[i].value >= 0; i++)
     {
         if (filter[i].modes & mode
                 && filter[i].data_mode_filter == data_mode_filter_active)
@@ -3328,7 +3323,6 @@ static int kenwood_find_slope_filter_for_value(RIG *rig, vfo_t vfo,
         struct kenwood_slope_filter *filter, int value, int *frequency_hz)
 {
     int retval;
-    int i;
     freq_t freq;
     int cache_ms_freq;
     rmode_t mode;
@@ -3359,7 +3353,7 @@ static int kenwood_find_slope_filter_for_value(RIG *rig, vfo_t vfo,
         data_mode_filter_active = 0;
     }
 
-    for (i = 0; filter[i].value >= 0; i++)
+    for (int i = 0; filter[i].value >= 0; i++)
     {
         if (filter[i].modes & mode
                 && filter[i].data_mode_filter == data_mode_filter_active)
@@ -4732,7 +4726,7 @@ int kenwood_get_ctcss_tone(RIG *rig, vfo_t vfo, tone_t *tone)
     struct kenwood_priv_data *priv = STATE(rig)->priv;
     struct rig_caps *caps;
     char tonebuf[3];
-    int i, retval;
+    int retval;
     unsigned int tone_idx;
 
     ENTERFUNC;
@@ -4802,7 +4796,7 @@ int kenwood_get_ctcss_tone(RIG *rig, vfo_t vfo, tone_t *tone)
     }
 
     /* check this tone exists. That's better than nothing. */
-    for (i = 0; i < tone_idx; i++)
+    for (int i = 0; i < tone_idx; i++)
     {
         if (caps->ctcss_list[i] == 0)
         {
@@ -4880,7 +4874,7 @@ int kenwood_get_ctcss_sql(RIG *rig, vfo_t vfo, tone_t *tone)
     char cmd[4];
     char tonebuf[6];
     int offs;
-    int i, retval;
+    int retval;
     unsigned int tone_idx;
 
     ENTERFUNC;
@@ -4941,7 +4935,7 @@ int kenwood_get_ctcss_sql(RIG *rig, vfo_t vfo, tone_t *tone)
     }
 
     /* check this tone exists. That's better than nothing. */
-    for (i = 0; i < tone_idx; i++)
+    for (int i = 0; i < tone_idx; i++)
     {
         if (caps->ctcss_list[i] == 0)
         {

--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -998,19 +998,19 @@ int kenwood_open(RIG *rig)
         rig_debug(RIG_DEBUG_TRACE, "%s: got ID so try PS\n", __func__);
         err = rig_get_powerstat(rig, &powerstat);
 
-        if (err == RIG_OK && powerstat == 0 && priv->poweron == 0
+        if (err == RIG_OK && powerstat == 0 && !priv->poweron
                 && STATE(rig)->auto_power_on)
         {
-            priv->has_ps = 1;
+            priv->has_ps = true;
             rig_debug(RIG_DEBUG_TRACE, "%s: got PS0 so powerup\n", __func__);
             rig_set_powerstat(rig, 1);
         }
         else if (err == -RIG_ETIMEOUT) // Some rigs like TS-450 don't have PS cmd
         {
-            priv->has_ps = 0;
+            priv->has_ps = false;
         }
 
-        priv->poweron = 1;
+        priv->poweron = true;
 
         err = RIG_OK;  // reset our err back to OK for later checks
     }
@@ -1228,7 +1228,7 @@ int kenwood_close(RIG *rig)
 
     ENTERFUNC;
 
-    if (priv->poweron == 0) { RETURNFUNC(RIG_OK); } // nothing to do
+    if (!priv->poweron) { RETURNFUNC(RIG_OK); } // nothing to do
 
     if (!no_restore_ai && priv->trn_state >= 0)
     {

--- a/rigs/kenwood/kenwood.h
+++ b/rigs/kenwood/kenwood.h
@@ -25,6 +25,7 @@
 #define _KENWOOD_H 1
 
 #include <string.h>
+#include <stdbool.h>
 
 #include "hamlib/rig_state.h"
 #include "token.h"
@@ -158,26 +159,26 @@ struct kenwood_priv_data
     unsigned fw_rev_uint; /* firmware revision as a number 1.07 -> 107 */
     char verify_cmd[4];   /* command used to verify set commands */
     int verify_cmd_len;   /* length of above command - set when cmd built */
-    int is_emulation;     /* flag for TS-2000 emulations */
     void *data;           /* model specific data */
     rmode_t curr_mode;    /* used for is_emulation to avoid get_mode on VFOB */
     struct timespec cache_start;
     char last_if_response[KENWOOD_MAX_BUF_LEN];
-    int poweron;   /* to avoid powering on more than once */
-    int has_ps;    /* rig has PS cmd */
     int ag_format; /* which AG command is being used...see LEVEL_AF in kenwood.c*/
     int has_rit2; /* rig has set 2 rit command -- can set rit 0-99999 directly */
     int micgain_min, micgain_max; /* varies by rig so we figure it out automagically */
-    int is_k2;
-    int is_k3;
-    int is_k3s;
-    int is_kx3;
-    int is_kx2;
-    int is_k4;
-    int is_k4d;
-    int is_k4hd;
+    bool poweron;        /* to avoid powering on more than once */
+    bool is_emulation;   /* flag for TS-2000 emulations */
+    bool has_ps;         /* rig has PS cmd */
+    bool is_k2;
+    bool is_k3;
+    bool is_k3s;
+    bool is_kx3;
+    bool is_kx2;
+    bool is_k4;
+    bool is_k4d;
+    bool is_k4hd;
     int no_id;  // if true will not send ID; with every set command
-    int opened; // true once rig_open is called to avoid setting VFOA every open call
+    //int opened; // true once rig_open is called to avoid setting VFOA every open call
     rmode_t modeA;
     rmode_t modeB;
     int datamodeA; // datamode status from get_mode or set_mode
@@ -189,7 +190,7 @@ struct kenwood_priv_data
     short voice_mem_min, voice_mem_max; // Voice channel range
     const char *voice_mem_start, *voice_mem_stop; // Commands to do the thing to do
     rmode_t last_mode_pc; // last mode memory for PC command
-    int power_now,power_min,power_max;
+    int power_now, power_min, power_max;
 };
 
 

--- a/rigs/yaesu/ft857.c
+++ b/rigs/yaesu/ft857.c
@@ -980,7 +980,6 @@ int ft857_get_dcd(RIG *rig, vfo_t vfo, dcd_t *dcd)
 int ft857_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
     unsigned char data[YAESU_CMD_LENGTH - 1];
-    int i;
     ptt_t ptt = RIG_PTT_ON;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: called \n", __func__);
@@ -988,7 +987,7 @@ int ft857_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     rig_debug(RIG_DEBUG_VERBOSE, "ft857: requested freq = %"PRIfreq" Hz\n", freq);
 
     // cannot set freq while PTT is on
-    for (i = 0; i < 10 && ptt == RIG_PTT_ON; ++i)
+    for (int i = 0; i < 10 && ptt == RIG_PTT_ON; ++i)
     {
         int retval = ft857_get_ptt(rig, vfo, &ptt);
 

--- a/rigs/yaesu/ftx1/ftx1_audio.c
+++ b/rigs/yaesu/ftx1/ftx1_audio.c
@@ -487,11 +487,10 @@ static const int ftx1_vd_code_to_ms[] = {
  */
 static int ftx1_ms_to_vd_code(int ms)
 {
-    int i;
     int best = 0;
     int best_diff = abs(ms - ftx1_vd_code_to_ms[0]);
 
-    for (i = 1; i < (int)FTX1_VD_CODE_COUNT; i++)
+    for (int i = 1; i < (int)FTX1_VD_CODE_COUNT; i++)
     {
         int diff = abs(ms - ftx1_vd_code_to_ms[i]);
 

--- a/rigs/yaesu/ftx1/ftx1_ctcss.c
+++ b/rigs/yaesu/ftx1/ftx1_ctcss.c
@@ -48,9 +48,7 @@ static const unsigned int ftx1_ctcss_tones[] = {
 /* Convert CTCSS frequency (in 0.1 Hz) to tone number (0-based per spec) */
 int ftx1_freq_to_tone_num(unsigned int freq)
 {
-    int i;
-
-    for (i = 0; i <= FTX1_CTCSS_MAX; i++)
+    for (int i = 0; i <= FTX1_CTCSS_MAX; i++)
     {
         if (ftx1_ctcss_tones[i] == freq)
         {

--- a/rigs/yaesu/ftx1/ftx1_cw.c
+++ b/rigs/yaesu/ftx1/ftx1_cw.c
@@ -261,11 +261,10 @@ static const int ftx1_sd_code_to_ms[] = {
  */
 static int ftx1_ms_to_sd_code(int ms)
 {
-    int i;
     int best = 0;
     int best_diff = abs(ms - ftx1_sd_code_to_ms[0]);
 
-    for (i = 1; i < (int)FTX1_SD_CODE_COUNT; i++)
+    for (int i = 1; i < (int)FTX1_SD_CODE_COUNT; i++)
     {
         int diff = abs(ms - ftx1_sd_code_to_ms[i]);
 

--- a/rigs/yaesu/ftx1/ftx1_menu.c
+++ b/rigs/yaesu/ftx1/ftx1_menu.c
@@ -541,9 +541,7 @@ static const struct ftx1_menu_item ftx1_menu_table[] = {
  */
 const struct ftx1_menu_item *ftx1_menu_find_token(token_t token)
 {
-    size_t i;
-
-    for (i = 0; i < FTX1_MENU_TABLE_SIZE; i++)
+    for (size_t i = 0; i < FTX1_MENU_TABLE_SIZE; i++)
     {
         if (ftx1_menu_table[i].token == token)
         {
@@ -757,14 +755,12 @@ static int ftx1_ext_parms_initialized = 0;
  */
 static void ftx1_init_ext_parms(void)
 {
-    size_t i;
-
     if (ftx1_ext_parms_initialized)
     {
         return;
     }
 
-    for (i = 0; i < FTX1_MENU_TABLE_SIZE; i++)
+    for (size_t i = 0; i < FTX1_MENU_TABLE_SIZE; i++)
     {
         const struct ftx1_menu_item *item = &ftx1_menu_table[i];
 

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -280,9 +280,7 @@ static const antivox_cmd_entry_t antivox_cmd_table[] = {
  */
 static int lookup_antivox_cmd(nc_rigid_t rig_id, int is_get, const char **cmd)
 {
-    int i;
-
-    for (i = 0; antivox_cmd_table[i].set_cmd != NULL; i++)
+    for (int i = 0; antivox_cmd_table[i].set_cmd != NULL; i++)
     {
         if (antivox_cmd_table[i].rig_id == rig_id)
         {
@@ -1073,7 +1071,6 @@ int newcat_60m_exception(RIG *rig, freq_t freq, rmode_t mode)
     struct newcat_priv_data *priv = (struct newcat_priv_data *)STATE(rig)->priv;
     int err;
     int channel = -1;
-    int i;
     vfo_t vfo_mode;
 
     if (!(freq > 5.2 && freq < 5.5)) // we're not on 60M
@@ -1128,7 +1125,7 @@ int newcat_60m_exception(RIG *rig, freq_t freq, rmode_t mode)
     }
 
     // find the nearest slot below what is requested
-    for (i = 0; i < 5; ++i)
+    for (int i = 0; i < 5; ++i)
     {
         if ((long)freq == freq_60m[i]) { channel = i; }
     }
@@ -7331,7 +7328,7 @@ int newcat_set_bank(RIG *rig, vfo_t vfo, int bank)
 int newcat_set_mem(RIG *rig, vfo_t vfo, int ch)
 {
     struct newcat_priv_data *priv = (struct newcat_priv_data *)STATE(rig)->priv;
-    int err, i;
+    int err;
     ncboolean restore_vfo;
     chan_t *chan_list;
     channel_t valid_chan;
@@ -7346,7 +7343,7 @@ int newcat_set_mem(RIG *rig, vfo_t vfo, int ch)
 
     chan_list = rig->caps->chan_list;
 
-    for (i = 0; i < HAMLIB_CHANLSTSIZ && !RIG_IS_CHAN_END(chan_list[i]); i++)
+    for (int i = 0; i < HAMLIB_CHANLSTSIZ && !RIG_IS_CHAN_END(chan_list[i]); i++)
     {
         if (ch >= chan_list[i].startc &&
                 ch <= chan_list[i].endc)
@@ -9235,7 +9232,6 @@ static int set_roofing_filter(RIG *rig, vfo_t vfo, int index)
     char main_sub_vfo = '0';
     char roofing_filter_choice = 0;
     int err;
-    int i;
 
     ENTERFUNC;
 
@@ -9256,7 +9252,7 @@ static int set_roofing_filter(RIG *rig, vfo_t vfo, int index)
         RETURNFUNC(-RIG_ENAVAIL);
     }
 
-    for (i = 0; i < priv_caps->roofing_filter_count; i++)
+    for (int i = 0; i < priv_caps->roofing_filter_count; i++)
     {
         const struct newcat_roofing_filter *current_filter = &roofing_filters[i];
         char set_value = current_filter->set_value;
@@ -9298,7 +9294,6 @@ static int set_roofing_filter_for_width(RIG *rig, vfo_t vfo, int width)
 {
     struct newcat_priv_caps *priv_caps = (struct newcat_priv_caps *)rig->caps->priv;
     int index = 0;
-    int i;
 
     ENTERFUNC;
 
@@ -9307,7 +9302,7 @@ static int set_roofing_filter_for_width(RIG *rig, vfo_t vfo, int width)
         RETURNFUNC(-RIG_ENAVAIL);
     }
 
-    for (i = 0; i < priv_caps->roofing_filter_count; i++)
+    for (int i = 0; i < priv_caps->roofing_filter_count; i++)
     {
         const struct newcat_roofing_filter *current_filter =
                 &priv_caps->roofing_filters[i];
@@ -9342,7 +9337,6 @@ static int get_roofing_filter(RIG *rig, vfo_t vfo,
     char rf_vfo = 'X';
     int err;
     int n;
-    int i;
 
     ENTERFUNC;
 
@@ -9376,7 +9370,7 @@ static int get_roofing_filter(RIG *rig, vfo_t vfo,
         RETURNFUNC(-RIG_EPROTO);
     }
 
-    for (i = 0; i < priv_caps->roofing_filter_count; i++)
+    for (int i = 0; i < priv_caps->roofing_filter_count; i++)
     {
         struct newcat_roofing_filter *current_filter = &roofing_filters[i];
 
@@ -10987,9 +10981,7 @@ struct
 
 rmode_t newcat_rmode(char mode)
 {
-    int i;
-
-    for (i = 0; i < sizeof(newcat_mode_conv) / sizeof(newcat_mode_conv[0]); i++)
+    for (int i = 0; i < sizeof(newcat_mode_conv) / sizeof(newcat_mode_conv[0]); i++)
     {
         if (newcat_mode_conv[i].modechar == mode)
         {
@@ -11004,9 +10996,7 @@ rmode_t newcat_rmode(char mode)
 
 char newcat_modechar(rmode_t rmode)
 {
-    int i;
-
-    for (i = 0; i < sizeof(newcat_mode_conv) / sizeof(newcat_mode_conv[0]); i++)
+    for (int i = 0; i < sizeof(newcat_mode_conv) / sizeof(newcat_mode_conv[0]); i++)
     {
         if (newcat_mode_conv[i].mode == rmode)
         {
@@ -11022,13 +11012,12 @@ char newcat_modechar(rmode_t rmode)
 rmode_t newcat_rmode_width(RIG *rig, vfo_t vfo, char mode, pbwidth_t *width)
 {
     ncboolean narrow;
-    int i;
 
     ENTERFUNC2;
 
     *width = RIG_PASSBAND_NORMAL;
 
-    for (i = 0; i < sizeof(newcat_mode_conv) / sizeof(newcat_mode_conv[0]); i++)
+    for (int i = 0; i < sizeof(newcat_mode_conv) / sizeof(newcat_mode_conv[0]); i++)
     {
         if (newcat_mode_conv[i].modechar == mode)
         {

--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -810,10 +810,10 @@ int newcat_open(RIG *rig)
               __func__, handshake[rig->caps->serial_handshake]);
 
     /* Ensure rig is powered on */
-    if (priv->poweron == 0 && rig_s->auto_power_on)
+    if (!priv->poweron && rig_s->auto_power_on)
     {
         rig_set_powerstat(rig, 1);
-        priv->poweron = 1;
+        priv->poweron = true;
     }
 
     priv->question_mark_response_means_rejected = 0;
@@ -949,10 +949,10 @@ int newcat_close(RIG *rig)
                                                    supported */
     }
 
-    if (priv->poweron != 0 && rig_s->auto_power_off && rig_s->comm_state)
+    if (priv->poweron && rig_s->auto_power_off && rig_s->comm_state)
     {
         rig_set_powerstat(rig, 0);
-        priv->poweron = 0;
+        priv->poweron = false;
     }
 
 #if 0 // this apparently does not work -- we can't query EX103
@@ -3697,7 +3697,7 @@ int newcat_set_powerstat(RIG *rig, powerstat_t status)
     case RIG_POWER_OFF:
     case RIG_POWER_STANDBY:
         retval = write_block(rp, (unsigned char *) "PS0;", 4);
-        priv->poweron = 0;
+        priv->poweron = false;
         RETURNFUNC(retval);
 
     default:
@@ -3721,7 +3721,7 @@ int newcat_set_powerstat(RIG *rig, powerstat_t status)
             if (retval == RIG_OK)
             {
                 rp->retry = retry_save;
-                priv->poweron = 1;
+                priv->poweron = true;
                 RETURNFUNC(retval);
             }
 
@@ -3801,12 +3801,12 @@ int newcat_get_powerstat(RIG *rig, powerstat_t *status)
         {
         case '1':
             *status = RIG_POWER_ON;
-            priv->poweron = 1;
+            priv->poweron = true;
             RETURNFUNC(RIG_OK);
 
         case '0':
             *status = RIG_POWER_OFF;
-            priv->poweron = 0;
+            priv->poweron = false;
             RETURNFUNC(RIG_OK);
 
         default:

--- a/rigs/yaesu/newcat.h
+++ b/rigs/yaesu/newcat.h
@@ -130,22 +130,19 @@ struct newcat_priv_caps
  */
 struct newcat_priv_data
 {
-    char                cmd_str[NEWCAT_DATA_LEN];       /* command string buffer */
-    char
-    ret_data[NEWCAT_DATA_LEN];      /* returned data--max value, most are less */
-    int
-    current_mem;                    /* private memory channel number */
-    int
-    rig_id;                         /* rig id from CAT Command ID; */
-    int trn_state;  /* AI state found at startup */
-    int fast_set_commands; /* do not check for ACK/NAK; needed for high throughput > 100 commands/s */
-    int width_frequency; /* found at startup */
+    char cmd_str[NEWCAT_DATA_LEN]; /* command string buffer */
+    char ret_data[NEWCAT_DATA_LEN];/* returned data--max value, most are less */
+    int current_mem;               /* private memory channel number */
+    int rig_id;                    /* rig id from CAT Command ID; */
+    int trn_state;                 /* AI state found at startup */
+    int fast_set_commands;         /* do not check for ACK/NAK; needed for high throughput > 100 commands/s */
+    int width_frequency;           /* found at startup */
     struct timespec cache_start;
     char last_if_response[NEWCAT_DATA_LEN];
-    int poweron; /* to prevent powering on more than once */
-    int question_mark_response_means_rejected; /* the question mark response has multiple meanings */
-    char front_rear_status; /* e.g. FTDX5000 EX103 status */
-    int split_st_command_missing; /* is ST command gone?  assume not until proven otherwise */
+    char front_rear_status;        /* e.g. FTDX5000 EX103 status */
+    bool poweron;                  /* to prevent powering on more than once */
+    bool split_st_command_missing; /* is ST command gone?  assume not until proven otherwise */
+    bool question_mark_response_means_rejected; /* the question mark response has multiple meanings */
     int band_index;
     /* FTX-1 specific fields - per-rig instance storage */
     int ftx1_head_type;          /* FTX1_HEAD_FIELD_BATTERY/12V/SPA1/UNKNOWN */

--- a/rigs/yaesu/vr5000.c
+++ b/rigs/yaesu/vr5000.c
@@ -644,9 +644,7 @@ int set_vr5000(RIG *rig, vfo_t vfo, freq_t freq, rmode_t mode, pbwidth_t width,
  */
 int find_tuning_step(RIG *rig, vfo_t vfo, rmode_t mode, shortfreq_t *ts)
 {
-    int i;
-
-    for (i = 0; i < HAMLIB_TSLSTSIZ; i++)
+    for (int i = 0; i < HAMLIB_TSLSTSIZ; i++)
     {
         if ((rig->caps->tuning_steps[i].modes & mode) != 0)
         {
@@ -663,9 +661,7 @@ int find_tuning_step(RIG *rig, vfo_t vfo, rmode_t mode, shortfreq_t *ts)
  */
 int check_tuning_step(RIG *rig, vfo_t vfo, rmode_t mode, shortfreq_t ts)
 {
-    int i;
-
-    for (i = 0; i < HAMLIB_TSLSTSIZ; i++)
+    for (int i = 0; i < HAMLIB_TSLSTSIZ; i++)
     {
         if (rig->caps->tuning_steps[i].ts == ts &&
                 ((rig->caps->tuning_steps[i].modes & mode) != 0))

--- a/rigs/yaesu/yaesu.c
+++ b/rigs/yaesu/yaesu.c
@@ -141,7 +141,7 @@ DECLARE_PROBERIG_BACKEND(yaesu)
 {
     unsigned char idbuf[YAESU_CMD_LENGTH + 1];
     static const unsigned char cmd[YAESU_CMD_LENGTH] = { 0x00, 0x00, 0x00, 0x00, 0xfa};
-    int id_len = -1, i, id1, id2;
+    int id_len = -1, id1, id2;
     int retval = -1;
     static const int rates[] = { 4800, 57600, 9600, 38400, 0 };  /* possible baud rates */
     int rates_idx;
@@ -207,7 +207,7 @@ DECLARE_PROBERIG_BACKEND(yaesu)
     id2 = idbuf[4];
 
 
-    for (i = 0; yaesu_id_list[i].model != RIG_MODEL_NONE; i++)
+    for (int i = 0; yaesu_id_list[i].model != RIG_MODEL_NONE; i++)
     {
         if (id1 == yaesu_id_list[i].id1 && id2 == yaesu_id_list[i].id2)
         {

--- a/rotators/amsat/if100.c
+++ b/rotators/amsat/if100.c
@@ -39,7 +39,7 @@ if100_set_position(ROT *rot, azimuth_t az, elevation_t el)
     int retval;
     int az_i;
     int el_i;
-    int dataout, i;
+    int dataout;
     double az_scale, el_scale;
 
     rig_debug(RIG_DEBUG_TRACE, "%s called: %f %f\n", __func__, az, el);
@@ -68,7 +68,7 @@ if100_set_position(ROT *rot, azimuth_t az, elevation_t el)
         return retval;
     }
 
-    for (i = 0; i < 16; i++)
+    for (int i = 0; i < 16; i++)
     {
         if (dataout & 0x8000)
         {

--- a/rotators/grbltrk/grbltrk.c
+++ b/rotators/grbltrk/grbltrk.c
@@ -169,7 +169,6 @@ grbl_request(ROT *rot, char *request, uint32_t req_size, char *response,
 static int
 grbl_init(ROT *rot)
 {
-    int i;
     uint32_t init_count;
     char rsp[RSIZE];
     uint32_t resp_size;
@@ -187,7 +186,7 @@ grbl_init(ROT *rot)
 
     init_count = sizeof(grbl_init_list) / sizeof(grbl_init_list[0]);
 
-    for (i = 0; i < init_count; i++)
+    for (int i = 0; i < init_count; i++)
     {
         int retval;
 
@@ -340,13 +339,11 @@ grbltrk_rot_get_position(ROT *rot, azimuth_t *az, elevation_t *el)
     char dummy0[256];
     char dummy1[256];
 
-    int i;
-
     rot_debug(RIG_DEBUG_TRACE, "%s called\n", __func__);
 
     //snprintf(req, sizeof(req), "?\r\n");
 
-    for (i = 0; i < 5; i++)
+    for (int i = 0; i < 5; i++)
     {
         int retval;
         retval = grbl_request(rot, grbl_get_pos, strlen(grbl_get_pos), rsp, &rsp_size);

--- a/rotators/ts7400/include/io.c
+++ b/rotators/ts7400/include/io.c
@@ -15,7 +15,6 @@
 int main(int argc, char **argv)
 {
     volatile unsigned int *PEDR, *PEDDR, *PBDR, *PBDDR, *GPIOBDB;
-    int i;
     unsigned char state;
     unsigned char *start;
     int fd = open("/dev/mem", O_RDWR | O_SYNC);
@@ -41,7 +40,7 @@ int main(int argc, char **argv)
 
 
     // blink 5 times, sleep 1 second so it's visible
-    for (i = 0; i < 5; i++)
+    for (int i = 0; i < 5; i++)
     {
         *PEDR = 0xff;
         sleep(1);

--- a/security/security.c
+++ b/security/security.c
@@ -73,9 +73,8 @@ void rig_make_key(char key[33])
     const char *all =
         "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ123467890!@#$%^&*()_=~<>/?";
     int max = strlen(all);
-    int i;
 
-    for (i = 0; i < 32; ++i)
+    for (int i = 0; i < 32; ++i)
     {
         key[i] = all[my_rand(max)];
     }

--- a/simulators/sim.h
+++ b/simulators/sim.h
@@ -4,6 +4,26 @@
 #include <unistd.h>
 #include <string.h>
 
+/* Define macros for handling attributes, if the compiler implements them
+ *   Should be available in c23-capable compilers, or c++11 ones
+ */
+// From ISO/IEC 9899:202y n3301 working draft
+#ifndef __has_c_attribute
+#define __has_c_attribute(x) 0
+#endif
+
+// Macro for allowing unused variables/functions to go unmentioned
+// This is really a C23 feature, so older compilers may still produce
+//   a warning - please ignore it.
+#if __has_c_attribute(maybe_unused)
+#define MAY_BE_UNUSED [[maybe_unused]]
+#else
+#define MAY_BE_UNUSED
+#endif
+
+// Size of command buffer
+#define BUFSIZE 256
+
 /* ID 0310 == 310, Must drop leading zero */
 typedef enum nc_rigid_e
 {
@@ -92,9 +112,6 @@ int openPort(char *comport) // doesn't matter for using pts devices
 }
 #endif
 
-// Size of command buffer
-#define BUFSIZE 256
-
 int
 getmyline(int fd, char *buf)
 {
@@ -140,3 +157,27 @@ getmyline5(int fd, unsigned char *buf)
 
     return i;
 }
+
+/* Vendor specific data and routines
+ *
+ * Some may be re-implementation of Hamlib, but let's keep them disjoint
+ */
+#if SIM == Icom
+
+#include "../rigs/icom/icom_defs.h"
+
+MAY_BE_UNUSED
+static const char *mode_names[] = {
+  "LSB", "USB", "AM", "CW", "RTTY", "FM", "WFM", "CW-R", "RTTY-R" };
+
+MAY_BE_UNUSED
+static int acknak(int fd, unsigned char *frame, unsigned char status)
+{
+  frame[4] = status;
+  frame[5] = FI;
+  return write(fd, frame, ACKFRMLEN);
+}
+
+#elif SIM == Kenwood
+#elif SIM == Yaesu
+#endif

--- a/simulators/simic705.c
+++ b/simulators/simic705.c
@@ -9,14 +9,15 @@
 #include <errno.h>
 
 #include "misc.h"
-#include "sim.h"
 /* Simulators really shouldn't be using ANY of the definitions
  *  from the Hamlib rig.h parameters, but only those of the
  *  rig itself.  This still won't be a clean room implementation,
  *  but lets try to use as many as possible of Icom's definitions
  *  for the rig parameters.
  */
-#include "../rigs/icom/icom_defs.h"
+
+#define SIM Icom
+#include "sim.h"
 
 #define X25
 #undef SATMODE
@@ -45,6 +46,7 @@ int agc_time = 1;
 int ovf_status = 0;
 int powerstat = 1;
 const char *vfonames[2] = {"VFOA", "VFOB"};
+unsigned char civ_addr = 0xA4;    //Default
 
 int
 frameGet(int fd, unsigned char *buf)
@@ -89,7 +91,10 @@ void frameParse(int fd, unsigned char *frame, int len)
 {
     double freq;
     int n = 0;
-    unsigned char acknak = ACK; // Hope for the best
+    unsigned char response = ACK; // Hope for the best
+#ifdef X25
+    int target_vfo;   // For selected/unselected vfo
+#endif
 
     if (len == 0)
     {
@@ -157,18 +162,14 @@ void frameParse(int fd, unsigned char *frame, int len)
         if (current_vfo == S_VFOA || current_vfo == S_MAIN) { freqA = freq; }
         else { freqB = freq; }
 
-        frame[4] = ACK;
-        frame[5] = FI;
-        n = write(fd, frame, 6);
+        n = acknak(fd, frame, ACK);
         break;
 
     case C_SET_MODE: // 0x06
         if (current_vfo == S_VFOA || current_vfo == S_MAIN) { modeA = frame[6]; }
         else { modeB = frame[6]; }
 
-        frame[4] = ACK;
-        frame[5] = FI;
-        n = write(fd, frame, 6);
+        n = acknak(fd, frame, ACK);
         break;
 
     case C_SET_VFO: // 0x07
@@ -185,14 +186,12 @@ void frameParse(int fd, unsigned char *frame, int len)
             // Ditto
             break;
         default:
-            acknak = NAK;
+            response = NAK;
         }
 
         printf("set_vfo to %s\n", vfonames[current_vfo]);
 
-        frame[4] = acknak;
-        frame[5] = FI;
-        n = write(fd, frame, 6);
+        n = acknak(fd, frame, response);
         break;
 
     case C_CTL_SPLT: // 0x0F
@@ -209,9 +208,7 @@ void frameParse(int fd, unsigned char *frame, int len)
         else
         {
             printf("set split %d\n", split);
-            frame[4] = ACK;
-            frame[5] = FI;
-            n = write(fd, frame, 6);
+            n = acknak(fd, frame, ACK);
         }
 
         break;
@@ -223,7 +220,7 @@ void frameParse(int fd, unsigned char *frame, int len)
             printf("Set ant %d\n", -1);
             ant_curr = frame[5];
             ant_option = frame[6];
-            dump_hex(frame, 8);
+            dumphex(frame, 8);
         }
         else
         {
@@ -234,7 +231,7 @@ void frameParse(int fd, unsigned char *frame, int len)
         frame[6] = ant_option;
         frame[7] = 0xfd;
         printf("write 8 bytes\n");
-        dump_hex(frame, 8);
+        dumphex(frame, 8);
         n = write(fd, frame, 8);
         break;
 #endif
@@ -355,8 +352,8 @@ void frameParse(int fd, unsigned char *frame, int len)
         n = write(fd, frame, 7);
         break;
 
-    case C_RD_TRXID: // 0x19 miscellaneous things
-        frame[5] = 0xA4;
+    case C_RD_TRXID: // 0x19 Transceiver ID
+        frame[5] = civ_addr;
         frame[6] = FI;
         n = write(fd, frame, 7);
         break;
@@ -377,9 +374,7 @@ void frameParse(int fd, unsigned char *frame, int len)
             {
                 if (current_vfo == S_VFOA) { widthA = frame[6]; }
                 else { widthB = frame[6]; }
-                frame[4] = ACK;
-                frame[5] = FI;
-                n = write(fd, frame, 6);
+                n = acknak(fd, frame, ACK);
             }
             break;
 
@@ -396,9 +391,7 @@ void frameParse(int fd, unsigned char *frame, int len)
             {
                 printf("AGC_TIME RESPONSE******************************");
                 agc_time = frame[6];
-                frame[4] = 0xfb;
-                frame[5] = 0xfd;
-                n = write(fd, frame, 6);
+                n = acknak(fd, frame, ACK);
             }
 
             break;
@@ -428,9 +421,7 @@ void frameParse(int fd, unsigned char *frame, int len)
             else
             {
                 ptt = frame[6];
-                frame[7] = ACK;
-                frame[8] = FI;
-                n = write(fd, frame, 9);
+                n = acknak(fd, frame, ACK);
             }
 
             break;
@@ -443,9 +434,10 @@ void frameParse(int fd, unsigned char *frame, int len)
 #ifdef X25
 
     case C_SEND_SEL_FREQ: // 0x25
+        target_vfo = current_vfo ^ frame[5];
         if (frame[6] == FI)
         {
-            if (frame[5] == 0x00)
+            if (target_vfo == 0x00)
             {
                 to_bcd(&frame[6], (long long)freqA, (civ_731_mode ? 4 : 5) * 2);
                 printf("X25 get_freqA=%.0f\n", freqA);
@@ -481,12 +473,10 @@ void frameParse(int fd, unsigned char *frame, int len)
             freq = from_bcd(&frame[6], (civ_731_mode ? 4 : 5) * 2);
             printf("set_freq to %.0f\n", freq);
 
-            if (frame[5] == 0x00) { freqA = freq; }
+            if (target_vfo == 0x00) { freqA = freq; }
             else { freqB = freq; }
 
-            frame[4] = 0xfb;
-            frame[5] = 0xfd;
-            n = write(fd, frame, 6);
+            n = acknak(fd, frame, ACK);
 #if 0
             // send async frame
             frame[2] = 0x00; // async freq
@@ -505,12 +495,12 @@ void frameParse(int fd, unsigned char *frame, int len)
         break;
 
     case C_SEND_SEL_MODE: // 0x26
-
+        target_vfo = current_vfo ^ frame[5];
         if (frame[6] == 0xfd) // then a query
         {
-            frame[6] = frame[5] == 0 ? modeA : modeB;
-            frame[7] = frame[5] == 0 ? datamodeA : datamodeB;
-            frame[8] = frame[5] == 0 ? filterA : filterB;
+            frame[6] = target_vfo == 0 ? modeA : modeB;
+            frame[7] = target_vfo == 0 ? datamodeA : datamodeB;
+            frame[8] = target_vfo == 0 ? filterA : filterB;
             frame[9] = 0xfd;
             printf("  ->");
             for (int i = 0; i < 10; ++i) { printf("%02x:", frame[i]); }
@@ -519,7 +509,7 @@ void frameParse(int fd, unsigned char *frame, int len)
         }
         else
         {
-            if (frame[5] == 0)
+            if (target_vfo == 0)
             {
                 modeA = frame[6];
                 datamodeA = frame[7];
@@ -532,9 +522,7 @@ void frameParse(int fd, unsigned char *frame, int len)
                 filterB = frame[8];
             }
 
-            frame[4] = ACK;
-            frame[5] = FI;
-            n = write(fd, frame, 6);
+            n = acknak(fd, frame, ACK);
         }
 
         break;
@@ -542,16 +530,12 @@ void frameParse(int fd, unsigned char *frame, int len)
 
     case 0x25:
         printf("x25 send nak\n");
-        frame[4] = NAK;
-        frame[5] = FI;
-        n = write(fd, frame, 6);
+        n = acknak(fd, frame, NAK);
         break;
 
     case 0x26:
         printf("x26 send nak\n");
-        frame[4] = NAK;
-        frame[5] = FI;
-        n = write(fd, frame, 6);
+        n = acknak(fd, frame, NAK);
         break;
 #endif
 
@@ -569,11 +553,11 @@ void rigStatus()
 {
     char vfoa = current_vfo == S_VFOA ? '*' : ' ';
     char vfob = current_vfo == S_VFOB ? '*' : ' ';
-    printf("%cVFOA: mode=%d datamode=%d width=%d freq=%.0f\n", vfoa, modeA,
+    printf("%cVFOA: mode=%s datamode=%d width=%d freq=%.0f\n", vfoa, mode_names[modeA],
            datamodeA,
            widthA,
            freqA);
-    printf("%cVFOB: mode=%d datamode=%d width=%d freq=%.0f\n", vfob, modeB,
+    printf("%cVFOB: mode=%s datamode=%d width=%d freq=%.0f\n", vfob, mode_names[modeB],
            datamodeB,
            widthB,
            freqB);

--- a/simulators/simic7300.c
+++ b/simulators/simic7300.c
@@ -9,15 +9,15 @@
 #include <errno.h>
 #include <sys/types.h>
 
-#include "hamlib/rig.h"
 #include "misc.h"
-#include "sim.h"
 
+#define SIM Icom
+#include "sim.h"
 
 #define X25
 
 int civ_731_mode = 0;
-vfo_t current_vfo = RIG_VFO_A;
+int current_vfo = S_VFOA;
 int split = 0;
 int keyspd = 85; // 85=20WPM
 int band = 8;
@@ -25,12 +25,14 @@ int band = 8;
 // we make B different from A to ensure we see a difference at startup
 float freqA = 14074000;
 float freqB = 14074500;
-mode_t modeA = RIG_MODE_PKTUSB;
-mode_t modeB = RIG_MODE_PKTUSB;
-int datamodeA = 0;
-int datamodeB = 0;
-pbwidth_t widthA = 1;
-pbwidth_t widthB = 2;
+int modeA = S_USB;
+int modeB = S_USB;
+int datamodeA = 1;
+int datamodeB = 1;
+unsigned char widthA = 1;
+unsigned char widthB = 2;
+unsigned char filterA = 2;
+unsigned char filterB = 2;
 ant_t ant_curr = 0;
 int ant_option = 0;
 int ptt = 0;
@@ -39,6 +41,7 @@ int agc_time = 1;
 int ovf_status = 0;
 int powerstat = 1;
 int keyertype = 0;
+unsigned char civ_addr = 0x94;  // 94=IC7300, B6=IC7300MK2 (defaults)
 
 int
 frameGet(int fd, unsigned char *buf)
@@ -50,14 +53,12 @@ frameGet(int fd, unsigned char *buf)
     while (read(fd, &c, 1) > 0)
     {
         buf[i++] = c;
-        printf("i=%d, c=0x%02x\n", i, c);
 
         if (c == 0xfd)
         {
             char mytime[256];
             date_strget(mytime, sizeof(mytime), 1);
-            printf("%s:", mytime); dumphex(buf, i);
-            printf("\n");
+            printf("\n%s:", mytime); dumphex(buf, i);
             // echo
             //n = write(fd, buf, i);
             //if (n != i) { printf("%s: error on write: %s\n", __func__, strerror(errno)); }
@@ -89,6 +90,8 @@ void frameParse(int fd, unsigned char *frame, int len)
 {
     double freq;
     int n = 0;
+    unsigned char response = ACK;
+    int target_vfo;
 
     if (len == 0)
     {
@@ -96,9 +99,7 @@ void frameParse(int fd, unsigned char *frame, int len)
         return;
     }
 
-    dumphex(frame, len);
-
-    if (frame[0] != 0xfe && frame[1] != 0xfe)
+    if (frame[0] != 0xfe || frame[1] != 0xfe)
     {
         printf("expected fe fe, got ");
         dumphex(frame, len);
@@ -112,7 +113,7 @@ void frameParse(int fd, unsigned char *frame, int len)
         if (frame[5] == 0xfd)
         {
             //from_bcd(frameackbuf[2], (civ_731_mode ? 4 : 5) * 2);
-            if (current_vfo == RIG_VFO_A || current_vfo == RIG_VFO_MAIN)
+            if (current_vfo == S_VFOA || current_vfo == S_MAIN)
             {
                 printf("get_freqA\n");
                 to_bcd(&frame[5], (long long)freqA, (civ_731_mode ? 4 : 5) * 2);
@@ -127,7 +128,7 @@ void frameParse(int fd, unsigned char *frame, int len)
 
             if (powerstat)
             {
-                dump_hex(frame, 11);
+                dumphex(frame, 11);
                 n = write(fd, frame, 11);
 
                 if (n <= 0) { fprintf(stderr, "%s(%d) write error %s\n", __func__, __LINE__, strerror(errno)); }
@@ -135,7 +136,7 @@ void frameParse(int fd, unsigned char *frame, int len)
         }
         else
         {
-            if (current_vfo == RIG_VFO_A)
+            if (current_vfo == S_VFOA)
             {
                 freqA = from_bcd(&frame[5], (civ_731_mode ? 4 : 5) * 2);
             }
@@ -144,16 +145,14 @@ void frameParse(int fd, unsigned char *frame, int len)
                 freqB = from_bcd(&frame[5], (civ_731_mode ? 4 : 5) * 2);
             }
 
-            frame[4] = 0xfb;
-            frame[5] = 0xfd;
-            n = write(fd, frame, 6);
+            n = acknak(fd, frame, ACK);
         }
 
 
         break;
 
     case 0x04:
-        if (current_vfo == RIG_VFO_A || current_vfo == RIG_VFO_MAIN)
+        if (current_vfo == S_VFOA || current_vfo == S_MAIN)
         {
             printf("get_modeA\n");
             frame[5] = modeA;
@@ -177,24 +176,20 @@ void frameParse(int fd, unsigned char *frame, int len)
         freq = from_bcd(&frame[5], (civ_731_mode ? 4 : 5) * 2);
         printf("set_freq to %.0f\n", freq);
 
-        if (current_vfo == RIG_VFO_A || current_vfo == RIG_VFO_MAIN) { freqA = freq; }
+        if (current_vfo == S_VFOA || current_vfo == S_MAIN) { freqA = freq; }
         else { freqB = freq; }
 
-        frame[4] = 0xfb;
-        frame[5] = 0xfd;
-        n = write(fd, frame, 6);
+        n = acknak(fd, frame, ACK);
 
         if (n <= 0) { fprintf(stderr, "%s(%d) write error %s\n", __func__, __LINE__, strerror(errno)); }
 
         break;
 
     case 0x06:
-        if (current_vfo == RIG_VFO_A || current_vfo == RIG_VFO_MAIN) { modeA = frame[6]; }
+        if (current_vfo == S_VFOA || current_vfo == S_MAIN) { modeA = frame[6]; }
         else { modeB = frame[6]; }
 
-        frame[4] = 0xfb;
-        frame[5] = 0xfd;
-        n = write(fd, frame, 6);
+        n = acknak(fd, frame, ACK);
 
         if (n <= 0) { fprintf(stderr, "%s(%d) write error %s\n", __func__, __LINE__, strerror(errno)); }
 
@@ -204,20 +199,18 @@ void frameParse(int fd, unsigned char *frame, int len)
 
         switch (frame[5])
         {
-        case 0x00: current_vfo = RIG_VFO_A; break;
+        case 0x00:
+        case 0x01: current_vfo = frame[5]; break;
 
-        case 0x01: current_vfo = RIG_VFO_B; break;
+        case 0xa0: freqB = freqA; break;
 
-        case 0xd0: current_vfo = RIG_VFO_MAIN; break;
+        case 0xb0: freq = freqA; freqA = freqB; freqB = freq; break;
 
-        case 0xd1: current_vfo = RIG_VFO_SUB; break;
+        default: response = NAK;
+
         }
 
-        printf("set_vfo to %s\n", rig_strvfo(current_vfo));
-
-        frame[4] = 0xfb;
-        frame[5] = 0xfd;
-        n = write(fd, frame, 6);
+        n = acknak(fd, frame, response);
 
         if (n <= 0) { fprintf(stderr, "%s(%d) write error %s\n", __func__, __LINE__, strerror(errno)); }
 
@@ -237,9 +230,7 @@ void frameParse(int fd, unsigned char *frame, int len)
         {
             printf("set split %d\n", 1);
             split = frame[5];
-            frame[4] = 0xfb;
-            frame[5] = 0xfd;
-            n = write(fd, frame, 6);
+            n = acknak(fd, frame, ACK);
 
             if (n <= 0) { fprintf(stderr, "%s(%d) write error %s\n", __func__, __LINE__, strerror(errno)); }
         }
@@ -252,7 +243,7 @@ void frameParse(int fd, unsigned char *frame, int len)
             printf("Set ant %d\n", -1);
             ant_curr = frame[5];
             ant_option = frame[6];
-            dump_hex(frame, 8);
+            dumphex(frame, 8);
         }
         else
         {
@@ -263,7 +254,7 @@ void frameParse(int fd, unsigned char *frame, int len)
         frame[6] = ant_option;
         frame[7] = 0xfd;
         printf("write 8 bytes\n");
-        dump_hex(frame, 8);
+        dumphex(frame, 8);
         n = write(fd, frame, 8);
 
         if (n <= 0) { fprintf(stderr, "%s(%d) write error %s\n", __func__, __LINE__, strerror(errno)); }
@@ -318,21 +309,17 @@ void frameParse(int fd, unsigned char *frame, int len)
             break;
 
         case 0x0c:
-            dumphex(frame, 10);
-            printf("subcmd=0x0c #1\n");
-
             if (frame[6] != 0xfd) // then we have data
             {
                 printf("subcmd=0x0c #1\n");
                 keyspd = from_bcd(&frame[6], 2);
-                frame[6] = 0xfb;
-                n = write(fd, frame, 7);
+                n = acknak(fd, frame, ACK);
 
                 if (n <= 0) { fprintf(stderr, "%s(%d) write error %s\n", __func__, __LINE__, strerror(errno)); }
             }
             else
             {
-                printf("subcmd=0x0c #1\n");
+                printf("subcmd=0x0c #2\n");
                 to_bcd(&frame[6], keyspd, 2);
                 frame[8] = 0xfd;
                 n = write(fd, frame, 9);
@@ -416,8 +403,8 @@ void frameParse(int fd, unsigned char *frame, int len)
 
         break;
 
-    case 0x19: // miscellaneous things
-        frame[5] = 0x94;
+    case 0x19: // Read Transceiver ID
+        frame[5] = civ_addr;
         frame[6] = 0xfd;
         n = write(fd, frame, 7);
 
@@ -441,9 +428,7 @@ void frameParse(int fd, unsigned char *frame, int len)
             {
                 band = frame[6];
                 printf("Band select=%d\n", band);
-                frame[4] = 0xfb;
-                frame[5] = 0xfe;
-                n = write(fd, frame, 6);
+                n = acknak(fd, frame, ACK);
 
                 if (n <= 0) { fprintf(stderr, "%s(%d) write error %s\n", __func__, __LINE__, strerror(errno)); }
             }
@@ -451,14 +436,23 @@ void frameParse(int fd, unsigned char *frame, int len)
             break;
 
         case 0x03:  // width
-            if (current_vfo == RIG_VFO_A || current_vfo == RIG_VFO_MAIN) { frame[6] = widthA; }
-            else { frame[6] = widthB; }
+            if (frame[6] == 0xfd)
+            {
+                if (current_vfo == S_VFOA || current_vfo == S_MAIN) { frame[6] = widthA; }
+                else { frame[6] = widthB; }
 
-            frame[7] = 0xfd;
-            n = write(fd, frame, 8);
+                frame[7] = 0xfd;
+                n = write(fd, frame, 8);
 
-            if (n <= 0) { fprintf(stderr, "%s(%d) write error %s\n", __func__, __LINE__, strerror(errno)); }
+                if (n <= 0) { fprintf(stderr, "%s(%d) write error %s\n", __func__, __LINE__, strerror(errno)); }
 
+            }
+            else
+            {
+                if (current_vfo == S_VFOA || current_vfo == S_MAIN) { widthA = frame[6]; }
+                else { widthB = frame[6]; }
+                n = acknak(fd, frame, ACK);
+            }
             break;
 
         case 0x04: // AGC TIME
@@ -476,9 +470,7 @@ void frameParse(int fd, unsigned char *frame, int len)
             {
                 printf("AGC_TIME RESPONSE******************************");
                 agc_time = frame[6];
-                frame[4] = 0xfb;
-                frame[5] = 0xfd;
-                n = write(fd, frame, 6);
+                n = acknak(fd, frame, ACK);
 
                 if (n <= 0) { fprintf(stderr, "%s(%d) write error %s\n", __func__, __LINE__, strerror(errno)); }
             }
@@ -499,9 +491,7 @@ void frameParse(int fd, unsigned char *frame, int len)
                     break;
                 }
 
-                frame[4] = 0xfb;
-                frame[5] = 0xfd;
-                n = write(fd, frame, 6);
+                n = acknak(fd, frame, ACK);
 
                 if (n <= 0) { fprintf(stderr, "%s(%d) write error %s\n", __func__, __LINE__, strerror(errno)); }
             }
@@ -553,9 +543,10 @@ case 0x1c:
 #ifdef X25
 
 case 0x25:
+    target_vfo = frame[5] ^ current_vfo;
     if (frame[6] == 0xfd)
     {
-        if (frame[5] == 0x00)
+        if (target_vfo == 0x00)
         {
             to_bcd(&frame[6], (long long)freqA, (civ_731_mode ? 4 : 5) * 2);
             printf("X25 get_freqA=%.0f\n", freqA);
@@ -597,12 +588,10 @@ case 0x25:
         freq = from_bcd(&frame[6], (civ_731_mode ? 4 : 5) * 2);
         printf("set_freq to %.0f\n", freq);
 
-        if (frame[5] == 0x00) { freqA = freq; }
+        if (target_vfo == 0x00) { freqA = freq; }
         else { freqB = freq; }
 
-        frame[4] = 0xfb;
-        frame[5] = 0xfd;
-        n = write(fd, frame, 6);
+        n = acknak(fd, frame, ACK);
 
         if (n <= 0) { fprintf(stderr, "%s(%d) write error %s\n", __func__, __LINE__, strerror(errno)); }
 
@@ -627,50 +616,43 @@ case 0x25:
     break;
 
 case 0x26:
-    for (int i = 0; i < 6; ++i) { printf("%02x:", frame[i]); }
-
+    target_vfo = frame[5] ^ current_vfo;
     if (frame[6] == 0xfd) // then a query
     {
-        for (int i = 0; i < 6; ++i) { printf("%02x:", frame[i]); }
-
-        frame[6] = frame[5] == 0 ? modeA : modeB;
-        frame[7] = frame[5] == 0 ? datamodeA : datamodeB;
-        frame[8] = 0xfd;
-        n = write(fd, frame, 9);
+        frame[6] = target_vfo == 0 ? modeA : modeB;
+        frame[7] = target_vfo == 0 ? datamodeA : datamodeB;
+        frame[8] = target_vfo == 0 ? filterA : filterB;
+        frame[9] = 0xfd;
+        n = write(fd, frame, 10);
 
         if (n <= 0) { fprintf(stderr, "%s(%d) write error %s\n", __func__, __LINE__, strerror(errno)); }
     }
     else
     {
-        for (int i = 0; i < 12; ++i) { printf("%02x:", frame[i]); }
-
-        if (frame[6] == 0)
+        if (target_vfo == 0)
         {
-            modeA = frame[7];
-            datamodeA = frame[8];
+            modeA = frame[6];
+            datamodeA = frame[7];
+            filterA = frame[8];
         }
         else
         {
-            modeB = frame[7];
-            datamodeB = frame[8];
+            modeB = frame[6];
+            datamodeB = frame[7];
+            filterB = frame[8];
         }
 
-        frame[4] = 0xfb;
-        frame[5] = 0xfd;
-        n = write(fd, frame, 6);
+        n = acknak(fd, frame, ACK);
 
         if (n <= 0) { fprintf(stderr, "%s(%d) write error %s\n", __func__, __LINE__, strerror(errno)); }
     }
 
-    printf("\n");
     break;
 #else
 
 case 0x25:
     printf("x25 send nak\n");
-    frame[4] = 0xfa;
-    frame[5] = 0xfd;
-    n = write(fd, frame, 6);
+    n = acknak(fd, frame, NAK);
 
     if (n <= 0) { fprintf(stderr, "%s(%d) write error %s\n", __func__, __LINE__, strerror(errno)); }
 
@@ -678,9 +660,7 @@ case 0x25:
 
 case 0x26:
     printf("x26 send nak\n");
-    frame[4] = 0xfa;
-    frame[5] = 0xfd;
-    n = write(fd, frame, 6);
+    n = acknak(fd, frame, NAK);
 
     if (n <= 0) { fprintf(stderr, "%s(%d) write error %s\n", __func__, __LINE__, strerror(errno)); }
 
@@ -698,13 +678,13 @@ if (n == 0) { printf("Write failed=%s\n", strerror(errno)); }
 
 void rigStatus()
 {
-char vfoa = current_vfo == RIG_VFO_A ? '*' : ' ';
-char vfob = current_vfo == RIG_VFO_B ? '*' : ' ';
-printf("%cVFOA: mode=%d datamode=%d width=%ld freq=%.0f\n", vfoa, modeA,
+char vfoa = current_vfo == S_VFOA ? '*' : ' ';
+char vfob = current_vfo == S_VFOB ? '*' : ' ';
+printf("%cVFOA: mode=%s datamode=%d width=%02x freq=%.0f\n", vfoa, mode_names[modeA],
        datamodeA,
        widthA,
        freqA);
-printf("%cVFOB: mode=%d datamode=%d width=%ld freq=%.0f\n", vfob, modeB,
+printf("%cVFOB: mode=%s datamode=%d width=%02x freq=%.0f\n", vfob, mode_names[modeB],
        datamodeB,
        widthB,
        freqB);

--- a/simulators/simts890.c
+++ b/simulators/simts890.c
@@ -1466,9 +1466,9 @@ int main(int argc, char *argv[])
  */
 static int freq2band(int freq)
 {
-    int i, retval = -1;  // Assume the worst
+    int retval = -1;  // Assume the worst
 
-    for (i = 0; i < NBANDS; i++)
+    for (int i = 0; i < NBANDS; i++)
     {
         if (freq >= band_limits[i].low && freq <= band_limits[i].high)
         {

--- a/src/ext.c
+++ b/src/ext.c
@@ -46,7 +46,6 @@
 static int rig_has_ext_token(RIG *rig, hamlib_token_t token)
 {
     const int *ext_tokens = rig->caps->ext_tokens;
-    int i;
 
     if (ext_tokens == NULL)
     {
@@ -55,7 +54,7 @@ static int rig_has_ext_token(RIG *rig, hamlib_token_t token)
         return 1;
     }
 
-    for (i = 0; ext_tokens[i] != TOK_BACKEND_NONE; i++)
+    for (int i = 0; ext_tokens[i] != TOK_BACKEND_NONE; i++)
     {
         if (ext_tokens[i] == token)
         {

--- a/src/iofunc.c
+++ b/src/iofunc.c
@@ -610,7 +610,6 @@ static ssize_t port_read_generic(hamlib_port_t *p, void *buf, size_t count,
                                  int direct)
 {
     int fd = p->fd;
-    int i;
     ssize_t bytes_read;
 
     if (!direct)
@@ -638,7 +637,7 @@ static ssize_t port_read_generic(hamlib_port_t *p, void *buf, size_t count,
             unsigned char *pbuf = buf;
 
             /* clear MSB */
-            for (i = 0; i < bytes_read; i++)
+            for (int i = 0; i < bytes_read; i++)
             {
                 pbuf[i] &= ~0x80;
             }
@@ -817,9 +816,7 @@ static ssize_t port_read_generic(hamlib_port_t *p, void *buf, size_t count,
         ssize_t ret = read(fd, buf, count);
 
         /* clear MSB */
-        ssize_t i;
-
-        for (i = 0; i < ret; i++)
+        for (ssize_t i = 0; i < ret; i++)
         {
             pbuf[i] &= ~0x80;
         }
@@ -1101,9 +1098,7 @@ int HAMLIB_API write_block(hamlib_port_t *p, const unsigned char *txbuffer,
 
     if (p->write_delay > 0)
     {
-        int i;
-
-        for (i = 0; i < count; i++)
+        for (int i = 0; i < count; i++)
         {
             ret = port_write(p, txbuffer + i, 1);
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -193,7 +193,6 @@ unsigned char *HAMLIB_API to_bcd(unsigned char bcd_data[],
 unsigned long long HAMLIB_API from_bcd(const unsigned char bcd_data[],
                                        unsigned bcd_len)
 {
-    int i;
     freq_t f = 0;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
@@ -203,7 +202,7 @@ unsigned long long HAMLIB_API from_bcd(const unsigned char bcd_data[],
         f = bcd_data[bcd_len / 2] & 0x0f;
     }
 
-    for (i = (bcd_len / 2) - 1; i >= 0; i--)
+    for (int i = (bcd_len / 2) - 1; i >= 0; i--)
     {
         f *= 10;
         f += bcd_data[i] >> 4;
@@ -231,8 +230,6 @@ unsigned char *HAMLIB_API to_bcd_be(unsigned char bcd_data[],
                                     unsigned long long freq,
                                     unsigned bcd_len)
 {
-    int i;
-
     /* '450'/4 -> 0,4;5,0 */
     /* '450'/3 -> 4,5;0,x */
 
@@ -246,7 +243,7 @@ unsigned char *HAMLIB_API to_bcd_be(unsigned char bcd_data[],
         freq /= 10;
     }
 
-    for (i = (bcd_len / 2) - 1; i >= 0; i--)
+    for (int i = (bcd_len / 2) - 1; i >= 0; i--)
     {
         unsigned char a = freq % 10;
         freq /= 10;
@@ -273,12 +270,11 @@ unsigned char *HAMLIB_API to_bcd_be(unsigned char bcd_data[],
 unsigned long long HAMLIB_API from_bcd_be(const unsigned char bcd_data[],
         unsigned bcd_len)
 {
-    int i;
     freq_t f = 0;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    for (i = 0; i < bcd_len / 2; i++)
+    for (int i = 0; i < bcd_len / 2; i++)
     {
         f *= 10;
         f += bcd_data[i] >> 4;
@@ -522,11 +518,9 @@ static const struct
  */
 rmode_t HAMLIB_API rig_parse_mode(const char *s)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    for (i = 0 ; (s != NULL) && (mode_str[i].str[0] != '\0'); i++)
+    for (int i = 0 ; (s != NULL) && (mode_str[i].str[0] != '\0'); i++)
     {
         if (!strcmp(s, mode_str[i].str))
         {
@@ -549,8 +543,6 @@ rmode_t HAMLIB_API rig_parse_mode(const char *s)
  */
 const char *HAMLIB_API rig_strrmode(rmode_t mode)
 {
-    int i;
-
     // only enable if needed for debugging -- too verbose otherwise
     //rig_debug(RIG_DEBUG_TRACE, "%s called mode=0x%"PRXll"\n", __func__, mode);
 
@@ -559,7 +551,7 @@ const char *HAMLIB_API rig_strrmode(rmode_t mode)
         return "";
     }
 
-    for (i = 0 ; mode_str[i].str[0] != '\0'; i++)
+    for (int i = 0 ; mode_str[i].str[0] != '\0'; i++)
     {
         if (mode == mode_str[i].mode)
         {
@@ -581,8 +573,6 @@ const char *HAMLIB_API rig_strrmode(rmode_t mode)
  */
 int HAMLIB_API rig_strrmodes(rmode_t modes, char *buf, int buflen)
 {
-    int i;
-
     // only enable if needed for debugging -- too verbose otherwise
     //rig_debug(RIG_DEBUG_TRACE, "%s called mode=0x%"PRXll"\n", __func__, mode);
 
@@ -592,7 +582,7 @@ int HAMLIB_API rig_strrmodes(rmode_t modes, char *buf, int buflen)
         return RIG_OK;
     }
 
-    for (i = 0 ; mode_str[i].str[0] != '\0'; i++)
+    for (int i = 0 ; mode_str[i].str[0] != '\0'; i++)
     {
         if (modes & mode_str[i].mode)
         {
@@ -650,11 +640,9 @@ static const struct
  */
 vfo_t HAMLIB_API rig_parse_vfo(const char *s)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    for (i = 0 ; vfo_str[i].str[0] != '\0'; i++)
+    for (int i = 0 ; vfo_str[i].str[0] != '\0'; i++)
     {
         if (!strcmp(s, vfo_str[i].str))
         {
@@ -679,12 +667,10 @@ vfo_t HAMLIB_API rig_parse_vfo(const char *s)
  */
 const char *HAMLIB_API rig_strvfo(vfo_t vfo)
 {
-    int i;
-
     //a bit too verbose
     //rig_debug(RIG_DEBUG_TRACE, "%s called\n", __func__);
 
-    for (i = 0 ; vfo_str[i].str[0] != '\0'; i++)
+    for (int i = 0 ; vfo_str[i].str[0] != '\0'; i++)
     {
         if (vfo == vfo_str[i].vfo)
         {
@@ -833,11 +819,9 @@ uint64_t rig_idx2setting(int i)
  */
 int HAMLIB_API rig_bit2idx(uint64_t v)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    for (i = 0; i < 64; i++)
+    for (int i = 0; i < 64; i++)
     {
         if (v & rig_idx2setting(i))
         {
@@ -858,11 +842,9 @@ int HAMLIB_API rig_bit2idx(uint64_t v)
  */
 setting_t HAMLIB_API rig_parse_func(const char *s)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    for (i = 0 ; rig_func_str[i].str[0] != '\0'; i++)
+    for (int i = 0 ; rig_func_str[i].str[0] != '\0'; i++)
     {
         if (!strcmp(s, rig_func_str[i].str))
         {
@@ -883,11 +865,9 @@ setting_t HAMLIB_API rig_parse_func(const char *s)
 // cppcheck-suppress unusedFunction
 setting_t HAMLIB_API rig_parse_band(const char *s)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    for (i = 0 ; rig_bandselect_str[i].str != NULL; i++)
+    for (int i = 0 ; rig_bandselect_str[i].str != NULL; i++)
     {
         if (!strcmp(s, rig_bandselect_str[i].str))
         {
@@ -909,11 +889,9 @@ setting_t HAMLIB_API rig_parse_band(const char *s)
  */
 setting_t HAMLIB_API rot_parse_func(const char *s)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    for (i = 0 ; rot_func_str[i].str[0] != '\0'; i++)
+    for (int i = 0 ; rot_func_str[i].str[0] != '\0'; i++)
     {
         if (!strcmp(s, rot_func_str[i].str))
         {
@@ -934,11 +912,9 @@ setting_t HAMLIB_API rot_parse_func(const char *s)
  */
 setting_t HAMLIB_API amp_parse_func(const char *s)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    for (i = 0 ; amp_func_str[i].str[0] != '\0'; i++)
+    for (int i = 0 ; amp_func_str[i].str[0] != '\0'; i++)
     {
         if (!strcmp(s, amp_func_str[i].str))
         {
@@ -959,8 +935,6 @@ setting_t HAMLIB_API amp_parse_func(const char *s)
  */
 const char *HAMLIB_API rig_strfunc(setting_t func)
 {
-    int i;
-
     // too verbose to keep on unless debugging this in particular
     //rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
@@ -969,7 +943,7 @@ const char *HAMLIB_API rig_strfunc(setting_t func)
         return "";
     }
 
-    for (i = 0; rig_func_str[i].str[0] != '\0'; i++)
+    for (int i = 0; rig_func_str[i].str[0] != '\0'; i++)
     {
         if (func == rig_func_str[i].func)
         {
@@ -990,8 +964,6 @@ const char *HAMLIB_API rig_strfunc(setting_t func)
  */
 const char *HAMLIB_API rot_strfunc(setting_t func)
 {
-    int i;
-
     // too verbose to keep on unless debugging this in particular
     //rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
@@ -1000,7 +972,7 @@ const char *HAMLIB_API rot_strfunc(setting_t func)
         return "";
     }
 
-    for (i = 0; rot_func_str[i].str[0] != '\0'; i++)
+    for (int i = 0; rot_func_str[i].str[0] != '\0'; i++)
     {
         if (func == rot_func_str[i].func)
         {
@@ -1021,8 +993,6 @@ const char *HAMLIB_API rot_strfunc(setting_t func)
  */
 const char *HAMLIB_API amp_strfunc(setting_t func)
 {
-    int i;
-
     // too verbose to keep on unless debugging this in particular
     //rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
@@ -1031,7 +1001,7 @@ const char *HAMLIB_API amp_strfunc(setting_t func)
         return "";
     }
 
-    for (i = 0; amp_func_str[i].str[0] != '\0'; i++)
+    for (int i = 0; amp_func_str[i].str[0] != '\0'; i++)
     {
         if (func == amp_func_str[i].func)
         {
@@ -1210,11 +1180,9 @@ int check_level_param(RIG *rig, setting_t level, value_t val, gran_t **gran)
  */
 setting_t HAMLIB_API rig_parse_level(const char *s)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    for (i = 0 ; rig_level_str[i].str[0] != '\0'; i++)
+    for (int i = 0 ; rig_level_str[i].str[0] != '\0'; i++)
     {
         if (!strcmp(s, rig_level_str[i].str))
         {
@@ -1235,11 +1203,9 @@ setting_t HAMLIB_API rig_parse_level(const char *s)
  */
 setting_t HAMLIB_API rot_parse_level(const char *s)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    for (i = 0 ; rot_level_str[i].str[0] != '\0'; i++)
+    for (int i = 0 ; rot_level_str[i].str[0] != '\0'; i++)
     {
         if (!strcmp(s, rot_level_str[i].str))
         {
@@ -1260,14 +1226,10 @@ setting_t HAMLIB_API rot_parse_level(const char *s)
  */
 setting_t HAMLIB_API amp_parse_level(const char *s)
 {
-    int i;
-
-    rig_debug(RIG_DEBUG_VERBOSE, "%s called level=%s\n", __func__, s);
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called str=%s\n", __func__,
               amp_level_str[0].str);
 
-    for (i = 0 ; amp_level_str[i].str[0] != '\0'; i++)
+    for (int i = 0 ; amp_level_str[i].str[0] != '\0'; i++)
     {
         rig_debug(RIG_DEBUG_VERBOSE, "%s called checking=%s\n", __func__,
                   amp_level_str[i].str);
@@ -1291,8 +1253,6 @@ setting_t HAMLIB_API amp_parse_level(const char *s)
  */
 const char *HAMLIB_API rig_strlevel(setting_t level)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_CACHE, "%s called\n", __func__);
 
     if (level == RIG_LEVEL_NONE)
@@ -1300,7 +1260,7 @@ const char *HAMLIB_API rig_strlevel(setting_t level)
         return "";
     }
 
-    for (i = 0; rig_level_str[i].str[0] != '\0'; i++)
+    for (int i = 0; rig_level_str[i].str[0] != '\0'; i++)
     {
         if (level == rig_level_str[i].level)
         {
@@ -1321,8 +1281,6 @@ const char *HAMLIB_API rig_strlevel(setting_t level)
  */
 const char *HAMLIB_API rot_strlevel(setting_t level)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
     if (level == ROT_LEVEL_NONE)
@@ -1330,7 +1288,7 @@ const char *HAMLIB_API rot_strlevel(setting_t level)
         return "";
     }
 
-    for (i = 0; rot_level_str[i].str[0] != '\0'; i++)
+    for (int i = 0; rot_level_str[i].str[0] != '\0'; i++)
     {
         if (level == rot_level_str[i].level)
         {
@@ -1351,8 +1309,6 @@ const char *HAMLIB_API rot_strlevel(setting_t level)
  */
 const char *HAMLIB_API amp_strlevel(setting_t level)
 {
-    int i;
-
     //rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
     if (level == AMP_LEVEL_NONE)
@@ -1360,7 +1316,7 @@ const char *HAMLIB_API amp_strlevel(setting_t level)
         return "";
     }
 
-    for (i = 0; amp_level_str[i].str[0] != '\0'; i++)
+    for (int i = 0; amp_level_str[i].str[0] != '\0'; i++)
     {
         if (level == amp_level_str[i].level)
         {
@@ -1427,11 +1383,9 @@ static const struct
  */
 setting_t HAMLIB_API rig_parse_parm(const char *s)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    for (i = 0 ; rig_parm_str[i].str[0] != '\0'; i++)
+    for (int i = 0 ; rig_parm_str[i].str[0] != '\0'; i++)
     {
         if (!strcmp(s, rig_parm_str[i].str))
         {
@@ -1452,11 +1406,9 @@ setting_t HAMLIB_API rig_parse_parm(const char *s)
  */
 setting_t HAMLIB_API rot_parse_parm(const char *s)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    for (i = 0 ; rot_parm_str[i].str[0] != '\0'; i++)
+    for (int i = 0 ; rot_parm_str[i].str[0] != '\0'; i++)
     {
         if (!strcmp(s, rot_parm_str[i].str))
         {
@@ -1477,11 +1429,9 @@ setting_t HAMLIB_API rot_parse_parm(const char *s)
  */
 setting_t HAMLIB_API amp_parse_parm(const char *s)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    for (i = 0 ; amp_parm_str[i].str[0] != '\0'; i++)
+    for (int i = 0 ; amp_parm_str[i].str[0] != '\0'; i++)
     {
         if (!strcmp(s, amp_parm_str[i].str))
         {
@@ -1502,8 +1452,6 @@ setting_t HAMLIB_API amp_parse_parm(const char *s)
  */
 const char *HAMLIB_API rig_strparm(setting_t parm)
 {
-    int i;
-
 //    rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
     if (parm == RIG_PARM_NONE)
@@ -1511,7 +1459,7 @@ const char *HAMLIB_API rig_strparm(setting_t parm)
         return "";
     }
 
-    for (i = 0; rig_parm_str[i].str[0] != '\0'; i++)
+    for (int i = 0; rig_parm_str[i].str[0] != '\0'; i++)
     {
         if (parm == rig_parm_str[i].parm)
         {
@@ -1532,8 +1480,6 @@ const char *HAMLIB_API rig_strparm(setting_t parm)
  */
 const char *HAMLIB_API rot_strparm(setting_t parm)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
     if (parm == ROT_PARM_NONE)
@@ -1541,7 +1487,7 @@ const char *HAMLIB_API rot_strparm(setting_t parm)
         return "";
     }
 
-    for (i = 0; rot_parm_str[i].str[0] != '\0'; i++)
+    for (int i = 0; rot_parm_str[i].str[0] != '\0'; i++)
     {
         if (parm == rot_parm_str[i].parm)
         {
@@ -1562,8 +1508,6 @@ const char *HAMLIB_API rot_strparm(setting_t parm)
  */
 const char *HAMLIB_API amp_strparm(setting_t parm)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
     if (parm == AMP_PARM_NONE)
@@ -1571,7 +1515,7 @@ const char *HAMLIB_API amp_strparm(setting_t parm)
         return "";
     }
 
-    for (i = 0; amp_parm_str[i].str[0] != '\0'; i++)
+    for (int i = 0; amp_parm_str[i].str[0] != '\0'; i++)
     {
         if (parm == amp_parm_str[i].parm)
         {
@@ -1609,14 +1553,12 @@ static const struct
  */
 const char *HAMLIB_API rig_stragclevel(enum agc_level_e level)
 {
-    int i;
-
     if (level < 0)
     {
         return "";
     }
 
-    for (i = 0; rig_agc_level_str[i].str[0] != '\0'; i++)
+    for (int i = 0; rig_agc_level_str[i].str[0] != '\0'; i++)
     {
         if (level == rig_agc_level_str[i].level)
         {
@@ -1731,11 +1673,9 @@ static const struct
  */
 vfo_op_t HAMLIB_API rig_parse_vfo_op(const char *s)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    for (i = 0 ; vfo_op_str[i].str[0] != '\0'; i++)
+    for (int i = 0 ; vfo_op_str[i].str[0] != '\0'; i++)
     {
         if (!strcmp(s, vfo_op_str[i].str))
         {
@@ -1756,12 +1696,10 @@ vfo_op_t HAMLIB_API rig_parse_vfo_op(const char *s)
  */
 const char *HAMLIB_API rig_strvfop(vfo_op_t op)
 {
-    int i;
-
 // too verbose
 //    rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    for (i = 0; vfo_op_str[i].str[0] != '\0'; i++)
+    for (int i = 0; vfo_op_str[i].str[0] != '\0'; i++)
     {
         if (op == vfo_op_str[i].vfo_op)
         {
@@ -1801,11 +1739,9 @@ static const struct
  */
 scan_t HAMLIB_API rig_parse_scan(const char *s)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    for (i = 0 ; scan_str[i].str[0] != '\0'; i++)
+    for (int i = 0 ; scan_str[i].str[0] != '\0'; i++)
     {
         if (strcmp(s, scan_str[i].str) == 0)
         {
@@ -1826,8 +1762,6 @@ scan_t HAMLIB_API rig_parse_scan(const char *s)
  */
 const char *HAMLIB_API rig_strscan(scan_t rscan)
 {
-    int i;
-
 // too verbose
 //    rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
@@ -1836,7 +1770,7 @@ const char *HAMLIB_API rig_strscan(scan_t rscan)
         return "";
     }
 
-    for (i = 0; scan_str[i].str[0] != '\0'; i++)
+    for (int i = 0; scan_str[i].str[0] != '\0'; i++)
     {
         if (rscan == scan_str[i].rscan)
         {
@@ -1926,11 +1860,9 @@ static const struct
  */
 chan_type_t HAMLIB_API rig_parse_mtype(const char *s)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    for (i = 0 ; mtype_str[i].str[0] != '\0'; i++)
+    for (int i = 0 ; mtype_str[i].str[0] != '\0'; i++)
     {
         if (strcmp(s, mtype_str[i].str) == 0)
         {
@@ -1951,8 +1883,6 @@ chan_type_t HAMLIB_API rig_parse_mtype(const char *s)
  */
 const char *HAMLIB_API rig_strmtype(chan_type_t mtype)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
     if (mtype == RIG_MTYPE_NONE)
@@ -1960,7 +1890,7 @@ const char *HAMLIB_API rig_strmtype(chan_type_t mtype)
         return "";
     }
 
-    for (i = 0; mtype_str[i].str[0] != '\0'; i++)
+    for (int i = 0; mtype_str[i].str[0] != '\0'; i++)
     {
         if (mtype == mtype_str[i].mtype)
         {
@@ -1991,14 +1921,12 @@ static const struct
  */
 const char *HAMLIB_API rig_strspectrummode(enum rig_spectrum_mode_e mode)
 {
-    int i;
-
     if (mode == RIG_SPECTRUM_MODE_NONE)
     {
         return "";
     }
 
-    for (i = 0; rig_spectrum_mode_str[i].str[0] != '\0'; i++)
+    for (int i = 0; rig_spectrum_mode_str[i].str[0] != '\0'; i++)
     {
         if (mode == rig_spectrum_mode_str[i].mode)
         {
@@ -2508,9 +2436,7 @@ static const struct
  */
 const char *HAMLIB_API rot_strstatus(rot_status_t status)
 {
-    int i;
-
-    for (i = 0 ; rot_status_str[i].str[0] != '\0'; i++)
+    for (int i = 0 ; rot_status_str[i].str[0] != '\0'; i++)
     {
         if (status == rot_status_str[i].status)
         {
@@ -2555,9 +2481,7 @@ static const struct
  */
 const char *HAMLIB_API amp_strstatus(amp_status_t status)
 {
-    int i;
-
-    for (i = 0 ; amp_status_str[i].str[0] != '\0'; i++)
+    for (int i = 0 ; amp_status_str[i].str[0] != '\0'; i++)
     {
         if (status == amp_status_str[i].status)
         {
@@ -2595,11 +2519,9 @@ static const struct
  */
 amp_op_t HAMLIB_API amp_parse_amp_op(const char *s)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    for (i = 0 ; amp_op_str[i].str[0] != '\0'; i++)
+    for (int i = 0 ; amp_op_str[i].str[0] != '\0'; i++)
     {
         if (!strcmp(s, amp_op_str[i].str))
         {
@@ -2620,9 +2542,7 @@ amp_op_t HAMLIB_API amp_parse_amp_op(const char *s)
  */
 const char *HAMLIB_API amp_strampop(amp_op_t op)
 {
-    int i;
-
-    for (i = 0; amp_op_str[i].str[0] != '\0'; i++)
+    for (int i = 0; amp_op_str[i].str[0] != '\0'; i++)
     {
         if (op == amp_op_str[i].amp_op)
         {
@@ -3036,9 +2956,7 @@ static const struct
  */
 const char *HAMLIB_API rig_strcommstatus(rig_comm_status_t status)
 {
-    int i;
-
-    for (i = 0; comm_status_str[i].str[0] != '\0'; i++)
+    for (int i = 0; comm_status_str[i].str[0] != '\0'; i++)
     {
         if (status == comm_status_str[i].status)
         {
@@ -3226,8 +3144,6 @@ const char *rig_get_band_str(RIG *rig, hamlib_band_t band, int which)
 // returns the rig's backend hamlib_band_t that can used to lookup the band str
 hamlib_band_t rig_get_band(RIG *rig, freq_t freq, int band)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
     if (freq == 0)
@@ -3260,7 +3176,7 @@ hamlib_band_t rig_get_band(RIG *rig, freq_t freq, int band)
         return RIG_BAND_UNUSED;
     }
 
-    for (i = 0 ; rig_bandselect_str[i].str != NULL; i++)
+    for (int i = 0 ; rig_bandselect_str[i].str != NULL; i++)
     {
         if (freq >= rig_bandselect_str[i].start && freq <= rig_bandselect_str[i].stop)
         {
@@ -3275,7 +3191,6 @@ hamlib_band_t rig_get_band(RIG *rig, freq_t freq, int band)
 int rig_get_band_rig(RIG *rig, freq_t freq, const char *band)
 {
     char bandlist[512];
-    int i;
 
     if (freq == 0 && band == NULL)
     {
@@ -3320,7 +3235,7 @@ int rig_get_band_rig(RIG *rig, freq_t freq, const char *band)
         return 0;
     }
 
-    for (i = 0 ; rig_bandselect_str[i].str != NULL; i++)
+    for (int i = 0 ; rig_bandselect_str[i].str != NULL; i++)
     {
         if (freq >= rig_bandselect_str[i].start && freq <= rig_bandselect_str[i].stop)
         {

--- a/src/misc.c
+++ b/src/misc.c
@@ -294,7 +294,6 @@ unsigned long long HAMLIB_API from_bcd_be(const unsigned char bcd_data[],
 size_t HAMLIB_API to_hex(size_t source_length, const unsigned char *source_data,
                          size_t dest_length, char *dest_data)
 {
-    size_t i;
     size_t length = source_length;
     const unsigned char *source = source_data;
     char *dest = dest_data;
@@ -309,7 +308,7 @@ size_t HAMLIB_API to_hex(size_t source_length, const unsigned char *source_data,
         length = dest_length / 2 - 1;
     }
 
-    for (i = 0; i < length; i++)
+    for (size_t i = 0; i < length; i++)
     {
         SNPRINTF(dest, dest_length - 2 * i, "%02X", source[0]);
         source++;
@@ -2978,7 +2977,6 @@ uint32_t CRC32_function(const uint8_t *buf, uint32_t len)
 {
 
     uint32_t crc;
-    uint8_t i;
 
     crc = 0xFFFFFFFF;
 
@@ -2987,7 +2985,7 @@ uint32_t CRC32_function(const uint8_t *buf, uint32_t len)
         uint32_t val;
         val = (crc^*buf++) & 0xFF;
 
-        for (i = 0; i < 8; i++)
+        for (uint8_t i = 0; i < 8; i++)
         {
             val = val & 1 ? (val >> 1) ^ 0xEDB88320 : val >> 1;
         }

--- a/src/register.c
+++ b/src/register.c
@@ -271,9 +271,7 @@ struct rig_caps *HAMLIB_API rig_get_caps(rig_model_t rig_model)
 //! @cond Doxygen_Suppress
 static int rig_lookup_backend(rig_model_t rig_model)
 {
-    int i;
-
-    for (i = 0; i < RIG_BACKEND_MAX && rig_backend_list[i].be_name; i++)
+    for (int i = 0; i < RIG_BACKEND_MAX && rig_backend_list[i].be_name; i++)
     {
         if (RIG_BACKEND_NUM(rig_model) ==
                 rig_backend_list[i].be_num)
@@ -403,14 +401,13 @@ int HAMLIB_API rig_list_foreach(int (*cfunc)(const struct rig_caps *,
                                 rig_ptr_t data)
 {
     struct rig_list *p;
-    int i;
 
     if (!cfunc)
     {
         return -RIG_EINVAL;
     }
 
-    for (i = 0; i < RIGLSTHASHSZ; i++)
+    for (int i = 0; i < RIGLSTHASHSZ; i++)
     {
         struct rig_list *next = NULL;
 
@@ -439,14 +436,13 @@ int HAMLIB_API rig_list_foreach_model(int (*cfunc)(const rig_model_t rig_model,
                                       rig_ptr_t data)
 {
     struct rig_list *p;
-    int i;
 
     if (!cfunc)
     {
         return -RIG_EINVAL;
     }
 
-    for (i = 0; i < RIGLSTHASHSZ; i++)
+    for (int i = 0; i < RIGLSTHASHSZ; i++)
     {
         struct rig_list *next = NULL;
 
@@ -484,10 +480,9 @@ static int dummy_rig_probe(const hamlib_port_t *p,
 //! @cond Doxygen_Suppress
 rig_model_t rig_probe_first(hamlib_port_t *p)
 {
-    int i;
     rig_model_t model;
 
-    for (i = 0; i < RIG_BACKEND_MAX && rig_backend_list[i].be_name; i++)
+    for (int i = 0; i < RIG_BACKEND_MAX && rig_backend_list[i].be_name; i++)
     {
         if (rig_backend_list[i].be_probe_all)
         {
@@ -516,9 +511,7 @@ int rig_probe_all_backends(hamlib_port_t *p,
                            rig_probe_func_t cfunc,
                            rig_ptr_t data)
 {
-    int i;
-
-    for (i = 0; i < RIG_BACKEND_MAX && rig_backend_list[i].be_name; i++)
+    for (int i = 0; i < RIG_BACKEND_MAX && rig_backend_list[i].be_name; i++)
     {
         if (rig_backend_list[i].be_probe_all)
         {
@@ -534,11 +527,9 @@ int rig_probe_all_backends(hamlib_port_t *p,
 //! @cond Doxygen_Suppress
 int rig_load_all_backends()
 {
-    int i;
-
     memset(rig_hash_table, 0, sizeof(rig_hash_table));
 
-    for (i = 0; i < RIG_BACKEND_MAX && rig_backend_list[i].be_name; i++)
+    for (int i = 0; i < RIG_BACKEND_MAX && rig_backend_list[i].be_name; i++)
     {
         rig_load_backend(rig_backend_list[i].be_name);
     }
@@ -559,10 +550,9 @@ typedef int (*backend_init_t)(rig_ptr_t);
 //! @cond Doxygen_Suppress
 int HAMLIB_API rig_load_backend(const char *be_name)
 {
-    int i;
     backend_init_t be_init;
 
-    for (i = 0; i < RIG_BACKEND_MAX && rig_backend_list[i].be_name; i++)
+    for (int i = 0; i < RIG_BACKEND_MAX && rig_backend_list[i].be_name; i++)
     {
         if (!strcmp(be_name, rig_backend_list[i].be_name))
         {

--- a/src/rig.c
+++ b/src/rig.c
@@ -3173,7 +3173,6 @@ int HAMLIB_API rig_get_mode(RIG *rig,
 pbwidth_t HAMLIB_API rig_passband_normal(RIG *rig, rmode_t mode)
 {
     const struct rig_state *rs;
-    int i;
 
     if (!rig)
     {
@@ -3190,7 +3189,7 @@ pbwidth_t HAMLIB_API rig_passband_normal(RIG *rig, rmode_t mode)
 
     if (mode == RIG_MODE_RTTYR) { mode = RIG_MODE_RTTY; }
 
-    for (i = 0; i < HAMLIB_FLTLSTSIZ && rs->filters[i].modes; i++)
+    for (int i = 0; i < HAMLIB_FLTLSTSIZ && rs->filters[i].modes; i++)
     {
         if (rs->filters[i].modes & mode)
         {
@@ -3225,7 +3224,6 @@ pbwidth_t HAMLIB_API rig_passband_narrow(RIG *rig, rmode_t mode)
 {
     const struct rig_state *rs;
     pbwidth_t normal;
-    int i;
 
     if (!rig)
     {
@@ -3237,7 +3235,7 @@ pbwidth_t HAMLIB_API rig_passband_narrow(RIG *rig, rmode_t mode)
 
     rs = STATE(rig);
 
-    for (i = 0; i < HAMLIB_FLTLSTSIZ - 1 && rs->filters[i].modes; i++)
+    for (int i = 0; i < HAMLIB_FLTLSTSIZ - 1 && rs->filters[i].modes; i++)
     {
         if (rs->filters[i].modes & mode)
         {
@@ -3278,7 +3276,6 @@ pbwidth_t HAMLIB_API rig_passband_wide(RIG *rig, rmode_t mode)
 {
     const struct rig_state *rs;
     pbwidth_t normal;
-    int i;
 
     if (!rig)
     {
@@ -3290,7 +3287,7 @@ pbwidth_t HAMLIB_API rig_passband_wide(RIG *rig, rmode_t mode)
 
     rs = STATE(rig);
 
-    for (i = 0; i < HAMLIB_FLTLSTSIZ - 1 && rs->filters[i].modes; i++)
+    for (int i = 0; i < HAMLIB_FLTLSTSIZ - 1 && rs->filters[i].modes; i++)
     {
         if (rs->filters[i].modes & mode)
         {
@@ -6813,7 +6810,6 @@ int HAMLIB_API rig_mW2power(RIG *rig,
 shortfreq_t HAMLIB_API rig_get_resolution(RIG *rig, rmode_t mode)
 {
     const struct rig_state *rs;
-    int i;
 
     if (!rig || !rig->caps || !mode)
     {
@@ -6825,7 +6821,7 @@ shortfreq_t HAMLIB_API rig_get_resolution(RIG *rig, rmode_t mode)
 
     rs = STATE(rig);
 
-    for (i = 0; i < HAMLIB_TSLSTSIZ && rs->tuning_steps[i].ts; i++)
+    for (int i = 0; i < HAMLIB_TSLSTSIZ && rs->tuning_steps[i].ts; i++)
     {
         if (rs->tuning_steps[i].modes & mode)
         {
@@ -7825,14 +7821,12 @@ const freq_range_t *HAMLIB_API rig_get_range(const freq_range_t *range_list,
         freq_t freq,
         rmode_t mode)
 {
-    int i;
-
     if (range_list == NULL)
     {
         return (NULL);
     }
 
-    for (i = 0; i < HAMLIB_FRQRANGESIZ; i++)
+    for (int i = 0; i < HAMLIB_FRQRANGESIZ; i++)
     {
         if (range_list[i].startf == 0 && range_list[i].endf == 0)
         {
@@ -7944,11 +7938,10 @@ static unsigned long crcTable[256];
 static unsigned long gen_crc(unsigned char *p, size_t n)
 {
     unsigned long crc = 0xfffffffful;
-    size_t i;
 
     if (crcTable[0] == 0) { make_crc_table(crcTable); }
 
-    for (i = 0; i < n; i++)
+    for (size_t i = 0; i < n; i++)
     {
         crc = crcTable[*p++ ^ (crc & 0xff)] ^ (crc >> 8);
     }

--- a/src/settings.c
+++ b/src/settings.c
@@ -981,11 +981,9 @@ int HAMLIB_API rig_get_ext_parm(RIG *rig, hamlib_token_t token, value_t *val)
  */
 int HAMLIB_API rig_setting2idx(setting_t s)
 {
-    int i;
-
     rig_debug(RIG_DEBUG_VERBOSE, "%s called\n", __func__);
 
-    for (i = 0; i < RIG_SETTING_MAX; i++)
+    for (int i = 0; i < RIG_SETTING_MAX; i++)
     {
         if (s & rig_idx2setting(i))
         {

--- a/tests/ampctl_parse.c
+++ b/tests/ampctl_parse.c
@@ -302,8 +302,6 @@ void hash_delete_all()
  */
 static void rp_getline(const char *s)
 {
-    int i;
-
     /* free allocated memory and set pointers to NULL */
     if (input_line)
     {
@@ -319,7 +317,7 @@ static void rp_getline(const char *s)
     /* cmd, arg1, arg2, arg3, arg4, arg5, arg6
      * arg5 and arg 6 are currently unused.
      */
-    for (i = 0; i < 7; i++)
+    for (int i = 0; i < 7; i++)
     {
         parsed_input[i] = NULL;
     }
@@ -334,9 +332,7 @@ static void rp_getline(const char *s)
  */
 char parse_arg(const char *arg)
 {
-    int i;
-
-    for (i = 0; test_list[i].cmd != 0; i++)
+    for (int i = 0; test_list[i].cmd != 0; i++)
     {
         if (!strncmp(arg, test_list[i].name, MAXNAMSIZ))
         {
@@ -1467,11 +1463,9 @@ void version()
 
 void usage_amp(FILE *fout)
 {
-    int i;
-
     fprintf(fout, "Commands (some may not be available for this amplifier):\n");
 
-    for (i = 0; test_list[i].cmd != 0; i++)
+    for (int i = 0; test_list[i].cmd != 0; i++)
     {
         int nbspaces;
         fprintf(fout,

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -518,8 +518,6 @@ static void strip_quotes(char *s)
  */
 static void rp_getline(const char *s)
 {
-    int i;
-
     /* free allocated memory and set pointers to NULL */
     if (input_line)
     {
@@ -532,7 +530,7 @@ static void rp_getline(const char *s)
         result = (char *)NULL;
     }
 
-    for (i = 0; i < 5; i++)
+    for (int i = 0; i < 5; i++)
     {
         parsed_input[i] = NULL;
     }
@@ -547,9 +545,7 @@ static void rp_getline(const char *s)
  */
 static char parse_arg(const char *arg)
 {
-    int i;
-
-    for (i = 0; test_list[i].cmd != 0x00; i++)
+    for (int i = 0; test_list[i].cmd != 0x00; i++)
     {
         if (!strncmp(arg, test_list[i].name, MAXNAMSIZ))
         {
@@ -1982,13 +1978,12 @@ declare_proto_rig(client_version)
 
 void usage_rig(FILE *fout)
 {
-    int i;
     int column = 1;
     int wrapped = 0;
 
     fprintf(fout, "Commands (some may not be available for this rig):\n");
 
-    for (i = 0; test_list[i].cmd != 0; i++)
+    for (int i = 0; test_list[i].cmd != 0; i++)
     {
         int nbspaces = 20; // longest arguments are 32 chars: "TX Frequency,TX Mode,TX Passband"
         fprintf(fout,
@@ -2046,7 +2041,6 @@ void usage_rig(FILE *fout)
 int print_conf_list(const struct confparams *cfp, rig_ptr_t data)
 {
     RIG *rig = (RIG *) data;
-    int i;
     char buf[128] = "";
 
     rig_get_conf2(rig, cfp->token, buf, sizeof(buf));
@@ -2080,7 +2074,7 @@ int print_conf_list(const struct confparams *cfp, rig_ptr_t data)
 
         printf("\tCombo: %s", cfp->u.c.combostr[0]);
 
-        for (i = 1 ; i < RIG_COMBO_MAX && cfp->u.c.combostr[i]; i++)
+        for (int i = 1 ; i < RIG_COMBO_MAX && cfp->u.c.combostr[i]; i++)
         {
             printf(", %s", cfp->u.c.combostr[i]);
         }
@@ -2577,7 +2571,6 @@ declare_proto_rig(test)
 declare_proto_rig(get_modes)
 {
     static char prntbuf[1024];
-    int i;
     char freqbuf[32];
 
     ENTERFUNC2;
@@ -2593,7 +2586,7 @@ declare_proto_rig(get_modes)
 
     fprintf(fout, "\nBandwidths:");
 
-    for (i = 1; i < RIG_MODE_TESTS_MAX; i <<= 1)
+    for (int i = 1; i < RIG_MODE_TESTS_MAX; i <<= 1)
     {
         pbwidth_t pbnorm = rig_passband_normal(rig, i);
 
@@ -2618,14 +2611,13 @@ declare_proto_rig(get_modes)
 
 declare_proto_rig(get_mode_bandwidths)
 {
-    int i;
     char freqbuf[32];
 
     ENTERFUNC2;
 
     rmode_t mode = rig_parse_mode(arg1);
 
-    for (i = 1; i < RIG_MODE_TESTS_MAX; i <<= 1)
+    for (int i = 1; i < RIG_MODE_TESTS_MAX; i <<= 1)
     {
         if (i != mode) { continue; }
 
@@ -5142,9 +5134,7 @@ declare_proto_rig(get_powerstat)
 
 static int hasbinary(char *s, int len)
 {
-    int i;
-
-    for (i = 0; i < len; ++i)
+    for (int i = 0; i < len; ++i)
     {
         if (!isascii(s[i])) { return (1); }
     }
@@ -5439,7 +5429,6 @@ declare_proto_rig(send_cmd)
 
         if (binary)   // convert our buf to a hex representation
         {
-            int i;
             char hex[8];
             int hexbufbytes = retval * 6;
             char *hexbuf = calloc(hexbufbytes, 1);
@@ -5447,7 +5436,7 @@ declare_proto_rig(send_cmd)
                       hexbufbytes);
             hexbuf[0] = 0;
 
-            for (i = 0; i < retval; ++i)
+            for (int i = 0; i < retval; ++i)
             {
                 SNPRINTF(hex, sizeof(hex), "\\0x%02X", (unsigned char)buf[i]);
 
@@ -5557,7 +5546,7 @@ declare_proto_rig(pause)
 static int rigctld_password_check(RIG *rig, const char *md5)
 {
     int retval;
-    int i, len, hits;
+    int len, hits = 0;
     char padded[HAMLIB_SECRET_LENGTH + 1];
     //fprintf(fout, "password %s\n", password);
     //rig_debug(RIG_DEBUG_TRACE, "%s: %s == %s\n", __func__, md5, rigctld_password);
@@ -5569,7 +5558,7 @@ static int rigctld_password_check(RIG *rig, const char *md5)
     padded[HAMLIB_SECRET_LENGTH] = '\0';     // Make sure it's a terminated string
 
     /* Brute force, constant time comparison */
-    for (i = hits = 0; i <= len; i++)
+    for (int i = 0; i <= len; i++)
     {
 	hits += (int)(padded[i] == mymd5[i]);
     }
@@ -6008,9 +5997,7 @@ declare_proto_rig(send_raw)
     }
     else if (is_binary)
     {
-        int i;
-
-        for (i = 0; i < reply_len; ++i)
+        for (int i = 0; i < reply_len; ++i)
         {
             fprintf(fout, "0x%02x ", buf[i]);
         }

--- a/tests/rotctl_parse.c
+++ b/tests/rotctl_parse.c
@@ -341,8 +341,6 @@ static void hash_delete_all()
  */
 static void rp_getline(const char *s)
 {
-    int i;
-
     /* free allocated memory and set pointers to NULL */
     if (input_line)
     {
@@ -358,7 +356,7 @@ static void rp_getline(const char *s)
     /* cmd, arg1, arg2, arg3, arg4, arg5, arg6
      * arg5 and arg 6 are currently unused.
      */
-    for (i = 0; i < 7; i++)
+    for (int i = 0; i < 7; i++)
     {
         parsed_input[i] = NULL;
     }
@@ -374,9 +372,7 @@ static void rp_getline(const char *s)
  */
 static char parse_arg(const char *arg)
 {
-    int i;
-
-    for (i = 0; test_list[i].cmd != 0; i++)
+    for (int i = 0; test_list[i].cmd != 0; i++)
     {
         if (!strncmp(arg, test_list[i].name, MAXNAMSIZ))
         {
@@ -1532,11 +1528,9 @@ void version()
 
 void usage_rot(FILE *fout)
 {
-    int i;
-
     fprintf(fout, "Commands (some may not be available for this rotator):\n");
 
-    for (i = 0; test_list[i].cmd != 0; i++)
+    for (int i = 0; test_list[i].cmd != 0; i++)
     {
         fprintf(fout,
                 "%c: %-12s(",


### PR DESCRIPTION
Reduce the scope or range of many variables

- Scope of iteration variables limited to the controlled loop
- Values of switch variables limited to true/false

General cleanup, removes distractions while reading code.

And then there is the fallout of trying to use a couple of simulators to observe the workings of the code - another session of trying to bring the Real World into simulators/*.c.

For master branch only