### PR TITLE
fix(rigctld): stop stream feeders before closing rig

### DIFF
--- a/test/test_netrigctl_stream.c
+++ b/test/test_netrigctl_stream.c
@@ -71,6 +71,7 @@ struct rigctld_proc
 {
     pid_t pid;
     int port;
+    int idle;
     char log_path[64];
 };
 
@@ -279,6 +280,9 @@ static int start_rigctld_once(struct rigctld_proc *proc,
 
     if (proc->pid == 0)
     {
+        char *child_argv[16];
+        int child_argc = 0;
+
         /* Child: silence stdout, but capture stderr in a per-daemon log;
          * /dev/null for stderr made failures undiagnosable. On redirect
          * failure the inherited stream simply stays in place. */
@@ -289,28 +293,32 @@ static int start_rigctld_once(struct rigctld_proc *proc,
             if (freopen("/dev/null", "w", stderr) == NULL) {}
         }
 
-        if (source_id_opt && set_conf_opt)
+        child_argv[child_argc++] = (char *)"rigctld";
+        child_argv[child_argc++] = (char *)"-m";
+        child_argv[child_argc++] = (char *)"1";
+        child_argv[child_argc++] = (char *)"-t";
+        child_argv[child_argc++] = port_str;
+        child_argv[child_argc++] = (char *)verbosity;
+
+        if (proc->idle)
         {
-            execlp(rigctld_path, "rigctld", "-m", "1", "-t", port_str, verbosity,
-                   "--stream-source-id", source_id_opt,
-                   "--set-conf", set_conf_opt, NULL);
-        }
-        else if (source_id_opt)
-        {
-            execlp(rigctld_path, "rigctld", "-m", "1", "-t", port_str, verbosity,
-                   "--stream-source-id", source_id_opt, NULL);
-        }
-        else if (set_conf_opt)
-        {
-            execlp(rigctld_path, "rigctld", "-m", "1", "-t", port_str, verbosity,
-                   "--set-conf", set_conf_opt, NULL);
-        }
-        else
-        {
-            execlp(rigctld_path, "rigctld", "-m", "1", "-t", port_str, verbosity,
-                   NULL);
+            child_argv[child_argc++] = (char *)"-R";
         }
 
+        if (source_id_opt)
+        {
+            child_argv[child_argc++] = (char *)"--stream-source-id";
+            child_argv[child_argc++] = (char *)source_id_opt;
+        }
+
+        if (set_conf_opt)
+        {
+            child_argv[child_argc++] = (char *)"--set-conf";
+            child_argv[child_argc++] = (char *)set_conf_opt;
+        }
+
+        child_argv[child_argc] = NULL;
+        execvp(rigctld_path, child_argv);
         _exit(127);
     }
 
@@ -328,6 +336,13 @@ static int start_rigctld_once(struct rigctld_proc *proc,
 
 static int start_rigctld(struct rigctld_proc *proc)
 {
+    return start_rigctld_opt(proc, NULL, NULL);
+}
+
+
+static int start_idle_rigctld(struct rigctld_proc *proc)
+{
+    proc->idle = 1;
     return start_rigctld_opt(proc, NULL, NULL);
 }
 
@@ -2661,6 +2676,226 @@ static int query_source_id_raw(int port)
 }
 
 
+struct raw_stream_connection
+{
+    int tcp_sock;
+    int udp_sock;
+};
+
+
+static int send_all(int sock, const void *buf, size_t len)
+{
+    const unsigned char *p = buf;
+
+    while (len > 0)
+    {
+        ssize_t n = send(sock, p, len, 0);
+
+        if (n <= 0)
+        {
+            return -1;
+        }
+
+        p += n;
+        len -= (size_t)n;
+    }
+
+    return 0;
+}
+
+
+static int raw_stream_open_once(int port, struct raw_stream_connection *conn)
+{
+    struct sockaddr_in addr;
+    const char *cmd = "+\\stream_open AUDIO_RX PCM_S16 48000\n";
+    char response[1024] = "";
+    size_t total = 0;
+    int stream_id = -1;
+    int udp_port = -1;
+    unsigned int subscribe_token = 0;
+
+    conn->tcp_sock = -1;
+    conn->udp_sock = -1;
+    conn->tcp_sock = socket(AF_INET, SOCK_STREAM, 0);
+
+    if (conn->tcp_sock < 0)
+    {
+        return -1;
+    }
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = htons(port);
+
+    if (connect(conn->tcp_sock, (struct sockaddr *)&addr, sizeof(addr)) < 0
+            || send_all(conn->tcp_sock, cmd, strlen(cmd)) < 0)
+    {
+        goto fail;
+    }
+
+    while (total < sizeof(response) - 1 && strstr(response, "RPRT") == NULL)
+    {
+        fd_set fds;
+        struct timeval tv = { 3, 0 };
+        FD_ZERO(&fds);
+        FD_SET(conn->tcp_sock, &fds);
+
+        if (select(conn->tcp_sock + 1, &fds, NULL, NULL, &tv) <= 0)
+        {
+            goto fail;
+        }
+
+        ssize_t n = recv(conn->tcp_sock, response + total,
+                         sizeof(response) - 1 - total, 0);
+
+        if (n <= 0)
+        {
+            goto fail;
+        }
+
+        total += (size_t)n;
+        response[total] = '\0';
+    }
+
+    const char *id_line = strstr(response, "stream_id: ");
+    const char *port_line = strstr(response, "udp_port: ");
+    const char *token_line = strstr(response, "subscribe_token: ");
+
+    if (!strstr(response, "RPRT 0") || !id_line || !port_line || !token_line
+            || sscanf(id_line, "stream_id: %d", &stream_id) != 1
+            || sscanf(port_line, "udp_port: %d", &udp_port) != 1
+            || sscanf(token_line, "subscribe_token: %u", &subscribe_token) != 1)
+    {
+        goto fail;
+    }
+
+    conn->udp_sock = socket(AF_INET, SOCK_DGRAM, 0);
+
+    if (conn->udp_sock < 0)
+    {
+        goto fail;
+    }
+
+    unsigned char packet[RIG_STREAM_HEADER_SIZE];
+    struct rig_stream_packet_header hdr;
+    stream_control_header_init(&hdr, RIG_STREAM_TYPE_AUDIO_RX,
+                               (uint16_t)stream_id, subscribe_token,
+                               RIG_STREAM_CTRL_SUBSCRIBE);
+    stream_packet_header_pack(&hdr, packet);
+    addr.sin_port = htons((uint16_t)udp_port);
+
+    if (sendto(conn->udp_sock, packet, sizeof(packet), 0,
+               (struct sockaddr *)&addr, sizeof(addr)) != (ssize_t)sizeof(packet))
+    {
+        goto fail;
+    }
+
+    fd_set fds;
+    struct timeval tv = { 3, 0 };
+    FD_ZERO(&fds);
+    FD_SET(conn->udp_sock, &fds);
+
+    if (select(conn->udp_sock + 1, &fds, NULL, NULL, &tv) <= 0)
+    {
+        goto fail;
+    }
+
+    ssize_t n = recv(conn->udp_sock, packet, sizeof(packet), 0);
+
+    if (n < RIG_STREAM_HEADER_SIZE
+            || stream_packet_header_unpack(packet, (size_t)n, &hdr) != 0
+            || hdr.stream_id != stream_id
+            || hdr.subscribe_token != subscribe_token
+            || !(hdr.control & RIG_STREAM_CTRL_SUBSCRIBE_ACK))
+    {
+        goto fail;
+    }
+
+    return 0;
+
+fail:
+
+    if (conn->udp_sock >= 0)
+    {
+        close(conn->udp_sock);
+        conn->udp_sock = -1;
+    }
+
+    if (conn->tcp_sock >= 0)
+    {
+        close(conn->tcp_sock);
+        conn->tcp_sock = -1;
+    }
+
+    return -1;
+}
+
+
+static int raw_stream_open(int port, struct raw_stream_connection *conn)
+{
+    for (int attempt = 0; attempt < 3; attempt++)
+    {
+        if (raw_stream_open_once(port, conn) == 0)
+        {
+            return 0;
+        }
+
+        usleep(100000);
+    }
+
+    return -1;
+}
+
+
+/* In idle mode the last control disconnect closes the backend rig. A live RX
+ * feeder must be joined before that close, even when the client never sends
+ * stream_close. */
+void test_idle_abrupt_disconnect_closes_stream(void)
+{
+    struct rigctld_proc proc = {0};
+    struct raw_stream_connection first = { -1, -1 };
+    struct raw_stream_connection reopened = { -1, -1 };
+
+    if (start_idle_rigctld(&proc) < 0)
+    {
+        TEST_CHECK_(0, "could not start idle rigctld");
+        return;
+    }
+
+    int opened = raw_stream_open(proc.port, &first);
+    TEST_CHECK(opened == 0);
+
+    if (opened < 0)
+    {
+        stop_rigctld(&proc);
+        return;
+    }
+
+    /* Drop the control session without a stream_close command. */
+    close(first.tcp_sock);
+    close(first.udp_sock);
+    usleep(250000);
+
+    TEST_CHECK(rigctld_alive(&proc));
+    opened = raw_stream_open(proc.port, &reopened);
+    TEST_CHECK(opened == 0);
+
+    if (reopened.tcp_sock >= 0)
+    {
+        close(reopened.tcp_sock);
+    }
+
+    if (reopened.udp_sock >= 0)
+    {
+        close(reopened.udp_sock);
+    }
+
+    usleep(250000);
+    stop_rigctld(&proc);
+}
+
+
 /* rigctld --stream-source-id stamps the CLI value; without it a stable
  * derived ID in 0x1000-0xFFFF is used, unchanged across a daemon restart
  * on the same static configuration. */
@@ -2724,6 +2959,7 @@ TEST_LIST =
     { "open_close_reopen",         test_open_close_reopen },
     { "rx_pause_resume",           test_rx_pause_resume },
     { "tx_flush_forwards",         test_tx_flush_forwards },
+    { "idle_abrupt_disconnect_closes_stream", test_idle_abrupt_disconnect_closes_stream },
     { "stream_source_id_cli_and_derived", test_stream_source_id_cli_and_derived },
     { "subscribe_retransmits_after_loss", test_subscribe_retransmits_after_loss },
     { "subscribe_ignores_non_ack_first", test_subscribe_ignores_non_ack_first },

--- a/test/test_rigctld_commands.c
+++ b/test/test_rigctld_commands.c
@@ -3420,6 +3420,87 @@ void test_tx_metadata_truncated_rejected(void)
 
 /* --- Stream control command tests --- */
 
+static int registry_lock_observed;
+
+
+static int stream_control_lock_probe(RIG *rig, struct rig_stream *stream)
+{
+    int ret;
+
+    (void)rig;
+    (void)stream;
+    ret = pthread_mutex_trylock(&g_stream_registry.lock);
+    registry_lock_observed = ret == EBUSY;
+
+    if (ret == 0)
+    {
+        pthread_mutex_unlock(&g_stream_registry.lock);
+    }
+
+    return RIG_OK;
+}
+
+
+static int stream_drain_lock_probe(RIG *rig, struct rig_stream *stream,
+                                   int timeout_ms)
+{
+    (void)timeout_ms;
+    return stream_control_lock_probe(rig, stream);
+}
+
+
+void test_cmd_stream_controls_hold_registry_lock(void)
+{
+    RIG *rig = stream_test_begin();
+    char buf[1024];
+    char cmd[64];
+    int stream_id = -1;
+    int udp_port = -1;
+
+    TEST_ASSERT(rig != NULL);
+
+    struct rig_caps probe_caps = *rig->caps;
+    probe_caps.stream_pause = stream_control_lock_probe;
+    probe_caps.stream_resume = stream_control_lock_probe;
+    probe_caps.stream_drain = stream_drain_lock_probe;
+    rig->caps = &probe_caps;
+
+    int ret = run_cmd(rig, "\\stream_open AUDIO_TX PCM_S16 48000",
+                      buf, sizeof(buf));
+    TEST_CHECK(ret == RIG_OK);
+
+    if (ret == RIG_OK)
+    {
+        TEST_CHECK(parse_open_response(buf, &stream_id, &udp_port) == 0);
+    }
+
+    if (stream_id >= 0)
+    {
+        registry_lock_observed = 0;
+        snprintf(cmd, sizeof(cmd), "\\stream_pause %d", stream_id);
+        TEST_CHECK(run_cmd(rig, cmd, buf, sizeof(buf)) == RIG_OK);
+        TEST_CHECK(registry_lock_observed);
+
+        registry_lock_observed = 0;
+        snprintf(cmd, sizeof(cmd), "\\stream_resume %d", stream_id);
+        TEST_CHECK(run_cmd(rig, cmd, buf, sizeof(buf)) == RIG_OK);
+        TEST_CHECK(registry_lock_observed);
+
+        registry_lock_observed = 0;
+        snprintf(cmd, sizeof(cmd), "\\stream_drain %d", stream_id);
+        TEST_CHECK(run_cmd(rig, cmd, buf, sizeof(buf)) == RIG_OK);
+        TEST_CHECK(registry_lock_observed);
+    }
+
+    if (stream_id >= 0)
+    {
+        snprintf(cmd, sizeof(cmd), "\\stream_close %d", stream_id);
+        run_cmd(rig, cmd, buf, sizeof(buf));
+    }
+
+    stream_test_end(rig);
+}
+
 void test_cmd_stream_pause_resume(void)
 {
     RIG *rig = stream_test_begin();
@@ -6047,6 +6128,8 @@ TEST_LIST =
     { "tx_metadata_truncated_rejected",     test_tx_metadata_truncated_rejected },
 
     /* Stream control commands */
+    { "cmd_stream_controls_hold_registry_lock",
+      test_cmd_stream_controls_hold_registry_lock },
     { "cmd_stream_pause_resume",            test_cmd_stream_pause_resume },
     { "cmd_stream_mute_unmute",             test_cmd_stream_mute_unmute },
     { "cmd_stream_pause_not_found",         test_cmd_stream_pause_not_found },

--- a/test/test_rigctld_stream.c
+++ b/test/test_rigctld_stream.c
@@ -859,6 +859,92 @@ void test_registry_close_by_client(void)
 }
 
 
+void test_registry_close_all(void)
+{
+    struct rigctld_stream_registry reg;
+    rigctld_stream_registry_init(&reg);
+
+    struct rigctld_stream *s1 = rigctld_stream_alloc();
+    struct rigctld_stream *s2 = rigctld_stream_alloc();
+    struct rigctld_stream *s3 = rigctld_stream_alloc();
+    TEST_ASSERT(s1 != NULL && s2 != NULL && s3 != NULL);
+
+    s1->stream_id = 1;
+    s1->type = RIG_STREAM_TYPE_AUDIO_RX;
+    s1->client_id = 10;
+    s2->stream_id = 2;
+    s2->type = RIG_STREAM_TYPE_AUDIO_TX;
+    s2->client_id = 20;
+    s3->stream_id = 3;
+    s3->type = RIG_STREAM_TYPE_IQ_RX;
+    s3->client_id = 10;
+
+    TEST_ASSERT(rigctld_stream_registry_insert(&reg, s1) == 0);
+    TEST_ASSERT(rigctld_stream_registry_insert(&reg, s2) == 0);
+    TEST_ASSERT(rigctld_stream_registry_insert(&reg, s3) == 0);
+
+    TEST_CHECK(rigctld_stream_registry_close_all(&reg) == 3);
+    TEST_CHECK(rigctld_stream_registry_count(&reg) == 0);
+    TEST_CHECK(rigctld_stream_registry_close_all(&reg) == 0);
+
+    /* Closing all leaves the registry initialized and reusable. */
+    struct rigctld_stream *replacement = rigctld_stream_alloc();
+    TEST_ASSERT(replacement != NULL);
+    replacement->stream_id = 4;
+    replacement->type = RIG_STREAM_TYPE_AUDIO_RX;
+    replacement->client_id = 30;
+    TEST_ASSERT(rigctld_stream_registry_insert(&reg, replacement) == 0);
+    TEST_CHECK(rigctld_stream_registry_count(&reg) == 1);
+    TEST_CHECK(rigctld_stream_registry_close_all(&reg) == 1);
+
+    rigctld_stream_registry_destroy(&reg);
+}
+
+
+static HAMLIB_ATOMIC int close_all_feeder_exited;
+
+
+static void *close_all_test_feeder(void *arg)
+{
+    struct rigctld_stream *stream = arg;
+
+    while (stream->running)
+    {
+        usleep(1000);
+    }
+
+    close_all_feeder_exited = 1;
+    return NULL;
+}
+
+
+void test_registry_close_all_stops_feeder(void)
+{
+    struct rigctld_stream_registry reg;
+    struct rigctld_stream *stream;
+
+    rigctld_stream_registry_init(&reg);
+    stream = rigctld_stream_alloc();
+    TEST_ASSERT(stream != NULL);
+
+    stream->stream_id = 1;
+    stream->type = RIG_STREAM_TYPE_AUDIO_RX;
+    stream->client_id = 10;
+    stream->running = 1;
+    close_all_feeder_exited = 0;
+    TEST_ASSERT(pthread_create(&stream->feeder_thread, NULL,
+                               close_all_test_feeder, stream) == 0);
+    stream->feeder_started = 1;
+    TEST_ASSERT(rigctld_stream_registry_insert(&reg, stream) == 0);
+
+    TEST_CHECK(rigctld_stream_registry_close_all(&reg) == 1);
+    TEST_CHECK(close_all_feeder_exited == 1);
+    TEST_CHECK(rigctld_stream_registry_count(&reg) == 0);
+
+    rigctld_stream_registry_destroy(&reg);
+}
+
+
 void test_registry_insert_full(void)
 {
     struct rigctld_stream_registry reg;
@@ -2683,6 +2769,8 @@ TEST_LIST =
     { "registry_remove",          test_registry_remove },
     { "registry_multiple_types",  test_registry_multiple_types },
     { "registry_close_by_client", test_registry_close_by_client },
+    { "registry_close_all",       test_registry_close_all },
+    { "registry_close_all_stops_feeder", test_registry_close_all_stops_feeder },
     { "registry_insert_full",     test_registry_insert_full },
     { "stream_alloc_defaults",    test_stream_alloc_defaults },
 

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -7043,13 +7043,10 @@ declare_proto_rig(stream_pause)
 
     if (!stream) { RETURNFUNC2(err); }
 
-    /* Release the registry lock before the (possibly blocking) backend call so
-     * one client's pause cannot stall every other client's stream command. The
-     * backend stream cannot be freed underneath us: rig_stream_close() drains
-     * its in-use count, which this call holds for its duration. */
-    rig_stream_t *backend = stream->backend_stream;
+    /* Keep the registry-owned handle pinned until the public API has entered
+     * and released its internal stream-lifetime guard. */
+    retval = rig_stream_pause(rig, stream->backend_stream);
     rigctld_stream_registry_unlock(&g_stream_registry);
-    retval = rig_stream_pause(rig, backend);
     RETURNFUNC2(retval);
 }
 
@@ -7067,10 +7064,8 @@ declare_proto_rig(stream_resume)
 
     if (!stream) { RETURNFUNC2(err); }
 
-    /* See stream_pause: drop the registry lock before the backend call. */
-    rig_stream_t *backend = stream->backend_stream;
+    retval = rig_stream_resume(rig, stream->backend_stream);
     rigctld_stream_registry_unlock(&g_stream_registry);
-    retval = rig_stream_resume(rig, backend);
     RETURNFUNC2(retval);
 }
 
