### PR TITLE
FT-857: add PKTFM and PKTLSB mode support

### DIFF
--- a/rigs/yaesu/ft857.c
+++ b/rigs/yaesu/ft857.c
@@ -112,6 +112,7 @@ enum ft857_native_cmd_e
     FT857_NATIVE_CAT_PWR_ON,
     FT857_NATIVE_CAT_PWR_OFF,
     FT857_NATIVE_CAT_EEPROM_READ,
+    FT857_NATIVE_CAT_EEPROM_WRITE,
     FT857_NATIVE_SIZE     /* end marker */
 };
 
@@ -217,6 +218,7 @@ static const yaesu_cmd_set_t ncmd[] =
     { 1, { 0x00, 0x00, 0x00, 0x00, 0x0f } }, /* pwr on */
     { 1, { 0x00, 0x00, 0x00, 0x00, 0x8f } }, /* pwr off */
     { 0, { 0x00, 0x00, 0x00, 0x00, 0xbb } }, /* eeprom read */
+    { 0, { 0x00, 0x00, 0x00, 0x00, 0xbc } }, /* eeprom write -- see set_mode() PKTLSB/PKTUSB */
 };
 
 enum ft857_digi
@@ -244,12 +246,14 @@ enum ft857_digi
             } }
 
 #define FT857_ALL_RX_MODES      (RIG_MODE_AM|RIG_MODE_CW|RIG_MODE_CWR|RIG_MODE_USB|\
-                                 RIG_MODE_LSB|RIG_MODE_RTTY|RIG_MODE_FM|RIG_MODE_PKTUSB)
+                                 RIG_MODE_LSB|RIG_MODE_RTTY|RIG_MODE_FM|RIG_MODE_PKTUSB|\
+                                 RIG_MODE_PKTLSB|RIG_MODE_PKTFM)
 #define FT857_SSB_CW_RX_MODES   (RIG_MODE_CW|RIG_MODE_CWR|RIG_MODE_USB|RIG_MODE_LSB)
 #define FT857_AM_FM_RX_MODES    (RIG_MODE_AM|RIG_MODE_FM)
 
 #define FT857_OTHER_TX_MODES    (RIG_MODE_AM|RIG_MODE_CW|RIG_MODE_USB|\
-                                 RIG_MODE_LSB|RIG_MODE_RTTY|RIG_MODE_FM|RIG_MODE_PKTUSB)
+                                 RIG_MODE_LSB|RIG_MODE_RTTY|RIG_MODE_FM|RIG_MODE_PKTUSB|\
+                                 RIG_MODE_PKTLSB|RIG_MODE_PKTFM)
 #define FT857_AM_TX_MODES       (RIG_MODE_AM)
 
 #define FT857_VFO_ALL           (RIG_VFO_A|RIG_VFO_B)
@@ -1033,10 +1037,77 @@ int ft857_set_mode(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
         break;
 
     case RIG_MODE_RTTY:
-    case RIG_MODE_PKTUSB:
         /* user has to have correct DIG mode setup on rig */
         index = FT857_NATIVE_CAT_SET_MODE_DIG;
         break;
+
+    case RIG_MODE_PKTUSB:
+    case RIG_MODE_PKTLSB:
+    {
+        /*
+         * The FT-857 CAT protocol has a single generic "DIG" mode command
+         * (no way to select LSB vs USB directly); the sideband actually
+         * used is a value stored in rig EEPROM at 0x0078 (bits 5-7 of the
+         * first byte -- the same location ft857_get_status() already
+         * reads to report PKTLSB/PKTUSB back via get_mode()). Force that
+         * byte to the generic "USER" DIG submode (as opposed to "RTTY" or
+         * "PSK") with the requested sideband, so a subsequent get_mode()
+         * agrees with what was just requested here, and so switching
+         * between PKTUSB and PKTLSB is actually deterministic instead of
+         * silently keeping whatever submode was last configured on the
+         * rig's own front panel.
+         *
+         * Mirrors the equivalent, already-upstream fix for the sibling
+         * FT-817 (Hamlib/Hamlib#1308, commit acc42665e), which uses the
+         * same mechanism at a different EEPROM address (0x65).
+         */
+        unsigned char data[YAESU_CMD_LENGTH];
+        unsigned char digmode_lo, digmode_hi;
+        int ret;
+
+        ret = ft857_read_eeprom(rig, 0x0078, &digmode_lo);
+
+        if (ret != RIG_OK)
+        {
+            return ret;
+        }
+
+        /* byte at 0x0079 shares the same EEPROM word; preserve it untouched */
+        ret = ft857_read_eeprom(rig, 0x0079, &digmode_hi);
+
+        if (ret != RIG_OK)
+        {
+            return ret;
+        }
+
+        memcpy(data, ncmd[FT857_NATIVE_CAT_EEPROM_WRITE].nseq, YAESU_CMD_LENGTH);
+        data[0] = 0x00;
+        data[1] = 0x78;
+        data[2] = (mode == RIG_MODE_PKTLSB ? FT857_DIGI_USER_L : FT857_DIGI_USER_U) << 5;
+        data[3] = digmode_hi;
+
+        ret = ft857_send_cmd(rig, FT857_NATIVE_CAT_SET_MODE_DIG);
+
+        if (ret != RIG_OK)
+        {
+            return ret;
+        }
+
+        if (data[2] != digmode_lo)
+        {
+            ret = ft857_send_icmd(rig, FT857_NATIVE_CAT_EEPROM_WRITE, data);
+
+            if (ret != RIG_OK)
+            {
+                return ret;
+            }
+        }
+
+        rig_force_cache_timeout(&((struct ft857_priv_data *)
+                                  STATE(rig)->priv)->fm_status_tv);
+
+        return RIG_OK;
+    }
 
     case RIG_MODE_FM:
         index = FT857_NATIVE_CAT_SET_MODE_FM;


### PR DESCRIPTION
dump_caps/M ? for the FT-857 is missing two modes the radio supports:

- **PKTFM** (9600bps packet FM, CAT byte `0x0c`): capability-advertisement gap only. The CAT command and `set_mode()`/`get_mode()` handling already exist; `RIG_MODE_PKTFM` just isn't in `FT857_ALL_RX_MODES`/`FT857_OTHER_TX_MODES`.
- **PKTLSB**: the FT-857 has one generic "DIG" command (`0x0a`) with no LSB/USB selector — sideband is stored in EEPROM at `0x0078` (bits 5-7), already read by `get_mode()` but never written. `set_mode()` now writes that byte (new `FT857_NATIVE_CAT_EEPROM_WRITE`, CAT byte `0xbc`) to the "USER" DIG submode with the requested sideband after sending DIG, skipping the write if the byte's already correct (per @dforsi's suggestion in #2142).

Mirrors the FT-817's existing fix for the same problem (#1308, `acc42665e`), same mechanism at a different EEPROM address (`0x65` vs `0x0078`).

Verified on real FT-857D hardware: PKTFM selects PKT mode; PKTUSB↔PKTLSB round-trips both directions; RTTY's auto-fallback to PKTUSB still works.

Closes #2142.