### PR TITLE
Rewrite AT-D578UVIII backend with dual-mode serial protocol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,25 @@ The radio exposes two distinct serial protocols on the same 115200 8N1 port:
 
 Protocol analysis based on [jrobertfisher/AT-D578UV-software-mic](https://github.com/jrobertfisher/AT-D578UV-software-mic) and firmware reverse engineering of the D578UV v1.21 and BT-01 v1.02 firmware images.
 
+## Raw command passthrough
+
+When `rigctld` is running in COM mode (`commode=1`), third-party software can send arbitrary ADATA commands to the radio using Hamlib's `w` (send_cmd) interface — even for functions the driver doesn't explicitly support. The driver handles COM MODE session management and keepalive automatically; the keepalive thread yields to raw commands so they won't collide.
+
+Example from `rigctl`:
+
+```bash
+# Send raw ADATA command 0x57 (1-byte payload) and read 22-byte ACK
+w +ADATA:00,001\r\nW\r\n 22
+```
+
+From `rigctld` over TCP (port 4532 by default):
+
+```
+w +ADATA:00,001\r\nW\r\n 22
+```
+
+This lets any ADATA-aware software leverage the driver's session without needing to manage the serial port, COM MODE handshake, or keepalive directly. The radio's firmware supports 34 ADATA command bytes — see the protocol map spreadsheet for the full list.
+
 ---
 
 For general Hamlib documentation, API reference, and supported radios, see the [upstream project](https://github.com/Hamlib/Hamlib).

--- a/README.md
+++ b/README.md
@@ -1,186 +1,106 @@
-Hamlib
-======
+# AnyTone AT-D578UVIII Hamlib Fork
 
-(C) Frank Singleton 2000 (vk3fcs@ix.netcom.com)  
-(C) Stephane Fillod 2000-2011  
-(C) The Hamlib Group 2000-2025  
+This is a fork of [Hamlib](https://github.com/Hamlib/Hamlib) with an updated backend driver for the AnyTone AT-D578UVIII (and AT-D578UV Pro) dual-band mobile radio. The upstream Hamlib project provides shared libraries for amateur radio equipment control across hundreds of supported radios — see the [official repository](https://github.com/Hamlib/Hamlib) for full documentation.
 
+This fork focuses on the `rigs/anytone/` backend, adding dual-mode operation, frequency/VFO control, and clock support via the radio's BT-01 Bluetooth microphone serial protocol.
 
-The purpose of this project is to provide stable, flexible, shared libraries
-that enable quicker development of amateur radio equipment control
-applications.
+---
 
-The master repository is https://github.com/Hamlib/Hamlib  
-The backup repository is https://sourceforge.net/projects/hamlib/  
+## Features
 
-Daily snapshots of the *master branch* are available at
-https://hamlib.sourceforge.net/snapshots/
+**Default mode** (`commode=0`) — direct serial mic protocol:
+- PTT on/off (used by VARA, fldigi, etc.)
+- No COM MODE handshake, no radio display lockout
+- Keys PTT on whichever VFO is currently selected on the radio, using the properties of that channel or VFO mode — behaves exactly like the physical mic PTT
 
-Daily snapshots of the *Hamlib-4.7 branch* are available at
-https://github.com/Hamlib/Hamlib/tree/Hamlib-4.7
+**COM mode** (`-C commode=1`) — BT-01 ADATA protocol:
+- PTT on/off
+- Get/set frequency
+- Get/set VFO (A/B)
+- Set clock (date/time)
+- Radio displays "EXTERNAL CABLE MODE" while connected
 
-> **Note:** Major changes are planned for Hamlib 5 (current *master branch*)
-> which will introduce incompatibilities with existing software that uses
-> Hamlib.  Until a given software application announces support for Hamlib 5,
-> use the snapshots and releases from the *Hamlib-4.7* branch.
+### COM mode limitations
 
-Development happens on the GitHub master (often by merging feature branches)
-and each release has a release branch.
+Frequency control in COM mode has specific requirements:
 
-Many amateur radio transceivers come with serial (RS-232, USB, etc.) or
-Ethernet/WiFi/Bluetooth interfaces that allow software to control the radio.
-This project will endeavour to provide shared libraries that greatly simplify
-the application programmer's interaction with radio equipment and other
-controllable devices such as rotators, amplifiers, etc.
+- **set_freq only works when Channel A is selected AND VFO A is in VFO mode.** If VFO A is in MR (memory) mode, the radio will report the frequency associated with the selected memory channel but will refuse to change it.
+- **If VFO B is selected**, get_freq will return the frequency of VFO A (either the VFO entry or the memory channel frequency), not VFO B. set_freq will also be refused in this state.
+- **PTT works regardless** — it will key whichever VFO is selected, even VFO B. Even when frequency changes are refused, PTT will still transmit on the currently selected channel.
 
-Supported Radios
-----------------
+## Usage
 
-The Hamlib Wiki page, Supported Radios, contains a snapshot of the supported
-radios at the time of the last Hamlib release.  Go to
-https://github.com/Hamlib/Hamlib/wiki to reach the Wiki.
+```bash
+# PTT only (default, no radio lockout)
+rigctl -m 37001 -s 115200 -r /dev/ttyUSB0
 
-Hamlib Design
--------------
+# Full control (freq/vfo/clock, locks radio display)
+rigctl -m 37001 -C commode=1 -s 115200 -r /dev/ttyUSB0
+```
 
-The library provides functions for radio, rotator and amplifier control,
-and data retrieval for supported devices.  A number of functions useful
-for calculating distance and bearing and grid square conversion are included.
+On macOS the serial device is typically `/dev/cu.usbserial-*` or `/dev/cu.SLAB_USBtoUART`.
 
-libhamlib.so -  library that provides generic API for all RIG types.
-    This is what application programs will "see".  Will have different
-    names on other platforms, e.g. libhamlib-4.dll on MS windows.  Also
-    contains all radio, rotator and amplifier "backends" provided by Hamlib.
+## Build from source
 
-Backend Examples are:
----------------------
+### Prerequisites
 
-1. `yaesu` will provide connectivity to Yaesu FT 747GX Transceiver, FT 847
-   "Earth Station", etc. via a unified API.
+```bash
+# Debian/Ubuntu
+sudo apt install git build-essential automake autoconf libtool pkg-config libusb-1.0-0-dev
 
-2. `xxxx` will provide connectivity to the Wiz-bang moon-melter 101A (yikes..)
+# macOS (Homebrew)
+brew install automake autoconf libtool pkg-config libusb
+```
 
-Hamlib will also enable developers to develop professional looking GUI's
-towards a unified control library API, and they will not have to worry about
-the underlying connection towards physical hardware.
+### Fresh clone and build
 
-Initially serial (RS232) connectivity will be handled, but we expect that IP
-(and other) connectivity will follow afterwards.  Connection via a USB port
-is accomplished via the Linux kernel support.  USB to serial converters are
-well supported.  Other such devices may be supported as long as they present
-a serial (RS-232) interface to Hamlib.
+```bash
+git clone https://github.com/CowboyPilot/Hamlib.git
+cd Hamlib
+./bootstrap
+./configure --prefix=/usr/local
+make -j"$(nproc 2>/dev/null || sysctl -n hw.ncpu)"
+sudo make install
+sudo ldconfig 2>/dev/null   # Linux only
+```
 
-Availability
-------------
+### Pull updates and rebuild
 
-Most distributions have the latest Hamlib release in their testing or alpha
-versions of their distribution.  Check your package manager for the Hamlib
-version included in your distribution.
+```bash
+cd Hamlib
+git pull
+make -j"$(nproc 2>/dev/null || sysctl -n hw.ncpu)"
+sudo make install
+sudo ldconfig 2>/dev/null   # Linux only
+```
 
-Developing with Hamlib API
---------------------------
+If `make` fails after a pull (new files or changed build config), do a full reconfigure:
 
-API documentation is at:
+```bash
+./bootstrap
+./configure --prefix=/usr/local
+make -j"$(nproc 2>/dev/null || sysctl -n hw.ncpu)"
+sudo make install
+sudo ldconfig 2>/dev/null   # Linux only
+```
 
-        https://github.com/Hamlib/Hamlib/wiki/Documentation
+## Verify installation
 
-Take a look at tests/README for more info on simple programming examples and
-test programs.
+```bash
+rigctl -l | grep -i anytone
+# Should show:
+#  37001  AnyTone  AT-D578UVIII  ...  Beta  RIG_MODEL_ATD578UVIII
+```
 
-C++ programming is supported and language bindings are available for Perl,
-Python, and TCL.  A network daemon utility is also available for any
-programming language that supports network sockets (even netcat!).
+## Protocol notes
 
+The radio exposes two distinct serial protocols on the same 115200 8N1 port:
 
-Compiling
----------
+- **Direct mic protocol**: raw byte commands (0x06 keepalive, 0x41 PTT). No initialization required, no display lockout. This is what `commode=0` uses.
+- **BT-01 ADATA protocol**: `+ADATA:00,NNN\r\n` framed commands. Requires a COM MODE handshake on open and causes "EXTERNAL CABLE MODE" display lockout. This is what `commode=1` enables.
 
-Hamlib is entirely developed using GNU tools, on various operating systems.
-The library may be compiled from a source "tarball" by the familiar "three
-step":
+Protocol analysis based on [jrobertfisher/AT-D578UV-software-mic](https://github.com/jrobertfisher/AT-D578UV-software-mic) and firmware reverse engineering of the D578UV v1.21 and BT-01 v1.02 firmware images.
 
-        ./configure
-        make
-        sudo make install
+---
 
-For debugging use this configure command:
-
-        ./configure CFLAGS=-g -O0 -fPIC --no-create --no-recursion
-
-See the `INSTALL` file for more information.
-
-To recompile Hamlib, run:
-
-        make clean
-
-to remove all object files and binaries, otherwise `make` won't do anything!
-
-Contributing
-------------
-
-Consult the `README.betatester` and `README.developer` files in this directory
-if you feel like testing or helping with Hamlib development.
-
-Contributions of rig specifications and protocol documentation are highly
-encouraged.  Do keep in mind that in some cases the manufacturer may not
-provide complete control information or it is only available under a
-Non-Disclosure Agreement (NDA).  Any documentation *must* be publicly
-available so we can legally write and distribute Free Software supporting a
-given device.
-
-The Hamlib team is very interested to hear from you, how Hamlib builds and
-works on your system, especially on non-Linux system or non-PC systems. We
-try to make Hamlib as portable as possible.
-
-Please report in case of problems at hamlib-developer@lists.sourceforge.net
-Git email formatted patches or in unified diff format are welcome!
-
-Also, take a look at http://sourceforge.net/projects/hamlib/ Here you will
-find a mail list, link to the Wiki, and the latest releases.  Feedback,
-questions, etc. about Hamlib are very welcome at the mail list:
-
-        <hamlib-developer@lists.sourceforge.net>
-
-Hamlib Version Numbers
-----------------------
-
-Like other software projects, Hamlib uses a version numbering scheme to help
-program authors and users understand which releases are compatible and which
-are not.  Hamlib releases now follow the format of:
-
-Major.minor.point
-
-Where
-
-Major:  Currently at 4, but can be advanced when changes to the API require
-client programs to be rewritten to take advantage of new features of Hamlib.
-This number has advanced several times throughout the life of Hamlib.
-Advancement of the major number signals frontend API changes that require
-modification of client source and Application Binary Interface changes that
-require relinking to the library (Note, the latter does not apply to
-applications using the `*ctld` daemons, but the command API may change).
-
-Minor:  This number advances when either new backend(s) or new rig model(s) to
-existing backend(s) are added.  Advancing this number informs client program
-authors (and users of those programs) that new model/backend support has been
-added.  Will also include bug fixes since the last point release.
-
-Point:  Formerly could be undefined (e.g. Hamlib 4.6) and would advance to 1
-(e.g.  Hamlib 4.6.1) for any bug fixes or feature additions to existing
-model(s) or backend(s), then to 2, etc.  New rig models or backends are not
-included in point releases.  When *major* or *minor* is advanced, *point* will
-reset to `0`.  **Note:** All future releases beginning with 4.7.0 will include
-all values to lessen confusion.
-
-Release schedule
-----------------
-
-Hamlib has a "ready when it's ready" philosophy.  There is no set schedule,
-though we'd like at least one *minor* release in a given year and a *major*
-release every several years.
-
-
-Have Fun / Frank S / Stephane F / The Hamlib Group
-
-  73's de vk3fcs/km5ws / f8cfe
-
+For general Hamlib documentation, API reference, and supported radios, see the [upstream project](https://github.com/Hamlib/Hamlib).

--- a/rigs/anytone/README.md
+++ b/rigs/anytone/README.md
@@ -95,4 +95,8 @@ The radio exposes two distinct serial protocols on the same 115200 8N1 port:
 - **Direct mic protocol**: raw byte commands (0x06 keepalive, 0x41 PTT). No initialization required, no display lockout. This is what `commode=0` uses.
 - **BT-01 ADATA protocol**: `+ADATA:00,NNN\r\n` framed commands. Requires a COM MODE handshake on open and causes "EXTERNAL CABLE MODE" display lockout. This is what `commode=1` enables.
 
+## Raw command passthrough
+
+When running in COM mode, third-party software can send arbitrary ADATA commands through `rigctld`'s `w` (send_cmd) interface. The driver's keepalive thread automatically yields to raw commands so they won't collide. This lets any ADATA-aware software leverage the driver's session without managing the serial port, COM MODE handshake, or keepalive directly.
+
 Protocol analysis based on [jrobertfisher/AT-D578UV-software-mic](https://github.com/jrobertfisher/AT-D578UV-software-mic) and firmware reverse engineering of the D578UV v1.21 and BT-01 v1.02 firmware images.

--- a/rigs/anytone/README.md
+++ b/rigs/anytone/README.md
@@ -7,6 +7,7 @@ Hamlib driver for the AnyTone AT-D578UVIII (and AT-D578UV Pro) dual-band mobile 
 **Default mode** (`commode=0`) — direct serial mic protocol:
 - PTT on/off (used by VARA, fldigi, etc.)
 - No COM MODE handshake, no radio display lockout
+- Keys PTT on whichever VFO is currently selected on the radio, using the properties of that channel or VFO mode — behaves exactly like the physical mic PTT
 
 **COM mode** (`-C commode=1`) — BT-01 ADATA protocol:
 - PTT on/off
@@ -14,6 +15,14 @@ Hamlib driver for the AnyTone AT-D578UVIII (and AT-D578UV Pro) dual-band mobile 
 - Get/set VFO (A/B)
 - Set clock (date/time)
 - Radio displays "EXTERNAL CABLE MODE" while connected
+
+### COM mode limitations
+
+Frequency control in COM mode has specific requirements:
+
+- **set_freq only works when Channel A is selected AND VFO A is in VFO mode.** If VFO A is in MR (memory) mode, the radio will report the frequency associated with the selected memory channel but will refuse to change it.
+- **If VFO B is selected**, get_freq will return the frequency of VFO A (either the VFO entry or the memory channel frequency), not VFO B. set_freq will also be refused in this state.
+- **PTT works regardless** — it will key whichever VFO is selected, even VFO B. Even when frequency changes are refused, PTT will still transmit on the currently selected channel.
 
 ## Usage
 

--- a/rigs/anytone/README.md
+++ b/rigs/anytone/README.md
@@ -1,0 +1,89 @@
+# AnyTone AT-D578UVIII Hamlib Backend
+
+Hamlib driver for the AnyTone AT-D578UVIII (and AT-D578UV Pro) dual-band mobile radio.
+
+## Features
+
+**Default mode** (`commode=0`) — direct serial mic protocol:
+- PTT on/off (used by VARA, fldigi, etc.)
+- No COM MODE handshake, no radio display lockout
+
+**COM mode** (`-C commode=1`) — BT-01 ADATA protocol:
+- PTT on/off
+- Get/set frequency
+- Get/set VFO (A/B)
+- Set clock (date/time)
+- Radio displays "EXTERNAL CABLE MODE" while connected
+
+## Usage
+
+```bash
+# PTT only (default, no radio lockout)
+rigctl -m 37001 -s 115200 -r /dev/ttyUSB0
+
+# Full control (freq/vfo/clock, locks radio display)
+rigctl -m 37001 -C commode=1 -s 115200 -r /dev/ttyUSB0
+```
+
+On macOS the serial device is typically `/dev/cu.usbserial-*` or `/dev/cu.SLAB_USBtoUART`.
+
+## Build from source
+
+### Prerequisites
+
+```bash
+# Debian/Ubuntu
+sudo apt install git build-essential automake autoconf libtool pkg-config libusb-1.0-0-dev
+
+# macOS (Homebrew)
+brew install automake autoconf libtool pkg-config libusb
+```
+
+### Fresh clone and build
+
+```bash
+git clone https://github.com/CowboyPilot/Hamlib.git
+cd Hamlib
+./bootstrap
+./configure --prefix=/usr/local
+make -j"$(nproc 2>/dev/null || sysctl -n hw.ncpu)"
+sudo make install
+sudo ldconfig 2>/dev/null   # Linux only
+```
+
+### Pull updates and rebuild
+
+```bash
+cd Hamlib
+git pull
+make -j"$(nproc 2>/dev/null || sysctl -n hw.ncpu)"
+sudo make install
+sudo ldconfig 2>/dev/null   # Linux only
+```
+
+If `make` fails after a pull (new files or changed build config), do a full reconfigure:
+
+```bash
+./bootstrap
+./configure --prefix=/usr/local
+make -j"$(nproc 2>/dev/null || sysctl -n hw.ncpu)"
+sudo make install
+sudo ldconfig 2>/dev/null   # Linux only
+```
+
+## Verify installation
+
+```bash
+rigctl -l | grep -i anytone
+# Should show:
+#  37001  AnyTone  AT-D578UVIII  ...  Beta  RIG_MODEL_ATD578UVIII
+```
+
+## Protocol notes
+
+The radio exposes two distinct serial protocols on the same 115200 8N1 port:
+
+- **Direct mic protocol**: raw byte commands (0x06 keepalive, 0x41 PTT). No initialization required, no display lockout. This is what `commode=0` uses.
+- **BT-01 ADATA protocol**: `+ADATA:00,NNN\r\n` framed commands. Requires a COM MODE handshake on open and causes "EXTERNAL CABLE MODE" display lockout. This is what `commode=1` enables.
+
+Protocol analysis based on [jrobertfisher/AT-D578UV-software-mic](https://github.com/jrobertfisher/AT-D578UV-software-mic) and firmware reverse engineering of the D578UV v1.21 and BT-01 v1.02 firmware images.

--- a/rigs/anytone/anytone.c
+++ b/rigs/anytone/anytone.c
@@ -669,15 +669,16 @@ int anytone_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
     to_bcd_be(&freq_data[18], (unsigned long long)(freq / 10), 8);
 
+    unsigned char ack[22];
+
     MUTEX_LOCK(&p->mutex);
     rig_flush(RIGPORT(rig));
 
     write_block(RIGPORT(rig), vfo_sel, sizeof(vfo_sel));
-    hl_usleep(50 * 1000);
+    read_block(RIGPORT(rig), ack, 22);
 
     write_block(RIGPORT(rig), freq_data, sizeof(freq_data));
-    hl_usleep(50 * 1000);
-    rig_flush(RIGPORT(rig));
+    read_block(RIGPORT(rig), ack, 22);
 
     MUTEX_UNLOCK(&p->mutex);
 
@@ -726,10 +727,12 @@ int anytone_set_clock(RIG *rig, int year, int month, int day,
               __func__, year, month, day, hour, min,
               cmd[16], cmd[17], cmd[18], cmd[19], cmd[20]);
 
+    unsigned char ack[22];
+
     MUTEX_LOCK(&p->mutex);
-    anytone_transaction(rig, cmd, sizeof(cmd), NULL, 0, 0);
-    hl_usleep(50 * 1000);
     rig_flush(RIGPORT(rig));
+    write_block(RIGPORT(rig), cmd, sizeof(cmd));
+    read_block(RIGPORT(rig), ack, 22);
     MUTEX_UNLOCK(&p->mutex);
 
     RETURNFUNC(RIG_OK);

--- a/rigs/anytone/anytone.c
+++ b/rigs/anytone/anytone.c
@@ -118,7 +118,11 @@ static void *anytone_thread(void *vrig)
 
     while (p->runflag)
     {
-        MUTEX_LOCK(&p->mutex);
+        if (pthread_mutex_trylock(&p->mutex) != 0)
+        {
+            hl_usleep(1000 * 1000);
+            continue;
+        }
 
         enum rig_debug_level_e debug_level_save;
         rig_get_debug(&debug_level_save);

--- a/rigs/anytone/anytone.c
+++ b/rigs/anytone/anytone.c
@@ -387,9 +387,12 @@ int anytone_get_vfo(RIG *rig, vfo_t *vfo)
     };
 
     MUTEX_LOCK(&p->mutex);
-    anytone_transaction(rig, cmd, sizeof(cmd), reply, sizeof(reply), 114);
+    anytone_transaction(rig, cmd, sizeof(cmd), reply, sizeof(reply), 116);
     MUTEX_UNLOCK(&p->mutex);
 
+    // VFO indicator is near the end of the 99-byte payload
+    // With 116-byte frame (15 header + 99 payload + 2 trailer),
+    // check byte 113 (payload offset 98) per original protocol analysis
     if (reply[113] == 0x9b)
     {
         *vfo = RIG_VFO_A;

--- a/rigs/anytone/anytone.c
+++ b/rigs/anytone/anytone.c
@@ -495,36 +495,36 @@ int anytone_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 // ---------------------------------------------------------------------------
 int anytone_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
-    anytone_priv_data_t *p = STATE(rig)->priv;
+    char cmd[32];
     int retval;
-    int retry = 2;
+    hamlib_port_t *rp = RIGPORT(rig);
+    anytone_priv_data_t *p = STATE(rig)->priv;
 
     ENTERFUNC;
 
-    // +ADATA:00,006\r\n + \x04 \xSUB \x07 \x00 \x00 \x00 + \r\n = 23 bytes
-    unsigned char cmd[23] = {
-        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
-        0x30, 0x2C, 0x30, 0x30, 0x36, 0x0D, 0x0A,
-        0x04, 0x2C, 0x07, 0x00, 0x00, 0x00,
-        0x0D, 0x0A
-    };
+    SNPRINTF(cmd, sizeof(cmd), "+ADATA:00,006\r\n");
+    cmd[15] = 0x04;
+    cmd[16] = 0x2c;
+    cmd[17] = 0x07;
+    cmd[18] = 0x00;
+    cmd[19] = 0x00;
+    cmd[20] = 0x00;
+    cmd[21] = 0x00;
+    cmd[22] = 0x00;
+    cmd[23] = 0x0d;
+    cmd[24] = 0x0a;
 
-    if (vfo == RIG_VFO_B)
-    {
-        cmd[16] = 0x2D;
-    }
+    if (vfo == RIG_VFO_B) { cmd[16] = 0x2d; }
 
+    int retry = 2;
     MUTEX_LOCK(&p->mutex);
-    rig_flush(RIGPORT(rig));
+    rig_flush(rp);
 
     do
     {
+        write_block(rp, (unsigned char *)cmd, 25);
         unsigned char buf[512];
-        retval = write_block(RIGPORT(rig), cmd, sizeof(cmd));
-
-        if (retval != RIG_OK) { break; }
-
-        retval = read_block(RIGPORT(rig), buf, 138);
+        retval = read_block(rp, buf, 138);
 
         if (retval == 138)
         {
@@ -542,53 +542,62 @@ int anytone_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 }
 
 // ---------------------------------------------------------------------------
-// anytone_set_freq — enter frequency via keypad button emulation
+// anytone_set_freq — direct frequency set via 0x5A/0x2F command pair
 //
-// Converts frequency (Hz) to an 8-digit string (10 Hz resolution) and
-// sends each digit as a button press/release via +ADATA-wrapped 0x41
-// commands. The radio must be in VFO mode for this to work.
+// Decoded from BT-01 protocol capture:
+//   Packet 1: +ADATA:00,005  0x5A [VFO] 0x00 0x00 0x00
+//   Packet 2: +ADATA:00,023  0x2F 0x03 0x00 [BCD freq 4 bytes] [constant data]
 //
-// This uses the same button protocol as the AT-D578UV-software-mic
-// console program, wrapped in BT-01 +ADATA framing.
+// VFO byte: 0x02 = VFO A, 0x01 = VFO B
+// Frequency: BCD big-endian, 10 Hz resolution (same encoding as get_freq)
 // ---------------------------------------------------------------------------
 int anytone_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
     anytone_priv_data_t *p = STATE(rig)->priv;
-    char digits[16];
-    int i;
-    unsigned long freq_10hz;
 
     ENTERFUNC;
 
-    // Digit key codes: 0->0x01, 1->0x02, ... 9->0x0A
-    static const unsigned char digit_to_key[10] = {
-        ANYTONE_KEY_0, ANYTONE_KEY_1, ANYTONE_KEY_2, ANYTONE_KEY_3,
-        ANYTONE_KEY_4, ANYTONE_KEY_5, ANYTONE_KEY_6, ANYTONE_KEY_7,
-        ANYTONE_KEY_8, ANYTONE_KEY_9
+    rig_debug(RIG_DEBUG_VERBOSE, "%s: vfo=%s freq=%g\n", __func__,
+              rig_strvfo(vfo), freq);
+
+    // Packet 1: VFO select — +ADATA:00,005\r\n + 5A VFO 00 00 00 + \r\n
+    unsigned char vfo_sel[22] = {
+        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+        0x30, 0x2C, 0x30, 0x30, 0x35, 0x0D, 0x0A,
+        0x5A, 0x02, 0x00, 0x00, 0x00,
+        0x0D, 0x0A
     };
 
-    freq_10hz = (unsigned long)(freq / 10.0 + 0.5);
-    SNPRINTF(digits, sizeof(digits), "%08lu", freq_10hz);
+    if (vfo == RIG_VFO_B)
+    {
+        vfo_sel[16] = 0x01;
+    }
 
-    rig_debug(RIG_DEBUG_VERBOSE, "%s: freq=%g digits=%s\n", __func__, freq,
-              digits);
+    // Packet 2: Frequency data — +ADATA:00,023\r\n + 23-byte payload + \r\n
+    unsigned char freq_data[40] = {
+        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+        0x30, 0x2C, 0x30, 0x32, 0x33, 0x0D, 0x0A,
+        0x2F, 0x03, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+        0x15, 0x50, 0x00, 0x00,
+        0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0xCF, 0x09, 0x00,
+        0x0D, 0x0A
+    };
+
+    // BCD-encode frequency at payload bytes 3-6 (array offset 18-21)
+    to_bcd_be(&freq_data[18], (unsigned long long)(freq / 10), 8);
 
     MUTEX_LOCK(&p->mutex);
     rig_flush(RIGPORT(rig));
 
-    for (i = 0; i < 8; i++)
-    {
-        int d = digits[i] - '0';
+    write_block(RIGPORT(rig), vfo_sel, sizeof(vfo_sel));
+    hl_usleep(50 * 1000);
 
-        if (d < 0 || d > 9)
-        {
-            rig_debug(RIG_DEBUG_ERR, "%s: bad digit '%c'\n", __func__, digits[i]);
-            MUTEX_UNLOCK(&p->mutex);
-            RETURNFUNC(-RIG_EINVAL);
-        }
-
-        anytone_send_button(rig, digit_to_key[d]);
-    }
+    write_block(RIGPORT(rig), freq_data, sizeof(freq_data));
+    hl_usleep(50 * 1000);
+    rig_flush(RIGPORT(rig));
 
     MUTEX_UNLOCK(&p->mutex);
 

--- a/rigs/anytone/anytone.c
+++ b/rigs/anytone/anytone.c
@@ -132,8 +132,8 @@ static void *anytone_thread(void *vrig)
             rig_set_debug(RIG_DEBUG_WARN);
         }
 
-        //write_block(rp, keepalive, sizeof(keepalive));
-        //rig_flush(rp);
+        write_block(rp, keepalive, sizeof(keepalive));
+        rig_flush(rp);
 
         if (rig_need_debug(RIG_DEBUG_CACHE) == 0)
         {
@@ -314,7 +314,7 @@ int anytone_open(RIG *rig)
         0x0D, 0x0A
     };
 
-    write_block(rp, wakeup, sizeof(wakeup));
+    //write_block(rp, wakeup, sizeof(wakeup));
     hl_usleep(500 * 1000);
 
     // --- Step 2: Enter COM MODE ---

--- a/rigs/anytone/anytone.c
+++ b/rigs/anytone/anytone.c
@@ -132,8 +132,8 @@ static void *anytone_thread(void *vrig)
             rig_set_debug(RIG_DEBUG_WARN);
         }
 
-        write_block(rp, keepalive, sizeof(keepalive));
-        rig_flush(rp);
+        //write_block(rp, keepalive, sizeof(keepalive));
+        //rig_flush(rp);
 
         if (rig_need_debug(RIG_DEBUG_CACHE) == 0)
         {

--- a/rigs/anytone/anytone.c
+++ b/rigs/anytone/anytone.c
@@ -129,9 +129,7 @@ static void *anytone_thread(void *vrig)
         }
 
         write_block(rp, keepalive, sizeof(keepalive));
-
-        unsigned char buf[32];
-        read_block(rp, buf, 22);
+        rig_flush(rp);
 
         if (rig_need_debug(RIG_DEBUG_CACHE) == 0)
         {

--- a/rigs/anytone/anytone.c
+++ b/rigs/anytone/anytone.c
@@ -528,9 +528,9 @@ int anytone_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
     {
         write_block(rp, (unsigned char *)cmd, 25);
         unsigned char buf[512];
-        retval = read_block(rp, buf, 138);
+        retval = read_block(rp, buf, 135);
 
-        if (retval == 138)
+        if (retval == 135)
         {
             *freq = from_bcd_be(&buf[17], 8) * 10;
             rig_debug(RIG_DEBUG_VERBOSE, "%s: freq=%g\n", __func__, *freq);

--- a/rigs/anytone/anytone.c
+++ b/rigs/anytone/anytone.c
@@ -301,11 +301,10 @@ int anytone_open(RIG *rig)
     int retval = RIG_OK;
     hamlib_port_t *rp = RIGPORT(rig);
     anytone_priv_data_t *p = STATE(rig)->priv;
-    int i;
 
     ENTERFUNC;
 
-    // --- Step 1: Wake-up heartbeats (3x) ---
+    // --- Step 1: Wake-up heartbeat ---
     unsigned char wakeup[18] = {
         0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
         0x30, 0x2C, 0x30, 0x30, 0x31, 0x0D, 0x0A,
@@ -313,14 +312,8 @@ int anytone_open(RIG *rig)
         0x0D, 0x0A
     };
 
-    for (i = 0; i < 3; i++)
-    {
-        write_block(rp, wakeup, sizeof(wakeup));
-        hl_usleep(200 * 1000);
-    }
-
-    // Discard any heartbeat responses before proceeding
-    rig_flush(rp);
+    write_block(rp, wakeup, sizeof(wakeup));
+    hl_usleep(500 * 1000);
 
     // --- Step 2: Enter COM MODE ---
     // +ADATA:00,016\r\n + \x01 + "D578UV COM MODE" + \r\n = 33 bytes
@@ -335,33 +328,6 @@ int anytone_open(RIG *rig)
     write_block(rp, commode, sizeof(commode));
     hl_usleep(500 * 1000);
     rig_flush(rp);
-
-    // --- Step 3: Send COM CHECK END ---
-    // +ADATA:00,014\r\n + 'd' + "COM CHECK END" + \r\n = 31 bytes
-    unsigned char checkend[31] = {
-        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
-        0x30, 0x2C, 0x30, 0x31, 0x34, 0x0D, 0x0A,
-        0x64,
-        'C', 'O', 'M', ' ', 'C', 'H', 'E', 'C', 'K', ' ', 'E', 'N', 'D',
-        0x0D, 0x0A
-    };
-
-    write_block(rp, checkend, sizeof(checkend));
-    hl_usleep(200 * 1000);
-    rig_flush(rp);
-
-    // --- Step 4: Release ---
-    // +ADATA:00,000\r\n\r\n = 17 bytes
-    unsigned char release[17] = {
-        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
-        0x30, 0x2C, 0x30, 0x30, 0x30, 0x0D, 0x0A,
-        0x0D, 0x0A
-    };
-
-    write_block(rp, release, sizeof(release));
-    hl_usleep(200 * 1000);
-    write_block(rp, release, sizeof(release));
-    hl_usleep(200 * 1000);
 
     // --- Step 7: Start keep-alive thread ---
     int err = pthread_create(&p->thread_id, NULL, anytone_thread, (void *)rig);

--- a/rigs/anytone/anytone.c
+++ b/rigs/anytone/anytone.c
@@ -97,7 +97,10 @@ DECLARE_PROBERIG_BACKEND(anytone)
 }
 
 // ---------------------------------------------------------------------------
-// Keep-alive thread — sends BT-01 heartbeat every second
+// Keep-alive thread — branches on commode flag
+//
+// commode=0: sends raw 0x06 byte every second
+// commode=1: sends +ADATA:00,001\r\n a \r\n every second
 // ---------------------------------------------------------------------------
 static void *anytone_thread(void *vrig)
 {
@@ -105,16 +108,23 @@ static void *anytone_thread(void *vrig)
     hamlib_port_t *rp = RIGPORT(rig);
     anytone_priv_data_t *p = STATE(rig)->priv;
 
-    rig_debug(RIG_DEBUG_TRACE, "%s: anytone_thread started\n", __func__);
+    rig_debug(RIG_DEBUG_TRACE, "%s: anytone_thread started (commode=%d)\n",
+              __func__, p->commode);
     p->runflag = 1;
 
-    // Heartbeat: +ADATA:00,001\r\na\r\n (18 bytes)
-    unsigned char keepalive[] = {
+    // ADATA heartbeat: +ADATA:00,001\r\na\r\n (18 bytes)
+    unsigned char keepalive_adata[] = {
         0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
         0x30, 0x2C, 0x30, 0x30, 0x31, 0x0D, 0x0A,
         0x61,
         0x0D, 0x0A
     };
+
+    // Raw mic heartbeat: single 0x06 byte
+    unsigned char keepalive_mic[] = { 0x06 };
+
+    unsigned char *ka = p->commode ? keepalive_adata : keepalive_mic;
+    int ka_len = p->commode ? (int)sizeof(keepalive_adata) : (int)sizeof(keepalive_mic);
 
     while (p->runflag)
     {
@@ -132,7 +142,7 @@ static void *anytone_thread(void *vrig)
             rig_set_debug(RIG_DEBUG_WARN);
         }
 
-        write_block(rp, keepalive, sizeof(keepalive));
+        write_block(rp, ka, ka_len);
         rig_flush(rp);
 
         if (rig_need_debug(RIG_DEBUG_CACHE) == 0)
@@ -210,16 +220,11 @@ static int anytone_transaction(RIG *rig, unsigned char *cmd, int cmd_len,
 
 // ---------------------------------------------------------------------------
 // anytone_send_button — send a button press+release via +ADATA framing
-//
-// Wraps the direct serial protocol's 0x41 button command inside +ADATA.
-// The radio may or may not accept this while in BT-01 COM MODE — this is
-// the mechanism the BT-01 Bluetooth microphone uses for its own buttons.
 // ---------------------------------------------------------------------------
 static int anytone_send_button(RIG *rig, unsigned char key)
 {
     hamlib_port_t *rp = RIGPORT(rig);
 
-    // +ADATA:00,008\r\n + 0x41 button packet + \r\n
     unsigned char press[25] = {
         0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
         0x30, 0x2C, 0x30, 0x30, 0x38, 0x0D, 0x0A,
@@ -262,6 +267,7 @@ int anytone_init(RIG *rig)
 
         STATE(rig)->priv = p;
         p->vfo_curr = RIG_VFO_NONE;
+        p->commode = 0;
         pthread_mutex_init(&p->mutex, NULL);
     }
 
@@ -287,51 +293,88 @@ int anytone_cleanup(RIG *rig)
 }
 
 // ---------------------------------------------------------------------------
-// anytone_open — full BT-01 handshake per the captured protocol
+// anytone_set_conf / anytone_get_conf — backend configuration
+// ---------------------------------------------------------------------------
+int anytone_set_conf(RIG *rig, hamlib_token_t token, const char *val)
+{
+    anytone_priv_data_t *p = STATE(rig)->priv;
+
+    ENTERFUNC;
+
+    switch (token)
+    {
+    case TOK_COMMODE:
+        p->commode = atoi(val) ? 1 : 0;
+        rig_debug(RIG_DEBUG_VERBOSE, "%s: commode=%d\n", __func__, p->commode);
+        break;
+
+    default:
+        RETURNFUNC(-RIG_EINVAL);
+    }
+
+    RETURNFUNC(RIG_OK);
+}
+
+int anytone_get_conf(RIG *rig, hamlib_token_t token, char *val)
+{
+    anytone_priv_data_t *p = STATE(rig)->priv;
+
+    ENTERFUNC;
+
+    switch (token)
+    {
+    case TOK_COMMODE:
+        SNPRINTF(val, 128, "%d", p->commode);
+        break;
+
+    default:
+        RETURNFUNC(-RIG_EINVAL);
+    }
+
+    RETURNFUNC(RIG_OK);
+}
+
+// ---------------------------------------------------------------------------
+// anytone_open
 //
-// Sequence from the working BT-01 software mic:
-//   1. Send wake-up heartbeat 3x with delays
-//   2. Send "\x01D578UV COM MODE" — radio enters external cable mode
-//   3. Read COM MODE acknowledgment
-//   4. Send "\x64COM CHECK END" — complete the handshake
-//   5. Read acknowledgment
-//   6. Send +ADATA:00,000 release
-//   7. Start keep-alive thread
+// commode=0: no handshake, just start keepalive thread
+// commode=1: BT-01 COM MODE handshake, then keepalive thread
 // ---------------------------------------------------------------------------
 int anytone_open(RIG *rig)
 {
-    int retval = RIG_OK;
     hamlib_port_t *rp = RIGPORT(rig);
     anytone_priv_data_t *p = STATE(rig)->priv;
 
     ENTERFUNC;
 
-    // --- Step 1: Wake-up heartbeat ---
-    unsigned char wakeup[18] = {
-        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
-        0x30, 0x2C, 0x30, 0x30, 0x31, 0x0D, 0x0A,
-        0x61,
-        0x0D, 0x0A
-    };
+    if (p->commode)
+    {
+        // --- Wake-up heartbeat ---
+        unsigned char wakeup[18] = {
+            0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+            0x30, 0x2C, 0x30, 0x30, 0x31, 0x0D, 0x0A,
+            0x61,
+            0x0D, 0x0A
+        };
 
-    write_block(rp, wakeup, sizeof(wakeup));
-    hl_usleep(500 * 1000);
+        write_block(rp, wakeup, sizeof(wakeup));
+        hl_usleep(500 * 1000);
 
-    // --- Step 2: Enter COM MODE ---
-    // +ADATA:00,016\r\n + \x01 + "D578UV COM MODE" + \r\n = 33 bytes
-    unsigned char commode[33] = {
-        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
-        0x30, 0x2C, 0x30, 0x31, 0x36, 0x0D, 0x0A,
-        0x01,
-        'D', '5', '7', '8', 'U', 'V', ' ', 'C', 'O', 'M', ' ', 'M', 'O', 'D', 'E',
-        0x0D, 0x0A
-    };
+        // --- Enter COM MODE ---
+        unsigned char commode[33] = {
+            0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+            0x30, 0x2C, 0x30, 0x31, 0x36, 0x0D, 0x0A,
+            0x01,
+            'D', '5', '7', '8', 'U', 'V', ' ', 'C', 'O', 'M', ' ', 'M', 'O', 'D', 'E',
+            0x0D, 0x0A
+        };
 
-    write_block(rp, commode, sizeof(commode));
-    hl_usleep(500 * 1000);
-    rig_flush(rp);
+        write_block(rp, commode, sizeof(commode));
+        hl_usleep(500 * 1000);
+        rig_flush(rp);
+    }
 
-    // --- Step 7: Start keep-alive thread ---
+    // Start keep-alive thread (both modes)
     int err = pthread_create(&p->thread_id, NULL, anytone_thread, (void *)rig);
 
     if (err)
@@ -356,19 +399,22 @@ int anytone_close(RIG *rig)
     p->runflag = 0;
     pthread_join(p->thread_id, NULL);
 
-    unsigned char release[17] = {
-        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
-        0x30, 0x2C, 0x30, 0x30, 0x30, 0x0D, 0x0A,
-        0x0D, 0x0A
-    };
+    if (p->commode)
+    {
+        unsigned char release[17] = {
+            0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+            0x30, 0x2C, 0x30, 0x30, 0x30, 0x0D, 0x0A,
+            0x0D, 0x0A
+        };
 
-    anytone_transaction(rig, release, sizeof(release), NULL, 0, 0);
+        anytone_transaction(rig, release, sizeof(release), NULL, 0, 0);
+    }
 
     RETURNFUNC(RIG_OK);
 }
 
 // ---------------------------------------------------------------------------
-// anytone_get_vfo
+// anytone_get_vfo — requires commode=1
 // ---------------------------------------------------------------------------
 int anytone_get_vfo(RIG *rig, vfo_t *vfo)
 {
@@ -378,7 +424,12 @@ int anytone_get_vfo(RIG *rig, vfo_t *vfo)
 
     ENTERFUNC;
 
-    // +ADATA:00,006\r\n + \x04\x05\x00\x00\x00\x00 + \r\n = 23 bytes
+    if (!p->commode)
+    {
+        rig_debug(RIG_DEBUG_ERR, "%s: requires -C commode=1\n", __func__);
+        RETURNFUNC(-RIG_ENAVAIL);
+    }
+
     unsigned char cmd[23] = {
         0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
         0x30, 0x2C, 0x30, 0x30, 0x36, 0x0D, 0x0A,
@@ -390,9 +441,6 @@ int anytone_get_vfo(RIG *rig, vfo_t *vfo)
     anytone_transaction(rig, cmd, sizeof(cmd), reply, sizeof(reply), 116);
     MUTEX_UNLOCK(&p->mutex);
 
-    // VFO indicator is near the end of the 99-byte payload
-    // With 116-byte frame (15 header + 99 payload + 2 trailer),
-    // check byte 113 (payload offset 98) per original protocol analysis
     if (reply[113] == 0x9b)
     {
         *vfo = RIG_VFO_A;
@@ -414,7 +462,7 @@ int anytone_get_vfo(RIG *rig, vfo_t *vfo)
 }
 
 // ---------------------------------------------------------------------------
-// anytone_set_vfo — toggle VFO via Sub A/B button press
+// anytone_set_vfo — toggle VFO via Sub A/B button press, requires commode=1
 // ---------------------------------------------------------------------------
 int anytone_set_vfo(RIG *rig, vfo_t vfo)
 {
@@ -422,6 +470,12 @@ int anytone_set_vfo(RIG *rig, vfo_t vfo)
     vfo_t curr_vfo;
 
     ENTERFUNC;
+
+    if (!p->commode)
+    {
+        rig_debug(RIG_DEBUG_ERR, "%s: requires -C commode=1\n", __func__);
+        RETURNFUNC(-RIG_ENAVAIL);
+    }
 
     anytone_get_vfo(rig, &curr_vfo);
 
@@ -453,11 +507,15 @@ int anytone_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
 }
 
 // ---------------------------------------------------------------------------
-// anytone_set_ptt — corrected PTT using the 0x56 (V) command
+// anytone_set_ptt
 //
-// Working protocol from BT-01 capture:
-//   PTT ON:  +ADATA:00,023\r\n V \x01 + 21 zero bytes \r\n
-//   PTT OFF: +ADATA:00,023\r\n V \x00 + 21 zero bytes \r\n
+// commode=0: raw 8-byte 0x41 button command, no ADATA framing
+//   ON:  0x41 0x01 0x00 0x00 0x00 0x00 0x00 0x06
+//   OFF: 0x41 0x00 0x00 0x00 0x00 0x00 0x00 0x06
+//
+// commode=1: ADATA-wrapped 0x56 command (40 bytes)
+//   ON:  +ADATA:00,023\r\n 0x56 0x01 + 21 zeros \r\n
+//   OFF: +ADATA:00,023\r\n 0x56 0x00 + 21 zeros \r\n
 // ---------------------------------------------------------------------------
 int anytone_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 {
@@ -465,29 +523,40 @@ int anytone_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 
     ENTERFUNC;
 
-    // +ADATA:00,023\r\n (15) + V + on/off + 21 zeros (23) + \r\n (2) = 40 bytes
-    unsigned char ptton[40] = {
-        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
-        0x30, 0x2C, 0x30, 0x32, 0x33, 0x0D, 0x0A,
-        0x56, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x0D, 0x0A
-    };
-
-    unsigned char pttoff[40] = {
-        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
-        0x30, 0x2C, 0x30, 0x32, 0x33, 0x0D, 0x0A,
-        0x56, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x0D, 0x0A
-    };
-
-    unsigned char *cmd = ptt ? ptton : pttoff;
-
     MUTEX_LOCK(&p->mutex);
-    anytone_transaction(rig, cmd, 40, NULL, 0, 0);
+
+    if (p->commode)
+    {
+        unsigned char ptton[40] = {
+            0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+            0x30, 0x2C, 0x30, 0x32, 0x33, 0x0D, 0x0A,
+            0x56, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x0D, 0x0A
+        };
+
+        unsigned char pttoff[40] = {
+            0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+            0x30, 0x2C, 0x30, 0x32, 0x33, 0x0D, 0x0A,
+            0x56, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x0D, 0x0A
+        };
+
+        unsigned char *cmd = ptt ? ptton : pttoff;
+        anytone_transaction(rig, cmd, 40, NULL, 0, 0);
+    }
+    else
+    {
+        unsigned char ptton[8]  = { 0x41, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x06 };
+        unsigned char pttoff[8] = { 0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x06 };
+
+        unsigned char *cmd = ptt ? ptton : pttoff;
+        write_block(RIGPORT(rig), cmd, 8);
+    }
+
     p->ptt = ptt;
     MUTEX_UNLOCK(&p->mutex);
 
@@ -495,10 +564,7 @@ int anytone_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 }
 
 // ---------------------------------------------------------------------------
-// anytone_get_freq — query VFO frequency via BT-01 0x04 subcommand
-//
-// Subcommand 0x2c = VFO A channel data, 0x2d = VFO B channel data.
-// Response is 138 bytes; frequency is BCD-encoded at offset 17 (4 bytes).
+// anytone_get_freq — requires commode=1
 // ---------------------------------------------------------------------------
 int anytone_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
@@ -508,6 +574,12 @@ int anytone_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
     anytone_priv_data_t *p = STATE(rig)->priv;
 
     ENTERFUNC;
+
+    if (!p->commode)
+    {
+        rig_debug(RIG_DEBUG_ERR, "%s: requires -C commode=1\n", __func__);
+        RETURNFUNC(-RIG_ENAVAIL);
+    }
 
     SNPRINTF(cmd, sizeof(cmd), "+ADATA:00,006\r\n");
     cmd[15] = 0x04;
@@ -549,14 +621,7 @@ int anytone_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 }
 
 // ---------------------------------------------------------------------------
-// anytone_set_freq — direct frequency set via 0x5A/0x2F command pair
-//
-// Decoded from BT-01 protocol capture:
-//   Packet 1: +ADATA:00,005  0x5A [VFO] 0x00 0x00 0x00
-//   Packet 2: +ADATA:00,023  0x2F 0x03 0x00 [BCD freq 4 bytes] [constant data]
-//
-// VFO byte: 0x02 = VFO A, 0x01 = VFO B
-// Frequency: BCD big-endian, 10 Hz resolution (same encoding as get_freq)
+// anytone_set_freq — requires commode=1
 // ---------------------------------------------------------------------------
 int anytone_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
@@ -564,8 +629,12 @@ int anytone_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
     ENTERFUNC;
 
-    // Pad short entries with trailing zeros to 9 digits (Hz)
-    // e.g. 14652 -> 146520000 (146.520 MHz)
+    if (!p->commode)
+    {
+        rig_debug(RIG_DEBUG_ERR, "%s: requires -C commode=1\n", __func__);
+        RETURNFUNC(-RIG_ENAVAIL);
+    }
+
     while (freq > 0 && freq < 100000000)
     {
         freq *= 10;
@@ -574,7 +643,6 @@ int anytone_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     rig_debug(RIG_DEBUG_VERBOSE, "%s: vfo=%s freq=%g\n", __func__,
               rig_strvfo(vfo), freq);
 
-    // Packet 1: VFO select — +ADATA:00,005\r\n + 5A VFO 00 00 00 + \r\n
     unsigned char vfo_sel[22] = {
         0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
         0x30, 0x2C, 0x30, 0x30, 0x35, 0x0D, 0x0A,
@@ -587,7 +655,6 @@ int anytone_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
         vfo_sel[16] = 0x01;
     }
 
-    // Packet 2: Frequency data — +ADATA:00,023\r\n + 23-byte payload + \r\n
     unsigned char freq_data[40] = {
         0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
         0x30, 0x2C, 0x30, 0x32, 0x33, 0x0D, 0x0A,
@@ -600,7 +667,6 @@ int anytone_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
         0x0D, 0x0A
     };
 
-    // BCD-encode frequency at payload bytes 3-6 (array offset 18-21)
     to_bcd_be(&freq_data[18], (unsigned long long)(freq / 10), 8);
 
     MUTEX_LOCK(&p->mutex);
@@ -616,6 +682,86 @@ int anytone_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
     MUTEX_UNLOCK(&p->mutex);
 
     RETURNFUNC(RIG_OK);
+}
+
+// ---------------------------------------------------------------------------
+// anytone_set_clock — requires commode=1
+//
+// Probe confirmed: 0x55 with 6-byte payload modifies the radio's clock.
+// Sending all zeros set the date to 2070-01-01 00:00, suggesting the firmware
+// may apply a +70 year offset or use a non-standard epoch. The encoding
+// below uses straight BCD (YY MM DD HH MM) — if the radio shows the wrong
+// year, adjust the offset in the year byte calculation.
+// ---------------------------------------------------------------------------
+int anytone_set_clock(RIG *rig, int year, int month, int day,
+                      int hour, int min, int sec, double msec, int utc_offset)
+{
+    anytone_priv_data_t *p = STATE(rig)->priv;
+
+    ENTERFUNC;
+
+    if (!p->commode)
+    {
+        rig_debug(RIG_DEBUG_ERR, "%s: requires -C commode=1\n", __func__);
+        RETURNFUNC(-RIG_ENAVAIL);
+    }
+
+    // +ADATA:00,006\r\n  0x55 YY MM DD HH MM  \r\n  = 23 bytes
+    unsigned char cmd[23] = {
+        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+        0x30, 0x2C, 0x30, 0x30, 0x36, 0x0D, 0x0A,
+        0x55, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x0D, 0x0A
+    };
+
+    int yy = year % 100;
+    cmd[16] = (unsigned char)(((yy / 10) << 4) | (yy % 10));
+    cmd[17] = (unsigned char)(((month / 10) << 4) | (month % 10));
+    cmd[18] = (unsigned char)(((day / 10) << 4) | (day % 10));
+    cmd[19] = (unsigned char)(((hour / 10) << 4) | (hour % 10));
+    cmd[20] = (unsigned char)(((min / 10) << 4) | (min % 10));
+
+    rig_debug(RIG_DEBUG_VERBOSE,
+              "%s: setting clock to %04d-%02d-%02d %02d:%02d (BCD: %02X %02X %02X %02X %02X)\n",
+              __func__, year, month, day, hour, min,
+              cmd[16], cmd[17], cmd[18], cmd[19], cmd[20]);
+
+    MUTEX_LOCK(&p->mutex);
+    anytone_transaction(rig, cmd, sizeof(cmd), NULL, 0, 0);
+    hl_usleep(50 * 1000);
+    rig_flush(RIGPORT(rig));
+    MUTEX_UNLOCK(&p->mutex);
+
+    RETURNFUNC(RIG_OK);
+}
+
+// ---------------------------------------------------------------------------
+// anytone_get_clock — requires commode=1
+//
+// Not yet confirmed by probe. Command 0x58 (same len==6 check as 0x55) is
+// the most likely getter candidate but returned only a 5-byte ACK during
+// probing (possibly because the zero payload was invalid). Needs testing
+// with the radio to confirm the response format.
+// ---------------------------------------------------------------------------
+int anytone_get_clock(RIG *rig, int *year, int *month, int *day,
+                      int *hour, int *min, int *sec, double *msec,
+                      int *utc_offset)
+{
+    anytone_priv_data_t *p = STATE(rig)->priv;
+
+    ENTERFUNC;
+
+    if (!p->commode)
+    {
+        rig_debug(RIG_DEBUG_ERR, "%s: requires -C commode=1\n", __func__);
+        RETURNFUNC(-RIG_ENAVAIL);
+    }
+
+    rig_debug(RIG_DEBUG_WARN,
+              "%s: get_clock not yet confirmed — command 0x58 needs radio testing\n",
+              __func__);
+
+    RETURNFUNC(-RIG_ENIMPL);
 }
 
 // ---------------------------------------------------------------------------

--- a/rigs/anytone/anytone.c
+++ b/rigs/anytone/anytone.c
@@ -557,6 +557,13 @@ int anytone_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 
     ENTERFUNC;
 
+    // Pad short entries with trailing zeros to 9 digits (Hz)
+    // e.g. 14652 -> 146520000 (146.520 MHz)
+    while (freq > 0 && freq < 100000000)
+    {
+        freq *= 10;
+    }
+
     rig_debug(RIG_DEBUG_VERBOSE, "%s: vfo=%s freq=%g\n", __func__,
               rig_strvfo(vfo), freq);
 

--- a/rigs/anytone/anytone.c
+++ b/rigs/anytone/anytone.c
@@ -128,6 +128,14 @@ static void *anytone_thread(void *vrig)
 
     while (p->runflag)
     {
+        // Skip keepalive if a raw command (rig_send_raw / rigctld 'w')
+        // or a backend transaction is in progress
+        if (STATE(rig)->transaction_active)
+        {
+            hl_usleep(1000 * 1000);
+            continue;
+        }
+
         if (pthread_mutex_trylock(&p->mutex) != 0)
         {
             hl_usleep(1000 * 1000);

--- a/rigs/anytone/anytone.c
+++ b/rigs/anytone/anytone.c
@@ -301,7 +301,6 @@ int anytone_open(RIG *rig)
     int retval = RIG_OK;
     hamlib_port_t *rp = RIGPORT(rig);
     anytone_priv_data_t *p = STATE(rig)->priv;
-    unsigned char reply[512];
     int i;
 
     ENTERFUNC;
@@ -320,6 +319,9 @@ int anytone_open(RIG *rig)
         hl_usleep(200 * 1000);
     }
 
+    // Discard any heartbeat responses before proceeding
+    rig_flush(rp);
+
     // --- Step 2: Enter COM MODE ---
     // +ADATA:00,016\r\n + \x01 + "D578UV COM MODE" + \r\n = 33 bytes
     unsigned char commode[33] = {
@@ -331,18 +333,10 @@ int anytone_open(RIG *rig)
     };
 
     write_block(rp, commode, sizeof(commode));
-
-    // --- Step 3: Read COM MODE response ---
-    // Expected: +ADATA:00,004\r\n\x03\x01\x00\x00\r\n = 21 bytes
     hl_usleep(500 * 1000);
-    retval = read_block(rp, reply, 21);
+    rig_flush(rp);
 
-    if (retval < 0)
-    {
-        rig_debug(RIG_DEBUG_WARN, "%s: no COM MODE response\n", __func__);
-    }
-
-    // --- Step 4: Send COM CHECK END ---
+    // --- Step 3: Send COM CHECK END ---
     // +ADATA:00,014\r\n + 'd' + "COM CHECK END" + \r\n = 31 bytes
     unsigned char checkend[31] = {
         0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
@@ -353,18 +347,10 @@ int anytone_open(RIG *rig)
     };
 
     write_block(rp, checkend, sizeof(checkend));
-
-    // --- Step 5: Read COM CHECK END response ---
-    // Expected: +ADATA:00,005\r\n\x03\x64\x00\x00\x67\r\n = 22 bytes
     hl_usleep(200 * 1000);
-    retval = read_block(rp, reply, 22);
+    rig_flush(rp);
 
-    if (retval < 0)
-    {
-        rig_debug(RIG_DEBUG_WARN, "%s: no COM CHECK END response\n", __func__);
-    }
-
-    // --- Step 6: Release ---
+    // --- Step 4: Release ---
     // +ADATA:00,000\r\n\r\n = 17 bytes
     unsigned char release[17] = {
         0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,

--- a/rigs/anytone/anytone.c
+++ b/rigs/anytone/anytone.c
@@ -2,10 +2,14 @@
 //    AnyTone D578 Hamlib Backend
 // ---------------------------------------------------------------------------
 //
-//  d578.c
+//  anytone.c
 //
 //  Created by Michael Black W9MDB
 //  Copyright © 2023 Michael Black W9MDB.
+//
+//  Protocol analysis and fixes based on jrobertfisher's AT-D578UV-software-mic
+//  BT-01 Bluetooth microphone protocol capture.
+//  https://github.com/jrobertfisher/AT-D578UV-software-mic
 //
 //   This library is free software; you can redistribute it and/or
 //   modify it under the terms of the GNU Lesser General Public
@@ -48,6 +52,7 @@
 // ---------------------------------------------------------------------------
 
 #include "anytone.h"
+
 static int anytone_transaction(RIG *rig, unsigned char *cmd, int cmd_len,
                         unsigned char *reply, int reply_len, int expected_len);
 
@@ -59,8 +64,6 @@ DECLARE_INITRIG_BACKEND(anytone)
 
     return retval;
 }
-
-
 
 // ---------------------------------------------------------------------------
 // proberig_anytone
@@ -83,7 +86,6 @@ DECLARE_PROBERIG_BACKEND(anytone)
     port->parm.serial.stop_bits = 1;
     port->retry = 1;
 
-
     retval = serial_open(port);
 
     if (retval != RIG_OK)
@@ -94,33 +96,42 @@ DECLARE_PROBERIG_BACKEND(anytone)
     return retval;
 }
 
-// AnyTone needs a keep-alive to emulate the MIC
-// Apparently to keep the rig from getting stuck in PTT if mic disconnects
+// ---------------------------------------------------------------------------
+// Keep-alive thread — sends BT-01 heartbeat every second
+// ---------------------------------------------------------------------------
 static void *anytone_thread(void *vrig)
 {
     RIG *rig = (RIG *)vrig;
     hamlib_port_t *rp = RIGPORT(rig);
     anytone_priv_data_t *p = STATE(rig)->priv;
+
     rig_debug(RIG_DEBUG_TRACE, "%s: anytone_thread started\n", __func__);
     p->runflag = 1;
 
+    // Heartbeat: +ADATA:00,001\r\na\r\n (18 bytes)
+    unsigned char keepalive[] = {
+        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+        0x30, 0x2C, 0x30, 0x30, 0x31, 0x0D, 0x0A,
+        0x61,
+        0x0D, 0x0A
+    };
+
     while (p->runflag)
     {
-        char c[64];
-        SNPRINTF(c, sizeof(c), "+ADATA:00,001\r\na\r\n");
         MUTEX_LOCK(&p->mutex);
-        // if we don't have CACHE debug enabled then we only show WARN and higher for this rig
+
         enum rig_debug_level_e debug_level_save;
         rig_get_debug(&debug_level_save);
 
         if (rig_need_debug(RIG_DEBUG_CACHE) == 0)
         {
-            rig_set_debug(RIG_DEBUG_WARN);    // only show WARN debug otherwise too verbose
+            rig_set_debug(RIG_DEBUG_WARN);
         }
 
-        write_block(rp, (unsigned char *)c, strlen(c));
-        char buf[32];
-        read_block(rp, (unsigned char *)buf, 22);
+        write_block(rp, keepalive, sizeof(keepalive));
+
+        unsigned char buf[32];
+        read_block(rp, buf, 22);
 
         if (rig_need_debug(RIG_DEBUG_CACHE) == 0)
         {
@@ -128,7 +139,7 @@ static void *anytone_thread(void *vrig)
         }
 
         MUTEX_UNLOCK(&p->mutex);
-        hl_usleep(1000 * 1000); // 1-second loop
+        hl_usleep(1000 * 1000);
     }
 
     return NULL;
@@ -137,18 +148,16 @@ static void *anytone_thread(void *vrig)
 // ---------------------------------------------------------------------------
 // anytone_send
 // ---------------------------------------------------------------------------
-static int anytone_send(RIG  *rig,
-                 unsigned char *cmd, int cmd_len)
+static int anytone_send(RIG *rig, unsigned char *cmd, int cmd_len)
 {
-    int               retval       = RIG_OK;
+    int retval = RIG_OK;
     hamlib_port_t *rp = RIGPORT(rig);
 
     ENTERFUNC;
 
     rig_flush(rp);
 
-    retval = write_block(rp, (unsigned char *) cmd,
-                         cmd_len);
+    retval = write_block(rp, cmd, cmd_len);
 
     RETURNFUNC(retval);
 }
@@ -156,22 +165,20 @@ static int anytone_send(RIG  *rig,
 // ---------------------------------------------------------------------------
 // anytone_receive
 // ---------------------------------------------------------------------------
-static int anytone_receive(RIG  *rig, unsigned char *buf, int buf_len, int expected)
+static int anytone_receive(RIG *rig, unsigned char *buf, int buf_len,
+                           int expected)
 {
-    int               retval       = RIG_OK;
+    int retval = RIG_OK;
     hamlib_port_t *rp = RIGPORT(rig);
 
     ENTERFUNC;
 
-//    retval = read_string(rp, (unsigned char *) buf, buf_len,
-//                         NULL, 0, 0, expected);
     retval = read_block(rp, buf, expected);
 
     if (retval > 0)
     {
+        rig_debug(RIG_DEBUG_VERBOSE, "%s: read %d bytes\n", __func__, retval);
         retval = RIG_OK;
-        rig_debug(RIG_DEBUG_VERBOSE, "%s: read %d byte=0x%02x\n", __func__, retval,
-                  buf[0]);
     }
 
     RETURNFUNC(retval);
@@ -183,8 +190,7 @@ static int anytone_receive(RIG  *rig, unsigned char *buf, int buf_len, int expec
 static int anytone_transaction(RIG *rig, unsigned char *cmd, int cmd_len,
                         unsigned char *reply, int reply_len, int expected_len)
 {
-    int retval   = RIG_OK;
-    //anytone_priv_data_t *p = STATE(rig)->priv;
+    int retval = RIG_OK;
 
     ENTERFUNC;
 
@@ -192,15 +198,50 @@ static int anytone_transaction(RIG *rig, unsigned char *cmd, int cmd_len,
 
     if (retval == RIG_OK && expected_len != 0)
     {
-        int len = anytone_receive(rig, reply, reply_len,  expected_len);
-        rig_debug(RIG_DEBUG_VERBOSE, "%s(%d): rx len=%d\n", __func__, __LINE__, len);
+        int len = anytone_receive(rig, reply, reply_len, expected_len);
+        rig_debug(RIG_DEBUG_VERBOSE, "%s(%d): rx len=%d\n", __func__, __LINE__,
+                  len);
     }
 
     RETURNFUNC(retval);
 }
 
 // ---------------------------------------------------------------------------
-// Function anytone_init
+// anytone_send_button — send a button press+release via +ADATA framing
+//
+// Wraps the direct serial protocol's 0x41 button command inside +ADATA.
+// The radio may or may not accept this while in BT-01 COM MODE — this is
+// the mechanism the BT-01 Bluetooth microphone uses for its own buttons.
+// ---------------------------------------------------------------------------
+static int anytone_send_button(RIG *rig, unsigned char key)
+{
+    hamlib_port_t *rp = RIGPORT(rig);
+
+    // +ADATA:00,008\r\n + 0x41 button packet + \r\n
+    unsigned char press[25] = {
+        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+        0x30, 0x2C, 0x30, 0x30, 0x38, 0x0D, 0x0A,
+        0x41, 0x00, 0x01, 0x00, key, 0x00, 0x00, 0x06,
+        0x0D, 0x0A
+    };
+
+    unsigned char release[25] = {
+        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+        0x30, 0x2C, 0x30, 0x30, 0x38, 0x0D, 0x0A,
+        0x41, 0x00, 0x00, 0x00, key, 0x00, 0x00, 0x06,
+        0x0D, 0x0A
+    };
+
+    write_block(rp, press, sizeof(press));
+    hl_usleep(100 * 1000);
+    write_block(rp, release, sizeof(release));
+    hl_usleep(100 * 1000);
+
+    return RIG_OK;
+}
+
+// ---------------------------------------------------------------------------
+// anytone_init
 // ---------------------------------------------------------------------------
 int anytone_init(RIG *rig)
 {
@@ -210,35 +251,26 @@ int anytone_init(RIG *rig)
 
     if (rig != NULL)
     {
-        anytone_priv_data_ptr p = NULL;
-
-        // Get new Priv Data
-
-        p = calloc(1, sizeof(anytone_priv_data_t));
+        anytone_priv_data_ptr p = calloc(1, sizeof(anytone_priv_data_t));
 
         if (p == NULL)
         {
-            retval = -RIG_ENOMEM;
-            RETURNFUNC(retval);
+            RETURNFUNC(-RIG_ENOMEM);
         }
-        else
-        {
-            STATE(rig)->priv = p;
-            p->vfo_curr = RIG_VFO_NONE;
-            pthread_mutex_init(&p->mutex, NULL);
-        }
+
+        STATE(rig)->priv = p;
+        p->vfo_curr = RIG_VFO_NONE;
+        pthread_mutex_init(&p->mutex, NULL);
     }
 
     RETURNFUNC(retval);
 }
 
 // ---------------------------------------------------------------------------
-// Function anytone_cleanup
+// anytone_cleanup
 // ---------------------------------------------------------------------------
 int anytone_cleanup(RIG *rig)
 {
-    int retval = RIG_OK;
-
     if (rig == NULL)
     {
         return -RIG_EARG;
@@ -249,33 +281,104 @@ int anytone_cleanup(RIG *rig)
     free(STATE(rig)->priv);
     STATE(rig)->priv = NULL;
 
-    RETURNFUNC(retval);
+    RETURNFUNC(RIG_OK);
 }
 
 // ---------------------------------------------------------------------------
-// Function anytone_open
+// anytone_open — full BT-01 handshake per the captured protocol
+//
+// Sequence from the working BT-01 software mic:
+//   1. Send wake-up heartbeat 3x with delays
+//   2. Send "\x01D578UV COM MODE" — radio enters external cable mode
+//   3. Read COM MODE acknowledgment
+//   4. Send "\x64COM CHECK END" — complete the handshake
+//   5. Read acknowledgment
+//   6. Send +ADATA:00,000 release
+//   7. Start keep-alive thread
 // ---------------------------------------------------------------------------
 int anytone_open(RIG *rig)
 {
     int retval = RIG_OK;
     hamlib_port_t *rp = RIGPORT(rig);
+    anytone_priv_data_t *p = STATE(rig)->priv;
+    unsigned char reply[512];
+    int i;
 
     ENTERFUNC;
 
-    unsigned char cmd[] = { 0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30, 0x30, 0x2C, 0x30, 0x30, 0x31, 0x0d, 0x0a, 'a', 0x0d, 0x0a };
-    write_block(rp, cmd, sizeof(cmd));
-    hl_usleep(500 * 1000);
-    char cmd2[64];
-    SNPRINTF(cmd2, sizeof(cmd2), "+ADATA:00,016\r\n%cD578UV COM MODE\r\n", 0x01);
-    write_block(rp, (unsigned char *)cmd2, strlen(cmd2));
-    SNPRINTF(cmd2, sizeof(cmd2), "+ADATA:00,000\r\n");
-    unsigned char reply[512];
-    anytone_transaction(rig, (unsigned char *)cmd2, strlen(cmd2), reply,
-                        sizeof(reply), strlen(cmd2));
+    // --- Step 1: Wake-up heartbeats (3x) ---
+    unsigned char wakeup[18] = {
+        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+        0x30, 0x2C, 0x30, 0x30, 0x31, 0x0D, 0x0A,
+        0x61,
+        0x0D, 0x0A
+    };
 
-    pthread_t id;
-    // will start the keep alive
-    int err = pthread_create(&id, NULL, anytone_thread, (void *)rig);
+    for (i = 0; i < 3; i++)
+    {
+        write_block(rp, wakeup, sizeof(wakeup));
+        hl_usleep(200 * 1000);
+    }
+
+    // --- Step 2: Enter COM MODE ---
+    // +ADATA:00,016\r\n + \x01 + "D578UV COM MODE" + \r\n = 33 bytes
+    unsigned char commode[33] = {
+        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+        0x30, 0x2C, 0x30, 0x31, 0x36, 0x0D, 0x0A,
+        0x01,
+        'D', '5', '7', '8', 'U', 'V', ' ', 'C', 'O', 'M', ' ', 'M', 'O', 'D', 'E',
+        0x0D, 0x0A
+    };
+
+    write_block(rp, commode, sizeof(commode));
+
+    // --- Step 3: Read COM MODE response ---
+    // Expected: +ADATA:00,004\r\n\x03\x01\x00\x00\r\n = 21 bytes
+    hl_usleep(500 * 1000);
+    retval = read_block(rp, reply, 21);
+
+    if (retval < 0)
+    {
+        rig_debug(RIG_DEBUG_WARN, "%s: no COM MODE response\n", __func__);
+    }
+
+    // --- Step 4: Send COM CHECK END ---
+    // +ADATA:00,014\r\n + 'd' + "COM CHECK END" + \r\n = 31 bytes
+    unsigned char checkend[31] = {
+        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+        0x30, 0x2C, 0x30, 0x31, 0x34, 0x0D, 0x0A,
+        0x64,
+        'C', 'O', 'M', ' ', 'C', 'H', 'E', 'C', 'K', ' ', 'E', 'N', 'D',
+        0x0D, 0x0A
+    };
+
+    write_block(rp, checkend, sizeof(checkend));
+
+    // --- Step 5: Read COM CHECK END response ---
+    // Expected: +ADATA:00,005\r\n\x03\x64\x00\x00\x67\r\n = 22 bytes
+    hl_usleep(200 * 1000);
+    retval = read_block(rp, reply, 22);
+
+    if (retval < 0)
+    {
+        rig_debug(RIG_DEBUG_WARN, "%s: no COM CHECK END response\n", __func__);
+    }
+
+    // --- Step 6: Release ---
+    // +ADATA:00,000\r\n\r\n = 17 bytes
+    unsigned char release[17] = {
+        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+        0x30, 0x2C, 0x30, 0x30, 0x30, 0x0D, 0x0A,
+        0x0D, 0x0A
+    };
+
+    write_block(rp, release, sizeof(release));
+    hl_usleep(200 * 1000);
+    write_block(rp, release, sizeof(release));
+    hl_usleep(200 * 1000);
+
+    // --- Step 7: Start keep-alive thread ---
+    int err = pthread_create(&p->thread_id, NULL, anytone_thread, (void *)rig);
 
     if (err)
     {
@@ -284,49 +387,68 @@ int anytone_open(RIG *rig)
         RETURNFUNC(-RIG_EINTERNAL);
     }
 
-    RETURNFUNC(retval);
+    RETURNFUNC(RIG_OK);
 }
 
 // ---------------------------------------------------------------------------
-// Function anytone_close
+// anytone_close
 // ---------------------------------------------------------------------------
 int anytone_close(RIG *rig)
 {
-    int retval = RIG_OK;
     anytone_priv_data_t *p = STATE(rig)->priv;
 
     ENTERFUNC;
 
-    // Tell thread to give up
     p->runflag = 0;
-    char *cmd  = "+ADATA:00,000\r\n";
-    anytone_transaction(rig, (unsigned char *)cmd, strlen(cmd), NULL, 0, 0);
+    pthread_join(p->thread_id, NULL);
 
-    RETURNFUNC(retval);
+    unsigned char release[17] = {
+        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+        0x30, 0x2C, 0x30, 0x30, 0x30, 0x0D, 0x0A,
+        0x0D, 0x0A
+    };
+
+    anytone_transaction(rig, release, sizeof(release), NULL, 0, 0);
+
+    RETURNFUNC(RIG_OK);
 }
 
 // ---------------------------------------------------------------------------
-// Function anytone_get_vfo
+// anytone_get_vfo
 // ---------------------------------------------------------------------------
 int anytone_get_vfo(RIG *rig, vfo_t *vfo)
 {
     int retval = RIG_OK;
-    //char cmd[] = { 0x41, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x06 };
-    //char cmd[] = { "+ADATA06:00,001",0x41, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x06 };
+    anytone_priv_data_t *p = STATE(rig)->priv;
+    unsigned char reply[512];
 
     ENTERFUNC;
 
-    const anytone_priv_data_ptr p = (anytone_priv_data_ptr) STATE(rig)->priv;
-    unsigned char reply[512];
-    unsigned char cmd[] = { 0x2b, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3a, 0x30, 0x30, 0x2c, 0x30, 0x30, 0x36, 0x0d, 0x0a, 0x04, 0x05, 0x00, 0x00, 0x00, 0x00, 0x0d, 0x0a };
-    anytone_transaction(rig, cmd, sizeof(cmd), reply, sizeof(reply), 114);
+    // +ADATA:00,006\r\n + \x04\x05\x00\x00\x00\x00 + \r\n = 23 bytes
+    unsigned char cmd[23] = {
+        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+        0x30, 0x2C, 0x30, 0x30, 0x36, 0x0D, 0x0A,
+        0x04, 0x05, 0x00, 0x00, 0x00, 0x00,
+        0x0D, 0x0A
+    };
 
-    if (reply[113] == 0x9b) { *vfo = RIG_VFO_A; }
-    else if (reply[113] == 0x9c) { *vfo = RIG_VFO_B; }
+    MUTEX_LOCK(&p->mutex);
+    anytone_transaction(rig, cmd, sizeof(cmd), reply, sizeof(reply), 114);
+    MUTEX_UNLOCK(&p->mutex);
+
+    if (reply[113] == 0x9b)
+    {
+        *vfo = RIG_VFO_A;
+    }
+    else if (reply[113] == 0x9c)
+    {
+        *vfo = RIG_VFO_B;
+    }
     else
     {
-        *vfo = RIG_VFO_A; // default to VFOA
-        rig_debug(RIG_DEBUG_ERR, "%s: unknown vfo=0x%02x\n", __func__, reply[113]);
+        *vfo = RIG_VFO_A;
+        rig_debug(RIG_DEBUG_ERR, "%s: unknown vfo byte=0x%02x\n", __func__,
+                  reply[113]);
     }
 
     p->vfo_curr = *vfo;
@@ -335,126 +457,192 @@ int anytone_get_vfo(RIG *rig, vfo_t *vfo)
 }
 
 // ---------------------------------------------------------------------------
-// Function anytone_set_vfo
+// anytone_set_vfo — toggle VFO via Sub A/B button press
 // ---------------------------------------------------------------------------
 int anytone_set_vfo(RIG *rig, vfo_t vfo)
 {
+    anytone_priv_data_t *p = STATE(rig)->priv;
+    vfo_t curr_vfo;
+
     ENTERFUNC;
+
+    anytone_get_vfo(rig, &curr_vfo);
+
+    if (curr_vfo == vfo)
+    {
+        RETURNFUNC(RIG_OK);
+    }
+
+    MUTEX_LOCK(&p->mutex);
+    anytone_send_button(rig, ANYTONE_KEY_SUBAB);
+    MUTEX_UNLOCK(&p->mutex);
+
+    p->vfo_curr = vfo;
+
     RETURNFUNC(RIG_OK);
 }
 
 // ---------------------------------------------------------------------------
-// Function anytone_get_ptt
+// anytone_get_ptt
 // ---------------------------------------------------------------------------
 int anytone_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
 {
-    int retval = RIG_OK;
-
     ENTERFUNC;
 
     anytone_priv_data_t *p = STATE(rig)->priv;
     *ptt = p->ptt;
 
-    RETURNFUNC(retval);
+    RETURNFUNC(RIG_OK);
 }
+
 // ---------------------------------------------------------------------------
-// anytone_set_ptt
+// anytone_set_ptt — corrected PTT using the 0x56 (V) command
+//
+// Working protocol from BT-01 capture:
+//   PTT ON:  +ADATA:00,023\r\n V \x01 + 21 zero bytes \r\n
+//   PTT OFF: +ADATA:00,023\r\n V \x00 + 21 zero bytes \r\n
 // ---------------------------------------------------------------------------
 int anytone_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 {
     anytone_priv_data_t *p = STATE(rig)->priv;
-    int retval = RIG_OK;
 
     ENTERFUNC;
 
-    //char buf[8] = { 0x41, 0x00, 0x00, 0x00, 0x27, 0x00, 0x00, 0x06 };
-    unsigned char ptton[] =  { 0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30, 0x30, 0x2C, 0x30, 0x30, 0x31, 0x0d, 0x0a, 0x61, 0x0d, 0x0a };
-    unsigned char pttoff[] = { 0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30, 0x30, 0x2C, 0x30, 0x32, 0x33, 0x0d, 0x0a, 0x56, 0x0d, 0x0a };
-    void *pttcmd = ptton;
+    // +ADATA:00,023\r\n (15) + V + on/off + 21 zeros (23) + \r\n (2) = 40 bytes
+    unsigned char ptton[40] = {
+        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+        0x30, 0x2C, 0x30, 0x32, 0x33, 0x0D, 0x0A,
+        0x56, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x0D, 0x0A
+    };
 
-    if (!ptt) { pttcmd = pttoff; }
+    unsigned char pttoff[40] = {
+        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+        0x30, 0x2C, 0x30, 0x32, 0x33, 0x0D, 0x0A,
+        0x56, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x0D, 0x0A
+    };
 
-    //if (!ptt) { cmd = " (unsigned char*)+ADATA:00,023\r\nV\r\n"; }
+    unsigned char *cmd = ptt ? ptton : pttoff;
 
     MUTEX_LOCK(&p->mutex);
-    anytone_transaction(rig, pttcmd, sizeof(ptton), NULL, 0, 0);
+    anytone_transaction(rig, cmd, 40, NULL, 0, 0);
     p->ptt = ptt;
     MUTEX_UNLOCK(&p->mutex);
 
-    RETURNFUNC(retval);
+    RETURNFUNC(RIG_OK);
 }
 
+// ---------------------------------------------------------------------------
+// anytone_get_freq — query VFO frequency via BT-01 0x04 subcommand
+//
+// Subcommand 0x2c = VFO A channel data, 0x2d = VFO B channel data.
+// Response is 138 bytes; frequency is BCD-encoded at offset 17 (4 bytes).
+// ---------------------------------------------------------------------------
 int anytone_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
-    char cmd[32];
-    int retval;
-    hamlib_port_t *rp = RIGPORT(rig);
     anytone_priv_data_t *p = STATE(rig)->priv;
-
-    SNPRINTF(cmd, sizeof(cmd), "+ADATA:00,006\r\n");
-    cmd[15] = 0x04;
-    cmd[16] = 0x2c;
-    cmd[17] = 0x07;
-    cmd[18] = 0x00;
-    cmd[19] = 0x00;
-    cmd[21] = 0x00;
-    cmd[22] = 0x00;
-    cmd[23] = 0x0d;
-    cmd[24] = 0x0a;
-
-    if (vfo == RIG_VFO_B) { cmd[16] = 0x2d; }
-
+    int retval;
     int retry = 2;
+
+    ENTERFUNC;
+
+    // +ADATA:00,006\r\n + \x04 \xSUB \x07 \x00 \x00 \x00 + \r\n = 23 bytes
+    unsigned char cmd[23] = {
+        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+        0x30, 0x2C, 0x30, 0x30, 0x36, 0x0D, 0x0A,
+        0x04, 0x2C, 0x07, 0x00, 0x00, 0x00,
+        0x0D, 0x0A
+    };
+
+    if (vfo == RIG_VFO_B)
+    {
+        cmd[16] = 0x2D;
+    }
+
     MUTEX_LOCK(&p->mutex);
-    rig_flush(rp);
+    rig_flush(RIGPORT(rig));
 
     do
     {
-        write_block(rp, (unsigned char *)cmd, 25);
         unsigned char buf[512];
-        retval = read_block(rp, buf, 138);
+        retval = write_block(RIGPORT(rig), cmd, sizeof(cmd));
+
+        if (retval != RIG_OK) { break; }
+
+        retval = read_block(RIGPORT(rig), buf, 138);
 
         if (retval == 138)
         {
             *freq = from_bcd_be(&buf[17], 8) * 10;
-            rig_debug(RIG_DEBUG_VERBOSE, "%s: VFOA freq=%g\n", __func__, *freq);
+            rig_debug(RIG_DEBUG_VERBOSE, "%s: freq=%g\n", __func__, *freq);
             retval = RIG_OK;
+            break;
         }
     }
-    while (retval != 138 && --retry > 0);
+    while (--retry > 0);
 
     MUTEX_UNLOCK(&p->mutex);
 
-    return RIG_OK;
+    RETURNFUNC(retval == RIG_OK ? RIG_OK : -RIG_EIO);
 }
 
+// ---------------------------------------------------------------------------
+// anytone_set_freq — enter frequency via keypad button emulation
+//
+// Converts frequency (Hz) to an 8-digit string (10 Hz resolution) and
+// sends each digit as a button press/release via +ADATA-wrapped 0x41
+// commands. The radio must be in VFO mode for this to work.
+//
+// This uses the same button protocol as the AT-D578UV-software-mic
+// console program, wrapped in BT-01 +ADATA framing.
+// ---------------------------------------------------------------------------
 int anytone_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-    char cmd[64];
-    hamlib_port_t *rp = RIGPORT(rig);
     anytone_priv_data_t *p = STATE(rig)->priv;
+    char digits[16];
+    int i;
+    unsigned long freq_10hz;
 
-    if (vfo == RIG_VFO_A)
-    {
-        snprintf(cmd, sizeof(cmd), "ADATA:00,005\r\n%c%c%c%c\r\n", 2, 0, 0, 0);
-    }
-    else
-    {
-        snprintf(cmd, sizeof(cmd), "ADATA:00,005\r\n%c%c%c%c\r\n", 1, 0, 0, 0);
-    }
+    ENTERFUNC;
+
+    // Digit key codes: 0->0x01, 1->0x02, ... 9->0x0A
+    static const unsigned char digit_to_key[10] = {
+        ANYTONE_KEY_0, ANYTONE_KEY_1, ANYTONE_KEY_2, ANYTONE_KEY_3,
+        ANYTONE_KEY_4, ANYTONE_KEY_5, ANYTONE_KEY_6, ANYTONE_KEY_7,
+        ANYTONE_KEY_8, ANYTONE_KEY_9
+    };
+
+    freq_10hz = (unsigned long)(freq / 10.0 + 0.5);
+    SNPRINTF(digits, sizeof(digits), "%08lu", freq_10hz);
+
+    rig_debug(RIG_DEBUG_VERBOSE, "%s: freq=%g digits=%s\n", __func__, freq,
+              digits);
 
     MUTEX_LOCK(&p->mutex);
-    rig_flush(rp);
-    write_block(rp, (unsigned char *) cmd, 20);
-    unsigned char backend[] = { 0x2f, 0x03, 0x00, 0xff, 0xff, 0xff, 0xff, 0x15, 0x50, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xcf, 0x09, 0x00, 0x00, 0x0d, 0x0a};
-    snprintf(cmd, sizeof(cmd), "ADATA:00,023\r\n");
-    int bytes = strlen(cmd) + sizeof(backend);
-    memcpy(&cmd[15], backend, sizeof(backend));
-    hl_usleep(10 * 1000);
-    write_block(rp, (unsigned char *)cmd, bytes);
+    rig_flush(RIGPORT(rig));
+
+    for (i = 0; i < 8; i++)
+    {
+        int d = digits[i] - '0';
+
+        if (d < 0 || d > 9)
+        {
+            rig_debug(RIG_DEBUG_ERR, "%s: bad digit '%c'\n", __func__, digits[i]);
+            MUTEX_UNLOCK(&p->mutex);
+            RETURNFUNC(-RIG_EINVAL);
+        }
+
+        anytone_send_button(rig, digit_to_key[d]);
+    }
+
     MUTEX_UNLOCK(&p->mutex);
 
-    return -RIG_ENIMPL;
+    RETURNFUNC(RIG_OK);
 }
 
 // ---------------------------------------------------------------------------

--- a/rigs/anytone/anytone.c
+++ b/rigs/anytone/anytone.c
@@ -314,7 +314,7 @@ int anytone_open(RIG *rig)
         0x0D, 0x0A
     };
 
-    //write_block(rp, wakeup, sizeof(wakeup));
+    write_block(rp, wakeup, sizeof(wakeup));
     hl_usleep(500 * 1000);
 
     // --- Step 2: Enter COM MODE ---

--- a/rigs/anytone/anytone.h
+++ b/rigs/anytone/anytone.h
@@ -1,9 +1,32 @@
+// ---------------------------------------------------------------------------
+//    AnyTone D578 Hamlib Backend
+// ---------------------------------------------------------------------------
+//
+//  anytone.h
+//
+//  Created by Michael Black W9MDB
+//  Copyright © 2023 Michael Black W9MDB.
+//
+//   This library is free software; you can redistribute it and/or
+//   modify it under the terms of the GNU Lesser General Public
+//   License as published by the Free Software Foundation; either
+//   version 2.1 of the License, or (at your option) any later version.
+//
+//   This library is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//   Lesser General Public License for more details.
+//
+//   You should have received a copy of the GNU Lesser General Public
+//   License along with this library; if not, write to the Free Software
+//   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
 #ifndef _ANYTONE_H
 #define _ANYTONE_H 1
 
 #include "hamlib/rig.h"
 
-#define BACKEND_VER "20231001"
+#define BACKEND_VER "20260627"
 
 #define ANYTONE_RESPSZ 64
 
@@ -14,13 +37,31 @@ extern struct rig_caps anytone_d578_caps;
 #define MUTEX_LOCK(var) pthread_mutex_lock(var)
 #define MUTEX_UNLOCK(var)  pthread_mutex_unlock(var)
 
+// Button key codes from the direct serial / BT-01 mic protocol
+#define ANYTONE_KEY_0     0x01
+#define ANYTONE_KEY_1     0x02
+#define ANYTONE_KEY_2     0x03
+#define ANYTONE_KEY_3     0x04
+#define ANYTONE_KEY_4     0x05
+#define ANYTONE_KEY_5     0x06
+#define ANYTONE_KEY_6     0x07
+#define ANYTONE_KEY_7     0x08
+#define ANYTONE_KEY_8     0x09
+#define ANYTONE_KEY_9     0x0A
+#define ANYTONE_KEY_STAR  0x0B
+#define ANYTONE_KEY_HASH  0x0C
+#define ANYTONE_KEY_SUBAB 0x0D
+#define ANYTONE_KEY_UP    0x10
+#define ANYTONE_KEY_DOWN  0x11
+
 typedef struct _anytone_priv_data
 {
     ptt_t         ptt;
     vfo_t         vfo_curr;
-    volatile int  runflag; // thread control
+    volatile int  runflag;
     char          buf[64];
     pthread_mutex_t mutex;
+    pthread_t     thread_id;
 } anytone_priv_data_t,
 * anytone_priv_data_ptr;
 
@@ -31,7 +72,7 @@ extern int anytone_open(RIG *rig);
 extern int anytone_close(RIG *rig);
 
 extern int anytone_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt);
-extern int anytone_get_ptt(RIG *rig, vfo_t vfo,ptt_t *ptt);
+extern int anytone_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt);
 
 extern int anytone_set_vfo(RIG *rig, vfo_t vfo);
 extern int anytone_get_vfo(RIG *rig, vfo_t *vfo);

--- a/rigs/anytone/anytone.h
+++ b/rigs/anytone/anytone.h
@@ -25,12 +25,16 @@
 #define _ANYTONE_H 1
 
 #include "hamlib/rig.h"
+#include "token.h"
 
-#define BACKEND_VER "20260627"
+#define BACKEND_VER "20260629"
 
 #define ANYTONE_RESPSZ 64
 
+#define TOK_COMMODE TOKEN_BACKEND(1)
+
 extern struct rig_caps anytone_d578_caps;
+extern const struct confparams anytone_cfg_params[];
 
 #include <pthread.h>
 #define MUTEX(var) static pthread_mutex_t var = PTHREAD_MUTEX_INITIALIZER
@@ -59,6 +63,7 @@ typedef struct _anytone_priv_data
     ptt_t         ptt;
     vfo_t         vfo_curr;
     volatile int  runflag;
+    int           commode;
     char          buf[64];
     pthread_mutex_t mutex;
     pthread_t     thread_id;
@@ -71,6 +76,9 @@ extern int anytone_cleanup(RIG *rig);
 extern int anytone_open(RIG *rig);
 extern int anytone_close(RIG *rig);
 
+extern int anytone_set_conf(RIG *rig, hamlib_token_t token, const char *val);
+extern int anytone_get_conf(RIG *rig, hamlib_token_t token, char *val);
+
 extern int anytone_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt);
 extern int anytone_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt);
 
@@ -79,5 +87,12 @@ extern int anytone_get_vfo(RIG *rig, vfo_t *vfo);
 
 extern int anytone_set_freq(RIG *rig, vfo_t vfo, freq_t freq);
 extern int anytone_get_freq(RIG *rig, vfo_t vfo, freq_t *freq);
+
+extern int anytone_set_clock(RIG *rig, int year, int month, int day,
+                             int hour, int min, int sec, double msec,
+                             int utc_offset);
+extern int anytone_get_clock(RIG *rig, int *year, int *month, int *day,
+                             int *hour, int *min, int *sec, double *msec,
+                             int *utc_offset);
 
 #endif /* _ANYTONE_H */

--- a/rigs/anytone/d578.c
+++ b/rigs/anytone/d578.c
@@ -26,10 +26,35 @@
 #define D578_VFO (RIG_VFO_A|RIG_VFO_B)
 #define D578_MODES (RIG_MODE_FM|RIG_MODE_AM)
 
+// ---------------------------------------------------------------------------
+// Backend configuration parameters
+//
+// commode=0 (default): direct serial mic protocol — PTT only, no lockout
+// commode=1: BT-01 ADATA/COM MODE — adds freq, VFO, clock control but
+//            locks the radio display to "EXTERNAL CABLE MODE"
+//
+// Usage: rigctl -m 37001 -C commode=1 -s 115200 -r /dev/ttyUSB0
+// ---------------------------------------------------------------------------
+const struct confparams anytone_cfg_params[] =
+{
+    {
+        TOK_COMMODE, "commode", "COM Mode",
+        "Enable ADATA/COM MODE for freq/vfo/clock (locks radio display)",
+        "0", RIG_CONF_CHECKBUTTON, { }
+    },
+    { RIG_CONF_END, NULL, }
+};
+
+// ---------------------------------------------------------------------------
+// Rig 37001 — AT-D578UVIII
+//
+// Default: direct serial mic protocol with PTT only.
+// With -C commode=1: enters BT-01 COM MODE for freq/vfo/clock control.
+// ---------------------------------------------------------------------------
 struct rig_caps anytone_d578_caps =
 {
     RIG_MODEL(RIG_MODEL_ATD578UVIII),
-    .model_name         =  "D578A",
+    .model_name         =  "AT-D578UVIII",
     .mfg_name           =  "AnyTone",
     .version            =  BACKEND_VER ".0",
     .copyright          =  "Michael Black W9MDB: GNU LGPL",
@@ -72,6 +97,10 @@ struct rig_caps anytone_d578_caps =
         RIG_FRNG_END,
     },
 
+    .cfgparams          =  anytone_cfg_params,
+    .set_conf           =  anytone_set_conf,
+    .get_conf           =  anytone_get_conf,
+
     .rig_init           =  anytone_init,
     .rig_cleanup        =  anytone_cleanup,
     .rig_open           =  anytone_open,
@@ -85,6 +114,9 @@ struct rig_caps anytone_d578_caps =
 
     .set_freq           =  anytone_set_freq,
     .get_freq           =  anytone_get_freq,
+
+    .set_clock          =  anytone_set_clock,
+    .get_clock          =  anytone_get_clock,
 
     .hamlib_check_rig_caps = HAMLIB_CHECK_RIG_CAPS
 };

--- a/rigs/anytone/d578.c
+++ b/rigs/anytone/d578.c
@@ -24,7 +24,7 @@
 #include "anytone.h"
 
 #define D578_VFO (RIG_VFO_A|RIG_VFO_B)
-#define D578_MODES (RIG_MODE_USB|RIG_MODE_AM)
+#define D578_MODES (RIG_MODE_FM|RIG_MODE_AM)
 
 struct rig_caps anytone_d578_caps =
 {
@@ -59,7 +59,6 @@ struct rig_caps anytone_d578_caps =
     .rx_range_list1 =
     {
         { MHz(108), MHz(174), D578_MODES, -1, -1, D578_VFO },
-        { MHz(144), MHz(148), D578_MODES, -1, -1, D578_VFO },
         { MHz(222), MHz(225), D578_MODES, -1, -1, D578_VFO },
         { MHz(420), MHz(450), D578_MODES, -1, -1, D578_VFO },
         RIG_FRNG_END,


### PR DESCRIPTION
## Summary

Rewrites the AnyTone AT-D578UVIII backend to support both serial protocols exposed by the radio on its 115200 8N1 port, selectable at runtime via a `-C commode=` config flag.

- **Default mode (`commode=0`)** — Direct serial mic protocol. Sends raw byte commands (0x06 keepalive, 0x41 PTT) with no initialization handshake and no radio display lockout. Ideal for digital mode software like VARA and fldigi that only need PTT control — the operator retains full use of the radio's front panel and the connection is invisible to the user.

- **COM mode (`commode=1`)** — BT-01 ADATA protocol. Performs a COM MODE handshake on open and uses `+ADATA:00,NNN\r\n` framed commands for PTT, get/set frequency, get/set VFO, and set clock. The radio displays "EXTERNAL CABLE MODE" while connected, locking the front panel. Suited for automated station control where frequency and VFO selection need to be driven programmatically.

The single rig model (37001) covers both modes — no changes to `riglist.h` or model registration required.

## Roadmap: raw command passthrough

The keepalive thread checks `transaction_active` before sending, so `rig_send_raw` / rigctld `w` commands pass through without collision. This is intentional — the radio's firmware accepts 34 distinct ADATA command bytes, most of which are undocumented. By exposing the driver's COM MODE session (handshake, keepalive, serial port management) to third-party software via the existing `w` interface, client applications can send arbitrary ADATA commands to explore and use protocol features that the backend doesn't yet implement natively.

This opens the door for a standalone BT-01 client program that connects through `rigctld` rather than managing the serial port directly — it gets session management for free and can coexist with other Hamlib clients sharing the same `rigctld` instance. As commands are identified and stabilized through this passthrough, they can be promoted to proper Hamlib API functions in the backend.

## Changes

All modifications are confined to `rigs/anytone/`:

- **anytone.c** — Keepalive thread branches on `commode`; `set_ptt` branches between raw 0x41 and ADATA 0x56; ADATA-only functions (`get_freq`, `set_freq`, `get_vfo`, `set_vfo`, `set_clock`) return `-RIG_ENAVAIL` when `commode=0`; keepalive yields to `transaction_active` for raw passthrough safety
- **anytone.h** — Added `commode` flag to priv struct, `TOK_COMMODE` config token, clock function declarations
- **d578.c** — `anytone_cfg_params[]` with `RIG_CONF_CHECKBUTTON` for commode; rig caps wired to all function pointers

## Test plan

- [ ] `rigctl -m 37001 -s 115200 -r /dev/ttyUSB0` — PTT on/off with no display lockout
- [ ] `rigctl -m 37001 -C commode=1 -s 115200 -r /dev/ttyUSB0` — PTT, `F`/`f` freq, `V`/`v` VFO, set_clock
- [ ] Verify `commode=0` functions return `-RIG_ENAVAIL` for freq/vfo/clock
- [ ] Verify raw `w` commands through `rigctld` in COM mode don't collide with keepalive

Protocol analysis based on [jrobertfisher/AT-D578UV-software-mic](https://github.com/jrobertfisher/AT-D578UV-software-mic) and firmware reverse engineering of the D578UV v1.21 and BT-01 v1.02 firmware images.