### PR TITLE
fix(kenwood): validate K4 VFO query responses

### DIFF
--- a/rigs/kenwood/elecraft.c
+++ b/rigs/kenwood/elecraft.c
@@ -591,10 +591,28 @@ static int elecraft_get_firmware_revision_level(RIG *rig, const char *cmd,
 
 //  FR;FT;TQ; is faster than IF;
 //  Works on K4
+static int parse_binary_response(const char *response, const char *command,
+                                 int *value)
+{
+    if (response[0] != command[0] || response[1] != command[1]
+            || (response[2] != '0' && response[2] != '1')
+            || response[3] != '\0')
+    {
+        rig_debug(RIG_DEBUG_ERR, "%s: invalid %s response '%s'\n", __func__,
+                  command, response);
+        return -RIG_EPROTO;
+    }
+
+    *value = response[2] - '0';
+    return RIG_OK;
+}
+
 int elecraft_get_vfo_tq(RIG *rig, vfo_t *vfo)
 {
     int retval;
-    int fr, ft, tq;
+    int fr = 0;
+    int ft = 0;
+    int tq = 0;
     char cmdbuf[10];
     char splitbuf[12];
 
@@ -609,9 +627,11 @@ int elecraft_get_vfo_tq(RIG *rig, vfo_t *vfo)
         RETURNFUNC2(retval);
     }
 
-    if (sscanf(splitbuf, "FR%1d", &fr) != 1)
+    retval = parse_binary_response(splitbuf, "FR", &fr);
+
+    if (retval != RIG_OK)
     {
-        rig_debug(RIG_DEBUG_ERR, "%s: unable to parse FR '%s'\n", __func__, splitbuf);
+        RETURNFUNC2(retval);
     }
 
     SNPRINTF(cmdbuf, sizeof(cmdbuf), "FT;");
@@ -622,9 +642,11 @@ int elecraft_get_vfo_tq(RIG *rig, vfo_t *vfo)
         RETURNFUNC2(retval);
     }
 
-    if (sscanf(splitbuf, "FT%1d", &ft) != 1)
+    retval = parse_binary_response(splitbuf, "FT", &ft);
+
+    if (retval != RIG_OK)
     {
-        rig_debug(RIG_DEBUG_ERR, "%s: unable to parse FT '%s'\n", __func__, splitbuf);
+        RETURNFUNC2(retval);
     }
 
 // We can use the TQX; command but we have to check that we have R32 firmware or higher
@@ -651,10 +673,11 @@ int elecraft_get_vfo_tq(RIG *rig, vfo_t *vfo)
         RETURNFUNC2(retval);
     }
 
-    if (sscanf(splitbuf, "TQ%1d", &tq) != 1)
+    retval = parse_binary_response(splitbuf, "TQ", &tq);
+
+    if (retval != RIG_OK)
     {
-        rig_debug(RIG_DEBUG_ERR, "%s: unable to parse TQ or TQX response of '%s'\n",
-                  __func__, splitbuf);
+        RETURNFUNC2(retval);
     }
 
     *vfo = STATE(rig)->tx_vfo = RIG_VFO_A;

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -34,6 +34,7 @@ testcache.sh
 testcookie
 testcookie.sh
 testctlparser
+testelecraftvfo
 testfreq
 testfreq.sh
 testftx1parsers

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -37,6 +37,7 @@ testcookie.sh
 testctlparser
 testdebug
 testdummyparm
+testelecraftvfo
 testfreq
 testfreq.sh
 testftx1parsers

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -16,7 +16,7 @@ bin_PROGRAMS = rigctl rigctld rigmem rigsmtr rigswr rotctl rotctld rigctlcom rig
 
 check_PROGRAMS = dumpmem testrig testrigopen testrigcaps testbcd testfreq listrigs testloc rig_bench testcache cachetest cachetest2 testcookie testdebug testdummyparm testgrid hamlibmodels testmW2power test2038
 check_PROGRAMS += testnetrigctl
-check_PROGRAMS += testctlparser testbandmetadata testicomts testgeministatus testgs100 testftx1parsers
+check_PROGRAMS += testctlparser testbandmetadata testicomts testgeministatus testgs100 testelecraftvfo testftx1parsers
 # Document building testsecurity
 ### check_PROGRAMS += testsecurity
 
