### PR TITLE
fix(ftx1): correct DCS parser format type

### DIFF
--- a/rigs/yaesu/ftx1/ftx1_ctcss.c
+++ b/rigs/yaesu/ftx1/ftx1_ctcss.c
@@ -322,8 +322,7 @@ int ftx1_set_dcs_code(RIG *rig, vfo_t vfo, tone_t code)
 int ftx1_get_dcs_code(RIG *rig, vfo_t vfo, tone_t *code)
 {
     struct newcat_priv_data *priv = STATE(rig)->priv;
-    int ret, p1p2;
-    unsigned int dcs_num;
+    int ret, p1p2, dcs_num;
 
     (void)vfo;  /* Unused */
 


### PR DESCRIPTION
The FTX-1 DCS getter parsed a signed integer into an unsigned variable and then logged it using a signed format. This caused a format type mismatch and undefined behavior.

Use a signed integer for the DCS table index, matching the parser, debug format, and range-check helper.

Tested with a warning-enabled full build and the FTX-1 parser test.