@@ -7175,11 +7170,8 @@ declare_proto_rig(stream_drain)
 
     if (!stream) { RETURNFUNC2(err); }
 
-    /* See stream_pause: drop the registry lock before the 1 s flush so it does
-     * not stall every other client's stream command for its whole duration. */
-    rig_stream_t *backend = stream->backend_stream;
+    retval = rig_stream_drain(rig, stream->backend_stream, 1000);
     rigctld_stream_registry_unlock(&g_stream_registry);
-    retval = rig_stream_drain(rig, backend, 1000);
     RETURNFUNC2(retval);
 }
 

--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -300,7 +300,6 @@ int main(int argc, char *argv[])
 #endif
 
     pthread_t thread;
-    pthread_attr_t attr;
     int vfo_mode = 0; /* vfo_mode=0 means target VFO is current VFO */
     int i;
     extern int is_rigctld;
@@ -1202,6 +1201,8 @@ int main(int argc, char *argv[])
         else
         {
             struct handle_data *arg;
+            pthread_attr_t attr;
+            int attr_ret;
 
             arg = calloc(1, sizeof(struct handle_data));
 
@@ -1247,7 +1248,7 @@ int main(int argc, char *argv[])
                           "Connection from %s:%s rejected — "
                           "max clients (%d) reached\n",
                           host, serv, RIGCTLD_MAX_CLIENTS);
