### PR TITLE
fix(core): preserve DATA submodes for generic packet requests

### DIFF
--- a/rigs/kenwood/kenwood.c
+++ b/rigs/kenwood/kenwood.c
@@ -2592,12 +2592,7 @@ int kenwood_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
     }
     else if (RIG_IS_TS990S)
     {
-        /* The TS990s has targetable read mode but can only set the mode
-           of the current VFO :( So we need to toggle the operating VFO
-           to set the "back" VFO mode. This is done here rather than not
-           setting caps.targetable_vfo to not include
-           RIG_TARGETABLE_MODE since the toggle is not required for
-           reading the mode. */
+        /* OM reads address either band, but writes affect the operating band. */
         vfo_t curr_vfo;
 
         err = kenwood_get_vfo_main_sub(rig, &curr_vfo);
@@ -2614,16 +2609,16 @@ int kenwood_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         SNPRINTF(buf, sizeof(buf), "OM0%c", c);  /* target vfo is ignored */
         err = kenwood_transaction(rig, buf, NULL, 0);
 
-        if (err == RIG_OK && vfo != RIG_VFO_CURR && vfo != curr_vfo)
+        if (vfo != RIG_VFO_CURR && vfo != curr_vfo)
         {
             int err2;
 
             err2 = kenwood_set_vfo_main_sub(rig, curr_vfo);
 
-            if (err2 != RIG_OK) { RETURNFUNC2(err2); }
+            if (err == RIG_OK) { err = err2; }
         }
 
-        return RIG_OK;
+        RETURNFUNC2(err);
     }
     else
     {

--- a/rigs/kenwood/ts990s.c
+++ b/rigs/kenwood/ts990s.c
@@ -31,7 +31,8 @@
 
 #define TS990S_AM_MODES RIG_MODE_AM
 #define TS990S_FM_MODES (RIG_MODE_FM|RIG_MODE_FMN)
-#define TS990S_OTHER_MODES (RIG_MODE_CW|RIG_MODE_CWR|RIG_MODE_SSB|RIG_MODE_FM|RIG_MODE_RTTY|RIG_MODE_RTTYR|RIG_MODE_PKTUSB|RIG_MODE_PKTLSB|RIG_MODE_USBD1|RIG_MODE_USBD2|RIG_MODE_USBD3|RIG_MODE_LSBD1|RIG_MODE_LSBD2|RIG_MODE_LSBD3)
+#define TS990S_PACKET_MODES (RIG_MODE_PKTUSB|RIG_MODE_PKTLSB|RIG_MODE_USBD1|RIG_MODE_USBD2|RIG_MODE_USBD3|RIG_MODE_LSBD1|RIG_MODE_LSBD2|RIG_MODE_LSBD3)
+#define TS990S_OTHER_MODES (RIG_MODE_CW|RIG_MODE_CWR|RIG_MODE_SSB|RIG_MODE_FM|RIG_MODE_RTTY|RIG_MODE_RTTYR|TS990S_PACKET_MODES)
 #define TS990S_HP_MODES (TS990S_OTHER_MODES|TS990S_FM_MODES)
 #define TS990S_ALL_MODES (TS990S_OTHER_MODES|TS990S_AM_MODES|TS990S_FM_MODES)
 
@@ -310,25 +311,23 @@ struct rig_caps ts990s_caps =
         {RIG_MODE_AM, kHz(2.5)},        /* default narrow - arbitrary choice */
         {RIG_MODE_AM, kHz(4)},
         {RIG_MODE_AM, kHz(3)},
-        {RIG_MODE_PKTLSB | RIG_MODE_PKTUSB, kHz(2.6)}, /* default normal */
-        {RIG_MODE_PKTLSB | RIG_MODE_PKTUSB, Hz(500)}, /* default narrow -
-                                                                                                        arbitrary choice */
-        {RIG_MODE_PKTLSB | RIG_MODE_PKTUSB, kHz(13)}, /* default wide -
-                                                                                                        arbitrary choice */
-        {RIG_MODE_PKTLSB | RIG_MODE_PKTUSB, kHz(2.8)},
-        {RIG_MODE_PKTLSB | RIG_MODE_PKTUSB, kHz(2.4)},
-        {RIG_MODE_PKTLSB | RIG_MODE_PKTUSB, kHz(2.2)},
-        {RIG_MODE_PKTLSB | RIG_MODE_PKTUSB, kHz(2.0)},
-        {RIG_MODE_PKTLSB | RIG_MODE_PKTUSB, kHz(1.5)},
-        {RIG_MODE_PKTLSB | RIG_MODE_PKTUSB, kHz(1.0)},
-        {RIG_MODE_PKTLSB | RIG_MODE_PKTUSB, Hz(600)},
-        {RIG_MODE_PKTLSB | RIG_MODE_PKTUSB, Hz(400)},
-        {RIG_MODE_PKTLSB | RIG_MODE_PKTUSB, Hz(300)},
-        {RIG_MODE_PKTLSB | RIG_MODE_PKTUSB, Hz(200)},
-        {RIG_MODE_PKTLSB | RIG_MODE_PKTUSB, Hz(150)},
-        {RIG_MODE_PKTLSB | RIG_MODE_PKTUSB, Hz(100)},
-        {RIG_MODE_PKTLSB | RIG_MODE_PKTUSB, Hz(80)},
-        {RIG_MODE_PKTLSB | RIG_MODE_PKTUSB, Hz(50)},
+        {TS990S_PACKET_MODES, kHz(2.6)}, /* default normal */
+        {TS990S_PACKET_MODES, Hz(500)}, /* default narrow - arbitrary choice */
+        {TS990S_PACKET_MODES, kHz(13)}, /* default wide - arbitrary choice */
+        {TS990S_PACKET_MODES, kHz(2.8)},
+        {TS990S_PACKET_MODES, kHz(2.4)},
+        {TS990S_PACKET_MODES, kHz(2.2)},
+        {TS990S_PACKET_MODES, kHz(2.0)},
+        {TS990S_PACKET_MODES, kHz(1.5)},
+        {TS990S_PACKET_MODES, kHz(1.0)},
+        {TS990S_PACKET_MODES, Hz(600)},
+        {TS990S_PACKET_MODES, Hz(400)},
+        {TS990S_PACKET_MODES, Hz(300)},
+        {TS990S_PACKET_MODES, Hz(200)},
+        {TS990S_PACKET_MODES, Hz(150)},
+        {TS990S_PACKET_MODES, Hz(100)},
+        {TS990S_PACKET_MODES, Hz(80)},
+        {TS990S_PACKET_MODES, Hz(50)},
         RIG_FLT_END,
     },
 

--- a/simulators/simts990.c
+++ b/simulators/simts990.c
@@ -382,18 +382,16 @@ int main(int argc, char *argv[])
             sprintf(buf, "OM0%c;", modeA);
             write(fd, buf, strlen(buf));
         }