@@ -61,6 +61,7 @@ testdebug_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
 testctlparser_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
 testgeministatus_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
 testgs100_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
+testelecraftvfo_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
 testicomts_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/rigs/icom
 testgeministatus_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/amplifiers/gemini
 testftx1parsers_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/rigs/yaesu/ftx1
@@ -88,6 +89,7 @@ testctlparser_LDADD = $(PTHREAD_LIBS) $(READLINE_LIBS) $(top_builddir)/rigs/dumm
 testicomts_LDADD = $(top_builddir)/rigs/icom/libhamlib-icom.la $(LDADD)
 testgeministatus_LDADD = $(PTHREAD_LIBS) $(top_builddir)/amplifiers/gemini/libhamlib-gemini.la $(LDADD)
 testgs100_LDADD = $(PTHREAD_LIBS) $(top_builddir)/rigs/gomspace/libhamlib-gomspace.la $(LDADD)
+testelecraftvfo_LDADD = $(PTHREAD_LIBS) $(top_builddir)/rigs/kenwood/libhamlib-kenwood.la $(LDADD)
 testftx1parsers_LDADD = $(top_builddir)/rigs/yaesu/libhamlib-yaesu.la $(LDADD)
 if TESTS_HAVE_LIBUSB
     rigtestlibusb_LDADD = $(LIBUSB_LIBS)
@@ -144,7 +146,7 @@ EXTRA_DIST = \
 check_SCRIPTS = amptest.sh test2038.sh testbcd.sh testcache.sh testcaps.sh testcookie.sh testfreq.sh testgrid.sh testloc.sh testrig.sh testrigcaps.sh
 check_SCRIPTS += testnetrigctl.sh testctlbounds.sh
 
-TESTS = $(check_SCRIPTS) testdebug testdummyparm testctlparser testbandmetadata testicomts testgeministatus testgs100 testftx1parsers
+TESTS = $(check_SCRIPTS) testdebug testdummyparm testctlparser testbandmetadata testicomts testgeministatus testgs100 testelecraftvfo testftx1parsers
 
 $(top_builddir)/src/libhamlib.la:
 	$(MAKE) -C $(top_builddir)/src/ libhamlib.la
@@ -163,6 +165,9 @@ $(top_builddir)/amplifiers/gemini/libhamlib-gemini.la:
 
 $(top_builddir)/rigs/gomspace/libhamlib-gomspace.la:
 	$(MAKE) -C $(top_builddir)/rigs/gomspace/ libhamlib-gomspace.la
+
+$(top_builddir)/rigs/kenwood/libhamlib-kenwood.la:
+	$(MAKE) -C $(top_builddir)/rigs/kenwood/ libhamlib-kenwood.la
 
 $(top_builddir)/rigs/yaesu/libhamlib-yaesu.la:
 	$(MAKE) -C $(top_builddir)/rigs/yaesu/ libhamlib-yaesu.la

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -22,6 +22,7 @@ DIRECT_TESTS = \
 	testdebug \
 	testdummyparm \
 	testft991idmeter \
+	testelecraftvfo \
 	testftx1parsers \
 	testgeministatus \
 	testgs100 \
@@ -122,6 +123,7 @@ testguohetec_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
 testid5100_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
 testnewcatset_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
 testicomfallback_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
+testelecraftvfo_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
 testicomts_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/rigs/icom
 testid5100_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/rigs/icom
 testicomfallback_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/rigs/icom
@@ -161,6 +163,7 @@ testid5100_LDADD = $(NET_LIBS) $(PTHREAD_LIBS) $(top_builddir)/rigs/icom/libhaml
 testicomfallback_LDADD = $(NET_LIBS) $(PTHREAD_LIBS) $(top_builddir)/rigs/icom/libhamlib-icom.la $(LDADD)
 testgeministatus_LDADD = $(PTHREAD_LIBS) $(top_builddir)/amplifiers/gemini/libhamlib-gemini.la $(LDADD)
 testgs100_LDADD = $(PTHREAD_LIBS) $(top_builddir)/rigs/gomspace/libhamlib-gomspace.la $(LDADD)
