### PR TITLE
FTX-1: fix antenna tuner / ATAS control (AC command model)

### DIFF
--- a/rigs/yaesu/ftx1/ftx1.c
+++ b/rigs/yaesu/ftx1/ftx1.c
@@ -571,6 +571,9 @@ static const struct confparams ftx1_ext_parms[] = {
     { TOK_OPT_GPS_PINNING, "OPT_GPS_PINNING", "OPT_GPS_PINNING", "GPS pinning (0-1)", "0", RIG_CONF_NUMERIC, { .n = { 0, 1, 1 } } },
     { TOK_OPT_GPS_BAUDRATE, "OPT_GPS_BAUDRATE", "OPT_GPS_BAUDRATE", "GPS baudrate (0-4)", "0", RIG_CONF_NUMERIC, { .n = { 0, 4, 1 } } },
 
+    /* ATAS motor control (write): 0=stop, 1=up, 2=down, 3=auto-tune start */
+    { TOK_ATAS_CTRL, "ATAS_CTRL", "ATAS_CTRL", "ATAS control (write): 0=stop,1=up,2=down,3=start", "0", RIG_CONF_NUMERIC, { .n = { 0, 3, 1 } } },
+
     /* Terminating entry */
     { RIG_CONF_END, NULL, }
 };
@@ -977,6 +980,12 @@ static int ftx1_set_ext_parm(RIG *rig, hamlib_token_t token, value_t val)
     rig_debug(RIG_DEBUG_VERBOSE, "%s: token=0x%lx val=%.0f\n", __func__,
               (unsigned long)token, val.f);
 
+    /* Synthetic control tokens are dispatched directly, not via the EX table */
+    if (token == TOK_ATAS_CTRL)
+    {
+        return ftx1_atas_ctrl(rig, (int)val.f);
+    }
+
     return ftx1_menu_set_token(rig, token, val);
 }
 
@@ -995,6 +1004,15 @@ static int ftx1_get_ext_parm(RIG *rig, hamlib_token_t token, value_t *val)
 {
     rig_debug(RIG_DEBUG_VERBOSE, "%s: token=0x%lx\n", __func__,
               (unsigned long)token);
+
+    /* ATAS_CTRL is write-only; report tune activity (0/1) so a read succeeds */
+    if (token == TOK_ATAS_CTRL)
+    {
+        int active = 0;
+        int ret = ftx1_get_tuner(rig, &active);
+        val->f = (float)active;
+        return ret;
+    }
 
     return ftx1_menu_get_token(rig, token, val);
 }

