### PR TITLE
fix(core): terminate empty hexadecimal output

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -298,7 +298,14 @@ size_t HAMLIB_API to_hex(size_t source_length, const unsigned char *source_data,
     const unsigned char *source = source_data;
     char *dest = dest_data;
 
-    if (source_length == 0 || dest_length == 0)
+    if (dest_length == 0)
+    {
+        return 0;
+    }
+
+    dest_data[0] = '\0';
+
+    if (source_length == 0)
     {
         return 0;
     }

--- a/tests/testbcd.c
+++ b/tests/testbcd.c
@@ -16,6 +16,7 @@
 int main(int argc, char *argv[])
 {
     unsigned char b[(MAXDIGITS + 1) / 2];
+    char hex[] = "x";
     freq_t f = 0;
     int digits = 10;
     int i;
@@ -23,6 +24,12 @@ int main(int argc, char *argv[])
     if (argc != 2 && argc != 3)
     {
         fprintf(stderr, "Usage: %s <freq> [digits]\n", argv[0]);
+        exit(1);
+    }
+
+    if (to_hex(0, NULL, sizeof(hex), hex) != 0 || hex[0] != '\0')
+    {
+        fprintf(stderr, "Empty hexadecimal output is not terminated\n");
         exit(1);
     }
 


### PR DESCRIPTION
Make `to_hex()` return a terminated empty string when there is no source data and the destination has space. This prevents callers such as the spectrum snapshot serializer from treating an untouched destination buffer as a C string. Add a small regression for the empty conversion.

Tested with the focused `testbcd` test, the zero-length spectrum snapshot loopback harness, and the full `make check` suite (20 tests).
