### PR TITLE
fix: remove debug history race in 4.7

### DIFF
--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -3328,6 +3328,15 @@ rig_set_debug_time_stamp HAMLIB_PARAMS((int flag));
 extern HAMLIB_EXPORT(int)
 rig_need_debug HAMLIB_PARAMS((enum rig_debug_level_e debug_level));
 
+#if defined(__MINGW_PRINTF_FORMAT)
+#define HAMLIB_ATTRIBUTE_FORMAT_PRINTF \
+    __attribute__((__format__(__MINGW_PRINTF_FORMAT, 2, 3)))
+#elif defined(__GNUC__) || defined(__clang__)
+#define HAMLIB_ATTRIBUTE_FORMAT_PRINTF \
+    __attribute__((__format__(__printf__, 2, 3)))
+#else
+#define HAMLIB_ATTRIBUTE_FORMAT_PRINTF
+#endif
 
 extern HAMLIB_EXPORT(void)add2debugmsgsave(const char *s);
 // this needs to be fairly big to avoid compiler warnings
@@ -3336,12 +3345,6 @@ extern HAMLIB_EXPORT_VAR(char) debugmsgsave2[DEBUGMSGSAVE_SIZE];  // last-1 debu
 // debugmsgsave3 is deprecated
 extern HAMLIB_EXPORT_VAR(char) debugmsgsave3[DEBUGMSGSAVE_SIZE];  // last-2 debug msg
 #define rig_debug_clear() { debugmsgsave[0] = debugmsgsave2[0] = debugmsgsave3[0] = 0; };
-#ifndef __cplusplus
-#ifdef __GNUC__
-// doing the debug macro with a dummy sprintf allows gcc to check the format string
-#define rig_debug(debug_level,fmt,...) do { snprintf(debugmsgsave2,sizeof(debugmsgsave2),fmt,__VA_ARGS__);rig_debug(debug_level,fmt,##__VA_ARGS__); add2debugmsgsave(debugmsgsave2); } while(0)
-#endif
-#endif
 
 // Measuring elapsed time -- local variable inside function when macro is used
 #define ELAPSED1 struct timespec __begin; elapsed_ms(&__begin, HAMLIB_ELAPSED_SET);