--- a/rigs/yaesu/ftx1/ftx1.c
+++ b/rigs/yaesu/ftx1/ftx1.c
@@ -336,7 +336,7 @@ static const struct confparams ftx1_ext_parms[] = {
     { TOK_GEN_BEEP_LEVEL, "GEN_BEEP_LEVEL", "GEN_BEEP_LEVEL", "GEN_BEEP_LEVEL (0-100)", "0", RIG_CONF_NUMERIC, { .n = { 0, 100, 1 } } },
     { TOK_GEN_RF_SQL_VR, "GEN_RF_SQL_VR", "GEN_RF_SQL_VR", "GEN_RF_SQL_VR (0-2)", "0", RIG_CONF_NUMERIC, { .n = { 0, 2, 1 } } },
     { TOK_GEN_TUN_LIN_PORT, "GEN_TUN_LIN_PORT", "GEN_TUN_LIN_PORT", "GEN_TUN_LIN_PORT (0-3)", "0", RIG_CONF_NUMERIC, { .n = { 0, 3, 1 } } },
-    { TOK_GEN_TUNER_SELECT, "GEN_TUNER_SELECT", "GEN_TUNER_SELECT", "GEN_TUNER_SELECT (0-3)", "0", RIG_CONF_NUMERIC, { .n = { 0, 3, 1 } } },
+    { TOK_GEN_TUNER_SELECT, "GEN_TUNER_SELECT", "GEN_TUNER_SELECT", "General tuner select: 0=Option, 1=ATAS", "0", RIG_CONF_NUMERIC, { .n = { 0, 1, 1 } } },
     { TOK_GEN_CAT1_RATE, "GEN_CAT1_RATE", "GEN_CAT1_RATE", "GEN_CAT1_RATE (0-4)", "0", RIG_CONF_NUMERIC, { .n = { 0, 4, 1 } } },
     { TOK_GEN_CAT1_TIMEOUT, "GEN_CAT1_TIMEOUT", "GEN_CAT1_TIMEOUT", "GEN_CAT1_TIMEOUT (0-3)", "0", RIG_CONF_NUMERIC, { .n = { 0, 3, 1 } } },
     { TOK_GEN_CAT1_STOP_BIT, "GEN_CAT1_STOP_BIT", "GEN_CAT1_STOP_BIT", "GEN_CAT1_STOP_BIT (0-1)", "0", RIG_CONF_NUMERIC, { .n = { 0, 1, 1 } } },
@@ -555,10 +555,10 @@ static const struct confparams ftx1_ext_parms[] = {
     { TOK_VMI_COLOR_CLAR, "VMI_COLOR_CLAR", "VMI_COLOR_CLAR", "VMI_COLOR_CLAR (0-1)", "0", RIG_CONF_NUMERIC, { .n = { 0, 1, 1 } } },
 
     /* SPA-1 Amplifier Settings (EX0307) - Require SPA-1 hardware */
-    { TOK_OPT_TUNER_ANT1, "OPT_TUNER_ANT1", "OPT_TUNER_ANT1", "Tuner ANT1 (0-3, SPA-1 only)", "0", RIG_CONF_NUMERIC, { .n = { 0, 3, 1 } } },
-    { TOK_OPT_TUNER_ANT2, "OPT_TUNER_ANT2", "OPT_TUNER_ANT2", "Tuner ANT2 (0-3, SPA-1 only)", "0", RIG_CONF_NUMERIC, { .n = { 0, 3, 1 } } },
+    { TOK_OPT_TUNER_ANT1, "OPT_TUNER_ANT1", "OPT_TUNER_ANT1", "Tuner type ANT1: 0=INT,1=INT_FAST,2=EXT,3=ATAS (INT needs SPA-1)", "0", RIG_CONF_NUMERIC, { .n = { 0, 3, 1 } } },
+    { TOK_OPT_TUNER_ANT2, "OPT_TUNER_ANT2", "OPT_TUNER_ANT2", "Tuner type ANT2: 0=INT,1=INT_FAST,2=EXT,3=ATAS (INT needs SPA-1)", "0", RIG_CONF_NUMERIC, { .n = { 0, 3, 1 } } },
     { TOK_OPT_ANT2_OP, "OPT_ANT2_OP", "OPT_ANT2_OP", "ANT2 operation (0-2, SPA-1 only)", "0", RIG_CONF_NUMERIC, { .n = { 0, 2, 1 } } },
-    { TOK_OPT_HF_ANT_SEL, "OPT_HF_ANT_SEL", "OPT_HF_ANT_SEL", "HF antenna select (0-1, SPA-1 only)", "0", RIG_CONF_NUMERIC, { .n = { 0, 1, 1 } } },
+    { TOK_OPT_HF_ANT_SEL, "OPT_HF_ANT_SEL", "OPT_HF_ANT_SEL", "HF antenna select: 0=ANT1, 1=ANT2", "0", RIG_CONF_NUMERIC, { .n = { 0, 1, 1 } } },
     { TOK_OPT_HF_MAX_PWR, "OPT_HF_MAX_PWR", "OPT_HF_MAX_PWR", "HF max power 5-100W (SPA-1 only)", "100", RIG_CONF_NUMERIC, { .n = { 5, 100, 1 } } },
     { TOK_OPT_50M_MAX_PWR, "OPT_50M_MAX_PWR", "OPT_50M_MAX_PWR", "50MHz max power 5-100W (SPA-1 only)", "100", RIG_CONF_NUMERIC, { .n = { 5, 100, 1 } } },
     { TOK_OPT_70M_MAX_PWR, "OPT_70M_MAX_PWR", "OPT_70M_MAX_PWR", "70MHz max power 5-50W (SPA-1 only)", "50", RIG_CONF_NUMERIC, { .n = { 5, 50, 1 } } },

--- a/rigs/yaesu/ftx1/ftx1.h
+++ b/rigs/yaesu/ftx1/ftx1.h
@@ -222,6 +222,23 @@ extern int ftx1_has_spa1(RIG *rig);
 extern int ftx1_get_head_type(RIG *rig);
 
 /*
+ * FTX-1 antenna tuner types (per-antenna, EX030701 for ANT1 / EX030702 for
+ * ANT2).  The active HF antenna is EX030704 (0=ANT1, 1=ANT2).  INT / INT(FAST)
+ * require the SPA-1/Optima amplifier; EXT and ATAS work on any head type.
+ * Hardware-verified against the rad-con model.
+ */
+#define FTX1_TUNER_TYPE_INT       0   /* Internal (SPA-1)      */
+#define FTX1_TUNER_TYPE_INT_FAST  1   /* Internal fast (SPA-1) */
+#define FTX1_TUNER_TYPE_EXT       2   /* External tuner        */
+#define FTX1_TUNER_TYPE_ATAS      3   /* ATAS motorized antenna */
+
+/*
+ * ftx1_get_effective_tuner_type - tuner type of the active HF antenna
+ * (defined in ftx1_ext.c).  Returns 0=INT, 1=INT(FAST), 2=EXT, 3=ATAS.
+ */
+extern int ftx1_get_effective_tuner_type(RIG *rig, int *type);
+
+/*
  * ftx1_ensure_vfo_mode - force the radio out of Memory mode if the driver
  * knows it entered via a prior set_mem.  Call at the top of any VFO-state
  * setter that would otherwise fail or behave transiently in Memory mode.

--- a/rigs/yaesu/ftx1/ftx1.h
+++ b/rigs/yaesu/ftx1/ftx1.h
@@ -239,6 +239,14 @@ extern int ftx1_get_head_type(RIG *rig);
 extern int ftx1_get_effective_tuner_type(RIG *rig, int *type);
 
 /*
+ * FTX-1 antenna-tuner AC operations (defined in ftx1_tx.c).
+ * ftx1_atas_ctrl action: 0=stop(AC120) 1=up(AC121) 2=down(AC122) 3=start(AC123).
+ */
+extern int ftx1_set_tuner(RIG *rig, int mode);
+extern int ftx1_get_tuner(RIG *rig, int *mode);
+extern int ftx1_atas_ctrl(RIG *rig, int action);
+
+/*
  * ftx1_ensure_vfo_mode - force the radio out of Memory mode if the driver
  * knows it entered via a prior set_mem.  Call at the top of any VFO-state
  * setter that would otherwise fail or behave transiently in Memory mode.

--- a/rigs/yaesu/ftx1/ftx1_ext.c
+++ b/rigs/yaesu/ftx1/ftx1_ext.c
@@ -12,9 +12,13 @@
  * Extended Menu Numbers (FTX-1 CAT spec page 10-13):
  *   Format: EX P1 P2 P3 P4; where P1=group, P2=section, P3=item, P4=value
  *
+ * Antenna tuner menu (hardware-verified against the rad-con model):
+ *   EX030104 GENERAL TUNER SELECT: 0=Option, 1=ATAS (neither needs SPA-1)
+ *   EX030701/EX030702 per-antenna type (ANT1/ANT2): 0=INT,1=INT(FAST),2=EXT,3=ATAS
+ *            - INT and INT(FAST) require the SPA-1 amplifier
+ *   EX030704 HF ANT SELECT: 0=ANT1, 1=ANT2
+ *
  * SPA-1 Specific Settings:
- *   EX030104 TUNER SELECT: 0=INT, 1=INT(FAST), 2=EXT, 3=ATAS
- *            - INT and INT(FAST) require SPA-1 amplifier
  *   EX030503-09 TX GENERAL (field head power limits):
  *            - HF/50M: 5-10W, V/U: 5-100W (field head only)
  *   EX030705-11 OPTION (SPA-1 power limits):
@@ -57,28 +61,22 @@
  */
 static int ftx1_check_ex_spa1_guardrail(RIG *rig, int group, int section, int item, int value)
 {
-    /*
-     * TUNER SELECT (EX030104): Values 0 (INT) and 1 (INT FAST) require SPA-1
-     * Internal tuner is only available in SPA-1 amplifier
-     */
-    if (group == FTX1_EX_TUNER_SELECT_GROUP &&
-        section == FTX1_EX_TUNER_SELECT_SECTION &&
-        item == FTX1_EX_TUNER_SELECT_ITEM)
-    {
-        if ((value == 0 || value == 1) && !ftx1_has_spa1(rig))
-        {
-            rig_debug(RIG_DEBUG_WARN,
-                      "%s: TUNER SELECT INT/INT(FAST) requires SPA-1 amplifier\n",
-                      __func__);
-            return -RIG_ENAVAIL;
-        }
-    }
+    (void)value;
 
     /*
-     * OPTION section (EX0307xx): SPA-1 max power settings
-     * These settings only apply when SPA-1 is connected
+     * GENERAL TUNER SELECT (EX030104) is 0=Option / 1=ATAS — neither requires
+     * SPA-1, so it is intentionally NOT gated here.  The per-antenna tuner
+     * *type* (EX030701/EX030702) is where INT/INT_FAST need SPA-1; that path
+     * is gated by FTX1_MENU_FLAG_SPA1 in ftx1_menu.c.
      */
-    if (group == FTX1_EX_OPTION_GROUP && section == FTX1_EX_OPTION_SECTION)
+
+    /*
+     * OPTION power-limit settings (EX030705-11): only apply with SPA-1.
+     * Items 1-4 in this section (tuner type, ANT2 op, HF ANT select) are NOT
+     * gated — EXT/ATAS tuning and antenna select work on any head type.
+     */
+    if (group == FTX1_EX_OPTION_GROUP && section == FTX1_EX_OPTION_SECTION &&
+        item >= 5)
     {
         if (!ftx1_has_spa1(rig))
         {
@@ -239,33 +237,25 @@ int ftx1_get_ex_menu(RIG *rig, int group, int section, int item, int *value)
 }
 
 /*
- * ftx1_set_tuner_select - Set antenna tuner type with SPA-1 guardrail
+ * ftx1_set_tuner_select - Set the GENERAL tuner select (EX030104)
  *
- * Values: 0=INT, 1=INT(FAST), 2=EXT, 3=ATAS
- * INT and INT(FAST) require SPA-1 amplifier
+ * 0 = Option (route tune per the active antenna's tuner type, EX030701/2)
+ * 1 = ATAS   (route tune to a motorized ATAS antenna)
+ *
+ * Neither value requires SPA-1.  The per-antenna tuner *type* (INT/INT_FAST/
+ * EXT/ATAS) is set via OPT_TUNER_ANT1/ANT2; INT/INT_FAST there need SPA-1.
  */
-int ftx1_set_tuner_select(RIG *rig, int tuner_type)
+int ftx1_set_tuner_select(RIG *rig, int tuner_select)
 {
-    rig_debug(RIG_DEBUG_VERBOSE, "%s: tuner_type=%d\n", __func__, tuner_type);
+    rig_debug(RIG_DEBUG_VERBOSE, "%s: tuner_select=%d\n", __func__, tuner_select);
 
-    if (tuner_type < 0 || tuner_type > 3)
+    if (tuner_select < 0 || tuner_select > 1)
     {
         return -RIG_EINVAL;
     }
 
-    /*
-     * GUARDRAIL: INT (0) and INT(FAST) (1) tuner types require SPA-1
-     */
-    if ((tuner_type == 0 || tuner_type == 1) && !ftx1_has_spa1(rig))
-    {
-        rig_debug(RIG_DEBUG_WARN,
-                  "%s: internal tuner (INT/INT FAST) requires SPA-1 amplifier\n",
-                  __func__);
-        return -RIG_ENAVAIL;
-    }
-
     /* EX030104 = group 3, section 1, item 4, 1 digit */
-    return ftx1_set_ex_menu(rig, 3, 1, 4, tuner_type, 1);
+    return ftx1_set_ex_menu(rig, 3, 1, 4, tuner_select, 1);
 }
 
 /*

--- a/rigs/yaesu/ftx1/ftx1_ext.c
+++ b/rigs/yaesu/ftx1/ftx1_ext.c
@@ -277,6 +277,43 @@ int ftx1_get_tuner_select(RIG *rig, int *tuner_type)
 }
 
 /*
+ * ftx1_get_effective_tuner_type - tuner type of the currently active HF antenna
+ *
+ * Reads the active antenna (EX030704: 0=ANT1, 1=ANT2), then the per-antenna
+ * tuner type (EX030701 for ANT1, EX030702 for ANT2).
+ * Returns 0=INT, 1=INT(FAST), 2=EXT, 3=ATAS.
+ *
+ * Mirrors the hardware-verified rad-con Power.getTuner(): the effective tuner
+ * is the per-antenna type of the active antenna, independent of the general
+ * TUNER SELECT (EX030104).
+ */
+int ftx1_get_effective_tuner_type(RIG *rig, int *type)
+{
+    int ret, ant, item;
+
+    /* Active HF antenna: EX030704 (0=ANT1, 1=ANT2) */
+    ret = ftx1_get_ex_menu(rig, 3, 7, 4, &ant);
+    if (ret != RIG_OK)
+    {
+        return ret;
+    }
+
+    /* ANT1 -> EX030701 (item 1), ANT2 -> EX030702 (item 2) */
+    item = (ant == 1) ? 2 : 1;
+
+    ret = ftx1_get_ex_menu(rig, 3, 7, item, type);
+    if (ret != RIG_OK)
+    {
+        return ret;
+    }
+
+    rig_debug(RIG_DEBUG_VERBOSE, "%s: active ant=%d, tuner type=%d\n",
+              __func__, ant, *type);
+
+    return RIG_OK;
+}
+
+/*
  * ftx1_set_max_power - Set max power limit with head type awareness
  *
  * TX GENERAL (field head) EX0305xx:

--- a/rigs/yaesu/ftx1/ftx1_menu.c
+++ b/rigs/yaesu/ftx1/ftx1_menu.c
@@ -187,7 +187,7 @@ static const struct ftx1_menu_item ftx1_menu_table[] = {
     { TOK_GEN_BEEP_LEVEL,    "GEN_BEEP_LEVEL",     3, 0, 100, 0 },
     { TOK_GEN_RF_SQL_VR,     "GEN_RF_SQL_VR",      1, 0, 2, 0 },
     { TOK_GEN_TUN_LIN_PORT,  "GEN_TUN_LIN_PORT",   1, 0, 3, 0 },
-    { TOK_GEN_TUNER_SELECT,  "GEN_TUNER_SELECT",   1, 0, 3, 0 },
+    { TOK_GEN_TUNER_SELECT,  "GEN_TUNER_SELECT",   1, 0, 1, 0 },  /* EX030104: 0=Option, 1=ATAS */
     { TOK_GEN_CAT1_RATE,     "GEN_CAT1_RATE",      1, 0, 4, 0 },
     { TOK_GEN_CAT1_TIMEOUT,  "GEN_CAT1_TIMEOUT",   1, 0, 3, 0 },
     { TOK_GEN_CAT1_STOP_BIT, "GEN_CAT1_STOP_BIT",  1, 0, 1, 0 },
@@ -268,11 +268,12 @@ static const struct ftx1_menu_item ftx1_menu_table[] = {
     { TOK_DIAL_MIC_DOWN,     "DIAL_MIC_DOWN",      2, 0, 20, 0 },
     { TOK_DIAL_MIC_SCAN,     "DIAL_MIC_SCAN",      1, 0, 1, 0 },
 
-    /* EX0307: OPTION (SPA-1) */
-    { TOK_OPT_TUNER_ANT1,    "OPT_TUNER_ANT1",     1, 0, 3, FTX1_MENU_FLAG_SPA1 },
-    { TOK_OPT_TUNER_ANT2,    "OPT_TUNER_ANT2",     1, 0, 3, FTX1_MENU_FLAG_SPA1 },
+    /* EX0307: OPTION — tuner type & ANT select work on any head type
+     * (only INT/INT_FAST are SPA-1-only, radio-enforced); power limits SPA-1. */
+    { TOK_OPT_TUNER_ANT1,    "OPT_TUNER_ANT1",     1, 0, 3, 0 },  /* 0=INT,1=INT_FAST,2=EXT,3=ATAS */
+    { TOK_OPT_TUNER_ANT2,    "OPT_TUNER_ANT2",     1, 0, 3, 0 },  /* 0=INT,1=INT_FAST,2=EXT,3=ATAS */
     { TOK_OPT_ANT2_OP,       "OPT_ANT2_OP",        1, 0, 2, FTX1_MENU_FLAG_SPA1 },
-    { TOK_OPT_HF_ANT_SEL,    "OPT_HF_ANT_SEL",     1, 0, 1, FTX1_MENU_FLAG_SPA1 },
+    { TOK_OPT_HF_ANT_SEL,    "OPT_HF_ANT_SEL",     1, 0, 1, 0 },  /* 0=ANT1, 1=ANT2 */
     { TOK_OPT_HF_MAX_PWR,    "OPT_HF_MAX_PWR",     3, 5, 100, FTX1_MENU_FLAG_SPA1 },
     { TOK_OPT_50M_MAX_PWR,   "OPT_50M_MAX_PWR",    3, 5, 100, FTX1_MENU_FLAG_SPA1 },
     { TOK_OPT_70M_MAX_PWR,   "OPT_70M_MAX_PWR",    3, 5, 50, FTX1_MENU_FLAG_SPA1 },

--- a/rigs/yaesu/ftx1/ftx1_menu.h
+++ b/rigs/yaesu/ftx1/ftx1_menu.h
@@ -285,6 +285,13 @@
 #define TOK_OPT_TUNER_ANT2      FTX1_TOKEN(3, 7, 2)
 #define TOK_OPT_ANT2_OP         FTX1_TOKEN(3, 7, 3)
 #define TOK_OPT_HF_ANT_SEL      FTX1_TOKEN(3, 7, 4)
+
+/*
+ * Synthetic control token (NOT an EX menu item): group 0xFF marks it as
+ * dispatched directly in ftx1_set_ext_parm/ftx1_get_ext_parm, never looked up
+ * in the EX menu table.  Write-only ATAS motor control.
+ */
+#define TOK_ATAS_CTRL           FTX1_TOKEN(0xFF, 0, 1)
 #define TOK_OPT_HF_MAX_PWR      FTX1_TOKEN(3, 7, 5)
 #define TOK_OPT_50M_MAX_PWR     FTX1_TOKEN(3, 7, 6)
 #define TOK_OPT_70M_MAX_PWR     FTX1_TOKEN(3, 7, 7)

--- a/rigs/yaesu/ftx1/ftx1_tx.c
+++ b/rigs/yaesu/ftx1/ftx1_tx.c
@@ -212,7 +212,22 @@ int ftx1_set_tuner(RIG *rig, int mode)
 
     if (mode == 0)
     {
-        SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "AC000;");
+        /*
+         * Stop / bypass.  The general AC000 stop is REJECTED with '?' when an
+         * ATAS is the selected tuner (hardware-verified on an FTX-1 + ATAS-120A)
+         * — an ATAS must be stopped with AC120.  Route by the active antenna's
+         * tuner type, mirroring rad-con (Power.stopTune=AC000, ATAS stop=AC120).
+         */
+        int type;
+        const char *stop = "AC000;";
+
+        if (ftx1_get_effective_tuner_type(rig, &type) == RIG_OK &&
+            type == FTX1_TUNER_TYPE_ATAS)
+        {
+            stop = "AC120;";
+        }
+
+        SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "%s", stop);
         return newcat_set_cmd(rig);
     }
 

--- a/rigs/yaesu/ftx1/ftx1_tx.c
+++ b/rigs/yaesu/ftx1/ftx1_tx.c
@@ -182,118 +182,112 @@ int ftx1_get_monitor(RIG *rig, int *status)
 }
 
 /*
- * FTX-1 AC command format: AC P1 P2 P3;
- *   P1 = Tuner on/off (0=off, 1=on)
- *   P2 = Tune start (0=no action, 1=start tune) - write only
- *   P3 = Unknown
+ * FTX-1 antenna-tuner AC command: AC P1 P2 P3;
+ *   P1  0=internal tuner / 1=external tuner port
+ *   P2  0=normal          / 2=ATAS
+ *   P3  0=off/stop  1=ON(or ATAS up)  2=ATAS down  3=tuning START
  *
- * Response format: AC P1 P2 P3; (3 digits)
- * Set format for tuner on/off: AC P1 0 0; (turn on/off without starting tune)
- * Set format for tune: AC 1 1 0; (turn on and start tune)
- *
- * IMPORTANT: The internal antenna tuner is ONLY available when the SPA-1
- * amplifier is connected (FTX-1 Optima configuration). When using the field
- * head only, this command will return an error from the radio.
+ * Read "AC;" returns "AC P1 P2 P3;", with P3 != '0' while a tune is active.
+ * AC set commands DO work (hardware-verified on an FTX-1 + ATAS-120A):
+ * AC103/AC123 start a tune, AC000/AC120 stop, AC121/AC122 nudge an ATAS motor.
+ * (The prior driver's AC110 was rejected with '?' — P3=0 is a stop, not a
+ * start.)  The tuner type is selected via GEN_TUNER_SELECT (EX030104) plus the
+ * per-antenna type OPT_TUNER_ANT1/ANT2; only INT/INT(FAST) need the SPA-1
+ * amplifier, so no SPA-1 gate is applied here.
  */
 
 /*
- * Set Antenna Tuner - SPA-1 REQUIRED
+ * ftx1_set_tuner - RIG_FUNC_TUNER on/off
  *
- * The AC command is STATUS-ONLY on FTX-1 (set returns '?').
- * Use GEN_TUNER_SELECT (EX030104) to control tuner:
- *   0 = OFF (bypass), 1 = INT, 2 = EXT, 3 = ATAS
- *
- * mode: 0=off (bypass), 1=on (internal tuner)
- * Note: mode=2 (start tune) is not supported via CAT.
+ * mode 0 = stop / bypass the tuner (AC000; rad-con Power.stopTune).
+ * mode 1 = "on": the FTX-1 has no persistent tuner-on state distinct from a
+ *          tune cycle, and the tuner type is chosen via the ext-parms, so this
+ *          is accepted as a no-op.  Start an actual tune with RIG_OP_TUNE.
  */
 int ftx1_set_tuner(RIG *rig, int mode)
 {
     struct newcat_priv_data *priv = STATE(rig)->priv;
-    int tuner_select;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: mode=%d\n", __func__, mode);
 
-    /*
-     * GUARDRAIL: Internal tuner requires SPA-1 amplifier
-     */
-    if (!ftx1_has_spa1(rig))
+    if (mode == 0)
     {
-        rig_debug(RIG_DEBUG_WARN,
-                  "%s: internal tuner requires SPA-1 amplifier (not detected)\n",
-                  __func__);
-        return -RIG_ENAVAIL;
+        SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "AC000;");
+        return newcat_set_cmd(rig);
     }
 
-    /* mode: 0=off, 1=on, 2=tune (not supported) */
-    switch (mode)
-    {
-    case 0:  /* Tuner off (bypass) */
-        tuner_select = 0;  /* EX030104 = 0 (OFF) */
-        break;
-
-    case 1:  /* Tuner on (internal) */
-        tuner_select = 1;  /* EX030104 = 1 (INT) */
-        break;
-
-    case 2:  /* Start tune - not supported via CAT */
-        rig_debug(RIG_DEBUG_WARN,
-                  "%s: start tune (mode=2) not supported via CAT\n", __func__);
-        return -RIG_ENIMPL;
-
-    default:
-        return -RIG_EINVAL;
-    }
-
-    /* Use EX030104 (GEN_TUNER_SELECT) instead of AC command */
-    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "EX030104%d;", tuner_select);
-    return newcat_set_cmd(rig);
+    rig_debug(RIG_DEBUG_VERBOSE,
+              "%s: FTX-1 has no tuner-on toggle; select the type via the "
+              "*_TUNER_* ext-parms and tune with RIG_OP_TUNE\n", __func__);
+    return RIG_OK;
 }
 
 /*
- * Get Antenna Tuner status - SPA-1 REQUIRED
+ * ftx1_get_tuner - RIG_FUNC_TUNER status
  *
- * Uses GEN_TUNER_SELECT (EX030104) to determine if tuner is enabled.
- * Returns: 0=off/bypass, 1=on (INT or other tuner selected)
+ * Reports whether a tune cycle is active by reading AC (P3 != '0'), mirroring
+ * rad-con Power.isTuning().  Works on any head type.
+ * Returns: *mode = 1 if tuning/active, 0 otherwise.
  */
 int ftx1_get_tuner(RIG *rig, int *mode)
 {
     struct newcat_priv_data *priv = STATE(rig)->priv;
-    int ret, tuner_select;
+    int ret;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s\n", __func__);
 
-    /*
-     * GUARDRAIL: Internal tuner requires SPA-1 amplifier
-     */
-    if (!ftx1_has_spa1(rig))
-    {
-        rig_debug(RIG_DEBUG_VERBOSE,
-                  "%s: no SPA-1 detected, tuner not available\n", __func__);
-        *mode = 0;
-        return RIG_OK;
-    }
-
-    /* Query GEN_TUNER_SELECT (EX030104) */
-    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "EX030104;");
+    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "AC;");
 
     ret = newcat_get_cmd(rig);
     if (ret != RIG_OK) return ret;
 