-                close(arg->sock);
+                socket_close(arg->sock);
                 free(arg);
                 continue;
             }
@@ -1258,14 +1259,51 @@ int main(int argc, char *argv[])
                       "Connection opened from %s:%s (client %d)\n",
                       host, serv, arg->client_id);
 
-            pthread_attr_init(&attr);
-            pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+            attr_ret = pthread_attr_init(&attr);
+
+            if (attr_ret != 0)
+            {
+                rig_debug(RIG_DEBUG_ERR, "pthread_attr_init: %s\n",
+                          strerror(attr_ret));
+                socket_close(arg->sock);
+                free(arg);
+                break;
+            }
+
+            attr_ret = pthread_attr_setdetachstate(&attr,
+                                                   PTHREAD_CREATE_DETACHED);
+
+            if (attr_ret != 0)
+            {
+                rig_debug(RIG_DEBUG_ERR, "pthread_attr_setdetachstate: %s\n",
+                          strerror(attr_ret));
+                int destroy_ret = pthread_attr_destroy(&attr);
+
+                if (destroy_ret != 0)
+                {
+                    rig_debug(RIG_DEBUG_WARN, "pthread_attr_destroy: %s\n",
+                              strerror(destroy_ret));
+                }
+
+                socket_close(arg->sock);
+                free(arg);
+                break;
+            }
 
             retcode = pthread_create(&thread, &attr, handle_socket, arg);