-        else if (strncmp(buf, "OM0", 3) == 0)
-        {
-            modeA = buf[3];
-        }
         else if (strncmp(buf, "OM1;", 4) == 0)
         {
             sprintf(buf, "OM1%c;", modeB);
             write(fd, buf, strlen(buf));
         }
-        else if (strncmp(buf, "OM1", 3) == 0)
+        else if (strncmp(buf, "OM0", 3) == 0 || strncmp(buf, "OM1", 3) == 0)
         {
-            modeB = buf[3];
+            /* OM writes ignore the band field and affect the operating band. */
+            if (operatingband == 0) { modeA = buf[3]; }
+            else { modeB = buf[3]; }
         }
         else if (strcmp(buf, "RM;") == 0)
         {

--- a/src/rig.c
+++ b/src/rig.c
@@ -2827,6 +2827,28 @@ int HAMLIB_API rig_get_freqs(RIG *rig, freq_t *freqA, freq_t freqB)
     return (-RIG_ENIMPL);
 }
 
+static int mode_satisfies_request(rmode_t requested, rmode_t current)
+{
+    if (requested == current)
+    {
+        return 1;
+    }
+
+    if (requested == RIG_MODE_PKTUSB)
+    {
+        return current == RIG_MODE_USBD1 || current == RIG_MODE_USBD2
+               || current == RIG_MODE_USBD3;
+    }
+
+    if (requested == RIG_MODE_PKTLSB)
+    {
+        return current == RIG_MODE_LSBD1 || current == RIG_MODE_LSBD2
+               || current == RIG_MODE_LSBD3;
+    }
+
+    return 0;
+}
+
 
 /**
  * \brief set the mode of the target VFO
@@ -2926,10 +2948,10 @@ int HAMLIB_API rig_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 #if 0
         // This should not be necessary anymore with the new filter method for Icom rigs
         // Hopefully fixes issue https://github.com/Hamlib/Hamlib/issues/1580
-        if (retcode == RIG_OK && mode == mode_curr
+        if (retcode == RIG_OK && mode_satisfies_request(mode, mode_curr)
                 && RIG_ICOM != RIG_BACKEND_NUM(rig->caps->rig_model))
 #else
-        if (retcode == RIG_OK && mode == mode_curr)
+        if (retcode == RIG_OK && mode_satisfies_request(mode, mode_curr))
 #endif
         {
             rig_debug(RIG_DEBUG_VERBOSE,

--- a/src/rig.c
+++ b/src/rig.c
@@ -2793,6 +2793,28 @@ int HAMLIB_API rig_get_freqs(RIG *rig, freq_t *freqA, freq_t freqB)
     return (-RIG_ENIMPL);
 }
 
+static int mode_satisfies_request(rmode_t requested, rmode_t current)
+{
+    if (requested == current)
+    {
+        return 1;
+    }
+
+    if (requested == RIG_MODE_PKTUSB)
+    {
+        return current == RIG_MODE_USBD1 || current == RIG_MODE_USBD2
+               || current == RIG_MODE_USBD3;
+    }
+
+    if (requested == RIG_MODE_PKTLSB)
+    {
+        return current == RIG_MODE_LSBD1 || current == RIG_MODE_LSBD2
+               || current == RIG_MODE_LSBD3;
+    }
+
+    return 0;
+}
+
 
 /**
  * \brief set the mode of the target VFO
@@ -2892,10 +2914,10 @@ int HAMLIB_API rig_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 #if 0
         // This should not be necessary anymore with the new filter method for Icom rigs
         // Hopefully fixes issue https://github.com/Hamlib/Hamlib/issues/1580
-        if (retcode == RIG_OK && mode == mode_curr
+        if (retcode == RIG_OK && mode_satisfies_request(mode, mode_curr)
                 && RIG_ICOM != RIG_BACKEND_NUM(rig->caps->rig_model))
 #else
-        if (retcode == RIG_OK && mode == mode_curr)
+        if (retcode == RIG_OK && mode_satisfies_request(mode, mode_curr))
 #endif
         {
             rig_debug(RIG_DEBUG_VERBOSE,

--- a/src/rig.c
+++ b/src/rig.c
@@ -2936,30 +2936,30 @@ int HAMLIB_API rig_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 
     vfo = vfo_fixup(rig, vfo, cachep->split);
 
-    // if we're not asking for bandwidth and the mode is already set we don't need to do it
-    // this will prevent flashing on some rigs like the TS-870
-    if (caps->get_mode && width == RIG_PASSBAND_NOCHANGE)
+    // Resolve a generic packet request against a specific DATA profile before setting it.
+    if (caps->get_mode && (width == RIG_PASSBAND_NOCHANGE
+                           || mode == RIG_MODE_PKTUSB || mode == RIG_MODE_PKTLSB)
+            && ((caps->targetable_vfo & RIG_TARGETABLE_MODE)
+                || vfo == rs->current_vfo))
     {
         rmode_t mode_curr;
         pbwidth_t width_curr;
         retcode = caps->get_mode(rig, vfo, &mode_curr, &width_curr);
 
-        // For Icom rigs we may need to force the filter so we always set mode
-#if 0
-        // This should not be necessary anymore with the new filter method for Icom rigs
-        // Hopefully fixes issue https://github.com/Hamlib/Hamlib/issues/1580
-        if (retcode == RIG_OK && mode_satisfies_request(mode, mode_curr)
-                && RIG_ICOM != RIG_BACKEND_NUM(rig->caps->rig_model))
-#else
         if (retcode == RIG_OK && mode_satisfies_request(mode, mode_curr))
-#endif
         {
-            rig_debug(RIG_DEBUG_VERBOSE,
-                      "%s: mode already %s and bw change not requested\n", __func__,
-                      rig_strrmode(mode));
-            ELAPSED2;
-            LOCK(0);
-            RETURNFUNC(RIG_OK);
+            mode = mode_curr;
+
+            if (width == RIG_PASSBAND_NOCHANGE)
+            {
+                rig_set_cache_mode(rig, vfo, mode_curr, width_curr);
+                rig_debug(RIG_DEBUG_VERBOSE,
+                          "%s: mode already %s and bw change not requested\n", __func__,
+                          rig_strrmode(mode_curr));
+                ELAPSED2;
+                LOCK(0);
+                RETURNFUNC(RIG_OK);
+            }
         }
     }
 
@@ -2988,7 +2988,7 @@ int HAMLIB_API rig_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
             rig_get_cache(rig, vfo, &cache_freq, &cache_ms_freq, &cache_mode,
                           &cache_ms_mode, &cache_width, &cache_ms_width);
 
-            if (cache_mode == mode)
+            if (cache_mode == mode && width == RIG_PASSBAND_NOCHANGE)
             {
                 rig_debug(RIG_DEBUG_TRACE, "%s: mode not changing, so ignoring\n",
                           __func__);
@@ -3021,7 +3021,37 @@ int HAMLIB_API rig_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
             RETURNFUNC(retcode);
         }
 
-        retcode = caps->set_mode(rig, vfo, mode, width);
+        int skip_set_mode = 0;
+
+        if (caps->get_mode && (width == RIG_PASSBAND_NOCHANGE
+                               || mode == RIG_MODE_PKTUSB || mode == RIG_MODE_PKTLSB))
+        {
+            rmode_t mode_curr;
+            pbwidth_t width_curr;
+
+            retcode = caps->get_mode(rig, vfo, &mode_curr, &width_curr);
+
+            if (retcode == RIG_OK && mode_satisfies_request(mode, mode_curr))
+            {
+                mode = mode_curr;
+
+                if (width == RIG_PASSBAND_NOCHANGE)
+                {
+                    width = width_curr;
+                    skip_set_mode = 1;
+                }
+            }
+            else
+            {
+                retcode = RIG_OK;
+            }
+        }
+
+        if (retcode == RIG_OK && !skip_set_mode)
+        {
+            retcode = caps->set_mode(rig, vfo, mode, width);
+        }
+
         /* try and revert even if we had an error above */
         rc2 = caps->set_vfo(rig, curr_vfo);
 