@@ -3352,7 +3355,7 @@ extern HAMLIB_EXPORT_VAR(char) debugmsgsave3[DEBUGMSGSAVE_SIZE];  // last-2 debu
 
 extern HAMLIB_EXPORT(void)
 rig_debug HAMLIB_PARAMS((enum rig_debug_level_e debug_level,
-                         const char *fmt, ...));
+                         const char *fmt, ...)) HAMLIB_ATTRIBUTE_FORMAT_PRINTF;
 
 extern HAMLIB_EXPORT(vprintf_cb_t)
 rig_set_debug_callback HAMLIB_PARAMS((vprintf_cb_t cb,

--- a/src/debug.c
+++ b/src/debug.c
@@ -34,6 +34,7 @@
 
 #include <stdarg.h>
 #include <stdio.h>  /* Standard input/output definitions */
+#include <stdlib.h>
 #include <string.h> /* String function definitions */
 #include <errno.h>
 
@@ -56,6 +57,7 @@
 
 /** \brief Sets the number of hexadecimal pairs to print per line. */
 #define DUMP_HEX_WIDTH 16
+#define DEBUG_HISTORY_STACK_SIZE 1024
 
 
 static int rig_debug_level = RIG_DEBUG_TRACE;
@@ -201,15 +203,50 @@ void HAMLIB_API rig_set_debug_time_stamp(int flag)
  * The formatted character string is passed to the `vfprintf`(3) C library
  * call and follows its format specification.
  */
-#undef rig_debug
 void HAMLIB_API rig_debug(enum rig_debug_level_e debug_level,
                           const char *fmt, ...)
 {
     static pthread_mutex_t client_debug_lock = PTHREAD_MUTEX_INITIALIZER;
+    char history_stack[DEBUG_HISTORY_STACK_SIZE];
+    char *history_msg = history_stack;
+    size_t history_capacity = sizeof(history_stack);
+    int history_len;
     va_list ap;
+
+    history_msg[0] = '\0';
+    va_start(ap, fmt);
+    history_len = vsnprintf(history_msg, history_capacity, fmt, ap);
+    va_end(ap);
+
+    if (history_len >= 0
+            && (size_t)history_len >= history_capacity
+            && (size_t)history_len < DEBUGMSGSAVE_SIZE)
+    {
+        history_capacity = (size_t)history_len + 1;
+        history_msg = malloc(history_capacity);
+
+        if (history_msg != NULL)
+        {
+            va_start(ap, fmt);
+            history_len = vsnprintf(history_msg, history_capacity, fmt, ap);
+            va_end(ap);
+
+            if (history_len != (int)history_capacity - 1)
+            {
+                history_len = -1;
+            }
+        }
+    }
 
     if (!rig_need_debug(debug_level))
     {
+        if (history_msg != NULL && history_len >= 0
+                && (size_t)history_len < history_capacity)
+        {
+            add2debugmsgsave(history_msg);
+        }
+
+        if (history_msg != history_stack) { free(history_msg); }
         return;
     }
 
@@ -275,6 +312,14 @@ void HAMLIB_API rig_debug(enum rig_debug_level_e debug_level,
     va_end(ap);
 #endif
     pthread_mutex_unlock(&client_debug_lock);
+
+    if (history_msg != NULL && history_len >= 0
+            && (size_t)history_len < history_capacity)
+    {
+        add2debugmsgsave(history_msg);
+    }
+
+    if (history_msg != history_stack) { free(history_msg); }
 }
 
 

--- a/src/rig.c
+++ b/src/rig.c
@@ -425,51 +425,49 @@ MUTEX(mutex_debugmsgsave);
  */
 void add2debugmsgsave(const char *s)
 {
-    const char *p;
-    char stmp[DEBUGMSGSAVE_SIZE];
-    int i, nlines;
-    int maxmsg = DEBUGMSGSAVE_SIZE / 2;
-    MUTEX_LOCK(mutex_debugmsgsave);
-    memset(stmp, 0, sizeof(stmp));
+    const size_t maxmsg = DEBUGMSGSAVE_SIZE / 2;
+    size_t append_len;
+    size_t current_len;
+    size_t i;
+    size_t nlines;
+    char *keep;
 
-    // we'll keep 20 lines including this one
-    // so count the lines
-    for (i = 0, nlines = 0; debugmsgsave[i] != 0; ++i)
+    MUTEX_LOCK(mutex_debugmsgsave);
+
+    current_len = strlen(debugmsgsave);
+    keep = debugmsgsave;
+
+    for (i = 0, nlines = 0; i < current_len; ++i)
     {
         if (debugmsgsave[i] == '\n') { ++nlines; }
     }
 
-    // strip the last 19 lines
-    p =  debugmsgsave;
-
-    while ((nlines > 19 || strlen(debugmsgsave) > maxmsg) && p != NULL)
+    while (nlines > 19 || current_len > maxmsg)
     {
-        p = strchr(debugmsgsave, '\n');
+        char *newline = strchr(keep, '\n');
 
-        if (p && strlen(p + 1) > 0)
+        if (newline == NULL)
         {
-            strcpy(stmp, p + 1);
-            strcpy(debugmsgsave, stmp);
-        }
-        else
-        {
-            debugmsgsave[0] = '\0';
+            keep += current_len;
+            current_len = 0;
+            break;
         }
 
+        size_t remove_len = (size_t)(newline + 1 - keep);
+        keep = newline + 1;
+        current_len -= remove_len;
         --nlines;
-
-        if (nlines == 0 && strlen(debugmsgsave) > maxmsg) { strcpy(debugmsgsave, "!!!!debugmsgsave too long\n"); }
     }
 
-    if (strlen(stmp) + strlen(s) + 1 < DEBUGMSGSAVE_SIZE)
+    if (keep != debugmsgsave)
     {
-        strcat(debugmsgsave, s);
+        memmove(debugmsgsave, keep, current_len + 1);
     }
-    else
+
+    append_len = strlen(s);
+    if (append_len <= sizeof(debugmsgsave) - current_len - 1)
     {
-        rig_debug(RIG_DEBUG_BUG,
-                  "%s: debugmsgsave overflow!! len of debugmsgsave=%d, len of add=%d\n", __func__,
-                  (int)strlen(debugmsgsave), (int)strlen(s));
+        memmove(debugmsgsave + current_len, s, append_len + 1);
     }
 
     MUTEX_UNLOCK(mutex_debugmsgsave);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -14,7 +14,7 @@ DISTCLEANFILES = rigctl.log rigctl.sum testbcd.log testbcd.sum
 
 bin_PROGRAMS = rigctl rigctld rigmem rigsmtr rigswr rotctl rotctld rigctlcom rigctltcp rigctlsync ampctl ampctld rigtestmcast rigtestmcastrx $(TESTLIBUSB)
 
-check_PROGRAMS = dumpmem testrig testrigopen testrigcaps testbcd testfreq listrigs testloc rig_bench testcache cachetest cachetest2 testcookie testgrid hamlibmodels testmW2power test2038
+check_PROGRAMS = dumpmem testrig testrigopen testrigcaps testbcd testfreq listrigs testloc rig_bench testcache cachetest cachetest2 testcookie testdebug testgrid hamlibmodels testmW2power test2038
 # Document building testsecurity
 ### check_PROGRAMS += testsecurity
 
@@ -55,6 +55,7 @@ ampctld_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS) -I$(top_builddir)/src
 rigctlcom_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS) -I$(top_builddir)/security
 rigctltcp_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS) -I$(top_builddir)/security
 rigctlsync_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS) -I$(top_builddir)/security