-    /* Parse value from EX030104N; (N = 0-3) */
-    if (sscanf(priv->ret_data + 8, "%1d", &tuner_select) != 1)
+    /* Response "AC P1 P2 P3;": P3 (offset 4) != '0' means a tune is active */
+    if (strlen(priv->ret_data) < 5)
     {
-        rig_debug(RIG_DEBUG_ERR, "%s: failed to parse '%s'\n", __func__,
+        rig_debug(RIG_DEBUG_ERR, "%s: short AC response '%s'\n", __func__,
                   priv->ret_data);
         return -RIG_EPROTO;
     }
 
-    /* 0=OFF(bypass), 1=INT, 2=EXT, 3=ATAS - report 0 as off, others as on */
-    *mode = (tuner_select > 0) ? 1 : 0;
+    *mode = (priv->ret_data[4] != '0') ? 1 : 0;
 
-    rig_debug(RIG_DEBUG_VERBOSE, "%s: mode=%d (tuner_select=%d)\n",
-              __func__, *mode, tuner_select);
+    rig_debug(RIG_DEBUG_VERBOSE, "%s: mode=%d (AC='%s')\n", __func__, *mode,
+              priv->ret_data);
 
     return RIG_OK;
+}
+
+/*
+ * ftx1_atas_ctrl - ATAS motor / tune control (write-only)
+ *
+ * Mirrors the hardware-tested rad-con AtasTunerProvider AC opcodes:
+ *   0 = stop            (AC120)
+ *   1 = manual up       (AC121, ~50 ms motor extend)
+ *   2 = manual down     (AC122, ~50 ms motor retract)
+ *   3 = auto-tune start (AC123)
+ * Exposed via the ATAS_CTRL ext-parm.  No SPA-1 required.
+ */
+int ftx1_atas_ctrl(RIG *rig, int action)
+{
+    struct newcat_priv_data *priv = STATE(rig)->priv;
+    const char *cmd;
+
+    rig_debug(RIG_DEBUG_VERBOSE, "%s: action=%d\n", __func__, action);
+
+    switch (action)
+    {
+    case 0: cmd = "AC120;"; break;  /* stop  */
+    case 1: cmd = "AC121;"; break;  /* up    */
+    case 2: cmd = "AC122;"; break;  /* down  */
+    case 3: cmd = "AC123;"; break;  /* start */
+    default:
+        rig_debug(RIG_DEBUG_ERR, "%s: invalid action %d (0-3)\n", __func__,
+                  action);
+        return -RIG_EINVAL;
+    }
+
+    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "%s", cmd);
+    return newcat_set_cmd(rig);
 }
 
 /* Set Break-In on/off (BI P1;) - type (semi/full) is EX020115 */