@@ -5217,14 +5247,8 @@ int HAMLIB_API rig_set_split_mode(RIG *rig,
                            || (rig->caps->rig_model == RIG_MODEL_NETRIGCTL)))
     {
         HAMLIB_TRACE;
-        retcode = caps->set_mode(rig, tx_vfo, tx_mode, tx_width);
+        retcode = rig_set_mode(rig, tx_vfo, tx_mode, tx_width);
         ELAPSED2;
-
-        if (retcode == RIG_OK)
-        {
-            rig_set_cache_mode(rig, tx_vfo, tx_mode, tx_width);
-        }
-
         RETURNFUNC(retcode);
     }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -24,7 +24,8 @@ DIRECT_TESTS = \
 	testftx1parsers \
 	testgeministatus \
 	testgs100 \
-	testicomts
+	testicomts \
+	testmodecompat
 
 GENERATED_TEST_WRAPPERS = \
 	test2038.sh \
@@ -126,6 +127,7 @@ testdebug_LDADD = $(PTHREAD_LIBS) $(LDADD)
 testnetrigctl_LDADD = $(top_builddir)/rigs/dummy/libhamlib-dummy.la
 testctlparser_SOURCES = testctlparser.c $(RIGCOMMONSRC)
 testctlparser_LDADD = $(PTHREAD_LIBS) $(READLINE_LIBS) $(top_builddir)/rigs/dummy/libhamlib-dummy.la $(LDADD)
+testmodecompat_LDADD = $(top_builddir)/rigs/dummy/libhamlib-dummy.la $(LDADD)
 testicomts_LDADD = $(top_builddir)/rigs/icom/libhamlib-icom.la $(LDADD)
 testgeministatus_LDADD = $(PTHREAD_LIBS) $(top_builddir)/amplifiers/gemini/libhamlib-gemini.la $(LDADD)
 testgs100_LDADD = $(PTHREAD_LIBS) $(top_builddir)/rigs/gomspace/libhamlib-gomspace.la $(LDADD)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -14,9 +14,50 @@ DISTCLEANFILES = rigctl.log rigctl.sum testbcd.log testbcd.sum
 
 bin_PROGRAMS = rigctl rigctld rigmem rigsmtr rigswr rotctl rotctld rigctlcom rigctltcp rigctlsync ampctl ampctld rigtestmcast rigtestmcastrx $(TESTLIBUSB)
 
-check_PROGRAMS = dumpmem testrig testrigopen testrigcaps testbcd testfreq listrigs testloc rig_bench testcache cachetest cachetest2 testcookie testdebug testdummyparm testgrid hamlibmodels testmW2power test2038
-check_PROGRAMS += testnetrigctl
-check_PROGRAMS += testctlparser testbandmetadata testicomts testgeministatus testgs100 testftx1parsers
+# Keep test registries sorted and one entry per line.
+# This keeps independent additions from editing shared lines.
+DIRECT_TESTS = \
+	testbandmetadata \
+	testctlparser \
+	testdebug \
+	testdummyparm \
+	testftx1parsers \
+	testgeministatus \
+	testgs100 \
+	testicomts
+
+GENERATED_TEST_WRAPPERS = \
+	test2038.sh \
+	testbcd.sh \
+	testcache.sh \
+	testcookie.sh \
+	testfreq.sh \
+	testgrid.sh \
+	testloc.sh \
+	testnetrigctl.sh \
+	testrig.sh \
+	testrigcaps.sh
+
+check_PROGRAMS = \
+	cachetest \
+	cachetest2 \
+	dumpmem \
+	hamlibmodels \
+	listrigs \
+	rig_bench \
+	test2038 \
+	testbcd \
+	testcache \
+	testcookie \
+	testfreq \
+	testgrid \
+	testloc \
+	testmW2power \
+	testnetrigctl \
+	testrig \
+	testrigcaps \
+	testrigopen \
+	$(DIRECT_TESTS)
 # Document building testsecurity
 ### check_PROGRAMS += testsecurity
 
@@ -141,10 +182,13 @@ EXTRA_DIST = \
 
 # Support 'make check' target for simple tests
 # Omitting cachetest.sh because it needs 2 instances of rigctld running
-check_SCRIPTS = amptest.sh test2038.sh testbcd.sh testcache.sh testcaps.sh testcookie.sh testfreq.sh testgrid.sh testloc.sh testrig.sh testrigcaps.sh
-check_SCRIPTS += testnetrigctl.sh testctlbounds.sh
+check_SCRIPTS = \
+	amptest.sh \
+	testcaps.sh \
+	testctlbounds.sh \
+	$(GENERATED_TEST_WRAPPERS)
 
-TESTS = $(check_SCRIPTS) testdebug testdummyparm testctlparser testbandmetadata testicomts testgeministatus testgs100 testftx1parsers
+TESTS = $(check_SCRIPTS) $(DIRECT_TESTS)
 
 $(top_builddir)/src/libhamlib.la:
 	$(MAKE) -C $(top_builddir)/src/ libhamlib.la
@@ -207,4 +251,11 @@ test2038.sh:
 	echo 'LD_LIBRARY_PATH=$(top_builddir)/src/.libs:$(top_builddir)/dummy/.libs ./test2038 1' > test2038.sh
 	chmod +x ./test2038.sh
 
-CLEANFILES = rigmatrix testrig.sh testfreq.sh testbcd.sh testloc.sh testrigcaps.sh testcache.sh testcookie.sh rigtestlibusb build-w32.sh build-w64.sh build-w64-jtsdk.sh testgrid.sh testrigcaps.sh test2038.sh testnetrigctl.sh tuner_control.log
+CLEANFILES = \
+	build-w32.sh \
+	build-w64-jtsdk.sh \
+	build-w64.sh \
+	rigmatrix \
+	rigtestlibusb \
+	tuner_control.log \
+	$(GENERATED_TEST_WRAPPERS)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -34,6 +34,7 @@ DIRECT_TESTS = \
 	testmodecompat \
 	testthd7x \
 	testthd75emu \
+	testts990s \
 	testid5100
 
 GENERATED_TEST_WRAPPERS = \