+testdebug_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
 if TESTS_HAVE_LIBUSB
     rigtestlibusb_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS) $(LIBUSB_CFLAGS)
 endif
@@ -72,6 +73,7 @@ rigmem_LDADD = $(LIBXML2_LIBS) $(LDADD)
 rigctlcom_LDADD = $(NET_LIBS) $(PTHREAD_LIBS) $(LDADD) $(READLINE_LIBS)
 rigctltcp_LDADD = $(NET_LIBS) $(PTHREAD_LIBS) $(LDADD) $(READLINE_LIBS)
 rigctlsync_LDADD = $(NET_LIBS) $(PTHREAD_LIBS) $(LDADD) $(READLINE_LIBS)
+testdebug_LDADD = $(PTHREAD_LIBS) $(LDADD)
 if TESTS_HAVE_LIBUSB
     rigtestlibusb_LDADD = $(LIBUSB_LIBS)
 endif
@@ -125,7 +127,7 @@ EXTRA_DIST = \
 # Omitting cachetest.sh because it needs 2 instances of rigctld running
 check_SCRIPTS = amptest.sh test2038.sh testbcd.sh testcache.sh testcaps.sh testcookie.sh testfreq.sh testgrid.sh testloc.sh testrig.sh testrigcaps.sh
 
-TESTS = $(check_SCRIPTS)
+TESTS = $(check_SCRIPTS) testdebug
 
 $(top_builddir)/src/libhamlib.la:
 	$(MAKE) -C $(top_builddir)/src/ libhamlib.la

