### PR TITLE
Rewrite AT-D578UVIII backend with dual-mode serial protocol support

### DIFF
--- a/rigs/anytone/README.md
+++ b/rigs/anytone/README.md
@@ -1,0 +1,43 @@
+# AnyTone AT-D578UVIII Hamlib Backend
+
+Driver for the AnyTone AT-D578UVIII (and AT-D578UV Pro) dual-band mobile radio.
+
+## Dual-mode operation
+
+A single rig model (37001) supports two serial protocols via the `-C commode=` runtime flag:
+
+**Default (`commode=0`)** — direct serial mic protocol:
+- PTT on/off (VARA, fldigi, etc.)
+- No handshake, no radio display lockout
+- Keys PTT on whichever VFO is selected — behaves like the physical mic
+
+**COM mode (`commode=1`)** — BT-01 ADATA protocol:
+- PTT, get/set frequency, get/set VFO, set clock
+- Radio displays "EXTERNAL CABLE MODE" while connected
+
+```bash
+# PTT only (no lockout)
+rigctl -m 37001 -s 115200 -r /dev/ttyUSB0
+
+# Full control (locks display)
+rigctl -m 37001 -C commode=1 -s 115200 -r /dev/ttyUSB0
+```
+
+### COM mode frequency limitations
+
+- **set_freq** requires Channel A selected with VFO A in VFO mode (not MR/memory mode)
+- **VFO B selected**: get_freq returns VFO A's frequency; set_freq is refused
+- **PTT** works regardless of VFO/mode selection
+
+## Raw command passthrough
+
+In COM mode, `rigctld`'s `w` (send_cmd) interface can send arbitrary ADATA commands. The keepalive thread yields to raw commands automatically, so third-party software can use protocol features the backend doesn't yet implement natively.
+
+## Protocol notes
+
+The radio exposes two protocols on 115200 8N1:
+
+- **Direct mic**: raw 0x06 keepalive, 0x41 PTT. No init, no lockout.
+- **BT-01 ADATA**: `+ADATA:00,NNN\r\n` framing. Requires COM MODE handshake.
+
+Protocol analysis based on [jrobertfisher/AT-D578UV-software-mic](https://github.com/jrobertfisher/AT-D578UV-software-mic) and firmware reverse engineering of the D578UV v1.21 and BT-01 v1.02 firmware images.

--- a/rigs/anytone/anytone.c
+++ b/rigs/anytone/anytone.c
@@ -2,10 +2,14 @@
 //    AnyTone D578 Hamlib Backend
 // ---------------------------------------------------------------------------
 //
-//  d578.c
+//  anytone.c
 //
 //  Created by Michael Black W9MDB
 //  Copyright © 2023 Michael Black W9MDB.
+//
+//  Protocol analysis and fixes based on jrobertfisher's AT-D578UV-software-mic
+//  BT-01 Bluetooth microphone protocol capture.
+//  https://github.com/jrobertfisher/AT-D578UV-software-mic
 //
 //   This library is free software; you can redistribute it and/or
 //   modify it under the terms of the GNU Lesser General Public
@@ -36,6 +40,8 @@
 
 #include "hamlib/config.h"
 #include "hamlib/rig.h"
+#include "hamlib/port.h"
+#include "hamlib/rig_state.h"
 #include "serial.h"
 #include "misc.h"
 #include "register.h"
@@ -46,6 +52,7 @@
 // ---------------------------------------------------------------------------
 
 #include "anytone.h"
+
 static int anytone_transaction(RIG *rig, unsigned char *cmd, int cmd_len,
                         unsigned char *reply, int reply_len, int expected_len);
 
@@ -57,8 +64,6 @@ DECLARE_INITRIG_BACKEND(anytone)
 
     return retval;
 }
-
-
 
 // ---------------------------------------------------------------------------
 // proberig_anytone
@@ -81,7 +86,6 @@ DECLARE_PROBERIG_BACKEND(anytone)
     port->parm.serial.stop_bits = 1;
     port->retry = 1;
 
-
     retval = serial_open(port);
 
     if (retval != RIG_OK)
@@ -92,41 +96,70 @@ DECLARE_PROBERIG_BACKEND(anytone)
     return retval;
 }
 