+            attr_ret = pthread_attr_destroy(&attr);
+
+            if (attr_ret != 0)
+            {
+                rig_debug(RIG_DEBUG_WARN, "pthread_attr_destroy: %s\n",
+                          strerror(attr_ret));
+            }
 
             if (retcode != 0)
             {
                 rig_debug(RIG_DEBUG_ERR, "pthread_create: %s\n", strerror(retcode));
+                socket_close(arg->sock);
+                free(arg);
                 break;
             }
 

--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -180,6 +180,19 @@ void mutex_rigctld(int lock)
 
 }
 
+
+/* The daemon registry owns feeder threads that retain rig_stream_t handles.
+ * They must be gone before rig_close() invalidates the rig's stream state. */
+static int rigctld_close_rig(void)
+{
+    int retcode;
+
+    rigctld_stream_registry_close_all(&g_stream_registry);
+    retcode = rig_close(my_rig);
+    rig_opened = 0;
+    return retcode;
+}
+
 #ifdef WIN32
 static BOOL WINAPI CtrlHandler(DWORD fdwCtrlType)
 {
@@ -881,7 +894,7 @@ int main(int argc, char *argv[])
     // So they need to release the rig when no clients are connected
     if (rigctld_idle)
     {
-        rig_close(my_rig);          /* we will reopen for clients */
+        rigctld_close_rig();
 
         if (verbose > RIG_DEBUG_ERR)
         {
@@ -1275,7 +1288,7 @@ int main(int argc, char *argv[])
 #else
     close(sock_listen);
 #endif
-    rig_close(my_rig);
+    rigctld_close_rig();
     mutex_rigctld(0);
 
     rigctld_stream_registry_destroy(&g_stream_registry);
@@ -1329,6 +1342,7 @@ void *handle_socket(void *arg)
     char send_cmd_term = '\r';  /* send_cmd termination char */
     int ext_resp = 0;
     char my_resp_sep = resp_sep;  // Separator for this connection, initial default
+    unsigned remaining_clients;
     rig_powerstat = RIG_POWER_ON; // defaults to power on
     struct timespec powerstat_check_time;
 
@@ -1455,8 +1469,7 @@ void *handle_socket(void *arg)
             do
             {
                 mutex_rigctld(1);
-                retcode = rig_close(my_rig);
-                rig_opened = 0;
+                retcode = rigctld_close_rig();
                 mutex_rigctld(0);
                 rig_debug(RIG_DEBUG_ERR, "%s: rig_close retcode=%d\n", __func__, retcode);
 
@@ -1480,18 +1493,19 @@ void *handle_socket(void *arg)
     while (!ctrl_c && (retcode == RIG_OK || RIG_IS_SOFT_ERRCODE(retcode)));
 
     mutex_rigctld(1);
+    rigctld_stream_registry_close_by_client(&g_stream_registry, my_client_id);
+    remaining_clients = --client_count;
 
-    if (rigctld_idle && client_count == 1)
+    if (rigctld_idle && remaining_clients == 0)
     {
-        rig_close(my_rig);
+        rigctld_close_rig();
 
         if (verbose > RIG_DEBUG_ERR) { printf("Closed rig model %s.  Will reopen for new clients\n", my_rig->caps->model_name); }
     }
 
-    --client_count;
     mutex_rigctld(0);
 
-    if (rigctld_idle && client_count > 0) { printf("%u client%s still connected so rig remains open\n", client_count, client_count > 1 ? "s" : ""); }
+    if (rigctld_idle && remaining_clients > 0) { printf("%u client%s still connected so rig remains open\n", remaining_clients, remaining_clients > 1 ? "s" : ""); }
 
 #if 0
     mutex_rigctld(1);
@@ -1529,8 +1543,6 @@ void *handle_socket(void *arg)
               "Connection closed from %s:%s\n",
               host,
               serv);
-
-    rigctld_stream_registry_close_by_client(&g_stream_registry, my_client_id);
 
 handle_exit:
 

--- a/tests/rigctld_stream.c
+++ b/tests/rigctld_stream.c
@@ -244,33 +244,7 @@ int rigctld_stream_registry_init(struct rigctld_stream_registry *reg)
 
 void rigctld_stream_registry_destroy(struct rigctld_stream_registry *reg)
 {
-    int t, i;
-
-    /* Collect all streams, then stop feeders outside lock to avoid deadlock */
-    struct rigctld_stream *all[RIG_STREAM_TYPE_COUNT * RIGCTLD_MAX_STREAMS];
-    int count = 0;
-
-    pthread_mutex_lock(&reg->lock);
-
-    for (t = 0; t < RIG_STREAM_TYPE_COUNT; t++)
-    {
-        for (i = 0; i < RIGCTLD_MAX_STREAMS; i++)
-        {
-            if (reg->streams[t][i] != NULL)
-            {
-                all[count++] = reg->streams[t][i];
-                reg->streams[t][i] = NULL;
-            }
-        }
-    }
-
-    pthread_mutex_unlock(&reg->lock);
-
-    for (i = 0; i < count; i++)
-    {
-        rigctld_stream_feeder_stop(all[i]);
-        rigctld_stream_cleanup_resources(all[i]);
-    }
+    rigctld_stream_registry_close_all(reg);
 
     pthread_mutex_destroy(&reg->lock);
     reg->initialized = 0;
@@ -475,8 +449,8 @@ void rigctld_stream_cleanup_resources(struct rigctld_stream *stream)
 }
 
 
-int rigctld_stream_registry_close_by_client(struct rigctld_stream_registry *reg,
-        int client_id)
+static int rigctld_stream_registry_close_matching(
+    struct rigctld_stream_registry *reg, int client_id, int close_all)
 {
     struct rigctld_stream *to_close[RIGCTLD_MAX_STREAMS * RIG_STREAM_TYPE_COUNT];
     int close_count = 0;
@@ -490,7 +464,8 @@ int rigctld_stream_registry_close_by_client(struct rigctld_stream_registry *reg,
         for (i = 0; i < RIGCTLD_MAX_STREAMS; i++)
         {
             if (reg->streams[t][i] != NULL
-                    && reg->streams[t][i]->client_id == client_id)
+                    && (close_all
+                        || reg->streams[t][i]->client_id == client_id))
             {
                 to_close[close_count++] = reg->streams[t][i];
                 reg->streams[t][i] = NULL;
@@ -500,7 +475,15 @@ int rigctld_stream_registry_close_by_client(struct rigctld_stream_registry *reg,
 
     pthread_mutex_unlock(&reg->lock);
 
-    /* Full cleanup outside lock (feeder_stop may block on pthread_join) */
+    /* Wake every feeder before joining any of them so teardown latency is
+     * bounded by the slowest feeder rather than the sum of their waits. */
+    for (i = 0; i < close_count; i++)
+    {
+        to_close[i]->running = 0;
+    }
+
+    /* Full cleanup outside lock: a feeder may need the registry lock while
+     * auto-closing before pthread_join can complete. */
     for (i = 0; i < close_count; i++)
     {
         rigctld_stream_feeder_stop(to_close[i]);
@@ -508,6 +491,19 @@ int rigctld_stream_registry_close_by_client(struct rigctld_stream_registry *reg,
     }
 
     return close_count;
+}
+
+
+int rigctld_stream_registry_close_by_client(struct rigctld_stream_registry *reg,
+        int client_id)
+{
+    return rigctld_stream_registry_close_matching(reg, client_id, 0);
+}
+
+
+int rigctld_stream_registry_close_all(struct rigctld_stream_registry *reg)
+{
+    return rigctld_stream_registry_close_matching(reg, 0, 1);
 }
 
 

--- a/tests/rigctld_stream.h
+++ b/tests/rigctld_stream.h
@@ -229,6 +229,10 @@ struct rigctld_stream *rigctld_stream_registry_remove(
 int rigctld_stream_registry_close_by_client(struct rigctld_stream_registry *reg,
         int client_id);
 
+/* Remove and free every stream while leaving the registry reusable.
+ * Returns the number of streams closed. */
+int rigctld_stream_registry_close_all(struct rigctld_stream_registry *reg);
+
 /* Count active streams in the registry. */
 int rigctld_stream_registry_count(struct rigctld_stream_registry *reg);
 


### PR DESCRIPTION
`rigctld` stream feeders retain backend stream handles owned by the rig's streaming state. Several rig-close paths could destroy that state before associated feeders stopped, leaving a feeder able to perform another read or write through an invalid handle.

The most direct case occurs in `--rigctld-idle` mode when the last client disconnects with an open stream. The same teardown ordering also existed during hard-error recovery and daemon shutdown.

This change centralizes rig shutdown around the required lifetime order:

1. Remove the applicable streams from the `rigctld` registry.
2. Signal all affected feeders to stop.
3. Join feeder threads outside the registry lock.
4. Release their backend streams and UDP resources.
5. Close the rig.

Normal disconnects close the departing client's streams before the last-client idle transition. Operations that close the shared rig first close every registered stream, because those handles cannot survive a rig close. The registry remains reusable after a close/reopen cycle.

The same close helper is used at idle startup and clears `rig_opened`, ensuring the first client reopens the rig instead of issuing commands against a closed session. Stream pause, resume, and drain handlers also retain the registry lock until the public API has acquired and released its internal lifetime guard, preventing feeder auto-close from invalidating a borrowed backend handle between lookup and use.

Client thread launch cleanup now destroys initialized thread attributes and releases the accepted socket and connection data when setup or `pthread_create()` fails.

Regression coverage includes:

- closing streams across multiple clients and stream types;
- stopping and joining an active feeder;
- repeated close-all calls and registry reuse;
- disconnecting an idle-mode client without `stream_close`;
- confirming idle startup and later client connections reopen the rig successfully;
- verifying pause, resume, and drain enter their backend hooks while the stream handle remains registry-protected.

Validated with the full test suite and focused ASan/UBSan runs. No public Hamlib API or stream wire-format changes.