+testelecraftvfo_LDADD = $(NET_LIBS) $(PTHREAD_LIBS) $(top_builddir)/rigs/kenwood/libhamlib-kenwood.la $(LDADD)
 testftx1parsers_LDADD = $(top_builddir)/rigs/yaesu/libhamlib-yaesu.la $(LDADD)
 testft991idmeter_LDADD = $(top_builddir)/rigs/yaesu/libhamlib-yaesu.la $(LDADD)
 testguohetec_LDADD = $(PTHREAD_LIBS) $(top_builddir)/rigs/guohetec/libhamlib-guohetec.la $(LDADD)
@@ -247,6 +250,9 @@ $(top_builddir)/rigs/gomspace/libhamlib-gomspace.la:
 
 $(top_builddir)/rigs/guohetec/libhamlib-guohetec.la:
 	$(MAKE) -C $(top_builddir)/rigs/guohetec/ libhamlib-guohetec.la
+
+$(top_builddir)/rigs/kenwood/libhamlib-kenwood.la:
+	$(MAKE) -C $(top_builddir)/rigs/kenwood/ libhamlib-kenwood.la
 
 $(top_builddir)/rigs/yaesu/libhamlib-yaesu.la:
 	$(MAKE) -C $(top_builddir)/rigs/yaesu/ libhamlib-yaesu.la

