### PR TITLE
fix: prevent dummy level buffer overflow

### DIFF
--- a/rigs/dummy/dummy.c
+++ b/rigs/dummy/dummy.c
@@ -1444,7 +1444,8 @@ static int dummy_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
         break;
     }
 
-    memcpy(val, &curr->levels[idx], sizeof(value_t));
+    memcpy(val, &curr->levels[idx], RIG_LEVEL_IS_FLOAT(level)
+           ? sizeof(curr->levels[idx].f) : sizeof(curr->levels[idx].i));
     rig_debug(RIG_DEBUG_VERBOSE, "%s called: %s\n", __func__,
               rig_strlevel(level));
 


### PR DESCRIPTION
I found this while running Hamlib’s `testrig` under AddressSanitizer. The dummy backend copied a full `value_t` into the result buffer even when `rig_get_strength()` supplied an `int`, causing a stack buffer overflow.

The fix keeps the existing alignment-safe copy but limits it to the selected integer or float member.

I ran the focused `testrig` test and the full Hamlib test suite under ASan/UBSan on macOS.
