### PR TITLE
Validate Elecraft K3/K4 SWR responses

### DIFF
--- a/rigs/kenwood/k3.c
+++ b/rigs/kenwood/k3.c
@@ -2347,8 +2347,7 @@ static int k3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     case RIG_LEVEL_SWR:
         if (RIG_IS_K4)
         {
-            retval = k4_get_bar_graph_level(rig, &val->f, NULL, NULL, NULL);
-            return RIG_OK;
+            return k4_get_bar_graph_level(rig, &val->f, NULL, NULL, NULL);
         }
         else
         {
@@ -2359,7 +2358,10 @@ static int k3_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
                 return retval;
             }
 
-            sscanf(levelbuf + 2, "%d", &lvl);
+            if (sscanf(levelbuf + 2, "%d", &lvl) != 1)
+            {
+                return -RIG_EPROTO;
+            }
         }
 
         val->f = (float) lvl / 10.0f;
@@ -2746,7 +2748,10 @@ int k4_get_bar_graph_level(RIG *rig, float *swr, float *pwr, float *alc,
         return retval;
     }
 
-    sscanf(levelbuf, "TM%03d%03d%03d%03d", &ialc, &icmp, &ifwd, &iswr);
+    if (sscanf(levelbuf, "TM%03d%03d%03d%03d", &ialc, &icmp, &ifwd, &iswr) != 4)
+    {
+        return -RIG_EPROTO;
+    }
 
     if (swr) { *swr = iswr / 10.0; }
 


### PR DESCRIPTION
## What changed

This is a small defensive fix for Elecraft SWR reads.

The [K3S/K3 Programmer's Reference](https://ftp.elecraft.com/KX2/Manuals%20Downloads/K3S%26K3%26KX3%26KX2%20Pgmrs%20Ref%2C%20G5.pdf) documents `SWnnn` replies, while the [K4 Programmer's Reference](https://ftp.elecraft.com/K4/Manuals%20Downloads/K4%20Programmer%27s%20Reference%2C%20rev.%20D12.pdf) documents SWR as the final field in `TMaaabbbcccddd`.

The existing code already converts the documented tenths-of-an-SWR-unit values correctly. This change simply checks that the numeric fields were parsed before using them and lets the K4 path return transaction or parsing errors instead of reporting a successful reading.

Normal, valid radio replies are handled exactly as before. An unexpected reply now produces a regular protocol error rather than a potentially bogus SWR value.

## Testing

- Full build completed successfully.
- All 13 tests passed.
- Checked valid and malformed K3 and K4 responses with a simulated serial endpoint.