--- a/tests/testelecraftvfo.c
+++ b/tests/testelecraftvfo.c
@@ -1,0 +1,359 @@
+/*
+ * Hamlib Elecraft K4 VFO response tests
+ * Copyright (c) 2026 by Hamlib Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
+#include "hamlib/rig.h"
+#include "hamlib/port.h"
+#include "hamlib/rig_state.h"
+
+extern struct rig_caps k4_caps;
+
+struct peer_case
+{
+    int fd;
+    const char *responses[3];
+    int status;
+};
+
+static int close_test_socket(int fd)
+{
+#ifdef _WIN32
+    return closesocket(fd);
+#else
+    return close(fd);
+#endif
+}
+
+static int read_test_socket(int fd, void *buffer, size_t length)
+{
+#ifdef _WIN32
+    return recv(fd, buffer, (int) length, 0);
+#else
+    return (int) read(fd, buffer, length);
+#endif
+}
+
+static int write_test_socket(int fd, const void *buffer, size_t length)
+{
+#ifdef _WIN32
+    return send(fd, buffer, (int) length, 0);
+#else
+    return (int) write(fd, buffer, length);
+#endif
+}
+
+static int open_test_connection(int sockets[2])
+{
+#ifdef _WIN32
+    SOCKET listener;
+    SOCKET client;
+    SOCKET peer;
+    struct sockaddr_in address;
+    int address_length = sizeof(address);
+
+    listener = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+
+    if (listener == INVALID_SOCKET) { return -1; }
+
+    memset(&address, 0, sizeof(address));
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    address.sin_port = 0;
+
+    if (bind(listener, (struct sockaddr *) &address, sizeof(address)) != 0 ||
+            listen(listener, 1) != 0 ||
+            getsockname(listener, (struct sockaddr *) &address,
+                        &address_length) != 0)
+    {
+        closesocket(listener);
+        return -1;
+    }
+
+    client = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+
+    if (client == INVALID_SOCKET ||
+            connect(client, (struct sockaddr *) &address,
+                    sizeof(address)) != 0)
+    {
+        if (client != INVALID_SOCKET) { closesocket(client); }
+
+        closesocket(listener);
+        return -1;
+    }
+
+    peer = accept(listener, NULL, NULL);
+    closesocket(listener);
+
+    if (peer == INVALID_SOCKET)
+    {
+        closesocket(client);
+        return -1;
+    }
+
+    sockets[0] = (int) client;
+    sockets[1] = (int) peer;
+    return 0;
+#else
+    return socketpair(AF_UNIX, SOCK_STREAM, 0, sockets);
+#endif
+}
+
+static int read_command(int fd, char *buffer, size_t capacity)
+{
+    size_t used = 0;
+
+    while (used + 1 < capacity)
+    {
+        int count = read_test_socket(fd, buffer + used, 1);
+
+        if (count != 1) { return -1; }
+
+        if (buffer[used++] == ';')
+        {
+            buffer[used] = '\0';
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
+static int write_all(int fd, const char *buffer, size_t length)
+{
+    size_t written = 0;
+
+    while (written < length)
+    {
+        int count = write_test_socket(fd, buffer + written, length - written);
+
+        if (count <= 0) { return -1; }
+
+        written += (size_t)count;
+    }
+
+    return 0;
+}
+
+static void *run_peer(void *arg)
+{
+    static const char *commands[] = { "FR;", "FT;", "TQ;" };
+    struct peer_case *test = arg;
+    char command[8];
+    size_t i;
+
+    test->status = -1;
+
+    for (i = 0; i < sizeof(commands) / sizeof(commands[0]); i++)
+    {
+        if (test->responses[i] == NULL) { break; }
+
+        if (read_command(test->fd, command, sizeof(command)) != 0
+                || strcmp(command, commands[i]) != 0)
+        {
+            return NULL;
+        }
+
+        if (write_all(test->fd, test->responses[i],
+                      strlen(test->responses[i])) != 0)
+        {
+            return NULL;
+        }
+    }
+
+    test->status = 0;
+    return NULL;
+}
+
+static int run_case(const char *name, const char *fr, const char *ft,
+                    const char *tq, int expected_retval,
+                    vfo_t expected_vfo, vfo_t expected_rx_vfo,
+                    vfo_t expected_tx_vfo)
+{
+    const vfo_t initial_vfo = RIG_VFO_MEM;
+    const vfo_t initial_rx_vfo = RIG_VFO_MAIN;
+    const vfo_t initial_tx_vfo = RIG_VFO_SUB;
+    int sockets[2];
+    pthread_t thread;
+    struct peer_case test =
+    {
+        .fd = -1,
+        .responses = { fr, ft, tq },
+        .status = -1
+    };
+    RIG *rig;
+    vfo_t vfo = initial_vfo;
+    vfo_t actual_rx_vfo;
+    vfo_t actual_tx_vfo;
+    int retval;
+
+    if (open_test_connection(sockets) != 0)
+    {
+        fprintf(stderr, "test socket setup failed\n");
+        return 1;
+    }
+
+    test.fd = sockets[1];
+
+    if (pthread_create(&thread, NULL, run_peer, &test) != 0)
+    {
+        close_test_socket(sockets[0]);
+        close_test_socket(sockets[1]);
+        return 1;
+    }
+
+    rig = rig_init(RIG_MODEL_K4);
+
+    if (rig == NULL)
+    {
+        close(sockets[0]);
+        close(sockets[1]);
+        pthread_join(thread, NULL);
+        return 1;
+    }
+
+    RIGPORT(rig)->fd = sockets[0];
+    RIGPORT(rig)->type.rig = RIG_PORT_NETWORK;
+    RIGPORT(rig)->timeout = 500;
+    RIGPORT(rig)->retry = 0;
+    STATE(rig)->rx_vfo = initial_rx_vfo;
+    STATE(rig)->tx_vfo = initial_tx_vfo;
+
+    retval = rig->caps->get_vfo(rig, &vfo);
+    actual_rx_vfo = STATE(rig)->rx_vfo;
+    actual_tx_vfo = STATE(rig)->tx_vfo;
+
+    RIGPORT(rig)->fd = -1;
+    rig_cleanup(rig);
+    close_test_socket(sockets[0]);
+    pthread_join(thread, NULL);
+    close_test_socket(sockets[1]);
+
+    if (expected_retval != RIG_OK)
+    {
+        expected_vfo = initial_vfo;
+        expected_rx_vfo = initial_rx_vfo;
+        expected_tx_vfo = initial_tx_vfo;
+    }
+
+    if (test.status != 0 || retval != expected_retval
+            || vfo != expected_vfo
+            || actual_rx_vfo != expected_rx_vfo
+            || actual_tx_vfo != expected_tx_vfo)
+    {
+        fprintf(stderr,
+                "%s: expected %d/%d/%d/%d, got %d/%d/%d/%d\n",
+                name, expected_retval, expected_vfo, expected_rx_vfo,
+                expected_tx_vfo, retval, vfo, actual_rx_vfo, actual_tx_vfo);
+        return 1;
+    }
+
+    return 0;
+}
+
+int main(void)
+{
+    int failed = 0;
+
+#ifdef _WIN32
+    WSADATA wsa_data;
+
+    if (WSAStartup(MAKEWORD(2, 2), &wsa_data) != 0)
+    {
+        fprintf(stderr, "WSAStartup failed\n");
+        return 1;
+    }
+
+#endif
+
+    rig_register(&k4_caps);
+
+    if (run_case("receive-vfo-a", "FR0;", "FT0;", "TQ0;", RIG_OK,
+                 RIG_VFO_A, RIG_VFO_MAIN, RIG_VFO_A) != 0)
+    {
+        failed = 1;
+        goto cleanup;
+    }
+
+    if (run_case("receive-vfo-b", "FR1;", "FT0;", "TQ0;", RIG_OK,
+                 RIG_VFO_B, RIG_VFO_B, RIG_VFO_B) != 0)
+    {
+        failed = 1;
+        goto cleanup;
+    }
+
+    if (run_case("transmit-split-off", "FR1;", "FT0;", "TQ1;", RIG_OK,
+                 RIG_VFO_A, RIG_VFO_MAIN, RIG_VFO_A) != 0)
+    {
+        failed = 1;
+        goto cleanup;
+    }
+
+    if (run_case("transmit-split-on", "FR0;", "FT1;", "TQ1;", RIG_OK,
+                 RIG_VFO_B, RIG_VFO_MAIN, RIG_VFO_B) != 0)
+    {
+        failed = 1;
+        goto cleanup;
+    }
+
+    if (run_case("malformed-fr", "FRX;", NULL, NULL, -RIG_EPROTO,
+                 RIG_VFO_NONE, RIG_VFO_NONE, RIG_VFO_NONE) != 0)
+    {
+        failed = 1;
+        goto cleanup;
+    }
+
+    if (run_case("malformed-ft", "FR0;", "FTX;", NULL, -RIG_EPROTO,
+                 RIG_VFO_NONE, RIG_VFO_NONE, RIG_VFO_NONE) != 0)
+    {
+        failed = 1;
+        goto cleanup;
+    }
+
+    if (run_case("malformed-tq", "FR0;", "FT0;", "TQX;", -RIG_EPROTO,
+                 RIG_VFO_NONE, RIG_VFO_NONE, RIG_VFO_NONE) != 0)
+    {
+        failed = 1;
+        goto cleanup;
+    }
+
+    if (run_case("invalid-fr-value", "FR9;", NULL, NULL, -RIG_EPROTO,
+                 RIG_VFO_NONE, RIG_VFO_NONE, RIG_VFO_NONE) != 0)
+    {
+        failed = 1;
+        goto cleanup;
+    }
+
+    if (run_case("invalid-ft-value", "FR0;", "FT2;", NULL, -RIG_EPROTO,
+                 RIG_VFO_NONE, RIG_VFO_NONE, RIG_VFO_NONE) != 0)
+    {
+        failed = 1;
+        goto cleanup;
+    }
+
+    failed = run_case("invalid-tq-value", "FR0;", "FT0;", "TQ7;",
+                      -RIG_EPROTO, RIG_VFO_NONE, RIG_VFO_NONE,
+                      RIG_VFO_NONE);
+
+cleanup:
+#ifdef _WIN32
+    WSACleanup();
+#endif
+    return failed;
+}

--- a/tests/testelecraftvfo.c
+++ b/tests/testelecraftvfo.c
@@ -222,8 +222,8 @@ static int run_case(const char *name, const char *fr, const char *ft,
 
     if (rig == NULL)
     {
-        close(sockets[0]);
-        close(sockets[1]);
+        close_test_socket(sockets[0]);
+        close_test_socket(sockets[1]);
         pthread_join(thread, NULL);
         return 1;
     }

--- a/tests/testelecraftvfo.c
+++ b/tests/testelecraftvfo.c
@@ -1,0 +1,242 @@
+/*
+ * Hamlib Elecraft K4 VFO response tests
+ * Copyright (c) 2026 by Hamlib Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "hamlib/rig.h"
+#include "hamlib/port.h"
+#include "hamlib/rig_state.h"
+
+extern struct rig_caps k4_caps;
+
+struct peer_case
+{
+    int fd;
+    const char *responses[3];
+    int status;
+};
+
+static int read_command(int fd, char *buffer, size_t capacity)
+{
+    size_t used = 0;
+
+    while (used + 1 < capacity)
+    {
+        ssize_t count = read(fd, buffer + used, 1);
+
+        if (count != 1) { return -1; }
+
+        if (buffer[used++] == ';')
+        {
+            buffer[used] = '\0';
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
+static int write_all(int fd, const char *buffer, size_t length)
+{
+    size_t written = 0;
+
+    while (written < length)
+    {
+        ssize_t count = write(fd, buffer + written, length - written);
+
+        if (count <= 0) { return -1; }
+
+        written += (size_t)count;
+    }
+
+    return 0;
+}
+
+static void *run_peer(void *arg)
+{
+    static const char *commands[] = { "FR;", "FT;", "TQ;" };
+    struct peer_case *test = arg;
+    char command[8];
+    size_t i;
+
+    test->status = -1;
+
+    for (i = 0; i < sizeof(commands) / sizeof(commands[0]); i++)
+    {
+        if (test->responses[i] == NULL) { break; }
+
+        if (read_command(test->fd, command, sizeof(command)) != 0
+                || strcmp(command, commands[i]) != 0)
+        {
+            return NULL;
+        }
+
+        if (write_all(test->fd, test->responses[i],
+                      strlen(test->responses[i])) != 0)
+        {
+            return NULL;
+        }
+    }
+
+    test->status = 0;
+    return NULL;
+}
+
+static int run_case(const char *name, const char *fr, const char *ft,
+                    const char *tq, int expected_retval,
+                    vfo_t expected_vfo, vfo_t expected_rx_vfo,
+                    vfo_t expected_tx_vfo)
+{
+    const vfo_t initial_vfo = RIG_VFO_MEM;
+    const vfo_t initial_rx_vfo = RIG_VFO_MAIN;
+    const vfo_t initial_tx_vfo = RIG_VFO_SUB;
+    int sockets[2];
+    pthread_t thread;
+    struct peer_case test =
+    {
+        .fd = -1,
+        .responses = { fr, ft, tq },
+        .status = -1
+    };
+    RIG *rig;
+    vfo_t vfo = initial_vfo;
+    vfo_t actual_rx_vfo;
+    vfo_t actual_tx_vfo;
+    int retval;
+
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) != 0)
+    {
+        perror("socketpair");
+        return 1;
+    }
+
+    test.fd = sockets[1];
+
+    if (pthread_create(&thread, NULL, run_peer, &test) != 0)
+    {
+        close(sockets[0]);
+        close(sockets[1]);
+        return 1;
+    }
+
+    rig = rig_init(RIG_MODEL_K4);
+
+    if (rig == NULL)
+    {
+        close(sockets[0]);
+        close(sockets[1]);
+        pthread_join(thread, NULL);
+        return 1;
+    }
+
+    RIGPORT(rig)->fd = sockets[0];
+    RIGPORT(rig)->timeout = 500;
+    RIGPORT(rig)->retry = 0;
+    STATE(rig)->rx_vfo = initial_rx_vfo;
+    STATE(rig)->tx_vfo = initial_tx_vfo;
+
+    retval = rig->caps->get_vfo(rig, &vfo);
+    actual_rx_vfo = STATE(rig)->rx_vfo;
+    actual_tx_vfo = STATE(rig)->tx_vfo;
+
+    RIGPORT(rig)->fd = -1;
+    rig_cleanup(rig);
+    close(sockets[0]);
+    pthread_join(thread, NULL);
+    close(sockets[1]);
+
+    if (expected_retval != RIG_OK)
+    {
+        expected_vfo = initial_vfo;
+        expected_rx_vfo = initial_rx_vfo;
+        expected_tx_vfo = initial_tx_vfo;
+    }
+
+    if (test.status != 0 || retval != expected_retval
+            || vfo != expected_vfo
+            || actual_rx_vfo != expected_rx_vfo
+            || actual_tx_vfo != expected_tx_vfo)
+    {
+        fprintf(stderr,
+                "%s: expected %d/%d/%d/%d, got %d/%d/%d/%d\n",
+                name, expected_retval, expected_vfo, expected_rx_vfo,
+                expected_tx_vfo, retval, vfo, actual_rx_vfo, actual_tx_vfo);
+        return 1;
+    }
+
+    return 0;
+}
+
+int main(void)
+{
+    rig_register(&k4_caps);
+
+    if (run_case("receive-vfo-a", "FR0;", "FT0;", "TQ0;", RIG_OK,
+                 RIG_VFO_A, RIG_VFO_MAIN, RIG_VFO_A) != 0)
+    {
+        return 1;
+    }
+
+    if (run_case("receive-vfo-b", "FR1;", "FT0;", "TQ0;", RIG_OK,
+                 RIG_VFO_B, RIG_VFO_B, RIG_VFO_B) != 0)
+    {
+        return 1;
+    }
+
+    if (run_case("transmit-split-off", "FR1;", "FT0;", "TQ1;", RIG_OK,
+                 RIG_VFO_A, RIG_VFO_MAIN, RIG_VFO_A) != 0)
+    {
+        return 1;
+    }
+
+    if (run_case("transmit-split-on", "FR0;", "FT1;", "TQ1;", RIG_OK,
+                 RIG_VFO_B, RIG_VFO_MAIN, RIG_VFO_B) != 0)
+    {
+        return 1;
+    }
+
+    if (run_case("malformed-fr", "FRX;", NULL, NULL, -RIG_EPROTO,
+                 RIG_VFO_NONE, RIG_VFO_NONE, RIG_VFO_NONE) != 0)
+    {
+        return 1;
+    }
+
+    if (run_case("malformed-ft", "FR0;", "FTX;", NULL, -RIG_EPROTO,
+                 RIG_VFO_NONE, RIG_VFO_NONE, RIG_VFO_NONE) != 0)
+    {
+        return 1;
+    }
+
+    if (run_case("malformed-tq", "FR0;", "FT0;", "TQX;", -RIG_EPROTO,
+                 RIG_VFO_NONE, RIG_VFO_NONE, RIG_VFO_NONE) != 0)
+    {
+        return 1;
+    }
+
+    if (run_case("invalid-fr-value", "FR9;", NULL, NULL, -RIG_EPROTO,
+                 RIG_VFO_NONE, RIG_VFO_NONE, RIG_VFO_NONE) != 0)
+    {
+        return 1;
+    }
+
+    if (run_case("invalid-ft-value", "FR0;", "FT2;", NULL, -RIG_EPROTO,
+                 RIG_VFO_NONE, RIG_VFO_NONE, RIG_VFO_NONE) != 0)
+    {
+        return 1;
+    }
+
+    return run_case("invalid-tq-value", "FR0;", "FT0;", "TQ7;",
+                    -RIG_EPROTO, RIG_VFO_NONE, RIG_VFO_NONE,
+                    RIG_VFO_NONE);
+}


### PR DESCRIPTION
## Summary

Validate the Elecraft K4 `FR`, `FT`, and `TQ` responses before using them to determine the active VFO. The parsing logic used in this PR is consistent with the latest Elecraft K4 developer docs.

The K4-specific `elecraft_get_vfo_tq()` path logged `sscanf()` failures but continued using the parsed variables. A malformed radio response could therefore read an uninitialized value, update Hamlib's cached VFO state, and return success with an arbitrary result.

## Fix

- Accept only `FR0`/`FR1`, `FT0`/`FT1`, and `TQ0`/`TQ1`.
- Return `-RIG_EPROTO` for malformed or unsupported values.
- Preserve existing transaction-error propagation.
- Defer caller-visible and cached VFO updates until all three responses have been validated.
- Preserve the existing RX, TX, and split behavior for valid K4 replies.

This path was originally added for #863. 

## Tests

Added a socket-backed K4 regression test covering:

- RX on VFO A and VFO B
- TX with split off
- TX with split on/VFO B
- Malformed FR, FT, and TQ responses
- Out-of-domain `FR9`, `FT2`, and `TQ7` responses
- Preservation of caller-visible and cached VFO state after protocol errors

Test results:

- Focused K4 regression: 1 passed
- Hamlib test suite: 22 passed
- C++ test suite: 1 passed

No physical K4 hardware was required.