-// AnyTone needs a keep-alive to emulate the MIC
-// Apparently to keep the rig from getting stuck in PTT if mic disconnects
+// ---------------------------------------------------------------------------
+// Keep-alive thread — branches on commode flag
+//
+// commode=0: sends raw 0x06 byte every second
+// commode=1: sends +ADATA:00,001\r\n a \r\n every second
+// ---------------------------------------------------------------------------
 static void *anytone_thread(void *vrig)
 {
     RIG *rig = (RIG *)vrig;
     hamlib_port_t *rp = RIGPORT(rig);
     anytone_priv_data_t *p = STATE(rig)->priv;
-    rig_debug(RIG_DEBUG_TRACE, "%s: anytone_thread started\n", __func__);
+
+    rig_debug(RIG_DEBUG_TRACE, "%s: anytone_thread started (commode=%d)\n",
+              __func__, p->commode);
     p->runflag = 1;
+
+    // ADATA heartbeat: +ADATA:00,001\r\na\r\n (18 bytes)
+    unsigned char keepalive_adata[] = {
+        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+        0x30, 0x2C, 0x30, 0x30, 0x31, 0x0D, 0x0A,
+        0x61,
+        0x0D, 0x0A
+    };
+
+    // Raw mic heartbeat: single 0x06 byte
+    unsigned char keepalive_mic[] = { 0x06 };
+
+    unsigned char *ka = p->commode ? keepalive_adata : keepalive_mic;
+    int ka_len = p->commode ? (int)sizeof(keepalive_adata) : (int)sizeof(keepalive_mic);
 
     while (p->runflag)
     {
-        char c[64];
-        SNPRINTF(c, sizeof(c), "+ADATA:00,001\r\na\r\n");
-        MUTEX_LOCK(p->priv.mutex);
-        // if we don't have CACHE debug enabled then we only show WARN and higher for this rig
+        // Skip keepalive if a raw command (rig_send_raw / rigctld 'w')
+        // or a backend transaction is in progress
+        if (STATE(rig)->transaction_active)
+        {
+            hl_usleep(1000 * 1000);
+            continue;
+        }
+
+        if (pthread_mutex_trylock(&p->mutex) != 0)
+        {
+            hl_usleep(1000 * 1000);
+            continue;
+        }
+
         enum rig_debug_level_e debug_level_save;
         rig_get_debug(&debug_level_save);
 
         if (rig_need_debug(RIG_DEBUG_CACHE) == 0)
         {
-            rig_set_debug(RIG_DEBUG_WARN);    // only show WARN debug otherwise too verbose
+            rig_set_debug(RIG_DEBUG_WARN);
         }
 
-        write_block(rp, (unsigned char *)c, strlen(c));
-        char buf[32];
-        read_block(rp, (unsigned char *)buf, 22);
+        write_block(rp, ka, ka_len);
+        rig_flush(rp);
 
         if (rig_need_debug(RIG_DEBUG_CACHE) == 0)
         {
             rig_set_debug(debug_level_save);
         }
 
-        MUTEX_UNLOCK(p->priv.mutex);
-        hl_usleep(1000 * 1000); // 1-second loop
+        MUTEX_UNLOCK(&p->mutex);
+        hl_usleep(1000 * 1000);
     }
 
     return NULL;
@@ -135,18 +168,16 @@ static void *anytone_thread(void *vrig)
 // ---------------------------------------------------------------------------
 // anytone_send
 // ---------------------------------------------------------------------------
-static int anytone_send(RIG  *rig,
-                 unsigned char *cmd, int cmd_len)
+static int anytone_send(RIG *rig, unsigned char *cmd, int cmd_len)
 {
-    int               retval       = RIG_OK;
+    int retval = RIG_OK;
     hamlib_port_t *rp = RIGPORT(rig);
 
     ENTERFUNC;
 
     rig_flush(rp);
 
-    retval = write_block(rp, (unsigned char *) cmd,
-                         cmd_len);
+    retval = write_block(rp, cmd, cmd_len);
 
     RETURNFUNC(retval);
 }
@@ -154,22 +185,20 @@ static int anytone_send(RIG  *rig,
 // ---------------------------------------------------------------------------
 // anytone_receive
 // ---------------------------------------------------------------------------
-static int anytone_receive(RIG  *rig, unsigned char *buf, int buf_len, int expected)
+static int anytone_receive(RIG *rig, unsigned char *buf, int buf_len,
+                           int expected)
 {
-    int               retval       = RIG_OK;
+    int retval = RIG_OK;
     hamlib_port_t *rp = RIGPORT(rig);
 
     ENTERFUNC;
 
-//    retval = read_string(rp, (unsigned char *) buf, buf_len,
-//                         NULL, 0, 0, expected);
     retval = read_block(rp, buf, expected);
 
     if (retval > 0)
     {
+        rig_debug(RIG_DEBUG_VERBOSE, "%s: read %d bytes\n", __func__, retval);
         retval = RIG_OK;
-        rig_debug(RIG_DEBUG_VERBOSE, "%s: read %d byte=0x%02x\n", __func__, retval,
-                  buf[0]);
     }
 
     RETURNFUNC(retval);
@@ -181,8 +210,7 @@ static int anytone_receive(RIG  *rig, unsigned char *buf, int buf_len, int expec
 static int anytone_transaction(RIG *rig, unsigned char *cmd, int cmd_len,
                         unsigned char *reply, int reply_len, int expected_len)
 {
-    int retval   = RIG_OK;
-    //anytone_priv_data_t *p = STATE(rig)->priv;
+    int retval = RIG_OK;
 
     ENTERFUNC;
 
@@ -190,15 +218,45 @@ static int anytone_transaction(RIG *rig, unsigned char *cmd, int cmd_len,
 
     if (retval == RIG_OK && expected_len != 0)
     {
-        int len = anytone_receive(rig, reply, reply_len,  expected_len);
-        rig_debug(RIG_DEBUG_VERBOSE, "%s(%d): rx len=%d\n", __func__, __LINE__, len);
+        int len = anytone_receive(rig, reply, reply_len, expected_len);
+        rig_debug(RIG_DEBUG_VERBOSE, "%s(%d): rx len=%d\n", __func__, __LINE__,
+                  len);
     }
 
     RETURNFUNC(retval);
 }
 
 // ---------------------------------------------------------------------------
-// Function anytone_init
+// anytone_send_button — send a button press+release via +ADATA framing
+// ---------------------------------------------------------------------------
+static int anytone_send_button(RIG *rig, unsigned char key)
+{
+    hamlib_port_t *rp = RIGPORT(rig);
+
+    unsigned char press[25] = {
+        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+        0x30, 0x2C, 0x30, 0x30, 0x38, 0x0D, 0x0A,
+        0x41, 0x00, 0x01, 0x00, key, 0x00, 0x00, 0x06,
+        0x0D, 0x0A
+    };
+
+    unsigned char release[25] = {
+        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+        0x30, 0x2C, 0x30, 0x30, 0x38, 0x0D, 0x0A,
+        0x41, 0x00, 0x00, 0x00, key, 0x00, 0x00, 0x06,
+        0x0D, 0x0A
+    };
+
+    write_block(rp, press, sizeof(press));
+    hl_usleep(100 * 1000);
+    write_block(rp, release, sizeof(release));
+    hl_usleep(100 * 1000);
+
+    return RIG_OK;
+}
+
+// ---------------------------------------------------------------------------
+// anytone_init
 // ---------------------------------------------------------------------------
 int anytone_init(RIG *rig)
 {
@@ -208,35 +266,27 @@ int anytone_init(RIG *rig)
 
     if (rig != NULL)
     {
-        anytone_priv_data_ptr p = NULL;
-
-        // Get new Priv Data
-
-        p = calloc(1, sizeof(anytone_priv_data_t));
+        anytone_priv_data_ptr p = calloc(1, sizeof(anytone_priv_data_t));
 
         if (p == NULL)
         {
-            retval = -RIG_ENOMEM;
-            RETURNFUNC(retval);
+            RETURNFUNC(-RIG_ENOMEM);
         }
-        else
-        {
-            STATE(rig)->priv = p;
-            p->vfo_curr = RIG_VFO_NONE;
-            pthread_mutex_init(&p->mutex, NULL);
-        }
+
+        STATE(rig)->priv = p;
+        p->vfo_curr = RIG_VFO_NONE;
+        p->commode = 0;
+        pthread_mutex_init(&p->mutex, NULL);
     }
 
     RETURNFUNC(retval);
 }
 
 // ---------------------------------------------------------------------------
-// Function anytone_cleanup
+// anytone_cleanup
 // ---------------------------------------------------------------------------
 int anytone_cleanup(RIG *rig)
 {
-    int retval = RIG_OK;
-
     if (rig == NULL)
     {
         return -RIG_EARG;
@@ -247,33 +297,93 @@ int anytone_cleanup(RIG *rig)
     free(STATE(rig)->priv);
     STATE(rig)->priv = NULL;
 
-    RETURNFUNC(retval);
+    RETURNFUNC(RIG_OK);
 }
 
 // ---------------------------------------------------------------------------
-// Function anytone_open
+// anytone_set_conf / anytone_get_conf — backend configuration
 // ---------------------------------------------------------------------------
-int anytone_open(RIG *rig)
+int anytone_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 {
-    int retval = RIG_OK;
-    hamlib_port_t *rp = RIGPORT(rig);
+    anytone_priv_data_t *p = STATE(rig)->priv;
 
     ENTERFUNC;
 
-    unsigned char cmd[] = { 0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30, 0x30, 0x2C, 0x30, 0x30, 0x31, 0x0d, 0x0a, 'a', 0x0d, 0x0a };
-    write_block(rp, cmd, sizeof(cmd));
-    hl_usleep(500 * 1000);
-    char cmd2[64];
-    SNPRINTF(cmd2, sizeof(cmd2), "+ADATA:00,016\r\n%cD578UV COM MODE\r\n", 0x01);
-    write_block(rp, (unsigned char *)cmd2, strlen(cmd2));
-    SNPRINTF(cmd2, sizeof(cmd2), "+ADATA:00,000\r\n");
-    unsigned char reply[512];
-    anytone_transaction(rig, (unsigned char *)cmd2, strlen(cmd2), reply,
-                        sizeof(reply), strlen(cmd2));
+    switch (token)
+    {
+    case TOK_COMMODE:
+        p->commode = atoi(val) ? 1 : 0;
+        rig_debug(RIG_DEBUG_VERBOSE, "%s: commode=%d\n", __func__, p->commode);
+        break;
 
-    pthread_t id;
-    // will start the keep alive
-    int err = pthread_create(&id, NULL, anytone_thread, (void *)rig);
+    default:
+        RETURNFUNC(-RIG_EINVAL);
+    }
+
+    RETURNFUNC(RIG_OK);
+}
+
+int anytone_get_conf(RIG *rig, hamlib_token_t token, char *val)
+{
+    anytone_priv_data_t *p = STATE(rig)->priv;
+
+    ENTERFUNC;
+
+    switch (token)
+    {
+    case TOK_COMMODE:
+        SNPRINTF(val, 128, "%d", p->commode);
+        break;
+
+    default:
+        RETURNFUNC(-RIG_EINVAL);
+    }
+
+    RETURNFUNC(RIG_OK);
+}
+
+// ---------------------------------------------------------------------------
+// anytone_open
+//
+// commode=0: no handshake, just start keepalive thread
+// commode=1: BT-01 COM MODE handshake, then keepalive thread
+// ---------------------------------------------------------------------------
+int anytone_open(RIG *rig)
+{
+    hamlib_port_t *rp = RIGPORT(rig);
+    anytone_priv_data_t *p = STATE(rig)->priv;
+
+    ENTERFUNC;
+
+    if (p->commode)
+    {
+        // --- Wake-up heartbeat ---
+        unsigned char wakeup[18] = {
+            0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+            0x30, 0x2C, 0x30, 0x30, 0x31, 0x0D, 0x0A,
+            0x61,
+            0x0D, 0x0A
+        };
+
+        write_block(rp, wakeup, sizeof(wakeup));
+        hl_usleep(500 * 1000);
+
+        // --- Enter COM MODE ---
+        unsigned char commode[33] = {
+            0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+            0x30, 0x2C, 0x30, 0x31, 0x36, 0x0D, 0x0A,
+            0x01,
+            'D', '5', '7', '8', 'U', 'V', ' ', 'C', 'O', 'M', ' ', 'M', 'O', 'D', 'E',
+            0x0D, 0x0A
+        };
+
+        write_block(rp, commode, sizeof(commode));
+        hl_usleep(500 * 1000);
+        rig_flush(rp);
+    }
+
+    // Start keep-alive thread (both modes)
+    int err = pthread_create(&p->thread_id, NULL, anytone_thread, (void *)rig);
 
     if (err)
     {
@@ -282,49 +392,76 @@ int anytone_open(RIG *rig)
         RETURNFUNC(-RIG_EINTERNAL);
     }
 
-    RETURNFUNC(retval);
+    RETURNFUNC(RIG_OK);
 }
 
 // ---------------------------------------------------------------------------
-// Function anytone_close
+// anytone_close
 // ---------------------------------------------------------------------------
 int anytone_close(RIG *rig)
 {
-    int retval = RIG_OK;
     anytone_priv_data_t *p = STATE(rig)->priv;
 
     ENTERFUNC;
 
-    // Tell thread to give up
     p->runflag = 0;
-    char *cmd  = "+ADATA:00,000\r\n";
-    anytone_transaction(rig, (unsigned char *)cmd, strlen(cmd), NULL, 0, 0);
+    pthread_join(p->thread_id, NULL);
 
-    RETURNFUNC(retval);
+    if (p->commode)
+    {
+        unsigned char release[17] = {
+            0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+            0x30, 0x2C, 0x30, 0x30, 0x30, 0x0D, 0x0A,
+            0x0D, 0x0A
+        };
+
+        anytone_transaction(rig, release, sizeof(release), NULL, 0, 0);
+    }
+
+    RETURNFUNC(RIG_OK);
 }
 
 // ---------------------------------------------------------------------------
-// Function anytone_get_vfo
+// anytone_get_vfo — requires commode=1
 // ---------------------------------------------------------------------------
 int anytone_get_vfo(RIG *rig, vfo_t *vfo)
 {
     int retval = RIG_OK;
-    //char cmd[] = { 0x41, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x06 };
-    //char cmd[] = { "+ADATA06:00,001",0x41, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x06 };
+    anytone_priv_data_t *p = STATE(rig)->priv;
+    unsigned char reply[512];
 
     ENTERFUNC;
 
-    const anytone_priv_data_ptr p = (anytone_priv_data_ptr) STATE(rig)->priv;
-    unsigned char reply[512];
-    unsigned char cmd[] = { 0x2b, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3a, 0x30, 0x30, 0x2c, 0x30, 0x30, 0x36, 0x0d, 0x0a, 0x04, 0x05, 0x00, 0x00, 0x00, 0x00, 0x0d, 0x0a };
-    anytone_transaction(rig, cmd, sizeof(cmd), reply, sizeof(reply), 114);
+    if (!p->commode)
+    {
+        rig_debug(RIG_DEBUG_ERR, "%s: requires -C commode=1\n", __func__);
+        RETURNFUNC(-RIG_ENAVAIL);
+    }
 
-    if (reply[113] == 0x9b) { *vfo = RIG_VFO_A; }
-    else if (reply[113] == 0x9c) { *vfo = RIG_VFO_B; }
+    unsigned char cmd[23] = {
+        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+        0x30, 0x2C, 0x30, 0x30, 0x36, 0x0D, 0x0A,
+        0x04, 0x05, 0x00, 0x00, 0x00, 0x00,
+        0x0D, 0x0A
+    };
+
+    MUTEX_LOCK(&p->mutex);
+    anytone_transaction(rig, cmd, sizeof(cmd), reply, sizeof(reply), 116);
+    MUTEX_UNLOCK(&p->mutex);
+
+    if (reply[113] == 0x9b)
+    {
+        *vfo = RIG_VFO_A;
+    }
+    else if (reply[113] == 0x9c)
+    {
+        *vfo = RIG_VFO_B;
+    }
     else
     {
-        *vfo = RIG_VFO_A; // default to VFOA
-        rig_debug(RIG_DEBUG_ERR, "%s: unknown vfo=0x%02x\n", __func__, reply[113]);
+        *vfo = RIG_VFO_A;
+        rig_debug(RIG_DEBUG_ERR, "%s: unknown vfo byte=0x%02x\n", __func__,
+                  reply[113]);
     }
 
     p->vfo_curr = *vfo;
@@ -333,60 +470,124 @@ int anytone_get_vfo(RIG *rig, vfo_t *vfo)
 }
 
 // ---------------------------------------------------------------------------
-// Function anytone_set_vfo
+// anytone_set_vfo — toggle VFO via Sub A/B button press, requires commode=1
 // ---------------------------------------------------------------------------
 int anytone_set_vfo(RIG *rig, vfo_t vfo)
 {
+    anytone_priv_data_t *p = STATE(rig)->priv;
+    vfo_t curr_vfo;
+
     ENTERFUNC;
+
+    if (!p->commode)
+    {
+        rig_debug(RIG_DEBUG_ERR, "%s: requires -C commode=1\n", __func__);
+        RETURNFUNC(-RIG_ENAVAIL);
+    }
+
+    anytone_get_vfo(rig, &curr_vfo);
+
+    if (curr_vfo == vfo)
+    {
+        RETURNFUNC(RIG_OK);
+    }
+
+    MUTEX_LOCK(&p->mutex);
+    anytone_send_button(rig, ANYTONE_KEY_SUBAB);
+    MUTEX_UNLOCK(&p->mutex);
+
+    p->vfo_curr = vfo;
+
     RETURNFUNC(RIG_OK);
 }
 
 // ---------------------------------------------------------------------------
-// Function anytone_get_ptt
+// anytone_get_ptt
 // ---------------------------------------------------------------------------
 int anytone_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
 {
-    int retval = RIG_OK;
-
     ENTERFUNC;
 
     anytone_priv_data_t *p = STATE(rig)->priv;
     *ptt = p->ptt;
 
-    RETURNFUNC(retval);
+    RETURNFUNC(RIG_OK);
 }
+
 // ---------------------------------------------------------------------------
 // anytone_set_ptt
+//
+// commode=0: raw 8-byte 0x41 button command, no ADATA framing
+//   ON:  0x41 0x01 0x00 0x00 0x00 0x00 0x00 0x06
+//   OFF: 0x41 0x00 0x00 0x00 0x00 0x00 0x00 0x06
+//
+// commode=1: ADATA-wrapped 0x56 command (40 bytes)
+//   ON:  +ADATA:00,023\r\n 0x56 0x01 + 21 zeros \r\n
+//   OFF: +ADATA:00,023\r\n 0x56 0x00 + 21 zeros \r\n
 // ---------------------------------------------------------------------------
 int anytone_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt)
 {
-    int retval = RIG_OK;
+    anytone_priv_data_t *p = STATE(rig)->priv;
 
     ENTERFUNC;
 
-    //char buf[8] = { 0x41, 0x00, 0x00, 0x00, 0x27, 0x00, 0x00, 0x06 };
-    unsigned char ptton[] =  { 0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30, 0x30, 0x2C, 0x30, 0x30, 0x31, 0x0d, 0x0a, 0x61, 0x0d, 0x0a };
-    unsigned char pttoff[] = { 0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30, 0x30, 0x2C, 0x30, 0x32, 0x33, 0x0d, 0x0a, 0x56, 0x0d, 0x0a };
-    void *pttcmd = ptton;
+    MUTEX_LOCK(&p->mutex);
 
-    if (!ptt) { pttcmd = pttoff; }
+    if (p->commode)
+    {
+        unsigned char ptton[40] = {
+            0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+            0x30, 0x2C, 0x30, 0x32, 0x33, 0x0D, 0x0A,
+            0x56, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x0D, 0x0A
+        };
 
-    //if (!ptt) { cmd = " (unsigned char*)+ADATA:00,023\r\nV\r\n"; }
+        unsigned char pttoff[40] = {
+            0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+            0x30, 0x2C, 0x30, 0x32, 0x33, 0x0D, 0x0A,
+            0x56, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x0D, 0x0A
+        };
 
-    MUTEX_LOCK(p->mutex);
-    anytone_transaction(rig, pttcmd, sizeof(ptton), NULL, 0, 0);
-    anytone_priv_data_t *p = STATE(rig)->priv;
+        unsigned char *cmd = ptt ? ptton : pttoff;
+        anytone_transaction(rig, cmd, 40, NULL, 0, 0);
+    }
+    else
+    {
+        unsigned char ptton[8]  = { 0x41, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x06 };
+        unsigned char pttoff[8] = { 0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x06 };
+
+        unsigned char *cmd = ptt ? ptton : pttoff;
+        write_block(RIGPORT(rig), cmd, 8);
+    }
+
     p->ptt = ptt;
-    MUTEX_UNLOCK(p->mutex);
+    MUTEX_UNLOCK(&p->mutex);
 
-    RETURNFUNC(retval);
+    RETURNFUNC(RIG_OK);
 }
 
+// ---------------------------------------------------------------------------
+// anytone_get_freq — requires commode=1
+// ---------------------------------------------------------------------------
 int anytone_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
     char cmd[32];
     int retval;
     hamlib_port_t *rp = RIGPORT(rig);
+    anytone_priv_data_t *p = STATE(rig)->priv;
+
+    ENTERFUNC;
+
+    if (!p->commode)
+    {
+        rig_debug(RIG_DEBUG_ERR, "%s: requires -C commode=1\n", __func__);
+        RETURNFUNC(-RIG_ENAVAIL);
+    }
 
     SNPRINTF(cmd, sizeof(cmd), "+ADATA:00,006\r\n");
     cmd[15] = 0x04;
@@ -394,6 +595,7 @@ int anytone_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
     cmd[17] = 0x07;
     cmd[18] = 0x00;
     cmd[19] = 0x00;
+    cmd[20] = 0x00;
     cmd[21] = 0x00;
     cmd[22] = 0x00;
     cmd[23] = 0x0d;
@@ -402,55 +604,175 @@ int anytone_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
     if (vfo == RIG_VFO_B) { cmd[16] = 0x2d; }
 
     int retry = 2;
-    MUTEX_LOCK(p->priv.mutex);
+    MUTEX_LOCK(&p->mutex);
     rig_flush(rp);
 
     do
     {
         write_block(rp, (unsigned char *)cmd, 25);
         unsigned char buf[512];
-        retval = read_block(rp, buf, 138);
+        retval = read_block(rp, buf, 135);
 
-        if (retval == 138)
+        if (retval == 135)
         {
             *freq = from_bcd_be(&buf[17], 8) * 10;
-            rig_debug(RIG_DEBUG_VERBOSE, "%s: VFOA freq=%g\n", __func__, *freq);
+            rig_debug(RIG_DEBUG_VERBOSE, "%s: freq=%g\n", __func__, *freq);
             retval = RIG_OK;
+            break;
         }
     }
-    while (retval != 138 && --retry > 0);
+    while (--retry > 0);
 
-    MUTEX_UNLOCK(p->priv.mutex);
+    MUTEX_UNLOCK(&p->mutex);
 
-    return RIG_OK;
+    RETURNFUNC(retval == RIG_OK ? RIG_OK : -RIG_EIO);
 }
 
+// ---------------------------------------------------------------------------
+// anytone_set_freq — requires commode=1
+// ---------------------------------------------------------------------------
 int anytone_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-    char cmd[64];
-    hamlib_port_t *rp = RIGPORT(rig);
+    anytone_priv_data_t *p = STATE(rig)->priv;
 
-    if (vfo == RIG_VFO_A)
+    ENTERFUNC;
+
+    if (!p->commode)
     {
-        snprintf(cmd, sizeof(cmd), "ADATA:00,005\r\n%c%c%c%c\r\n", 2, 0, 0, 0);
-    }
-    else
-    {
-        snprintf(cmd, sizeof(cmd), "ADATA:00,005\r\n%c%c%c%c\r\n", 1, 0, 0, 0);
+        rig_debug(RIG_DEBUG_ERR, "%s: requires -C commode=1\n", __func__);
+        RETURNFUNC(-RIG_ENAVAIL);
     }
 
-    MUTEX_LOCK(p->priv.mutex);
-    rig_flush(rp);
-    write_block(rp, (unsigned char *) cmd, 20);
-    unsigned char backend[] = { 0x2f, 0x03, 0x00, 0xff, 0xff, 0xff, 0xff, 0x15, 0x50, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xcf, 0x09, 0x00, 0x00, 0x0d, 0x0a};
-    snprintf(cmd, sizeof(cmd), "ADATA:00,023\r\n");
-    int bytes = strlen(cmd) + sizeof(backend);
-    memcpy(&cmd[15], backend, sizeof(backend));
-    hl_usleep(10 * 1000);
-    write_block(rp, (unsigned char *)cmd, bytes);
-    MUTEX_UNLOCK(p->priv.mutex);
+    while (freq > 0 && freq < 100000000)
+    {
+        freq *= 10;
+    }
 
-    return -RIG_ENIMPL;
+    rig_debug(RIG_DEBUG_VERBOSE, "%s: vfo=%s freq=%g\n", __func__,
+              rig_strvfo(vfo), freq);
+
+    unsigned char vfo_sel[22] = {
+        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+        0x30, 0x2C, 0x30, 0x30, 0x35, 0x0D, 0x0A,
+        0x5A, 0x02, 0x00, 0x00, 0x00,
+        0x0D, 0x0A
+    };
+
+    if (vfo == RIG_VFO_B)
+    {
+        vfo_sel[16] = 0x01;
+    }
+
+    unsigned char freq_data[40] = {
+        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+        0x30, 0x2C, 0x30, 0x32, 0x33, 0x0D, 0x0A,
+        0x2F, 0x03, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+        0x15, 0x50, 0x00, 0x00,
+        0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0xCF, 0x09, 0x00,
+        0x0D, 0x0A
+    };
+
+    to_bcd_be(&freq_data[18], (unsigned long long)(freq / 10), 8);
+
+    unsigned char ack[22];
+
+    MUTEX_LOCK(&p->mutex);
+    rig_flush(RIGPORT(rig));
+
+    write_block(RIGPORT(rig), vfo_sel, sizeof(vfo_sel));
+    read_block(RIGPORT(rig), ack, 22);
+
+    write_block(RIGPORT(rig), freq_data, sizeof(freq_data));
+    read_block(RIGPORT(rig), ack, 22);
+
+    MUTEX_UNLOCK(&p->mutex);
+
+    RETURNFUNC(RIG_OK);
+}
+
+// ---------------------------------------------------------------------------
+// anytone_set_clock — requires commode=1
+//
+// Probe confirmed: 0x55 with 6-byte payload modifies the radio's clock.
+// Sending all zeros set the date to 2070-01-01 00:00, suggesting the firmware
+// may apply a +70 year offset or use a non-standard epoch. The encoding
+// below uses straight BCD (YY MM DD HH MM) — if the radio shows the wrong
+// year, adjust the offset in the year byte calculation.
+// ---------------------------------------------------------------------------
+int anytone_set_clock(RIG *rig, int year, int month, int day,
+                      int hour, int min, int sec, double msec, int utc_offset)
+{
+    anytone_priv_data_t *p = STATE(rig)->priv;
+
+    ENTERFUNC;
+
+    if (!p->commode)
+    {
+        rig_debug(RIG_DEBUG_ERR, "%s: requires -C commode=1\n", __func__);
+        RETURNFUNC(-RIG_ENAVAIL);
+    }
+
+    // +ADATA:00,006\r\n  0x55 YY MM DD HH MM  \r\n  = 23 bytes
+    unsigned char cmd[23] = {
+        0x2B, 0x41, 0x44, 0x41, 0x54, 0x41, 0x3A, 0x30,
+        0x30, 0x2C, 0x30, 0x30, 0x36, 0x0D, 0x0A,
+        0x55, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x0D, 0x0A
+    };
+
+    int yy = year % 100;
+    cmd[16] = (unsigned char)(((yy / 10) << 4) | (yy % 10));
+    cmd[17] = (unsigned char)(((month / 10) << 4) | (month % 10));
+    cmd[18] = (unsigned char)(((day / 10) << 4) | (day % 10));
+    cmd[19] = (unsigned char)(((hour / 10) << 4) | (hour % 10));
+    cmd[20] = (unsigned char)(((min / 10) << 4) | (min % 10));
+
+    rig_debug(RIG_DEBUG_VERBOSE,
+              "%s: setting clock to %04d-%02d-%02d %02d:%02d (BCD: %02X %02X %02X %02X %02X)\n",
+              __func__, year, month, day, hour, min,
+              cmd[16], cmd[17], cmd[18], cmd[19], cmd[20]);
+
+    unsigned char ack[22];
+
+    MUTEX_LOCK(&p->mutex);
+    rig_flush(RIGPORT(rig));
+    write_block(RIGPORT(rig), cmd, sizeof(cmd));
+    read_block(RIGPORT(rig), ack, 22);
+    MUTEX_UNLOCK(&p->mutex);
+
+    RETURNFUNC(RIG_OK);
+}
+
+// ---------------------------------------------------------------------------
+// anytone_get_clock — requires commode=1
+//
+// Not yet confirmed by probe. Command 0x58 (same len==6 check as 0x55) is
+// the most likely getter candidate but returned only a 5-byte ACK during
+// probing (possibly because the zero payload was invalid). Needs testing
+// with the radio to confirm the response format.
+// ---------------------------------------------------------------------------
+int anytone_get_clock(RIG *rig, int *year, int *month, int *day,
+                      int *hour, int *min, int *sec, double *msec,
+                      int *utc_offset)
+{
+    anytone_priv_data_t *p = STATE(rig)->priv;
+
+    ENTERFUNC;
+
+    if (!p->commode)
+    {
+        rig_debug(RIG_DEBUG_ERR, "%s: requires -C commode=1\n", __func__);
+        RETURNFUNC(-RIG_ENAVAIL);
+    }
+
+    rig_debug(RIG_DEBUG_WARN,
+              "%s: get_clock not yet confirmed — command 0x58 needs radio testing\n",
+              __func__);
+
+    RETURNFUNC(-RIG_ENIMPL);
 }
 
 // ---------------------------------------------------------------------------

--- a/rigs/anytone/anytone.h
+++ b/rigs/anytone/anytone.h
@@ -1,13 +1,40 @@
+// ---------------------------------------------------------------------------
+//    AnyTone D578 Hamlib Backend
+// ---------------------------------------------------------------------------
+//
+//  anytone.h
+//
+//  Created by Michael Black W9MDB
+//  Copyright © 2023 Michael Black W9MDB.
+//
+//   This library is free software; you can redistribute it and/or
+//   modify it under the terms of the GNU Lesser General Public
+//   License as published by the Free Software Foundation; either
+//   version 2.1 of the License, or (at your option) any later version.
+//
+//   This library is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//   Lesser General Public License for more details.
+//
+//   You should have received a copy of the GNU Lesser General Public
+//   License along with this library; if not, write to the Free Software
+//   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
 #ifndef _ANYTONE_H
 #define _ANYTONE_H 1
 
 #include "hamlib/rig.h"
+#include "token.h"
 
-#define BACKEND_VER "20231001"
+#define BACKEND_VER "20260629"
 
 #define ANYTONE_RESPSZ 64
 
+#define TOK_COMMODE TOKEN_BACKEND(1)
+
 extern struct rig_caps anytone_d578_caps;
+extern const struct confparams anytone_cfg_params[];
 
 #ifdef PTHREAD
 #include <pthread.h>
@@ -20,13 +47,32 @@ extern struct rig_caps anytone_d578_caps;
 #define MUTEX_UNLOCK(var)
 #endif
 
+// Button key codes from the direct serial / BT-01 mic protocol
+#define ANYTONE_KEY_0     0x01
+#define ANYTONE_KEY_1     0x02
+#define ANYTONE_KEY_2     0x03
+#define ANYTONE_KEY_3     0x04
+#define ANYTONE_KEY_4     0x05
+#define ANYTONE_KEY_5     0x06
+#define ANYTONE_KEY_6     0x07
+#define ANYTONE_KEY_7     0x08
+#define ANYTONE_KEY_8     0x09
+#define ANYTONE_KEY_9     0x0A
+#define ANYTONE_KEY_STAR  0x0B
+#define ANYTONE_KEY_HASH  0x0C
+#define ANYTONE_KEY_SUBAB 0x0D
+#define ANYTONE_KEY_UP    0x10
+#define ANYTONE_KEY_DOWN  0x11
+
 typedef struct _anytone_priv_data
 {
     ptt_t         ptt;
     vfo_t         vfo_curr;
-    volatile int  runflag; // thread control
+    volatile int  runflag;
+    int           commode;
     char          buf[64];
     pthread_mutex_t mutex;
+    pthread_t     thread_id;
 } anytone_priv_data_t,
 * anytone_priv_data_ptr;
 
@@ -36,13 +82,23 @@ extern int anytone_cleanup(RIG *rig);
 extern int anytone_open(RIG *rig);
 extern int anytone_close(RIG *rig);
 
+extern int anytone_set_conf(RIG *rig, hamlib_token_t token, const char *val);
+extern int anytone_get_conf(RIG *rig, hamlib_token_t token, char *val);
+
 extern int anytone_set_ptt(RIG *rig, vfo_t vfo, ptt_t ptt);
-extern int anytone_get_ptt(RIG *rig, vfo_t vfo,ptt_t *ptt);
+extern int anytone_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt);
 
 extern int anytone_set_vfo(RIG *rig, vfo_t vfo);
 extern int anytone_get_vfo(RIG *rig, vfo_t *vfo);
 
 extern int anytone_set_freq(RIG *rig, vfo_t vfo, freq_t freq);
 extern int anytone_get_freq(RIG *rig, vfo_t vfo, freq_t *freq);
+
+extern int anytone_set_clock(RIG *rig, int year, int month, int day,
+                             int hour, int min, int sec, double msec,
+                             int utc_offset);
+extern int anytone_get_clock(RIG *rig, int *year, int *month, int *day,
+                             int *hour, int *min, int *sec, double *msec,
+                             int *utc_offset);
 
 #endif /* _ANYTONE_H */

--- a/rigs/anytone/d578.c
+++ b/rigs/anytone/d578.c
@@ -24,12 +24,37 @@
 #include "anytone.h"
 
 #define D578_VFO (RIG_VFO_A|RIG_VFO_B)
-#define D578_MODES (RIG_MODE_USB|RIG_MODE_AM)
+#define D578_MODES (RIG_MODE_FM|RIG_MODE_AM)
 
+// ---------------------------------------------------------------------------
+// Backend configuration parameters
+//
+// commode=0 (default): direct serial mic protocol — PTT only, no lockout
+// commode=1: BT-01 ADATA/COM MODE — adds freq, VFO, clock control but
+//            locks the radio display to "EXTERNAL CABLE MODE"
+//
+// Usage: rigctl -m 37001 -C commode=1 -s 115200 -r /dev/ttyUSB0
+// ---------------------------------------------------------------------------
+const struct confparams anytone_cfg_params[] =
+{
+    {
+        TOK_COMMODE, "commode", "COM Mode",
+        "Enable ADATA/COM MODE for freq/vfo/clock (locks radio display)",
+        "0", RIG_CONF_CHECKBUTTON, { }
+    },
+    { RIG_CONF_END, NULL, }
+};
+
+// ---------------------------------------------------------------------------
+// Rig 37001 — AT-D578UVIII
+//
+// Default: direct serial mic protocol with PTT only.
+// With -C commode=1: enters BT-01 COM MODE for freq/vfo/clock control.
+// ---------------------------------------------------------------------------
 struct rig_caps anytone_d578_caps =
 {
     RIG_MODEL(RIG_MODEL_ATD578UVIII),
-    .model_name         =  "D578A",
+    .model_name         =  "AT-D578UVIII",
     .mfg_name           =  "AnyTone",
     .version            =  BACKEND_VER ".0",
     .copyright          =  "Michael Black W9MDB: GNU LGPL",
@@ -59,7 +84,6 @@ struct rig_caps anytone_d578_caps =
     .rx_range_list1 =
     {
         { MHz(108), MHz(174), D578_MODES, -1, -1, D578_VFO },
-        { MHz(144), MHz(148), D578_MODES, -1, -1, D578_VFO },
         { MHz(222), MHz(225), D578_MODES, -1, -1, D578_VFO },
         { MHz(420), MHz(450), D578_MODES, -1, -1, D578_VFO },
         RIG_FRNG_END,
@@ -72,6 +96,10 @@ struct rig_caps anytone_d578_caps =
         { MHz(420), MHz(450), D578_MODES, W(1), W(25), D578_VFO },
         RIG_FRNG_END,
     },
+
+    .cfgparams          =  anytone_cfg_params,
+    .set_conf           =  anytone_set_conf,
+    .get_conf           =  anytone_get_conf,
 
     .rig_init           =  anytone_init,
     .rig_cleanup        =  anytone_cleanup,
@@ -86,6 +114,9 @@ struct rig_caps anytone_d578_caps =
 
     .set_freq           =  anytone_set_freq,
     .get_freq           =  anytone_get_freq,
+
+    .set_clock          =  anytone_set_clock,
+    .get_clock          =  anytone_get_clock,
 
     .hamlib_check_rig_caps = HAMLIB_CHECK_RIG_CAPS
 };


### PR DESCRIPTION
Backport of #2088 (master) rebased onto the `Hamlib-4.7` branch to resolve cherry-pick conflicts.

## Summary

Rewrites the AnyTone AT-D578UVIII backend to support both serial protocols exposed by the radio on its 115200 8N1 port, selectable at runtime via a `-C commode=` config flag. Single rig model (37001), all changes confined to `rigs/anytone/`.

**Default mode (`commode=0`)** — Direct serial mic protocol. Raw byte commands (0x06 keepalive, 0x41 PTT) with no handshake and no radio display lockout. Ideal for VARA, fldigi, and other software that only needs PTT — the operator keeps full use of the front panel.

**COM mode (`commode=1`)** — BT-01 ADATA protocol. `+ADATA:00,NNN\r\n` framed commands for PTT, get/set frequency, get/set VFO, and set clock. The radio displays "EXTERNAL CABLE MODE" while connected.

## Differences from master PR

- Retains `#ifdef PTHREAD` conditional guards in `anytone.h` (matching the 4.7 branch convention; master removed these)
- Otherwise identical driver code

## Raw command passthrough

The keepalive thread checks `transaction_active` before sending, so `rig_send_raw` / rigctld `w` commands pass through without collision. The radio's firmware accepts 34 ADATA command bytes, most undocumented — this lets client software explore and use protocol features through the driver's managed session (handshake, keepalive, serial port) without implementing them from scratch.

## Changes

- **anytone.c** — Keepalive thread branches on `commode`; `set_ptt` branches between raw 0x41 and ADATA 0x56; ADATA-only functions return `-RIG_ENAVAIL` when `commode=0`; keepalive yields to `transaction_active`
- **anytone.h** — `commode` flag in priv struct, `TOK_COMMODE` config token, clock function declarations
- **d578.c** — `anytone_cfg_params[]` with `RIG_CONF_CHECKBUTTON`; rig caps wired to all function pointers
- **README.md** — Backend documentation

## Test plan

- [ ] `rigctl -m 37001 -s 115200 -r /dev/ttyUSB0` — PTT on/off, no display lockout
- [ ] `rigctl -m 37001 -C commode=1 -s 115200 -r /dev/ttyUSB0` — PTT, freq, VFO, clock
- [ ] `commode=0` returns `-RIG_ENAVAIL` for freq/vfo/clock
- [ ] Raw `w` commands via `rigctld` in COM mode don't collide with keepalive

Protocol analysis based on [jrobertfisher/AT-D578UV-software-mic](https://github.com/jrobertfisher/AT-D578UV-software-mic) and firmware reverse engineering of the D578UV v1.21 and BT-01 v1.02 firmware images.