### PR TITLE
fix(guohetec): initialize fallback filter width

### DIFF
--- a/rigs/guohetec/pmr171.c
+++ b/rigs/guohetec/pmr171.c
@@ -299,6 +299,7 @@ static int pmr171_init(RIG *rig)
     {
         return -RIG_ENOMEM;
     }
+    data->filterBW = RIG_PASSBAND_NORMAL;
     STATE(rig)->priv = data;
     
     return RIG_OK;

--- a/rigs/guohetec/q900.c
+++ b/rigs/guohetec/q900.c
@@ -298,6 +298,7 @@ static int q900_init(RIG *rig)
     {
         return -RIG_ENOMEM;
     }
+    data->filterBW = RIG_PASSBAND_NORMAL;
     STATE(rig)->priv = data;
     
     return RIG_OK;


### PR DESCRIPTION
Initialize the PMR-171 and Q900 cached filter width to `RIG_PASSBAND_NORMAL` during backend setup. This keeps fallback mode queries from returning an undefined width.

Tested with `make check` and hardware-independent PMR-171/Q900 checks under Clang ASan/UBSan.