### PR TITLE
refactor(tests): make test registration less conflict-prone

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -14,9 +14,50 @@ DISTCLEANFILES = rigctl.log rigctl.sum testbcd.log testbcd.sum
 
 bin_PROGRAMS = rigctl rigctld rigmem rigsmtr rigswr rotctl rotctld rigctlcom rigctltcp rigctlsync ampctl ampctld rigtestmcast rigtestmcastrx $(TESTLIBUSB)
 
-check_PROGRAMS = dumpmem testrig testrigopen testrigcaps testbcd testfreq listrigs testloc rig_bench testcache cachetest cachetest2 testcookie testdebug testdummyparm testgrid hamlibmodels testmW2power test2038
-check_PROGRAMS += testnetrigctl
-check_PROGRAMS += testctlparser testbandmetadata testicomts testgeministatus testgs100 testftx1parsers
+# Keep test registries sorted and one entry per line.
+# This keeps independent additions from editing shared lines.
+DIRECT_TESTS = \
+	testbandmetadata \
+	testctlparser \
+	testdebug \
+	testdummyparm \
+	testftx1parsers \
+	testgeministatus \
+	testgs100 \
+	testicomts
+
+GENERATED_TEST_WRAPPERS = \
+	test2038.sh \
+	testbcd.sh \
+	testcache.sh \
+	testcookie.sh \
+	testfreq.sh \
+	testgrid.sh \
+	testloc.sh \
+	testnetrigctl.sh \
+	testrig.sh \
+	testrigcaps.sh
+
+check_PROGRAMS = \
+	cachetest \
+	cachetest2 \
+	dumpmem \
+	hamlibmodels \
+	listrigs \
+	rig_bench \
+	test2038 \
+	testbcd \
+	testcache \
+	testcookie \
+	testfreq \
+	testgrid \
+	testloc \
+	testmW2power \
+	testnetrigctl \
+	testrig \
+	testrigcaps \
+	testrigopen \
+	$(DIRECT_TESTS)
 # Document building testsecurity
 ### check_PROGRAMS += testsecurity
 
@@ -141,10 +182,13 @@ EXTRA_DIST = \
 
 # Support 'make check' target for simple tests
 # Omitting cachetest.sh because it needs 2 instances of rigctld running
-check_SCRIPTS = amptest.sh test2038.sh testbcd.sh testcache.sh testcaps.sh testcookie.sh testfreq.sh testgrid.sh testloc.sh testrig.sh testrigcaps.sh
-check_SCRIPTS += testnetrigctl.sh testctlbounds.sh
+check_SCRIPTS = \
+	amptest.sh \
+	testcaps.sh \
+	testctlbounds.sh \
+	$(GENERATED_TEST_WRAPPERS)
 
-TESTS = $(check_SCRIPTS) testdebug testdummyparm testctlparser testbandmetadata testicomts testgeministatus testgs100 testftx1parsers
+TESTS = $(check_SCRIPTS) $(DIRECT_TESTS)
 
 $(top_builddir)/src/libhamlib.la:
 	$(MAKE) -C $(top_builddir)/src/ libhamlib.la
@@ -207,4 +251,11 @@ test2038.sh:
 	echo 'LD_LIBRARY_PATH=$(top_builddir)/src/.libs:$(top_builddir)/dummy/.libs ./test2038 1' > test2038.sh
 	chmod +x ./test2038.sh
 
-CLEANFILES = rigmatrix testrig.sh testfreq.sh testbcd.sh testloc.sh testrigcaps.sh testcache.sh testcookie.sh rigtestlibusb build-w32.sh build-w64.sh build-w64-jtsdk.sh testgrid.sh testrigcaps.sh test2038.sh testnetrigctl.sh tuner_control.log
+CLEANFILES = \
+	build-w32.sh \
+	build-w64-jtsdk.sh \
+	build-w64.sh \
+	rigmatrix \
+	rigtestlibusb \
+	tuner_control.log \
+	$(GENERATED_TEST_WRAPPERS)


### PR DESCRIPTION
This tidies up the test registration in tests/Makefile.am so adding a test does not mean editing the same giant lines every time.

- Keeps test entries sorted and one per line.
- Shares direct-test and generated-wrapper lists where possible.
- Removes a duplicate CLEANFILES entry.
- Does not change which tests are built or run.

Main goal: fewer annoying merge conflicts when multiple PRs add tests.

Validated with autoreconf -fi and a fresh configure.