### PR TITLE
fix(tests): clear rigctld PID after startup timeout

### DIFF
--- a/test/test_netrigctl_stream.c
+++ b/test/test_netrigctl_stream.c
@@ -319,6 +319,7 @@ static int start_rigctld_once(struct rigctld_proc *proc,
     {
         kill(proc->pid, SIGTERM);
         waitpid(proc->pid, NULL, 0);
+        proc->pid = -1;
         return -1;
     }
 


### PR DESCRIPTION
When rigctld failed to start, the test code stopped and reaped the process but kept its old PID. Retry cleanup could then try to stop that same PID again, which might belong to another process if the operating system had already reused it. Clear the PID after reaping the failed child so retries cannot signal a stale process.