### PR TITLE
ftx1: round repeater offset to nearest menu step, reject negative

### DIFF
--- a/rigs/yaesu/ftx1/ftx1_freq.c
+++ b/rigs/yaesu/ftx1/ftx1_freq.c
@@ -395,8 +395,21 @@ int ftx1_set_rptr_offs(RIG *rig, vfo_t vfo, shortfreq_t offs)
         return -RIG_ENAVAIL;
     }
 
-    /* Convert Hz offset to menu value (use val.f for RIG_CONF_NUMERIC) */
-    val.f = (float)(offs / multiplier);
+    /* The offset is a magnitude; direction comes from set_rptr_shift. A
+     * negative value would truncate towards zero below and could be silently
+     * accepted as "no offset", so reject it explicitly. */
+    if (offs < 0)
+    {
+        rig_debug(RIG_DEBUG_ERR, "%s: negative offset %ld not supported, "
+                  "use set_rptr_shift for direction\n", __func__, offs);
+        return -RIG_EINVAL;
+    }
+
+    /* Convert Hz offset to menu value, rounding to the nearest representable
+     * step (use val.f for RIG_CONF_NUMERIC). The menu granularity is coarse --
+     * tens of kHz on the VHF/UHF bands -- so truncating here silently programs
+     * a different offset than the caller asked for. */
+    val.f = (float)((offs + multiplier / 2) / multiplier);
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: freq=%.0f token=0x%lx val=%.0f (offs=%ld, mult=%d)\n",
               __func__, freq, (unsigned long)token, val.f, offs, multiplier);


### PR DESCRIPTION
`ftx1_set_rptr_offs()` converts the requested offset into the EX menu's step count with a truncating integer division:

```c
val.f = (float)(offs / multiplier);
```

Any offset that isn't an exact multiple of the step is therefore silently programmed as a smaller one, and nothing is returned to tell the caller it was changed. This rounds to the nearest step instead.

It also rejects a negative offset up front. The offset is a magnitude — direction comes from `set_rptr_shift` — and truncation towards zero meant a small negative value was accepted as "no offset", while a larger one failed later in the menu range check. Now both are rejected consistently, before anything is written to the radio.

### Relationship to #2110

This is independent of #2110 and touches different lines, so the two merge cleanly in either order. But they're worth reading together: #2110 corrects the 144/430 MHz step from 10 kHz/100 kHz to the actual 50 kHz, which makes this truncation much easier to hit — with the correct step, a request for a 625 kHz offset lands 25 kHz low.

### Verification

Tested on an FTX-1 (Optima) over CAT, with #2110 applied so the step is the correct 50 kHz:

| `set_rptr_offs` | menu value | `get_rptr_offs` | |
|---|---|---|---|
| 625000 | 13 | 650000 | exactly half a step, rounds up |
| 630000 | 13 | 650000 | |
| 620000 | 12 | 600000 | |
| 624999 | 12 | 600000 | |
| 600000 | 12 | 600000 | exact, unchanged |
| -600000 | — | `-RIG_EINVAL` | menu value left untouched |

Builds clean with `-Wall -Wformat` (Apple Clang 21); GCC/MinGW untested on my side.