### PR TITLE
fix(dummy): copy string parameter values

### DIFF
--- a/rigs/dummy/dummy.c
+++ b/rigs/dummy/dummy.c
@@ -353,6 +353,14 @@ static int dummy_cleanup(RIG *rig)
     free(priv->ext_parms);
     free(priv->magic_conf);
 
+    for (int i = 0; i < RIG_SETTING_MAX; i++)
+    {
+        if (RIG_PARM_IS_STRING(rig_idx2setting(i)))
+        {
+            free(priv->parms[i].s);
+        }
+    }
+
     free(priv);
 
     rs->priv = NULL;
@@ -1689,6 +1697,7 @@ static int dummy_set_parm(RIG *rig, setting_t parm, value_t val)
     struct dummy_priv_data *priv = (struct dummy_priv_data *)STATE(rig)->priv;
     int idx;
     char pstr[32];
+    char *string_value = NULL;
 
     ENTERFUNC;
     idx = rig_setting2idx(parm);
@@ -1696,6 +1705,21 @@ static int dummy_set_parm(RIG *rig, setting_t parm, value_t val)
     if (idx >= RIG_SETTING_MAX)
     {
         RETURNFUNC(-RIG_EINVAL);
+    }
+
+    if (RIG_PARM_IS_STRING(parm))
+    {
+        if (val.cs == NULL)
+        {
+            RETURNFUNC(-RIG_EINVAL);
+        }
+
+        string_value = strdup(val.cs);
+
+        if (string_value == NULL)
+        {
+            RETURNFUNC(-RIG_ENOMEM);
+        }
     }
 
     if (RIG_PARM_IS_FLOAT(parm))
@@ -1714,7 +1738,16 @@ static int dummy_set_parm(RIG *rig, setting_t parm, value_t val)
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called: %s %s\n", __func__,
               rig_strparm(parm), pstr);
-    priv->parms[idx] = val;
+
+    if (string_value != NULL)
+    {
+        free(priv->parms[idx].s);
+        priv->parms[idx].s = string_value;
+    }
+    else
+    {
+        priv->parms[idx] = val;
+    }
 
     RETURNFUNC(RIG_OK);
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -14,7 +14,7 @@ DISTCLEANFILES = rigctl.log rigctl.sum testbcd.log testbcd.sum
 
 bin_PROGRAMS = rigctl rigctld rigmem rigsmtr rigswr rotctl rotctld rigctlcom rigctltcp rigctlsync ampctl ampctld rigtestmcast rigtestmcastrx $(TESTLIBUSB)
 
-check_PROGRAMS = dumpmem testrig testrigopen testrigcaps testbcd testfreq listrigs testloc rig_bench testcache cachetest cachetest2 testcookie testdebug testgrid hamlibmodels testmW2power test2038
+check_PROGRAMS = dumpmem testrig testrigopen testrigcaps testbcd testfreq listrigs testloc rig_bench testcache cachetest cachetest2 testcookie testdebug testdummyparm testgrid hamlibmodels testmW2power test2038
 check_PROGRAMS += testnetrigctl
 check_PROGRAMS += testctlparser testbandmetadata testicomts testgeministatus testgs100 testftx1parsers
 # Document building testsecurity
@@ -144,7 +144,7 @@ EXTRA_DIST = \
 check_SCRIPTS = amptest.sh test2038.sh testbcd.sh testcache.sh testcaps.sh testcookie.sh testfreq.sh testgrid.sh testloc.sh testrig.sh testrigcaps.sh
 check_SCRIPTS += testnetrigctl.sh testctlbounds.sh
 
-TESTS = $(check_SCRIPTS) testdebug testctlparser testbandmetadata testicomts testgeministatus testgs100 testftx1parsers
+TESTS = $(check_SCRIPTS) testdebug testdummyparm testctlparser testbandmetadata testicomts testgeministatus testgs100 testftx1parsers
 
 $(top_builddir)/src/libhamlib.la:
 	$(MAKE) -C $(top_builddir)/src/ libhamlib.la

--- a/tests/testdummyparm.c
+++ b/tests/testdummyparm.c
@@ -1,0 +1,84 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "hamlib/rig.h"
+#include "hamlib/riglist.h"
+
+
+static int check_string_parm(RIG *rig, setting_t parm, const char *first,
+                             const char *second)
+{
+    char input[32];
+    value_t value;
+    int status;
+
+    snprintf(input, sizeof(input), "%s", first);
+    value.cs = input;
+    status = rig_set_parm(rig, parm, value);
+
+    if (status != RIG_OK)
+    {
+        fprintf(stderr, "setting %s failed: %s\n", rig_strparm(parm),
+                rigerror(status));
+        return 1;
+    }
+
+    memset(input, 0, sizeof(input));
+    status = rig_get_parm(rig, parm, &value);
+
+    if (status != RIG_OK || value.cs == NULL || strcmp(value.cs, first) != 0)
+    {
+        fprintf(stderr, "%s did not retain its first string value\n",
+                rig_strparm(parm));
+        return 1;
+    }
+
+    snprintf(input, sizeof(input), "%s", second);
+    value.cs = input;
+    status = rig_set_parm(rig, parm, value);
+
+    if (status != RIG_OK)
+    {
+        fprintf(stderr, "replacing %s failed: %s\n", rig_strparm(parm),
+                rigerror(status));
+        return 1;
+    }
+
+    memset(input, 0, sizeof(input));
+    status = rig_get_parm(rig, parm, &value);
+
+    if (status != RIG_OK || value.cs == NULL || strcmp(value.cs, second) != 0)
+    {
+        fprintf(stderr, "%s did not retain its replacement string value\n",
+                rig_strparm(parm));
+        return 1;
+    }
+
+    return 0;
+}
+
+
+int main(void)
+{
+    RIG *rig = rig_init(RIG_MODEL_DUMMY);
+    int failed = 0;
+
+    if (rig == NULL)
+    {
+        fprintf(stderr, "failed to initialize Dummy rig\n");
+        return 1;
+    }
+
+    if (rig_open(rig) != RIG_OK)
+    {
+        fprintf(stderr, "failed to open Dummy rig\n");
+        rig_cleanup(rig);
+        return 1;
+    }
+
+    failed |= check_string_parm(rig, RIG_PARM_BANDSELECT, "BAND70CM", "BAND33CM");
+    failed |= check_string_parm(rig, RIG_PARM_KEYERTYPE, "BUG", "PADDLE");
+    rig_close(rig);
+    rig_cleanup(rig);
+    return failed;
+}


### PR DESCRIPTION
The Dummy backend was keeping caller-owned pointers for string parameters, which left `BANDSELECT` and `KEYERTYPE` dangling after the command parser returned. A later get could then read from an expired stack buffer and trigger a stack-use-after-return under ASan.

This change:

- Copies string values into backend-owned storage.
- Frees them when replaced or during cleanup.
- Leaves the existing numeric-parameter behavior unchanged.
- Adds focused set/get regression coverage for `BANDSELECT` and `KEYERTYPE`.