@@ -125,6 +126,7 @@ testid5100_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
 testnewcatset_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
 testicomfallback_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
 testelecraftvfo_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
+testts990s_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
 testicomts_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/rigs/icom
 testid5100_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/rigs/icom
 testicomfallback_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/rigs/icom
@@ -166,6 +168,7 @@ testicomfallback_LDADD = $(NET_LIBS) $(PTHREAD_LIBS) $(top_builddir)/rigs/icom/l
 testgeministatus_LDADD = $(PTHREAD_LIBS) $(top_builddir)/amplifiers/gemini/libhamlib-gemini.la $(LDADD)
 testgs100_LDADD = $(PTHREAD_LIBS) $(top_builddir)/rigs/gomspace/libhamlib-gomspace.la $(LDADD)
 testelecraftvfo_LDADD = $(NET_LIBS) $(PTHREAD_LIBS) $(top_builddir)/rigs/kenwood/libhamlib-kenwood.la $(LDADD)
+testts990s_LDADD = $(NET_LIBS) $(PTHREAD_LIBS) $(top_builddir)/rigs/kenwood/libhamlib-kenwood.la $(LDADD)
 testftx1parsers_LDADD = $(top_builddir)/rigs/yaesu/libhamlib-yaesu.la $(LDADD)
 testft991idmeter_LDADD = $(top_builddir)/rigs/yaesu/libhamlib-yaesu.la $(LDADD)
 testguohetec_LDADD = $(PTHREAD_LIBS) $(top_builddir)/rigs/guohetec/libhamlib-guohetec.la $(LDADD)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -31,6 +31,7 @@ DIRECT_TESTS = \
 	testicomts \
 	testnewcatset \
 	testrigctlprotocol \
+	testmodecompat \
 	testthd7x \
 	testthd75emu \
 	testid5100
@@ -158,6 +159,7 @@ testnetrigctl_LDADD = $(PTHREAD_LIBS) $(top_builddir)/rigs/dummy/libhamlib-dummy
 testctlparser_SOURCES = testctlparser.c $(RIGCOMMONSRC)
 testctlparser_LDADD = $(PTHREAD_LIBS) $(READLINE_LIBS) $(top_builddir)/rigs/dummy/libhamlib-dummy.la $(LDADD)
 testrigctlprotocol_LDADD = $(LDADD)
+testmodecompat_LDADD = $(top_builddir)/rigs/dummy/libhamlib-dummy.la $(LDADD)
 testicomts_LDADD = $(top_builddir)/rigs/icom/libhamlib-icom.la $(LDADD)
 testid5100_LDADD = $(NET_LIBS) $(PTHREAD_LIBS) $(top_builddir)/rigs/icom/libhamlib-icom.la $(LDADD)
 testicomfallback_LDADD = $(NET_LIBS) $(PTHREAD_LIBS) $(top_builddir)/rigs/icom/libhamlib-icom.la $(LDADD)

--- a/tests/testmodecompat.c
+++ b/tests/testmodecompat.c
@@ -1,0 +1,91 @@
+/*
+ * Hamlib generic and rig-specific mode compatibility tests
+ * Copyright (c) 2026 by Hamlib Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+#include <stdio.h>
+
+#include "hamlib/rig.h"
+#include "hamlib/riglist.h"
+
+static int expect_mode(RIG *rig, rmode_t initial, rmode_t requested,
+                       rmode_t expected)
+{
+    rmode_t actual;
+    pbwidth_t width;
+    int retval;
+
+    retval = rig_set_mode(rig, RIG_VFO_A, initial, 2400);
+
+    if (retval != RIG_OK)
+    {
+        fprintf(stderr, "cannot set initial mode %s: %s\n",
+                rig_strrmode(initial), rigerror(retval));
+        return 1;
+    }
+
+    retval = rig_set_mode(rig, RIG_VFO_A, requested,
+                          RIG_PASSBAND_NOCHANGE);
+
+    if (retval != RIG_OK)
+    {
+        fprintf(stderr, "cannot request mode %s: %s\n",
+                rig_strrmode(requested), rigerror(retval));
+        return 1;
+    }
+
+    retval = rig_get_mode(rig, RIG_VFO_A, &actual, &width);
+
+    if (retval != RIG_OK)
+    {
+        fprintf(stderr, "cannot read resulting mode: %s\n", rigerror(retval));
+        return 1;
+    }
+
+    if (actual != expected)
+    {
+        fprintf(stderr, "requesting %s from %s produced %s, expected %s\n",
+                rig_strrmode(requested), rig_strrmode(initial),
+                rig_strrmode(actual), rig_strrmode(expected));
+        return 1;
+    }
+
+    return 0;
+}
+
+int main(void)
+{
+    RIG *rig = rig_init(RIG_MODEL_DUMMY);
+    int failed = 0;
+
+    if (rig == NULL)
+    {
+        fprintf(stderr, "cannot initialize dummy rig\n");
+        return 1;
+    }
+
+    if (rig_open(rig) != RIG_OK)
+    {
+        fprintf(stderr, "cannot open dummy rig\n");
+        rig_cleanup(rig);
+        return 1;
+    }
+
+    failed |= expect_mode(rig, RIG_MODE_USBD2, RIG_MODE_PKTUSB,
+                          RIG_MODE_USBD2);
+    failed |= expect_mode(rig, RIG_MODE_LSBD3, RIG_MODE_PKTLSB,
+                          RIG_MODE_LSBD3);
+    failed |= expect_mode(rig, RIG_MODE_USBD2, RIG_MODE_USBD1,
+                          RIG_MODE_USBD1);
+    failed |= expect_mode(rig, RIG_MODE_USB, RIG_MODE_PKTUSB,
+                          RIG_MODE_PKTUSB);
+
+    rig_close(rig);
+    rig_cleanup(rig);
+    return failed;
+}

--- a/tests/testmodecompat.c
+++ b/tests/testmodecompat.c
@@ -13,54 +13,338 @@
 #include "hamlib/rig.h"
 #include "hamlib/riglist.h"
 
-static int expect_mode(RIG *rig, rmode_t initial, rmode_t requested,
-                       rmode_t expected)
+static struct rig_caps *dummy_caps;
+static int selected_only;
+static int query_error;
+static int write_error;
+static int restore_error;
+
+#define REQUIRE_OK(expression) do { \
+    int result = (expression); \
+    if (result != RIG_OK) { \
+        fprintf(stderr, "%s: %s: %s\n", __func__, #expression, rigerror(result)); \
+        return 1; \
+    } \
+} while (0)
+
+static int fixture_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode,
+                            pbwidth_t *width)
 {
-    rmode_t actual;
-    pbwidth_t width;
-    int retval;
+    if (query_error) { return query_error; }
 
-    retval = rig_set_mode(rig, RIG_VFO_A, initial, 2400);
-
-    if (retval != RIG_OK)
+    if (selected_only)
     {
-        fprintf(stderr, "cannot set initial mode %s: %s\n",
-                rig_strrmode(initial), rigerror(retval));
-        return 1;
+        /* A non-targetable radio observes its selected VFO, not the argument. */
+        int retval = dummy_caps->get_vfo(rig, &vfo);
+        if (retval != RIG_OK) { return retval; }
     }
 