--- a/rigs/yaesu/ftx1/ftx1_vfo.c
+++ b/rigs/yaesu/ftx1/ftx1_vfo.c
@@ -322,22 +322,40 @@ int ftx1_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op)
         break;
 
     case RIG_OP_TUNE:
+    {
         /*
-         * AC command format: AC P1 P2 P3;
-         *   P1=1 (tuner on), P2=1 (start tune), P3=0 (antenna)
+         * Start an antenna-tuner tune cycle.  AC command: AC P1 P2 P3;
+         *   P1 0=internal / 1=external tuner port
+         *   P2 0=normal   / 2=ATAS
+         *   P3 0=off/stop  1=ON(or ATAS up)  2=ATAS down  3=tuning START
          *
-         * Note: Current FTX-1 firmware returns '?' for AC set commands.
-         * We try anyway in case future firmware updates fix this.
-         * Tuner is only available on SPA-1/Optima configuration.
+         * The tune form depends on the tuner type selected for the active
+         * antenna (hardware-verified against the rad-con model):
+         *   ATAS  -> AC123 (P2=2 ATAS, P3=3 start)
+         *   other -> AC103 (external-port start; drives INT/INT_FAST/EXT)
+         *
+         * The old AC110 (P3=0) was a no-op the radio rejects with '?'.  The
+         * tuner *type* must already be selected (front panel, RIG_FUNC_TUNER,
+         * or the *_TUNER_* ext-parms); RIG_OP_TUNE only starts the cycle.
+         *
+         * No SPA-1 gate here: EXT and ATAS tune on any head type; only INT/
+         * INT(FAST) need SPA-1, and the radio rejects those itself if absent.
          */
-        if (!ftx1_has_spa1(rig))
+        int tuner_type;
+        int tret = ftx1_get_effective_tuner_type(rig, &tuner_type);
+
+        if (tret == RIG_OK && tuner_type == FTX1_TUNER_TYPE_ATAS)
         {
-            rig_debug(RIG_DEBUG_WARN, "%s: TUNE requires SPA-1 amplifier\n",
-                      __func__);
-            return -RIG_ENAVAIL;
+            SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "AC123;");
         }