--- a/tests/testdebug.c
+++ b/tests/testdebug.c
@@ -1,0 +1,206 @@
+/*
+ * Test debug history behavior.
+ *
+ * Copyright (C) 2026 The Hamlib Group
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <hamlib/rig.h>
+
+#define THREAD_COUNT 8
+#define PADDING_SIZE 1536
+#define MESSAGE_SIZE 1664
+#define HISTORY_LINE_COUNT 25
+#define RETAINED_LINE_COUNT 20
+
+struct start_gate
+{
+    pthread_mutex_t mutex;
+    pthread_cond_t condition;
+    int open;
+};
+
+struct worker_context
+{
+    struct start_gate *gate;
+    unsigned int thread;
+};
+
+static int ignore_debug_output(enum rig_debug_level_e debug_level,
+                               rig_ptr_t arg, const char *fmt, va_list ap)
+{
+    (void)debug_level;
+    (void)arg;
+    (void)fmt;
+    (void)ap;
+    return RIG_OK;
+}
+
+static int build_message(char *message, size_t size, unsigned int thread)
+{
+    char padding[PADDING_SIZE + 1];
+    int length;
+
+    memset(padding, (int)('A' + thread), PADDING_SIZE);
+    padding[PADDING_SIZE] = '\0';
+    length = snprintf(message, size,
+                      "concurrent history thread=%u padding=%s marker=%u\n",
+                      thread, padding, thread);
+
+    return length >= 0 && (size_t)length < size;
+}
+
+static void *worker(void *arg)
+{
+    struct worker_context *context = arg;
+    char message[MESSAGE_SIZE];
+
+    if (!build_message(message, sizeof(message), context->thread))
+    {
+        abort();
+    }
+
+    pthread_mutex_lock(&context->gate->mutex);
+    while (!context->gate->open)
+    {
+        pthread_cond_wait(&context->gate->condition, &context->gate->mutex);
+    }
+    pthread_mutex_unlock(&context->gate->mutex);
+
+    rig_debug(RIG_DEBUG_TRACE, "%s", message);
+    return NULL;
+}
+
+static int test_concurrent_history(void)
+{
+    struct start_gate gate = {
+        PTHREAD_MUTEX_INITIALIZER,
+        PTHREAD_COND_INITIALIZER,
+        0
+    };
+    struct worker_context contexts[THREAD_COUNT];
+    pthread_t threads[THREAD_COUNT];
+    size_t expected_length = 0;
+    unsigned int thread;
+
+    rig_debug_clear();
+    rig_set_debug(RIG_DEBUG_NONE);
+
+    for (thread = 0; thread < THREAD_COUNT; ++thread)
+    {
+        contexts[thread].gate = &gate;
+        contexts[thread].thread = thread;
+        if (pthread_create(&threads[thread], NULL, worker,
+                           &contexts[thread]) != 0)
+        {
+            fprintf(stderr, "failed to create worker thread %u\n", thread);
+            return 0;
+        }
+    }
+
+    pthread_mutex_lock(&gate.mutex);
+    gate.open = 1;
+    pthread_cond_broadcast(&gate.condition);
+    pthread_mutex_unlock(&gate.mutex);
+
+    for (thread = 0; thread < THREAD_COUNT; ++thread)
+    {
+        if (pthread_join(threads[thread], NULL) != 0)
+        {
+            fprintf(stderr, "failed to join worker thread %u\n", thread);
+            return 0;
+        }
+    }
+
+    pthread_cond_destroy(&gate.condition);
+    pthread_mutex_destroy(&gate.mutex);
+
+    for (thread = 0; thread < THREAD_COUNT; ++thread)
+    {
+        char expected[MESSAGE_SIZE];
+
+        if (!build_message(expected, sizeof(expected), thread))
+        {
+            return 0;
+        }
+        expected_length += strlen(expected);
+        if (strstr(debugmsgsave, expected) == NULL)
+        {
+            fprintf(stderr,
+                    "history does not contain an intact message "
+                    "from thread %u\n",
+                    thread);
+            return 0;
+        }
+    }
+
+    if (strlen(debugmsgsave) != expected_length)
+    {
+        fprintf(stderr, "history retained %zu bytes; expected %zu\n",
+                strlen(debugmsgsave), expected_length);
+        return 0;
+    }
+
+    return 1;
+}
+
+static int test_rolling_history(void)
+{
+    const char *history;
+    unsigned int line;
+
+    rig_debug_clear();
+    rig_set_debug_callback(ignore_debug_output, NULL);
+    rig_set_debug(RIG_DEBUG_TRACE);
+
+    for (line = 0; line < HISTORY_LINE_COUNT; ++line)
+    {
+        rig_debug(RIG_DEBUG_TRACE, "history line=%u\n", line);
+    }
+
+    rig_set_debug_callback(NULL, NULL);
+    rig_set_debug(RIG_DEBUG_NONE);
+
+    history = debugmsgsave;
+    for (line = HISTORY_LINE_COUNT - RETAINED_LINE_COUNT;
+            line < HISTORY_LINE_COUNT; ++line)
+    {
+        char expected[32];
+        int written = snprintf(expected, sizeof(expected),
+                               "history line=%u\n", line);
+
+        if (written < 0 || (size_t)written >= sizeof(expected)
+                || strncmp(history, expected, (size_t)written) != 0)
+        {
+            fprintf(stderr, "history did not retain line %u in order\n", line);
+            return 0;
+        }
+        history += written;
+    }
+
+    if (*history != '\0')
+    {
+        fprintf(stderr, "history retained more than %u lines\n",
+                RETAINED_LINE_COUNT);
+        return 0;
+    }
+
+    return 1;
+}
+
+int main(void)
+{
+    if (!test_concurrent_history() || !test_rolling_history())
+    {
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This backports #2105 to `Hamlib-4.7` for the forthcoming 4.7.3 release.

The only porting adjustment preserves the branch's existing `HAMLIB_PARAMS` declaration style while retaining printf-format checking.

The focused test passes under ASan/UBSan on macOS. The full suite reaches the same unrelated existing `testrig.sh` ASan failure in `dummy_get_level()`.