-    retval = rig_set_mode(rig, RIG_VFO_A, requested,
-                          RIG_PASSBAND_NOCHANGE);
+    return dummy_caps->get_mode(rig, vfo, mode, width);
+}
 
-    if (retval != RIG_OK)
+static int fixture_set_mode(RIG *rig, vfo_t vfo, rmode_t mode,
+                            pbwidth_t width)
+{
+    if (write_error) { return write_error; }
+
+    if (selected_only)
     {
-        fprintf(stderr, "cannot request mode %s: %s\n",
-                rig_strrmode(requested), rigerror(retval));
-        return 1;
+        int retval = dummy_caps->get_vfo(rig, &vfo);
+        if (retval != RIG_OK) { return retval; }
     }
 
-    retval = rig_get_mode(rig, RIG_VFO_A, &actual, &width);
+    return dummy_caps->set_mode(rig, vfo, mode, width);
+}
 
-    if (retval != RIG_OK)
+static int fixture_set_vfo(RIG *rig, vfo_t vfo)
+{
+    if (restore_error && vfo == RIG_VFO_A) { return restore_error; }
+    return dummy_caps->set_vfo(rig, vfo);
+}
+
+static int expect_state(RIG *rig, const char *scenario, vfo_t vfo,
+                        rmode_t expected_mode, pbwidth_t expected_width)
+{
+    rmode_t mode = RIG_MODE_NONE;
+    pbwidth_t width = RIG_PASSBAND_NORMAL;
+    int cached;
+
+    for (cached = 0; cached < 2; cached++)
     {
-        fprintf(stderr, "cannot read resulting mode: %s\n", rigerror(retval));
-        return 1;
+        int retval = cached ? rig_get_mode(rig, vfo, &mode, &width)
+                     : dummy_caps->get_mode(rig, vfo, &mode, &width);
+
+        if (retval != RIG_OK || mode != expected_mode || width != expected_width)
+        {
+            fprintf(stderr, "%s: %s %s read returned %s, %s/%ld; expected %s/%ld\n",
+                    scenario, rig_strvfo(vfo), cached ? "public" : "backend",
+                    rigerror(retval), rig_strrmode(mode), (long)width,
+                    rig_strrmode(expected_mode), (long)expected_width);
+            return 1;
+        }
     }
+
+    return 0;
+}
+
+static int expect_selected(RIG *rig, vfo_t expected)
+{
+    vfo_t actual;
+    REQUIRE_OK(dummy_caps->get_vfo(rig, &actual));
 
     if (actual != expected)
     {
-        fprintf(stderr, "requesting %s from %s produced %s, expected %s\n",
-                rig_strrmode(requested), rig_strrmode(initial),
-                rig_strrmode(actual), rig_strrmode(expected));
+        fprintf(stderr, "%s: selected %s, expected %s\n", __func__,
+                rig_strvfo(actual), rig_strvfo(expected));
         return 1;
     }
 
     return 0;
 }
 