-        SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "AC110;");
+        else
+        {
+            /* default (including read failure): external-port start */
+            SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "AC103;");
+        }
+
         break;
+    }
 
     case RIG_OP_TO_VFO:
         /* Copy current memory channel to VFO (MEM→VFO) */


### PR DESCRIPTION
## Summary

The FTX-1 backend's antenna-tuner control didn't work: `vfo_op TUNE` sent `AC110`, which the radio rejects (`?;`), so no tune ever started; the tuner menu model was inverted; and `RIG_FUNC_TUNER` misreported status. This fixes the tuner/ATAS path to the AC command model the radio actually implements, verified on an FTX-1 (Optima head) + ATAS-120A over CAT.

## Changes

- **`RIG_OP_TUNE`**: read the tuner type selected for the active antenna and send the correct tune form — `AC123` for ATAS, `AC103` otherwise — instead of the rejected `AC110`. (`AC` P3=3 is "tuning start"; the old P3=0 is a stop.)
- **Tuner menu model**: `EX030104` is the *general* tuner select (0=Option, 1=ATAS), not the per-antenna type. The per-antenna type (0=INT / 1=INT_FAST / 2=EXT / 3=ATAS) lives in `EX030701`/`EX030702`, chosen by the active antenna (`EX030704`). Corrected the ranges and dropped the SPA-1 gate from EXT/ATAS tuning and antenna-select — only INT/INT_FAST need the SPA-1 amplifier.
- **`RIG_FUNC_TUNER`**: report status from the `AC` reply (tune active) instead of misreading `EX030104`; stop with `AC120` for ATAS / `AC000` otherwise.
- **New `ATAS_CTRL` ext-parm** (write-only): 0=stop, 1=up, 2=down, 3=start — the ATAS motor controls (`AC120`/`AC121`/`AC122`/`AC123`).

## Verification

Hardware, FTX-1 (Optima) + ATAS-120A @ 115200 8N1:

- `vfo_op TUNE` → reads `EX030704`/`EX030701` → emits `AC123;`, accepted, tunes (15 m re-match ≈ 1.6:1). The old `AC110;` returns `?;` on the wire.
- `AC000;` is rejected (`?;`) while an ATAS is selected; `AC120;` is accepted — hence the type-aware stop.

Builds clean with Apple Clang (0 warnings on the touched files). Not tested with GCC/MinGW.

Only the FTX-1 backend is touched. (Related but out of scope: #2079 is the FT-891, a different AC generation — no FT-891 change here.)