+static int expect_error(const char *scenario, int actual, int expected)
+{
+    if (actual != expected)
+    {
+        fprintf(stderr, "%s: returned %s (%d), expected %s (%d)\n", scenario,
+                rigerror(actual), actual, rigerror(expected), expected);
+        return 1;
+    }
+
+    return 0;
+}
+
+static int test_profiles(RIG *rig)
+{
+    static const struct
+    {
+        rmode_t profile;
+        rmode_t generic;
+    } modes[] =
+    {
+        {RIG_MODE_USBD1, RIG_MODE_PKTUSB},
+        {RIG_MODE_USBD2, RIG_MODE_PKTUSB},
+        {RIG_MODE_USBD3, RIG_MODE_PKTUSB},
+        {RIG_MODE_LSBD1, RIG_MODE_PKTLSB},
+        {RIG_MODE_LSBD2, RIG_MODE_PKTLSB},
+        {RIG_MODE_LSBD3, RIG_MODE_PKTLSB}
+    };
+    static const pbwidth_t widths[] =
+    {
+        RIG_PASSBAND_NOCHANGE, 2400, 1800
+    };
+    size_t i, j;
+
+    for (i = 0; i < sizeof(modes) / sizeof(modes[0]); i++)
+    {
+        for (j = 0; j < sizeof(widths) / sizeof(widths[0]); j++)
+        {
+            char scenario[96];
+            pbwidth_t expected = widths[j] == RIG_PASSBAND_NOCHANGE ? 2400 : widths[j];
+            snprintf(scenario, sizeof(scenario), "%s requested as %s, width %ld",
+                     rig_strrmode(modes[i].profile), rig_strrmode(modes[i].generic),
+                     (long)widths[j]);
+            REQUIRE_OK(rig_set_mode(rig, RIG_VFO_A, modes[i].profile, 2400));
+            REQUIRE_OK(rig_set_mode(rig, RIG_VFO_A, modes[i].generic, widths[j]));
+
+            if (expect_state(rig, scenario, RIG_VFO_A, modes[i].profile, expected))
+            {
+                return 1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+static int test_mode_changes(RIG *rig)
+{
+    static const struct
+    {
+        const char *name;
+        rmode_t initial;
+        rmode_t request;
+    } cases[] =
+    {
+        {"explicit USB profile", RIG_MODE_USBD2, RIG_MODE_USBD1},
+        {"explicit LSB profile", RIG_MODE_LSBD2, RIG_MODE_LSBD3},
+        {"USB entering packet mode", RIG_MODE_USB, RIG_MODE_PKTUSB},
+        {"LSB entering packet mode", RIG_MODE_LSB, RIG_MODE_PKTLSB},
+        {"LSB to USB", RIG_MODE_LSBD2, RIG_MODE_PKTUSB},
+        {"USB to LSB", RIG_MODE_USBD3, RIG_MODE_PKTLSB}
+    };
+    size_t i;
+
+    for (i = 0; i < sizeof(cases) / sizeof(cases[0]); i++)
+    {
+        REQUIRE_OK(rig_set_mode(rig, RIG_VFO_A, cases[i].initial, 2400));
+        REQUIRE_OK(rig_set_mode(rig, RIG_VFO_A, cases[i].request,
+                               RIG_PASSBAND_NOCHANGE));
+
+        if (expect_state(rig, cases[i].name, RIG_VFO_A, cases[i].request, 2400))
+        {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+static int test_front_panel_change(RIG *rig)
+{
+    REQUIRE_OK(rig_set_mode(rig, RIG_VFO_A, RIG_MODE_USBD1, 2400));
+    /* A front-panel change bypasses the public setter and its cache updates. */
+    REQUIRE_OK(dummy_caps->set_mode(rig, RIG_VFO_A, RIG_MODE_USBD2, 1800));
+    REQUIRE_OK(rig_set_mode(rig, RIG_VFO_A, RIG_MODE_PKTUSB,
+                           RIG_PASSBAND_NOCHANGE));
+
+    if (expect_state(rig, "fresh profile query refreshes cache", RIG_VFO_A,
+                     RIG_MODE_USBD2, 1800)) { return 1; }
+
+    REQUIRE_OK(dummy_caps->set_mode(rig, RIG_VFO_A, RIG_MODE_USBD2, 2100));
+    REQUIRE_OK(rig_set_mode(rig, RIG_VFO_A, RIG_MODE_USBD2,
+                           RIG_PASSBAND_NOCHANGE));
+    return expect_state(rig, "exact-mode query refreshes width cache", RIG_VFO_A,
+                        RIG_MODE_USBD2, 2100);
+}
+
+static int test_split_fallback(RIG *rig)
+{
+    freq_t frequency;
+    REQUIRE_OK(rig_set_vfo(rig, RIG_VFO_A));
+    REQUIRE_OK(rig_set_mode(rig, RIG_VFO_A, RIG_MODE_LSBD3, 1800));
+    REQUIRE_OK(rig_set_mode(rig, RIG_VFO_B, RIG_MODE_USBD2, 2400));
+    REQUIRE_OK(rig_set_freq(rig, RIG_VFO_A, 7100000));
+    REQUIRE_OK(rig_set_freq(rig, RIG_VFO_B, 14074000));
+    REQUIRE_OK(rig_set_split_vfo(rig, RIG_VFO_A, RIG_SPLIT_ON, RIG_VFO_B));
+    REQUIRE_OK(rig_set_split_mode(rig, RIG_VFO_A, RIG_MODE_PKTUSB, 2100));
+
+    if (expect_state(rig, "split width preserves TX profile", RIG_VFO_B,
+                     RIG_MODE_USBD2, 2100)) { return 1; }
+
+    REQUIRE_OK(rig_set_split_freq_mode(rig, RIG_VFO_A, 14075000, RIG_MODE_PKTUSB,
+                                      RIG_PASSBAND_NOCHANGE));
+
+    if (expect_state(rig, "combined request preserves TX profile", RIG_VFO_B,
+                     RIG_MODE_USBD2, 2100)
+            || expect_state(rig, "split leaves RX mode intact", RIG_VFO_A,
+                            RIG_MODE_LSBD3, 1800)
+            || expect_selected(rig, RIG_VFO_A)) { return 1; }
+
+    REQUIRE_OK(dummy_caps->get_freq(rig, RIG_VFO_B, &frequency));
+
+    if (frequency != 14075000)
+    {
+        fprintf(stderr, "combined request left TX frequency at %.0f\n", frequency);
+        return 1;
+    }
+
+    REQUIRE_OK(dummy_caps->get_freq(rig, RIG_VFO_A, &frequency));
+
+    if (frequency != 7100000)
+    {
+        fprintf(stderr, "split request changed RX frequency to %.0f\n", frequency);
+        return 1;
+    }
+
+    REQUIRE_OK(rig_set_split_vfo(rig, RIG_VFO_A, RIG_SPLIT_OFF, RIG_VFO_A));
+    return 0;
+}
+
+static int test_selected_vfo(RIG *rig, struct rig_caps *caps)
+{
+    REQUIRE_OK(rig_set_mode(rig, RIG_VFO_A, RIG_MODE_USBD3, 1800));
+    REQUIRE_OK(rig_set_mode(rig, RIG_VFO_B, RIG_MODE_USBD3, 2400));
+    selected_only = 1;
+    caps->targetable_vfo &= ~RIG_TARGETABLE_MODE;
+    REQUIRE_OK(rig_set_mode(rig, RIG_VFO_B, RIG_MODE_PKTUSB,
+                           RIG_PASSBAND_NOCHANGE));
+
+    if (expect_state(rig, "resolve against selected target", RIG_VFO_B,
+                     RIG_MODE_USBD3, 2400)) { return 1; }
+
+    REQUIRE_OK(rig_set_mode(rig, RIG_VFO_B, RIG_MODE_USBD3, 2100));
+
+    if (expect_state(rig, "noncurrent mode still accepts width", RIG_VFO_B,
+                     RIG_MODE_USBD3, 2100)
+            || expect_state(rig, "noncurrent request preserves RX", RIG_VFO_A,
+                            RIG_MODE_USBD3, 1800)
+            || expect_selected(rig, RIG_VFO_A)) { return 1; }
+
+    selected_only = 0;
+    caps->targetable_vfo = dummy_caps->targetable_vfo;
+    return 0;
+}
+
+static int test_errors(RIG *rig, struct rig_caps *caps)
+{
+    REQUIRE_OK(rig_set_mode(rig, RIG_VFO_A, RIG_MODE_USBD2, 2400));
+    query_error = -RIG_EIO;
+
+    REQUIRE_OK(rig_set_mode(rig, RIG_VFO_A, RIG_MODE_PKTUSB, 1800));
+
+    query_error = 0;
+
+    if (expect_state(rig, "query failure falls back to setter", RIG_VFO_A,
+                     RIG_MODE_PKTUSB, 1800)) { return 1; }
+
+    REQUIRE_OK(rig_set_mode(rig, RIG_VFO_A, RIG_MODE_USBD2, 2400));
+    write_error = -RIG_EIO;
+
+    if (expect_error("mode write failure", rig_set_mode(rig, RIG_VFO_A,
+                     RIG_MODE_PKTUSB, 1800), -RIG_EIO)) { return 1; }
+
+    write_error = 0;
+
+    if (expect_state(rig, "failed write preserves radio and cache", RIG_VFO_A,
+                     RIG_MODE_USBD2, 2400)) { return 1; }
+
+    REQUIRE_OK(rig_set_mode(rig, RIG_VFO_B, RIG_MODE_LSBD2, 2400));
+    selected_only = 1;
+    caps->targetable_vfo &= ~RIG_TARGETABLE_MODE;
+    query_error = -RIG_EIO;
+
+    REQUIRE_OK(rig_set_mode(rig, RIG_VFO_B, RIG_MODE_PKTLSB, 1800));
+    if (expect_state(rig, "noncurrent query falls back to setter", RIG_VFO_B,
+                     RIG_MODE_PKTLSB, 1800)
+            || expect_selected(rig, RIG_VFO_A)) { return 1; }
+
+    query_error = 0;
+    write_error = -RIG_EIO;
+
+    if (expect_error("noncurrent write failure", rig_set_mode(rig, RIG_VFO_B,
+                     RIG_MODE_PKTLSB, 1800), -RIG_EIO)
+            || expect_selected(rig, RIG_VFO_A)) { return 1; }
+
+    restore_error = -RIG_ETIMEOUT;
+
+    if (expect_error("operation error precedes restore error",
+                     rig_set_mode(rig, RIG_VFO_B, RIG_MODE_PKTLSB, 1800),
+                     -RIG_EIO)) { return 1; }
+
+    restore_error = 0;
+    REQUIRE_OK(dummy_caps->set_vfo(rig, RIG_VFO_A));
+    write_error = 0;
+    restore_error = -RIG_ETIMEOUT;
+
+    if (expect_error("restore failure after successful write",
+                     rig_set_mode(rig, RIG_VFO_B, RIG_MODE_PKTLSB, 1800),
+                     -RIG_ETIMEOUT)
+            || expect_selected(rig, RIG_VFO_B)) { return 1; }
+
+    restore_error = 0;
+    REQUIRE_OK(dummy_caps->set_vfo(rig, RIG_VFO_A));
+    selected_only = 0;
+    caps->targetable_vfo = dummy_caps->targetable_vfo;
+    REQUIRE_OK(rig_set_mode(rig, RIG_VFO_A, RIG_MODE_PKTUSB, 1800));
+    return expect_state(rig, "setter-only backend remains usable", RIG_VFO_A,
+                        RIG_MODE_USBD2, 1800);
+}
+
 int main(void)
 {
     RIG *rig = rig_init(RIG_MODEL_DUMMY);
+    struct rig_caps caps;
     int failed = 0;
 
     if (rig == NULL)
@@ -76,15 +360,21 @@ int main(void)
         return 1;
     }
 
-    failed |= expect_mode(rig, RIG_MODE_USBD2, RIG_MODE_PKTUSB,
-                          RIG_MODE_USBD2);
-    failed |= expect_mode(rig, RIG_MODE_LSBD3, RIG_MODE_PKTLSB,
-                          RIG_MODE_LSBD3);
-    failed |= expect_mode(rig, RIG_MODE_USBD2, RIG_MODE_USBD1,
-                          RIG_MODE_USBD1);
-    failed |= expect_mode(rig, RIG_MODE_USB, RIG_MODE_PKTUSB,
-                          RIG_MODE_PKTUSB);
+    dummy_caps = rig->caps;
+    caps = *dummy_caps;
+    caps.get_mode = fixture_get_mode;
+    caps.set_mode = fixture_set_mode;
+    caps.set_vfo = fixture_set_vfo;
+    caps.set_split_mode = NULL;
+    caps.set_split_freq_mode = NULL;
+    rig->caps = &caps;
+    rig_set_cache_timeout_ms(rig, HAMLIB_CACHE_ALL, 60000);
 
+    failed = test_profiles(rig) || test_mode_changes(rig)
+             || test_front_panel_change(rig) || test_split_fallback(rig)
+             || test_selected_vfo(rig, &caps) || test_errors(rig, &caps);
+
+    rig->caps = dummy_caps;
     rig_close(rig);
     rig_cleanup(rig);
     return failed;

--- a/tests/testts990s.c
+++ b/tests/testts990s.c
@@ -1,0 +1,330 @@
+/*
+ * Hamlib TS-990S mode compatibility tests
+ * Copyright (c) 2026 by Hamlib Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
+#include "hamlib/rig.h"
+#include "hamlib/port.h"
+#include "hamlib/rig_state.h"
+
+extern struct rig_caps ts990s_caps;
+
+struct peer_state
+{
+    int fd;
+    char mode_main;
+    char mode_sub;
+    char operating_band;
+    int fail_next_mode;
+    int fail_verify;
+    int saw_data1_write;
+    int status;
+};
+
+static int close_socket(int fd)
+{
+#ifdef _WIN32
+    return closesocket((SOCKET)fd);
+#else
+    return close(fd);
+#endif
+}
+
+static int read_socket(int fd, char *buffer, size_t length)
+{
+#ifdef _WIN32
+    return recv((SOCKET)fd, buffer, (int)length, 0);
+#else
+    return (int)read(fd, buffer, length);
+#endif
+}
+
+static int write_socket(int fd, const char *buffer, size_t length)
+{
+#ifdef _WIN32
+    return send((SOCKET)fd, buffer, (int)length, 0);
+#else
+    return (int)write(fd, buffer, length);
+#endif
+}
+
+static int read_command(int fd, char *buffer, size_t capacity)
+{
+    size_t used = 0;
+
+    while (used + 1 < capacity)
+    {
+        int count = read_socket(fd, buffer + used, 1);
+
+        if (count <= 0) { return -1; }
+
+        if (buffer[used++] == ';')
+        {
+            buffer[used] = '\0';
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
+static int write_reply(int fd, const char *reply)
+{
+    size_t written = 0;
+    size_t length = strlen(reply);
+
+    while (written < length)
+    {
+        int count = write_socket(fd, reply + written, length - written);
+
+        if (count <= 0) { return -1; }
+
+        written += (size_t)count;
+    }
+
+    return 0;
+}
+
+static int handle_command(struct peer_state *peer, const char *command)
+{
+    char reply[16];
+
+    if (strcmp(command, "OM0;") == 0)
+    {
+        snprintf(reply, sizeof(reply), "OM0%c;", peer->mode_main);
+        return write_reply(peer->fd, reply);
+    }
+
+    if (strcmp(command, "OM1;") == 0)
+    {
+        snprintf(reply, sizeof(reply), "OM1%c;", peer->mode_sub);
+        return write_reply(peer->fd, reply);
+    }
+
+    if (strcmp(command, "CB;") == 0)
+    {
+        snprintf(reply, sizeof(reply), "CB%c;", peer->operating_band);
+        return write_reply(peer->fd, reply);
+    }
+
+    if (strcmp(command, "ID;") == 0)
+    {
+        if (peer->fail_verify)
+        {
+            peer->fail_verify = 0;
+            return write_reply(peer->fd, "?;");
+        }
+
+        return write_reply(peer->fd, "ID022;");
+    }
+
+    if (strncmp(command, "CB", 2) == 0 && command[2] != ';')
+    {
+        peer->operating_band = command[2];
+        return 0;
+    }
+
+    if (strncmp(command, "OM0", 3) == 0 && command[3] != ';')
+    {
+        if (command[3] == 'D') { peer->saw_data1_write = 1; }
+
+        if (peer->fail_next_mode)
+        {
+            peer->fail_next_mode = 0;
+            peer->fail_verify = 1;
+            return 0;
+        }
+
+        if (peer->operating_band == '0') { peer->mode_main = command[3]; }
+        else { peer->mode_sub = command[3]; }
+
+        return 0;
+    }
+
+    if (strncmp(command, "TB", 2) == 0)
+    {
+        return 0;
+    }
+
+    return -1;
+}
+
+static void *run_peer(void *arg)
+{
+    struct peer_state *peer = arg;
+    char command[16];
+
+    peer->status = 0;
+
+    for (;;)
+    {
+        if (read_command(peer->fd, command, sizeof(command)) != 0) { return NULL; }
+
+        if (handle_command(peer, command) != 0)
+        {
+            peer->status = 1;
+            return NULL;
+        }
+    }
+}
+
+static int open_test_connection(int sockets[2])
+{
+#ifdef _WIN32
+    (void)sockets;
+    return -1;
+#else
+    return socketpair(AF_UNIX, SOCK_STREAM, 0, sockets);
+#endif
+}
+
+static int run_case(const char *name, char mode_main, char mode_sub,
+                    rmode_t request, pbwidth_t width, int fail_next_mode,
+                    int split, vfo_t target_vfo, int expected_retval, char expected_main,
+                    char expected_sub, char expected_operating,
+                    int expect_data1_write)
+{
+    int sockets[2];
+    pthread_t thread;
+    struct peer_state peer;
+    RIG *rig;
+    int retval;
+
+    if (open_test_connection(sockets) != 0)
+    {
+        fprintf(stderr, "%s: socket setup failed\n", name);
+        return 1;
+    }
+
+    memset(&peer, 0, sizeof(peer));
+    peer.fd = sockets[1];
+    peer.mode_main = mode_main;
+    peer.mode_sub = mode_sub;
+    peer.operating_band = '0';
+    peer.fail_next_mode = fail_next_mode;
+
+    if (pthread_create(&thread, NULL, run_peer, &peer) != 0)
+    {
+        close_socket(sockets[0]);
+        close_socket(sockets[1]);
+        return 1;
+    }
+
+    rig = rig_init(RIG_MODEL_TS990S);
+
+    if (rig == NULL)
+    {
+        close_socket(sockets[0]);
+        pthread_join(thread, NULL);
+        close_socket(sockets[1]);
+        return 1;
+    }
+
+    RIGPORT(rig)->fd = sockets[0];
+    RIGPORT(rig)->type.rig = RIG_PORT_NETWORK;
+    RIGPORT(rig)->timeout = 500;
+    RIGPORT(rig)->retry = 0;
+    STATE(rig)->comm_state = 1;
+    STATE(rig)->current_vfo = RIG_VFO_MAIN;
+    STATE(rig)->rx_vfo = RIG_VFO_MAIN;
+    STATE(rig)->tx_vfo = RIG_VFO_SUB;
+
+    if (split)
+    {
+        retval = rig_set_split_vfo(rig, RIG_VFO_MAIN, RIG_SPLIT_ON, RIG_VFO_SUB);
+
+        if (retval != RIG_OK)
+        {
+            RIGPORT(rig)->fd = -1;
+            rig_cleanup(rig);
+            close_socket(sockets[0]);
+            pthread_join(thread, NULL);
+            close_socket(sockets[1]);
+            return 1;
+        }
+    }
+
+    if (split)
+    {
+        retval = rig_set_split_mode(rig, target_vfo, request, width);
+    }
+    else
+    {
+        retval = rig_set_mode(rig, target_vfo, request, width);
+    }
+
+    RIGPORT(rig)->fd = -1;
+    rig_cleanup(rig);
+    close_socket(sockets[0]);
+    pthread_join(thread, NULL);
+    close_socket(sockets[1]);
+
+    if (retval != expected_retval
+            || peer.status != 0
+            || peer.mode_main != expected_main
+            || peer.mode_sub != expected_sub
+            || peer.operating_band != expected_operating
+            || peer.saw_data1_write != expect_data1_write)
+    {
+        fprintf(stderr, "%s: result=%d mode=%c/%c operating=%c data1=%d\n",
+                name, retval, peer.mode_main, peer.mode_sub,
+                peer.operating_band, peer.saw_data1_write);
+        return 1;
+    }
+
+    return 0;
+}
+
+int main(void)
+{
+    int failed = 0;
+
+#ifdef _WIN32
+    return 77;
+#else
+    rig_register(&ts990s_caps);
+
+    {
+        RIG *rig = rig_init(RIG_MODEL_TS990S);
+
+        if (rig == NULL || rig_passband_normal(rig, RIG_MODE_USBD2) != 2600
+                || rig_passband_normal(rig, RIG_MODE_LSBD3) != 2600)
+        {
+            fprintf(stderr, "TS-990S DATA profiles do not advertise a normal width\n");
+            failed = 1;
+        }
+
+        if (rig != NULL) { rig_cleanup(rig); }
+    }
+
+    failed |= run_case("generic USB preserves USBD2", 'H', 'L',
+                       RIG_MODE_PKTUSB, RIG_PASSBAND_NOCHANGE, 0, 0, RIG_VFO_MAIN,
+                       RIG_OK, 'H', 'L', '0', 0);
+    failed |= run_case("explicit USB width preserves USBD2", 'H', 'L',
+                       RIG_MODE_PKTUSB, 2700, 0, 0, RIG_VFO_MAIN, RIG_OK,
+                       'H', 'L', '0', 0);
+    failed |= run_case("split generic USB preserves TX profile", 'H', 'H',
+                       RIG_MODE_PKTUSB, RIG_PASSBAND_NOCHANGE, 0, 1, RIG_VFO_MAIN,
+                       RIG_OK, 'H', 'H', '0', 0);
+    failed |= run_case("mode error restores operating VFO", 'H', 'L',
+                       RIG_MODE_USBD1, RIG_PASSBAND_NOCHANGE, 1, 0, RIG_VFO_SUB,
+                       -RIG_ETIMEOUT, 'H', 'L', '0', 1);
+
+    return failed;
+#endif
+}


### PR DESCRIPTION
## What changed

Hamlib 4.6 added distinct `USBD1`/`USBD2`/`USBD3` and `LSBD1`/`LSBD2`/`LSBD3` modes. On the TS-990S, that exposed a compatibility gap in `rig_set_mode()`: the current exact mode no longer compared equal to a generic `PKTUSB` request, so the Kenwood backend mapped the request to `USBD1` and sent `OM0D`. WSJT-X's `Data/Pkt` setting could therefore replace a manually selected USB-DATA2 or USB-DATA3 during transmit/receive transitions and QSY.

Kenwood's [PC command reference](https://www.kenwood.com/i/products/info/amateur/pdf/ts990_pc_command_en_rev2.pdf) defines `D`, `H`, and `L` as USB-DATA1, USB-DATA2, and USB-DATA3, while its [FT8 setup guide](https://www.kenwood.com/i/products/info/amateur/ts_990/pdf/ts990_ft8_settings_en.pdf) configures WSJT-X for `Data/Pkt` and supports Data Mode 1 through 3.

Treat an active USB-DATA1/2/3 mode as satisfying a generic `PKTUSB` request, and apply the same rule to LSB-DATA1/2/3 and `PKTLSB`. Exact submode requests remain directional, and a generic packet request still changes the mode when the radio is not already in the matching DATA family.

This preserves exact DATA submode reporting while restoring the no-op behavior that clients relied on before Hamlib 4.6.


I also made a corresponding PR in WSJTX to make the mode detection there have a better experience w.r.t. these various data submodes. It should be included in the 3.2.0 release.


## Testing

Added a hardware-independent public-API regression test covering:

- `PKTUSB` preserving `USBD2`
- `PKTLSB` preserving `LSBD3`
- an explicit `USBD1` request replacing `USBD2`
- `PKTUSB` still changing plain `USB`

```text
Focused test: 1/1 passed
Full C suite: 21/21 passed
C++ suite: 1/1 passed
```

No physical TS-990S was used.

Fixes #1990
