### PR TITLE
fix(rigctld): enforce password authentication consistently

### DIFF
--- a/doc/man1/rigctl.1
+++ b/doc/man1/rigctl.1
@@ -1635,8 +1635,26 @@ before sending the next command to the radio.
 .
 .TP
 .BR password " \(aq" \fIPassword\fP \(aq
-Sends password to rigctld when rigctld has been secured with -A.  Must use the 32-char shared secret from rigctld.
-(NOT IMPLEMENTED)
+Authenticate to a
+.B rigctld
+server started with
+.BR \-A .
+.B rigctld
+accepts a configuration password containing 1 to 64 bytes and prints a
+32-character bearer secret at startup.
+.I Password
+must be that exact bearer secret.
+Before authentication, the only rig commands accepted by the server are
+.BR \\password ,
+.BR \\chk_vfo ,
+and
+.B \\dump_state
+so clients can complete the opening handshake.  An unauthenticated connection
+must authenticate within 30 seconds of connection establishment and is closed
+after five failed password or unauthorized command attempts.  A failed
+password attempt after successful authentication revokes access and starts a
+new 30-second authentication deadline.  The secret is sent over plaintext TCP;
+use a trusted network or secure tunnel.
 .
 .TP
 .BR set_lock_mode " \(aq" \fILocked\fP \(aq

--- a/doc/man1/rigctld.1
+++ b/doc/man1/rigctld.1
@@ -30,6 +30,7 @@ rigctld \- TCP radio control daemon
 .OP \-t number
 .OP \-C parm=val
 .OP \-X seconds
+.OP \-A password
 .RB [ \-v [ \-Z ]]
 .YS
 .
@@ -405,11 +406,28 @@ Use only in combination with the
 option as it generates no output on its own.
 .
 .TP
-.BR \-A ", " \-\-password
-Sets password on
+.BR \-A ", " \-\-password = \fIPASSWORD\fP
+Enable password authentication using a configuration password containing 1 to
+64 bytes.
 .B rigctld
-which requires hamlib to use rig_set_password and rigctl to use \\password to access rigctld.  A 32-char shared secret will be displayed to be used on the client side.
-(NOT IMPLEMENTED)
+prints a 32-character bearer secret at startup.  Clients authenticate by
+submitting that exact secret with the
+.B \\password
+command.
+.IP
+Before authentication, the only accepted rig commands are
+.BR \\password ,
+.BR \\chk_vfo ,
+and
+.B \\dump_state
+so clients can complete the opening handshake.  An unauthenticated connection
+must authenticate within 30 seconds of connection establishment and is closed
+after five failed password or unauthorized command attempts.  A failed
+password attempt after successful authentication revokes access and starts a
+new 30-second authentication deadline.
+.IP
+The bearer secret is sent over plaintext TCP.  Use this option only on a trusted
+network or through a secure tunnel.
 .
 .TP
 .BR \-R ", " \-\-rigctld\-idle
@@ -1749,8 +1767,13 @@ before sending the next command to the radio.
 .
 .TP
 .BR password " \(aq" \fIPassword\fP \(aq
-Sends password to rigctld when rigctld has been secured with -A.  Must use the 32-char shared secret from rigctld.
-(NOT IMPLEMENTED)
+Authenticate to a
+.B rigctld
+server started with
+.BR \-A .
+.I Password
+must be the exact 32-character bearer secret printed by the server at startup.
+The secret is sent over plaintext TCP; use a trusted network or secure tunnel.
 .
 .TP
 .BR set_lock_mode " \(aq" \fILocked\fP \(aq
@@ -2376,11 +2399,12 @@ on the local host:
 .
 .SH SECURITY
 .
-No authentication whatsoever; DO NOT leave this TCP port open wide to the
-Internet.  Please ask if stronger security is needed or consider using a
-Secure Shell
-.RB ( ssh (1))
-tunnel.
+Authentication is optional and must be enabled with
+.BR -A .
+It uses a reusable bearer secret over plaintext TCP and does not provide
+encryption.  Do not expose this port to the Internet; use a trusted network or
+a secure tunnel such as Secure Shell
+.RB ( ssh (1)).
 .
 .PP
 As

--- a/doc/man1/rigctltcp.1
+++ b/doc/man1/rigctltcp.1
@@ -5,7 +5,7 @@
 .\"
 .\" Note: Please keep this page in sync with the source, rigctltcp.c
 .\"
-.TH RIGCTLTCP "1" "2026-02-14" "Hamlib" "Hamlib Utilities"
+.TH RIGCTLTCP "1" "2026-08-16" "Hamlib" "Hamlib Utilities"
 .
 .
 .SH NAME
@@ -34,7 +34,6 @@ rigctltcp \- TCP multicast control of radio transceivers and receivers
 .OP \-W secs
 .OP \-w secs
 .OP \-x option
-.OP \-A password
 .RB [ \-v [ \-Z ]]
 .YS
 .
@@ -455,21 +454,6 @@ Enable time stamps for the debug messages.
 Use only in combination with the
 .B \-v
 option as it generates no output on its own.
-.
-.
-.TP
-.BR \-A ", " \-\-password = \fIPASSWORD\fP
-Sets a password on
-.B rigctltcp
-which requires Hamlib to use
-.B rig_set_password
-and clients to use
-.I PASSWORD
-to access rigctltcp.
-.
-A 32 character shared secret will be displayed to be used on the client side.
-.IP
-.B (NOT IMPLEMENTED)
 .
 .
 .TP

--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -4056,7 +4056,7 @@ extern HAMLIB_EXPORT(int) hl_usleep(rig_useconds_t msec);
 extern HAMLIB_EXPORT(int) rig_cookie(RIG *rig, enum cookie_e cookie_cmd, char *cookie, int cookie_len);
 
 extern HAMLIB_EXPORT(int) rig_password(RIG *rig, const char *key1);
-extern HAMLIB_EXPORT(void) rig_password_generate_secret(char *pass,
+extern HAMLIB_EXPORT(void) rig_password_generate_secret(const char *pass,
         char result[HAMLIB_SECRET_LENGTH + 1]);
 extern HAMLIB_EXPORT(int) rig_send_raw(RIG *rig, const unsigned char* send, int send_len, unsigned char* reply, int reply_len, unsigned char *term);
 

--- a/rigs/dummy/netrigctl.c
+++ b/rigs/dummy/netrigctl.c
@@ -91,7 +91,8 @@ int netrigctl_get_vfo_mode(RIG *rig)
 /*
  * Helper function with protocol return code parsing
  */
-static int netrigctl_transaction(RIG *rig, char *cmd, int len, char *buf)
+static int netrigctl_transaction_internal(RIG *rig, char *cmd, int len,
+        char *buf, int sensitive)
 {
     int ret;
     hamlib_port_t *rp = RIGPORT(rig);
@@ -101,7 +102,8 @@ static int netrigctl_transaction(RIG *rig, char *cmd, int len, char *buf)
     /* flush anything in the read buffer before command is sent */
     rig_flush(rp);
 
-    ret = write_block(rp, (unsigned char *) cmd, len);
+    ret = sensitive ? write_block_sensitive(rp, (unsigned char *) cmd, len)
+          : write_block(rp, (unsigned char *) cmd, len);
 
     if (ret != RIG_OK)
     {
@@ -121,6 +123,11 @@ static int netrigctl_transaction(RIG *rig, char *cmd, int len, char *buf)
     }
 
     return ret;
+}
+
+static int netrigctl_transaction(RIG *rig, char *cmd, int len, char *buf)
+{
+    return netrigctl_transaction_internal(rig, cmd, len, buf, 0);
 }
 
 /* this will fill vfostr with the vfo value if the vfo mode is enabled
@@ -2936,13 +2943,13 @@ int netrigctl_password(RIG *rig, const char *key1)
     int retval;
 
     ENTERFUNC;
-    rig_debug(RIG_DEBUG_VERBOSE, "%s: key1=%s\n", __func__, key1);
+    rig_debug(RIG_DEBUG_VERBOSE, "%s: submitting password\n", __func__);
     SNPRINTF(cmdbuf, sizeof(cmdbuf), "\\password %s\n", key1);
-    retval = netrigctl_transaction(rig, cmdbuf, strlen(cmdbuf), buf);
+    retval = netrigctl_transaction_internal(rig, cmdbuf, strlen(cmdbuf), buf,
+                                            1);
 
-    if (retval != RIG_OK)
+    if (retval > RIG_OK)
     {
-        //rig_debug(RIG_DEBUG_ERR, "%s; retval = %d\n", __func__, retval);
         retval = -RIG_EPROTO;
     }
 

--- a/rigs/dummy/quisk.c
+++ b/rigs/dummy/quisk.c
@@ -167,7 +167,8 @@ int quisk_get_vfo_mode(RIG *rig)
 /*
  * Helper function with protocol return code parsing
  */
-static int quisk_transaction(RIG *rig, char *cmd, int len, char *buf)
+static int quisk_transaction_internal(RIG *rig, char *cmd, int len, char *buf,
+                                      int sensitive)
 {
     int ret;
     hamlib_port_t *rp = RIGPORT(rig);
@@ -177,7 +178,8 @@ static int quisk_transaction(RIG *rig, char *cmd, int len, char *buf)
     /* flush anything in the read buffer before command is sent */
     rig_flush(rp);
 
-    ret = write_block(rp, (unsigned char *) cmd, len);
+    ret = sensitive ? write_block_sensitive(rp, (unsigned char *) cmd, len)
+          : write_block(rp, (unsigned char *) cmd, len);
 
     if (ret != RIG_OK)
     {
@@ -198,6 +200,11 @@ static int quisk_transaction(RIG *rig, char *cmd, int len, char *buf)
     }
 
     return ret;
+}
+
+static int quisk_transaction(RIG *rig, char *cmd, int len, char *buf)
+{
+    return quisk_transaction_internal(rig, cmd, len, buf, 0);
 }
 
 /* this will fill vfostr with the vfo value if the vfo mode is enabled
@@ -2870,11 +2877,11 @@ int quisk_password(RIG *rig, const char *key1)
     int retval;
 
     ENTERFUNC;
-    rig_debug(RIG_DEBUG_VERBOSE, "%s: key1=%s\n", __func__, key1);
+    rig_debug(RIG_DEBUG_VERBOSE, "%s: submitting password\n", __func__);
     SNPRINTF(cmdbuf, sizeof(cmdbuf), "\\password %s\n", key1);
-    retval = quisk_transaction(rig, cmdbuf, strlen(cmdbuf), buf);
+    retval = quisk_transaction_internal(rig, cmdbuf, strlen(cmdbuf), buf, 1);
 
-    if (retval != RIG_OK) { retval = -RIG_EPROTO; }
+    if (retval > RIG_OK) { retval = -RIG_EPROTO; }
 
     RETURNFUNC(retval);
 }

--- a/scripts/MSVC/2022/x64/hamlibTest/libhamlib.def
+++ b/scripts/MSVC/2022/x64/hamlibTest/libhamlib.def
@@ -520,6 +520,7 @@ EXPORTS
     write_block @519
     write_block_sync @520
     write_block_sync_error @521
+    write_block_sensitive @522
 
 IMPORTS
 

--- a/scripts/MSVC/2022/x86/hamlibTest/libhamlib.def
+++ b/scripts/MSVC/2022/x86/hamlibTest/libhamlib.def
@@ -520,6 +520,7 @@ EXPORTS
     write_block @519
     write_block_sync @520
     write_block_sync_error @521
+    write_block_sensitive @522
 
 IMPORTS
 

--- a/security/password.c
+++ b/security/password.c
@@ -20,65 +20,36 @@
  *
  */
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include "hamlib/rig.h"
 #include "password.h"
 #include "md5.h"
 
-#define HAMLIB_SECRET_LENGTH 32
-
-// makes a 32-byte secret key from password using MD5
-// yes -- this is security-by-obscurity
-// but password hacking software doesn't use this type of logic
-// we want a repeatable password that is not subject to "normal" md5 decryption logic
-// could use a MAC address to make it more random but making that portable is TBD
-HAMLIB_EXPORT(void) rig_password_generate_secret(char *pass,
+HAMLIB_EXPORT(void) rig_password_generate_secret(const char *pass,
         char result[HAMLIB_SECRET_LENGTH + 1])
 {
-    unsigned int product;
-    char newpass[256];
-    product = pass[0];
+    char *secret;
 
-    int i;
-
-    for (i = 1; pass[i]; ++i)
+    if (result == NULL)
     {
-        product *= pass[i];
+        return;
     }
 
-    srand(product);
+    result[0] = '\0';
 
-    snprintf(newpass, sizeof(newpass) - 1, "%s\t%ld\t%ld", pass, (long)rand(),
-             (long)time(NULL));
-    //printf("debug=%s\n", newpass);
-    const char *md5str = rig_make_md5(newpass);
+    if (pass == NULL)
+    {
+        return;
+    }
 
-    strncpy(result, md5str, HAMLIB_SECRET_LENGTH);
-    result[HAMLIB_SECRET_LENGTH] = '\0';
+    secret = rig_make_md5(pass);
 
-    // now that we have the md5 we'll do the AES256
+    if (secret == NULL)
+    {
+        return;
+    }
 
-    printf("sharedkey=%s\n", result);
-
-    printf("\nCan be used with rigctl --password [secret]\nOr can be placed in ~/.hamlib_settings\n");
+    memcpy(result, secret, HAMLIB_SECRET_LENGTH + 1);
+    free(secret);
 }
-
-//#define TESTPASSWORD
-#ifdef TESTPASSWORD
-int main(int argc, const char *argv[])
-{
-    char secret[HAMLIB_SECRET_LENGTH + 1];
-    char password[HAMLIB_SECRET_LENGTH +
-                                       1]; // maximum length usable for password too
-
-    // anything longer will not be used to generate the secret
-    if (argc == 1) { strcpy(password, "testpass"); }
-    else { strcpy(password, argv[1]); }
-
-    printf("Using password \"%s\" to generate shared key\n", password);
-    rig_password_generate_secret(password, secret);
-    return 0;
-}
-#endif

--- a/src/iofunc.c
+++ b/src/iofunc.c
@@ -1060,8 +1060,9 @@ int HAMLIB_API port_flush_sync_pipes(hamlib_port_t *p)
  * it could work very well also with any file handle, like a socket.
  */
 
-int HAMLIB_API write_block(hamlib_port_t *p, const unsigned char *txbuffer,
-                           size_t count)
+static int write_block_internal(hamlib_port_t *p,
+                                const unsigned char *txbuffer,
+                                size_t count, int sensitive)
 {
     int ret;
 
@@ -1135,9 +1136,13 @@ int HAMLIB_API write_block(hamlib_port_t *p, const unsigned char *txbuffer,
         }
     }
 
-    rig_debug(RIG_DEBUG_TRACE, "%s(): TX %d bytes\n", __func__,
-              (int)count);
-    dump_hex((unsigned char *) txbuffer, count);
+    rig_debug(RIG_DEBUG_TRACE, "write_block(): TX %d bytes%s\n", (int)count,
+              sensitive ? " (sensitive data redacted)" : "");
+
+    if (!sensitive)
+    {
+        dump_hex((unsigned char *) txbuffer, count);
+    }
 
     if (p->post_write_delay > 0)
     {
@@ -1162,6 +1167,19 @@ int HAMLIB_API write_block(hamlib_port_t *p, const unsigned char *txbuffer,
     }
 
     return RIG_OK;
+}
+
+int HAMLIB_API write_block(hamlib_port_t *p, const unsigned char *txbuffer,
+                           size_t count)
+{
+    return write_block_internal(p, txbuffer, count, 0);
+}
+
+int HAMLIB_API write_block_sensitive(hamlib_port_t *p,
+                                     const unsigned char *txbuffer,
+                                     size_t count)
+{
+    return write_block_internal(p, txbuffer, count, 1);
 }
 
 static int read_block_generic(hamlib_port_t *p, unsigned char *rxbuffer,

--- a/src/iofunc.h
+++ b/src/iofunc.h
@@ -40,6 +40,10 @@ extern HAMLIB_EXPORT(int) write_block(hamlib_port_t *p,
                                       const unsigned char *txbuffer,
                                       size_t count);
 
+extern HAMLIB_EXPORT(int) write_block_sensitive(hamlib_port_t *p,
+                                                const unsigned char *txbuffer,
+                                                size_t count);
+
 extern HAMLIB_EXPORT(int) write_block_sync(hamlib_port_t *p,
                                            const unsigned char *txbuffer,
                                            size_t count);

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -69,6 +69,7 @@ test_netrigctl_stream_LDADD = $(LDADD) $(PTHREAD_LIBS) $(NET_LIBS)
 
 test_rigctld_commands_SOURCES = test_rigctld_commands.c \
     $(top_srcdir)/tests/rigctl_parse.c \
+    $(top_srcdir)/tests/rigctld_client.c \
     $(top_srcdir)/tests/rigctld_stream.c \
     $(top_srcdir)/tests/dumpcaps.c \
     $(top_srcdir)/tests/dumpstate.c \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -76,7 +76,7 @@ check_PROGRAMS = \
 # installed: it drives a radio's audio/IQ streams from the build tree.
 noinst_PROGRAMS = rigstreamtest
 
-RIGCOMMONSRC = rigctl_parse.c rigctl_parse.h rigctld_stream.c rigctld_stream.h rigctld_client.h dumpcaps.c dumpstate.c uthash.h rig_tests.c rig_tests.h dumpcaps.h
+RIGCOMMONSRC = rigctl_parse.c rigctl_parse.h rigctld_stream.c rigctld_stream.h rigctld_client.c rigctld_client.h dumpcaps.c dumpstate.c uthash.h rig_tests.c rig_tests.h dumpcaps.h
 ROTCOMMONSRC = rotctl_parse.c rotctl_parse.h dumpcaps_rot.c uthash.h dumpcaps_rot.h
 AMPCOMMONSRC = ampctl_parse.c ampctl_parse.h dumpcaps_amp.c uthash.h 
 

--- a/tests/rig_tests.c
+++ b/tests/rig_tests.c
@@ -1,7 +1,125 @@
+#include <stdio.h>
 #include <string.h>
 #include "hamlib/rig.h"
 #include "hamlib/rig_state.h"
 #include "misc.h"
+
+#define REDACTED_ARGUMENT "<redacted>"
+
+static int append_startup_text(char *buffer, size_t buffer_size,
+                               size_t *length, const char *text)
+{
+    size_t text_length = strlen(text);
+    size_t available;
+
+    if (*length >= buffer_size)
+    {
+        return -RIG_ETRUNC;
+    }
+
+    available = buffer_size - *length - 1;
+
+    if (text_length > available)
+    {
+        memcpy(buffer + *length, text, available);
+        *length += available;
+        buffer[*length] = '\0';
+        return -RIG_ETRUNC;
+    }
+
+    memcpy(buffer + *length, text, text_length + 1);
+    *length += text_length;
+    return RIG_OK;
+}
+
+static int is_password_command(const char *argument)
+{
+    return strcmp(argument, "password") == 0
+           || strcmp(argument, "\\password") == 0
+           || strcmp(argument, "+\\password") == 0
+           || (argument[0] == (char)0x98 && argument[1] == '\0');
+}
+
+int rigctl_format_startup_args(char *buffer, size_t buffer_size,
+                               const char *prefix, int argc,
+                               char *const argv[])
+{
+    size_t length = 0;
+    int redact_next = 0;
+    int result = RIG_OK;
+    int i;
+
+    if (buffer == NULL || buffer_size == 0 || prefix == NULL || argc < 0
+            || (argc > 0 && argv == NULL))
+    {
+        return -RIG_EINVAL;
+    }
+
+    buffer[0] = '\0';
+
+    if (append_startup_text(buffer, buffer_size, &length, prefix) != RIG_OK)
+    {
+        result = -RIG_ETRUNC;
+    }
+
+    for (i = 0; i < argc; ++i)
+    {
+        const char *argument = argv[i] == NULL ? "" : argv[i];
+        const char *display_argument = argument;
+        char redacted_option[sizeof("--password=" REDACTED_ARGUMENT)];
+
+        if (redact_next)
+        {
+            display_argument = REDACTED_ARGUMENT;
+            redact_next = 0;
+        }
+        else if (strcmp(argument, "-A") == 0
+                 || strcmp(argument, "--password") == 0
+                 || is_password_command(argument))
+        {
+            redact_next = 1;
+        }
+        else if (strncmp(argument, "-A", 2) == 0 && argument[2] != '\0')
+        {
+            snprintf(redacted_option, sizeof(redacted_option), "-A%s",
+                     REDACTED_ARGUMENT);
+            display_argument = redacted_option;
+        }
+        else if (strncmp(argument, "--password=", 11) == 0)
+        {
+            snprintf(redacted_option, sizeof(redacted_option),
+                     "--password=%s", REDACTED_ARGUMENT);
+            display_argument = redacted_option;
+        }
+
+        if (append_startup_text(buffer, buffer_size, &length, " ") != RIG_OK
+                || append_startup_text(buffer, buffer_size, &length,
+                                       display_argument) != RIG_OK)
+        {
+            result = -RIG_ETRUNC;
+        }
+    }
+
+    return result;
+}
+
+void rigctl_wipe_password(char *password)
+{
+    volatile unsigned char *cursor = (volatile unsigned char *)password;
+    size_t length;
+
+    if (cursor == NULL)
+    {
+        return;
+    }
+
+    length = strlen(password);
+
+    while (length-- > 0)
+    {
+        *cursor++ = '*';
+    }
+}
 
 
 // cppcheck-suppress unusedFunction

--- a/tests/rig_tests.h
+++ b/tests/rig_tests.h
@@ -1,3 +1,14 @@
+#ifndef RIG_TESTS_H
+#define RIG_TESTS_H
+
+#include <stddef.h>
+
 #include "hamlib/rig.h"
 
 int rig_test_cw(RIG *rig);
+int rigctl_format_startup_args(char *buffer, size_t buffer_size,
+                               const char *prefix, int argc,
+                               char *const argv[]);
+void rigctl_wipe_password(char *password);
+
+#endif

--- a/tests/rigctl.c
+++ b/tests/rigctl.c
@@ -69,6 +69,7 @@ extern int read_history();
 #include "hamlib/rig_state.h"
 #include "misc.h"
 #include "rigctl_parse.h"
+#include "rig_tests.h"
 #include "riglist.h"
 #include "token.h"
 
@@ -232,7 +233,6 @@ int main(int argc, char *argv[])
     int vfo_opt = 0;       /* vfo_opt = 0 means target VFO is 'currVFO' */
     char send_cmd_term = '\r';  /* send_cmd termination char */
     int ext_resp = 0;
-    int i;
     char rigstartup[1024];
     char vbuf[1024];
     rig_powerstat = RIG_POWER_ON; // defaults to power on
@@ -246,6 +246,7 @@ int main(int argc, char *argv[])
     if (err) { rig_debug(RIG_DEBUG_ERR, "%s: setvbuf err=%s\n", __func__, strerror(err)); }
 
     rig_set_debug(verbose);
+
     while (1)
     {
         int c;
@@ -474,9 +475,14 @@ int main(int argc, char *argv[])
         }
     }
 
-    SNPRINTF(rigstartup, sizeof(rigstartup), "%s(%d) Startup:", __FILE__, __LINE__);
+    {
+        char startup_prefix[sizeof(rigstartup)];
 
-    for (i = 0; i < argc; ++i) { strcat(rigstartup, " "); strcat(rigstartup, argv[i]); }
+        SNPRINTF(startup_prefix, sizeof(startup_prefix), "%s(%d) Startup:",
+                 __FILE__, __LINE__);
+        rigctl_format_startup_args(rigstartup, sizeof(rigstartup),
+                                   startup_prefix, argc, argv);
+    }
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s\n", rigstartup);
 
@@ -707,7 +713,7 @@ int main(int argc, char *argv[])
             {
                 SNPRINTF(hist_path, hist_path_size, "%s%s", hist_dir, hist_file);
             }
-	    else
+            else
             {
                 fprintf(stderr, "Allocation failed - no readline history\n");
             }
@@ -889,38 +895,38 @@ int main(int argc, char *argv[])
 static void usage(FILE *fout)
 {
     fprintf(fout, "Usage: rigctl [OPTION]... [COMMAND]...\n"
-           "Send COMMANDs to a connected radio transceiver or receiver.\n\n");
+                  "Send COMMANDs to a connected radio transceiver or receiver.\n\n");
 
     fprintf(fout,
-        "  -m, --model=ID                select radio model number. See model list (-l)\n"
-        "  -r, --rig-file=DEVICE         set device of the radio to operate on\n"
-        "  -p, --ptt-file=DEVICE         set device of the PTT device to operate on\n"
-        "  -d, --dcd-file=DEVICE         set device of the DCD device to operate on\n"
-        "  -P, --ptt-type=TYPE           set type of the PTT device to operate on\n"
-        "  -D, --dcd-type=TYPE           set type of the DCD device to operate on\n"
-        "  -s, --serial-speed=BAUD       set serial speed of the serial port\n"
-        "  -c, --civaddr=ID              set CI-V address, decimal (for Icom rigs only)\n"
-        "  -t, --send-cmd-term=CHAR      set send_cmd command termination char\n"
-        "  -C, --set-conf=PARM=VAL[,...] set config parameters\n"
-        "  -L, --show-conf               list all config parameters\n"
-        "  -l, --list                    list all model numbers and exit\n"
-        "  -u, --dump-caps               dump capabilities and exit\n"
-        "  -o, --vfo                     do not default to VFO_CURR, require extra vfo arg\n"
-        "  -n, --no-restore-ai           do not restore auto information mode on rig\n"
+            "  -m, --model=ID                select radio model number. See model list (-l)\n"
+            "  -r, --rig-file=DEVICE         set device of the radio to operate on\n"
+            "  -p, --ptt-file=DEVICE         set device of the PTT device to operate on\n"
+            "  -d, --dcd-file=DEVICE         set device of the DCD device to operate on\n"
+            "  -P, --ptt-type=TYPE           set type of the PTT device to operate on\n"
+            "  -D, --dcd-type=TYPE           set type of the DCD device to operate on\n"
+            "  -s, --serial-speed=BAUD       set serial speed of the serial port\n"
+            "  -c, --civaddr=ID              set CI-V address, decimal (for Icom rigs only)\n"
+            "  -t, --send-cmd-term=CHAR      set send_cmd command termination char\n"
+            "  -C, --set-conf=PARM=VAL[,...] set config parameters\n"
+            "  -L, --show-conf               list all config parameters\n"
+            "  -l, --list                    list all model numbers and exit\n"
+            "  -u, --dump-caps               dump capabilities and exit\n"
+            "  -o, --vfo                     do not default to VFO_CURR, require extra vfo arg\n"
+            "  -n, --no-restore-ai           do not restore auto information mode on rig\n"
 #ifdef HAVE_READLINE_HISTORY
-        "  -i, --read-history            read prior interactive session history\n"
-        "  -I, --save-history            save current interactive session history\n"
+            "  -i, --read-history            read prior interactive session history\n"
+            "  -I, --save-history            save current interactive session history\n"
 #endif
-        "  -v, --verbose                 set verbose mode, cumulative (-v to -vvvvv)\n"
-        "  -Y, --ignore-err              ignore rig_open errors\n"
-        "  -Z, --debug-time-stamps       enable time stamps for debug messages\n"
-        "  -h, --help                    display this help and exit\n"
-        "  -V, --version                 output version information and exit\n"
-        "  -!, --cookie                  use cookie control\n"
-        "  -#, --skip-init               skip rig initialization\n"
-        "  -                             read commands from standard input\n"
-        "\n"
-    );
+            "  -v, --verbose                 set verbose mode, cumulative (-v to -vvvvv)\n"
+            "  -Y, --ignore-err              ignore rig_open errors\n"
+            "  -Z, --debug-time-stamps       enable time stamps for debug messages\n"
+            "  -h, --help                    display this help and exit\n"
+            "  -V, --version                 output version information and exit\n"
+            "  -!, --cookie                  use cookie control\n"
+            "  -#, --skip-init               skip rig initialization\n"
+            "  -                             read commands from standard input\n"
+            "\n"
+           );
 
     usage_rig(fout);
 }
@@ -928,7 +934,9 @@ static void usage(FILE *fout)
 
 static void short_usage(FILE *fout)
 {
-    fprintf(fout, "Usage: rigctl [OPTION]... [-m ID] [-r DEVICE] [-s BAUD] [COMMAND...|-]\n");
-    fprintf(fout, "Send COMMANDs to a connected radio transceiver or receiver.\n\n");
+    fprintf(fout,
+            "Usage: rigctl [OPTION]... [-m ID] [-r DEVICE] [-s BAUD] [COMMAND...|-]\n");
+    fprintf(fout,
+            "Send COMMANDs to a connected radio transceiver or receiver.\n\n");
     fprintf(fout, "Type: rigctl --help for extended usage.\n");
 }

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -114,9 +114,10 @@ extern int read_history();
 
 #define ARG_IN  (ARG_IN1|ARG_IN2|ARG_IN3|ARG_IN4)
 #define ARG_OUT (ARG_OUT1|ARG_OUT2|ARG_OUT3|ARG_OUT4|ARG_OUT5)
+#define RIGCTLD_PASSWORD_MAX_LENGTH 64
 
 static int chk_vfo_executed;
-char rigctld_password[65];
+static char rigctld_secret[HAMLIB_SECRET_LENGTH + 1];
 int is_rigctld;
 extern int lock_mode; // used by rigctld
 extern powerstat_t rig_powerstat;
@@ -961,6 +962,38 @@ void rigctl_parse_init(/* int threaded */)
     }
 
     return;
+}
+
+int rigctld_password_configure(const char *password,
+                               char secret[HAMLIB_SECRET_LENGTH + 1])
+{
+    if (secret == NULL)
+    {
+        return -RIG_EINVAL;
+    }
+
+    secret[0] = '\0';
+
+    if (password == NULL || password[0] == '\0'
+            || strlen(password) > RIGCTLD_PASSWORD_MAX_LENGTH)
+    {
+        return -RIG_EINVAL;
+    }
+
+    rig_password_generate_secret(password, rigctld_secret);
+
+    if (rigctld_secret[0] == '\0')
+    {
+        return -RIG_EINTERNAL;
+    }
+
+    memcpy(secret, rigctld_secret, sizeof(rigctld_secret));
+    return RIG_OK;
+}
+
+int rigctld_password_is_enabled(void)
+{
+    return rigctld_secret[0] != '\0';
 }
 
 int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
@@ -5963,33 +5996,22 @@ declare_proto_rig(pause)
 }
 
 #if RIGCTLD_PASSWORDS
-// Compare our known secret with remote submission
-// Returns 1 if match, 0 if not
-static int rigctld_password_check(RIG *rig, const char *md5)
+static int rigctld_password_check(const char *secret)
 {
-    int retval;
-    int len, hits = 0;
-    char padded[HAMLIB_SECRET_LENGTH + 1];
-    //fprintf(fout, "password %s\n", password);
-    //rig_debug(RIG_DEBUG_TRACE, "%s: %s == %s\n", __func__, md5, rigctld_password);
+    unsigned char difference = 0;
 
-    char *mymd5 = rig_make_md5(rigctld_password);
-
-    len = strlen(mymd5);
-    strncpy(padded, md5, HAMLIB_SECRET_LENGTH);
-    padded[HAMLIB_SECRET_LENGTH] = '\0';     // Make sure it's a terminated string
-
-    /* Brute force, constant time comparison */
-    for (int i = 0; i <= len; i++)
+    if (strlen(secret) != HAMLIB_SECRET_LENGTH)
     {
-        hits += (int)(padded[i] == mymd5[i]);
+        return 0;
     }
 
-    retval = (hits == len + 1);     // Entire string + terminator
+    for (int i = 0; i < HAMLIB_SECRET_LENGTH; i++)
+    {
+        difference |= (unsigned char)secret[i]
+                      ^ (unsigned char)rigctld_secret[i];
+    }
 
-    free(mymd5);
-
-    return (retval);
+    return difference == 0;
 }
 
 /* 0x98 */
@@ -6003,7 +6025,7 @@ declare_proto_rig(password)
 
     if (is_rigctld)
     {
-        retval = rigctld_password_check(rig, key);
+        retval = rigctld_password_check(key);
         connection = pthread_getspecific(thread_data_key);
 
         if (connection)
@@ -6029,8 +6051,6 @@ declare_proto_rig(password)
     }
     else
     {
-        //rig_debug(RIG_DEBUG_ERR, "%s: password error, '%s'!='%s'\n", __func__,
-        //          key, rigctld_password);
         rig_debug(RIG_DEBUG_ERR, "%s: password error\n", __func__);
     }
 
@@ -6042,9 +6062,8 @@ declare_proto_rig(password)
 /* 0x99 */
 declare_proto_rig(set_password)
 {
-    const char *passwd = arg1;
-    strncpy(rigctld_password, passwd, sizeof(passwd) - 1);
-    rig_debug(RIG_DEBUG_ERR, "%s: set_password %s\n", __func__, rigctld_password);
+    char secret[HAMLIB_SECRET_LENGTH + 1];
+    rigctld_password_configure(arg1, secret);
     return (RIG_OK);
 }
 #endif

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -108,6 +108,7 @@ extern int read_history();
 #define ARG_IN4  0x40
 #define ARG_OUT4 0x80
 #define ARG_OUT5 0x100
+#define CMD_PREAUTH 0x2000
 #define ARG_IN_LINE 0x4000
 #define ARG_NOVFO 0x8000
 
@@ -387,8 +388,8 @@ static struct test_table test_list[] =
     { '4',  "mW2power",         ACTION(mW2power),       ARG_IN1 | ARG_IN2 | ARG_IN3 | ARG_OUT1 | ARG_NOVFO, "Power mW", "Freq", "Mode", "Power [0.0..1.0]" },
     { '1',  "dump_caps",        ACTION(dump_caps),      ARG_NOVFO },
     { '3',  "dump_conf",        ACTION(dump_conf),      ARG_NOVFO },
-    { 0x8f, "dump_state",       ACTION(dump_state),     ARG_OUT | ARG_NOVFO },
-    { 0xf0, "chk_vfo",          ACTION(chk_vfo),        ARG_NOVFO, "ChkVFO" },   /* rigctld only--check for VFO mode */
+    { 0x8f, "dump_state",       ACTION(dump_state),     ARG_OUT | ARG_NOVFO | CMD_PREAUTH },
+    { 0xf0, "chk_vfo",          ACTION(chk_vfo),        ARG_NOVFO | CMD_PREAUTH, "ChkVFO" },   /* rigctld only--check for VFO mode */
     { 0xf2, "set_vfo_opt",      ACTION(set_vfo_opt),    ARG_NOVFO | ARG_IN, "Status" }, /* turn vfo option on/off */
     { 0xf3, "get_vfo_info",     ACTION(get_vfo_info),   ARG_IN1 | ARG_NOVFO | ARG_OUT5, "VFO", "Freq", "Mode", "Width", "Split", "SatMode" }, /* get several vfo parameters at once */
     { 0xf5, "get_rig_info",     ACTION(get_rig_info),   ARG_NOVFO | ARG_OUT, "RigInfo" }, /* get several vfo parameters at once */
@@ -400,7 +401,7 @@ static struct test_table test_list[] =
     { 0xf1, "halt",             ACTION(halt),           ARG_NOVFO },   /* rigctld only--halt the daemon */
     { 0x8c, "pause",            ACTION(pause),          ARG_IN | ARG_NOVFO, "Seconds" },
 #if RIGCTLD_PASSWORDS
-    { 0x98, "password",         ACTION(password),       ARG_IN | ARG_NOVFO, "Password" },
+    { 0x98, "password",         ACTION(password),       ARG_IN | ARG_NOVFO | CMD_PREAUTH, "Password" },
 //    { 0x99, "set_password",     ACTION(set_password),   ARG_IN | ARG_NOVFO, "Password" },
 #endif
     { 0xa0, "set_separator",     ACTION(set_separator), ARG_IN | ARG_NOVFO, "Separator" },
@@ -981,6 +982,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
     char client_version[32];
     char name_format[8];
     char arg_format[8];
+    int password_missing;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: called, interactive=%d\n", __func__,
               interactive);
@@ -2022,7 +2024,18 @@ readline_repeat:
      */
     if (p1) { strip_quotes(p1); }
 
-    if (interactive && *ext_resp_ptr && !prompt && cmd != 0xf0)
+    connection = pthread_getspecific(thread_data_key);
+    password_missing = use_password
+                       && !(connection ? connection->is_passwordOK : 0)
+                       && !(cmd_entry->flags & CMD_PREAUTH);
+
+    if (password_missing)
+    {
+        rig_debug(RIG_DEBUG_ERR, "%s: password has not been provided\n", __func__);
+    }
+
+    if (!password_missing && interactive && *ext_resp_ptr && !prompt
+            && cmd != 0xf0)
     {
         char a1[MAXARGSZ + 2];
         char a2[MAXARGSZ + 2];
@@ -2061,35 +2074,15 @@ readline_repeat:
 
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo_opt=%d\n", __func__, *vfo_opt);
 
-    if (rs->comm_state == 0)
+    if (!password_missing && rs->comm_state == 0)
     {
         rig_debug(RIG_DEBUG_WARN, "%s: %p rig not open...trying to reopen\n", __func__,
                   &rs->comm_state);
         rig_open(my_rig);
     }
 
-    // chk_vfo is the one command we'll allow without a password
-    // since it's in the initial handshake
-    int preCmd =
-        0;  // some command are allowed without password to satisfy rigctld initialization from rigctl -m 2
-
-    if (cmd_entry->arg1 != NULL)
+    if (password_missing)
     {
-        if (strcmp(cmd_entry->arg1, "ChkVFO") == 0) { preCmd = 1; }
-        else if (strcmp(cmd_entry->arg1, "VFO") == 0) { preCmd = 1; }
-        else if (strcmp(cmd_entry->arg1, "Password") == 0) { preCmd = 1; }
-    }
-
-    connection = pthread_getspecific(
-                     thread_data_key);  // Get state of this connection
-
-    /* Streaming commands are gated even when they take no arguments */
-    int is_stream_cmd = (cmd >= 0xb0 && cmd <= 0xba);
-
-    if (use_password && !(connection ? connection->is_passwordOK : 0)
-            && (cmd_entry->arg1 != NULL || is_stream_cmd) && !preCmd)
-    {
-        rig_debug(RIG_DEBUG_ERR, "%s: password has not been provided\n", __func__);
         fflush(fin);
         retcode = -RIG_ESECURITY;
     }

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -37,6 +37,7 @@
 #include <unistd.h>
 #include <ctype.h>
 #include <errno.h>
+#include <limits.h>
 #include "rig_tests.h"
 
 // If true adds some debug statements to see flow of rigctl parsing
@@ -108,6 +109,7 @@ extern int read_history();
 #define ARG_IN4  0x40
 #define ARG_OUT4 0x80
 #define ARG_OUT5 0x100
+#define CMD_SENSITIVE 0x1000
 #define CMD_PREAUTH 0x2000
 #define ARG_IN_LINE 0x4000
 #define ARG_NOVFO 0x8000
@@ -270,10 +272,8 @@ declare_proto_rig(set_cache);
 declare_proto_rig(get_cache);
 declare_proto_rig(halt);
 declare_proto_rig(pause);
-#if RIGCTLD_PASSWORDS
 declare_proto_rig(password);
 //declare_proto_rig(set_password);
-#endif
 declare_proto_rig(set_clock);
 declare_proto_rig(get_clock);
 declare_proto_rig(set_separator);
@@ -401,10 +401,8 @@ static struct test_table test_list[] =
     { 0xf8, "set_clock",        ACTION(set_clock),      ARG_IN | ARG_NOVFO, "local or utc or YYYY-MM-DDTHH:MM:SS.sss+ZZ or YYYY-MM-DDTHH:MM+ZZ" },
     { 0xf1, "halt",             ACTION(halt),           ARG_NOVFO },   /* rigctld only--halt the daemon */
     { 0x8c, "pause",            ACTION(pause),          ARG_IN | ARG_NOVFO, "Seconds" },
-#if RIGCTLD_PASSWORDS
-    { 0x98, "password",         ACTION(password),       ARG_IN | ARG_NOVFO | CMD_PREAUTH, "Password" },
+    { 0x98, "password",         ACTION(password),       ARG_IN | ARG_NOVFO | CMD_PREAUTH | CMD_SENSITIVE, "Password" },
 //    { 0x99, "set_password",     ACTION(set_password),   ARG_IN | ARG_NOVFO, "Password" },
-#endif
     { 0xa0, "set_separator",     ACTION(set_separator), ARG_IN | ARG_NOVFO, "Separator" },
     { 0xa1, "get_separator",     ACTION(get_separator), ARG_NOVFO, "Separator" },
     { 0xa2, "set_lock_mode",     ACTION(set_lock_mode), ARG_IN | ARG_NOVFO, "Locked" },
@@ -996,6 +994,27 @@ int rigctld_password_is_enabled(void)
     return rigctld_secret[0] != '\0';
 }
 
+int rigctl_refresh_powerstat(RIG *rig)
+{
+    powerstat_t powerstat;
+    int retcode;
+
+    if (!rig || !rig->caps->get_powerstat || STATE(rig)->comm_state == 0)
+    {
+        return -RIG_ENAVAIL;
+    }
+
+    retcode = rig_get_powerstat(rig, &powerstat);
+
+    if (retcode == RIG_OK)
+    {
+        STATE(rig)->powerstat = powerstat;
+        rig_powerstat = powerstat;
+    }
+
+    return retcode;
+}
+
 int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
                  sync_cb_t sync_cb,
                  int interactive, int prompt, int *vfo_opt, char send_cmd_term,
@@ -1015,7 +1034,11 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
     char client_version[32];
     char name_format[8];
     char arg_format[8];
+    int open_retcode = RIG_OK;
+    int password_authenticated;
     int password_missing;
+    int preauth_command;
+    int sensitive_command;
 
     rig_debug(RIG_DEBUG_TRACE, "%s: called, interactive=%d\n", __func__,
               interactive);
@@ -1542,7 +1565,7 @@ int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
             return (RIG_OK);
         }
 
-        rig_debug(RIG_DEBUG_TRACE, "%s: input_line: %s\n", __func__, input_line);
+        rig_debug(RIG_DEBUG_TRACE, "%s: readline command received\n", __func__);
 
         /* Split input_line on any number of spaces to get the command token
          * Tabs are intercepted by readline for completion and a newline
@@ -1660,6 +1683,16 @@ readline_repeat:
             free(rp_hist_buf);
             return (RIG_OK);
         }
+
+#ifdef HAVE_READLINE_HISTORY
+
+        if ((cmd_entry->flags & CMD_SENSITIVE) && rp_hist_buf)
+        {
+            free(rp_hist_buf);
+            rp_hist_buf = NULL;
+        }
+
+#endif
 
         /* If vfo_opt is enabled (-o|--vfo) check if already given
          * or prompt for it.
@@ -2040,13 +2073,21 @@ readline_repeat:
 
     if (sync_cb) { sync_cb(1); }    /* lock if necessary */
 
+    connection = pthread_getspecific(thread_data_key);
+    password_authenticated = !use_password
+                             || (connection && connection->is_passwordOK);
+    preauth_command = use_password && (cmd_entry->flags & CMD_PREAUTH);
+    sensitive_command = cmd_entry->flags & CMD_SENSITIVE;
+    password_missing = use_password && !password_authenticated
+                       && !preauth_command;
+
     if (!prompt)
     {
         rig_debug(RIG_DEBUG_TRACE,
                   "rigctl(d): %c '%s' '%s' '%s' '%s'\n",
                   cmd,
                   rig_strvfo(vfo),
-                  p1 ? p1 : "",
+                  sensitive_command ? "<redacted>" : (p1 ? p1 : ""),
                   p2 ? p2 : "",
                   p3 ? p3 : "");
     }
@@ -2057,18 +2098,17 @@ readline_repeat:
      */
     if (p1) { strip_quotes(p1); }
 
-    connection = pthread_getspecific(thread_data_key);
-    password_missing = use_password
-                       && !(connection ? connection->is_passwordOK : 0)
-                       && !(cmd_entry->flags & CMD_PREAUTH);
-
     if (password_missing)
     {
         rig_debug(RIG_DEBUG_ERR, "%s: password has not been provided\n", __func__);
+
+        if (connection && connection->auth_failures < UINT_MAX)
+        {
+            connection->auth_failures++;
+        }
     }
 
-    if (!password_missing && interactive && *ext_resp_ptr && !prompt
-            && cmd != 0xf0)
+    if (interactive && *ext_resp_ptr && !prompt && cmd != 0xf0)
     {
         char a1[MAXARGSZ + 2];
         char a2[MAXARGSZ + 2];
@@ -2076,12 +2116,16 @@ readline_repeat:
         char vfo_str[MAXARGSZ + 2];
 
         *vfo_opt == 0 ? vfo_str[0] = '\0' : snprintf(vfo_str,
-                                     sizeof(vfo_str),
-                                     " %s",
-                                     rig_strvfo(vfo));
+            sizeof(vfo_str),
+            " %s",
+            rig_strvfo(vfo));
 
         // exception for get_vfo_info cmd which fails with log4om otherwise
-        if (*vfo_opt && cmd != 0xf3)
+        if (sensitive_command)
+        {
+            a1[0] = '\0';
+        }
+        else if (*vfo_opt && cmd != 0xf3)
         {
             p1 == NULL ? a1[0] = '\0' : snprintf(a1, sizeof(a1), ":%s", p1);
         }
@@ -2107,11 +2151,16 @@ readline_repeat:
 
     rig_debug(RIG_DEBUG_TRACE, "%s: vfo_opt=%d\n", __func__, *vfo_opt);
 
-    if (!password_missing && rs->comm_state == 0)
+    if (!password_missing && !preauth_command && rs->comm_state == 0)
     {
         rig_debug(RIG_DEBUG_WARN, "%s: %p rig not open...trying to reopen\n", __func__,
                   &rs->comm_state);
-        rig_open(my_rig);
+        open_retcode = rig_open(my_rig);
+
+        if (is_rigctld && open_retcode == RIG_OK)
+        {
+            rigctl_refresh_powerstat(my_rig);
+        }
     }
 
     if (password_missing)
@@ -2119,12 +2168,18 @@ readline_repeat:
         fflush(fin);
         retcode = -RIG_ESECURITY;
     }
-
+    else if (is_rigctld && open_retcode != RIG_OK)
+    {
+        retcode = open_retcode;
+    }
     else
     {
         // Allow only certain commands when the rig is powered off
-        if (rs->powerstat == RIG_POWER_OFF && (rig_powerstat == RIG_POWER_OFF
-                                               || rig_powerstat == RIG_POWER_STANDBY)
+        if (!preauth_command
+                && (rs->powerstat == RIG_POWER_OFF
+                    || rs->powerstat == RIG_POWER_STANDBY)
+                && (rig_powerstat == RIG_POWER_OFF
+                    || rig_powerstat == RIG_POWER_STANDBY)
                 && cmd_entry->cmd != '1' // dump_caps
                 && cmd_entry->cmd != '3' // dump_conf
                 && cmd_entry->cmd != 0x8f // dump_state
@@ -2192,7 +2247,7 @@ readline_repeat:
     }
 
 
-    if (retcode == -RIG_EIO)
+    if (retcode == -RIG_EIO && open_retcode == RIG_OK)
     {
         rig_debug(RIG_DEBUG_ERR, "%s: RIG_EIO?\n", __func__);
 
@@ -5521,7 +5576,7 @@ static int hex_digit_value(char digit)
 
 static int has_binary_command_prefix(const char *command)
 {
-    while (isspace((unsigned char)*command))
+    while (isspace((unsigned char) * command))
     {
         command++;
     }
@@ -5546,7 +5601,7 @@ static int decode_binary_command(const char *command, char *decoded,
     {
         int bytes_in_group = 0;
 
-        while (isspace((unsigned char)*p))
+        while (isspace((unsigned char) * p))
         {
             p++;
         }
@@ -5569,7 +5624,7 @@ static int decode_binary_command(const char *command, char *decoded,
             return -RIG_EINVAL;
         }
 
-        while (isxdigit((unsigned char)*p))
+        while (isxdigit((unsigned char) * p))
         {
             int high = hex_digit_value(p[0]);
             int low = hex_digit_value(p[1]);
@@ -5589,7 +5644,7 @@ static int decode_binary_command(const char *command, char *decoded,
             return -RIG_EINVAL;
         }
 
-        if (*p != '\0' && !isspace((unsigned char)*p) && *p != '\\'
+        if (*p != '\0' && !isspace((unsigned char) * p) && *p != '\\'
                 && *p != 'x' && *p != 'X')
         {
             return -RIG_EINVAL;
@@ -5995,7 +6050,6 @@ declare_proto_rig(pause)
     return (RIG_OK);
 }
 
-#if RIGCTLD_PASSWORDS
 static int rigctld_password_check(const char *secret)
 {
     unsigned char difference = 0;
@@ -6020,6 +6074,7 @@ declare_proto_rig(password)
     int retval = -RIG_EPROTO;
     const char *key = arg1;
     struct handle_data *connection;
+    int was_authenticated;
 
     ENTERFUNC2;
 
@@ -6027,15 +6082,40 @@ declare_proto_rig(password)
     {
         retval = rigctld_password_check(key);
         connection = pthread_getspecific(thread_data_key);
+        was_authenticated = connection && connection->is_passwordOK;
 
-        if (connection)
+        if (connection && retval == 1)
         {
-            connection->is_passwordOK = retval;
-            retval = retval == 1 ? RIG_OK : -RIG_EPROTO;
+            connection->is_passwordOK = 1;
+            connection->auth_failures = 0;
+
+            if (connection->client_pool)
+            {
+                rigctld_client_set_authenticated(connection->client_pool,
+                                                 connection->client_slot, 1);
+            }
+
+            retval = RIG_OK;
         }
         else
         {
-            retval = -RIG_EPROTO;
+            if (connection)
+            {
+                connection->is_passwordOK = 0;
+
+                if (was_authenticated && connection->client_pool)
+                {
+                    rigctld_client_set_authenticated(connection->client_pool,
+                                                     connection->client_slot, 0);
+                }
+
+                if (connection->auth_failures < UINT_MAX)
+                {
+                    connection->auth_failures++;
+                }
+            }
+
+            retval = -RIG_ESECURITY;
         }
     }
     else
@@ -6056,7 +6136,6 @@ declare_proto_rig(password)
 
     RETURNFUNC2(retval);
 }
-#endif
 
 #if 0 // don't think we need this yet
 /* 0x99 */
@@ -7194,7 +7273,7 @@ declare_proto_rig(stream_status)
 
     struct rig_stream_time_anchor anchor;
     int have_anchor = rig_stream_get_time_anchor(stream->backend_stream,
-                      &anchor) == RIG_OK;
+        &anchor) == RIG_OK;
     int paused = stream->backend_stream->paused;
     int muted = stream->backend_stream->muted;
 

--- a/tests/rigctl_parse.h
+++ b/tests/rigctl_parse.h
@@ -32,12 +32,7 @@
 #define RIGCTL_PARSE_END 1
 #define RIGCTL_PARSE_ERROR 2
 
-/*
- * Temporary disable of rigctld/rigctltcp passwords and their help text, so no expctations
- *   of them working
- * Set this to 1 when they are repaired
- */
-#define RIGCTLD_PASSWORDS 1
+struct rigctld_client_pool;
 
 /* Data that ties each thread to a connection
  * Serves as the initial thread data, then as the state info for individual
@@ -52,6 +47,9 @@ struct handle_data
     int vfo_mode;
     int use_password;
     int is_passwordOK;
+    unsigned int auth_failures;
+    struct rigctld_client_pool *client_pool;
+    int client_slot;
     int client_id;      /* Identifies the connection owning a stream */
 };
 
@@ -81,9 +79,11 @@ void rigctl_parse_init(void);
 int rigctld_password_configure(const char *password,
                                char secret[HAMLIB_SECRET_LENGTH + 1]);
 int rigctld_password_is_enabled(void);
+int rigctl_refresh_powerstat(RIG *rig);
 typedef void (*sync_cb_t)(int);
-int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc, sync_cb_t sync_cb,
-                 int interactive, int prompt, int * vfo_mode, char send_cmd_term,
-                 int * ext_resp_ptr, char * resp_sep_ptr, int use_password);
+int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc,
+                 sync_cb_t sync_cb,
+                 int interactive, int prompt, int *vfo_mode, char send_cmd_term,
+                 int *ext_resp_ptr, char *resp_sep_ptr, int use_password);
 
 #endif  /* RIGCTL_PARSE_H */

--- a/tests/rigctl_parse.h
+++ b/tests/rigctl_parse.h
@@ -78,6 +78,9 @@ int print_conf_list2(const struct confparams *cfp, rig_ptr_t data);
 int set_conf(RIG *my_rig, char *conf_parms);
 
 void rigctl_parse_init(void);
+int rigctld_password_configure(const char *password,
+                               char secret[HAMLIB_SECRET_LENGTH + 1]);
+int rigctld_password_is_enabled(void);
 typedef void (*sync_cb_t)(int);
 int rigctl_parse(RIG *my_rig, FILE *fin, FILE *fout, char *argv[], int argc, sync_cb_t sync_cb,
                  int interactive, int prompt, int * vfo_mode, char send_cmd_term,

--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -76,6 +76,7 @@
 #include "rigctl_parse.h"
 #include "rigctld_stream.h"
 #include "rigctld_client.h"
+#include "rig_tests.h"
 #include "riglist.h"
 #include "token.h"
 
@@ -110,9 +111,7 @@ static struct option long_options[] =
     {"twiddle_rit",     1, 0, 'w'},
     {"uplink",          1, 0, 'x'},
     {"debug-time-stamps", 0, 0, 'Z'},
-#if RIGCTLD_PASSWORDS
     {"password",        1, 0, 'A'},
-#endif
     {"rigctld-idle",    0, 0, 'R'},
     {"bind-all",        0, 0, 'b'},
     {"stream-metadata-interval", 1, 0, 'M'},
@@ -135,12 +134,11 @@ void *handle_socket(void *arg);
 static void usage(FILE *fout);
 static void short_usage(FILE *fout);
 
-static unsigned client_count;
+static struct rigctld_client_pool client_pool;
 static HAMLIB_ATOMIC int next_client_id =
     1;  /* Monotonically increasing client ID */
 
 static RIG *my_rig;             /* handle to rig (instance) */
-static volatile int rig_opened = 0;
 static int verbose = RIG_DEBUG_NONE;
 
 #ifdef HAVE_SIG_ATOMIC_T
@@ -288,7 +286,6 @@ int main(int argc, char *argv[])
     pthread_t thread;
     pthread_attr_t attr;
     int vfo_mode = 0; /* vfo_mode=0 means target VFO is current VFO */
-    int i;
     extern int is_rigctld;
 
     is_rigctld = 1;
@@ -334,12 +331,12 @@ int main(int argc, char *argv[])
             bind_all = 1;
             break;
 
-#if RIGCTLD_PASSWORDS
-
         case 'A':
         {
             char secret[HAMLIB_SECRET_LENGTH + 1];
             int retval = rigctld_password_configure(optarg, secret);
+
+            rigctl_wipe_password(optarg);
 
             if (retval != RIG_OK)
             {
@@ -350,8 +347,6 @@ int main(int argc, char *argv[])
             printf("Secret key: %s\n", secret);
             break;
         }
-
-#endif
 
         case 'M':
             stream_metadata_interval = atoi(optarg);
@@ -677,17 +672,22 @@ int main(int argc, char *argv[])
 
 #endif
 
-    SNPRINTF(rigstartup, sizeof(rigstartup), "%s(%d) Startup:", __FILE__, __LINE__);
+    {
+        char startup_prefix[sizeof(rigstartup)];
 
-    for (i = 0; i < argc; ++i) { strcat(rigstartup, " "); strcat(rigstartup, argv[i]); }
+        SNPRINTF(startup_prefix, sizeof(startup_prefix), "%s(%d) Startup:",
+                 __FILE__, __LINE__);
+        rigctl_format_startup_args(rigstartup, sizeof(rigstartup),
+                                   startup_prefix, argc, argv);
+    }
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s\n", rigstartup);
 
     rig_debug(RIG_DEBUG_VERBOSE, "rigctld %s\n", hamlib_version2);
     rig_debug(RIG_DEBUG_VERBOSE, "%s",
               "Report bugs to <hamlib-developer@lists.sourceforge.net>\n\n");
-    rig_debug(RIG_DEBUG_VERBOSE, "Max# of rigctld client services=%d\n",
-              NI_MAXSERV);
+    rig_debug(RIG_DEBUG_VERBOSE, "Maximum concurrent clients=%d\n",
+              RIGCTLD_MAX_CLIENTS);
 
     my_rig = rig_init(my_model);
 
@@ -816,12 +816,11 @@ int main(int argc, char *argv[])
     /* attempt to open rig to check early for issues */
     if (skip_open)
     {
-        rig_opened = 0;
+        retcode = RIG_OK;
     }
     else
     {
         retcode = rig_open(my_rig);
-        rig_opened = retcode == RIG_OK ? 1 : 0;
     }
 
     if (retcode != RIG_OK)
@@ -829,6 +828,12 @@ int main(int argc, char *argv[])
         fprintf(stderr, "rig_open: error = %s %s %s \n", rigerror(retcode), rig_file,
                 strerror(errno));
         // continue even if opening the rig fails, because it may be powered off
+    }
+    else if (!skip_open)
+    {
+        mutex_rigctld(1);
+        rigctl_refresh_powerstat(my_rig);
+        mutex_rigctld(0);
     }
 
     if (verbose > RIG_DEBUG_ERR)
@@ -1147,6 +1152,32 @@ int main(int argc, char *argv[])
 
     rigctl_parse_init();
 
+    retcode = rigctld_client_pool_init(&client_pool, RIGCTLD_MAX_CLIENTS,
+                                       rigctld_password_is_enabled()
+                                       ? RIGCTLD_AUTH_TIMEOUT_SECONDS * 1000U
+                                       : 0);
+
+    if (retcode != RIG_OK)
+    {
+        fprintf(stderr, "Unable to initialize client pool\n");
+        exit(1);
+    }
+
+    retcode = pthread_attr_init(&attr);
+
+    if (retcode == 0)
+    {
+        retcode = pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    }
+
+    if (retcode != 0)
+    {
+        fprintf(stderr, "Unable to initialize client threads: %s\n",
+                strerror(retcode));
+        rigctld_client_pool_destroy(&client_pool);
+        exit(1);
+    }
+
     /*
      * main loop accepting connections
      */
@@ -1234,13 +1265,17 @@ int main(int argc, char *argv[])
                           gai_strerror(retcode));
             }
 
-            if (client_count >= RIGCTLD_MAX_CLIENTS)
+            arg->client_pool = &client_pool;
+            arg->client_slot = rigctld_client_reserve(&client_pool, arg->sock,
+                arg->use_password);
+
+            if (!arg->client_slot)
             {
                 rig_debug(RIG_DEBUG_ERR,
                           "Connection from %s:%s rejected — "
                           "max clients (%d) reached\n",
                           host, serv, RIGCTLD_MAX_CLIENTS);
-                close(arg->sock);
+                rigctld_socket_close(arg->sock);
                 free(arg);
                 continue;
             }
@@ -1251,15 +1286,16 @@ int main(int argc, char *argv[])
                       "Connection opened from %s:%s (client %d)\n",
                       host, serv, arg->client_id);
 
-            pthread_attr_init(&attr);
-            pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
-
             retcode = pthread_create(&thread, &attr, handle_socket, arg);
 
             if (retcode != 0)
             {
                 rig_debug(RIG_DEBUG_ERR, "pthread_create: %s\n", strerror(retcode));
-                break;
+                rigctld_client_detach_socket(&client_pool, arg->client_slot);
+                rigctld_socket_close(arg->sock);
+                rigctld_client_release(&client_pool, arg->client_slot);
+                free(arg);
+                continue;
             }
 
         }
@@ -1268,12 +1304,12 @@ int main(int argc, char *argv[])
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: while loop done\n", __func__);
 
-    /* allow threads to finish current action */
-    mutex_rigctld(1);
+    pthread_attr_destroy(&attr);
+    unsigned int clients = rigctld_client_count(&client_pool);
 
-    if (client_count)
+    if (clients)
     {
-        rig_debug(RIG_DEBUG_WARN, "%u outstanding client(s)\n", client_count);
+        rig_debug(RIG_DEBUG_WARN, "%u outstanding client(s)\n", clients);
     }
 
 #ifdef __MINGW__
@@ -1281,9 +1317,14 @@ int main(int argc, char *argv[])
 #else
     close(sock_listen);
 #endif
+
+    rigctld_client_pool_stop(&client_pool);
+
+    mutex_rigctld(1);
     rig_close(my_rig);
     mutex_rigctld(0);
 
+    rigctld_client_pool_destroy(&client_pool);
     rigctld_stream_registry_destroy(&g_stream_registry);
     rig_cleanup(my_rig); /* if you care about memory */
 
@@ -1321,6 +1362,15 @@ static FILE *get_fsockin(struct handle_data *handle_data_arg)
 #endif
 }
 
+static void close_idle_rig(void *data)
+{
+    RIG *rig = data;
+
+    mutex_rigctld(1);
+    rig_close(rig);
+    mutex_rigctld(0);
+}
+
 /*
  * This is the function run by the threads
  */
@@ -1335,8 +1385,18 @@ void *handle_socket(void *arg)
     char send_cmd_term = '\r';  /* send_cmd termination char */
     int ext_resp = 0;
     char my_resp_sep = resp_sep;  // Separator for this connection, initial default
-    rig_powerstat = RIG_POWER_ON; // defaults to power on
     struct timespec powerstat_check_time;
+    int auth_timeout_active = handle_data_arg->use_password;
+    int my_client_id = handle_data_arg->client_id;
+    int my_client_slot = handle_data_arg->client_slot;
+    unsigned int clients;
+
+    if (auth_timeout_active
+            && rigctld_socket_set_timeout(handle_data_arg->sock,
+                                          RIGCTLD_AUTH_TIMEOUT_SECONDS) != RIG_OK)
+    {
+        goto handle_exit;
+    }
 
     fsockin = get_fsockin(handle_data_arg);
 
@@ -1363,97 +1423,92 @@ void *handle_socket(void *arg)
 
     if (0 != retcode)
     {
-        rig_debug(RIG_DEBUG_ERR, "%s: Could not set thread daya\n", __func__);
-        // What do we do here?
+        rig_debug(RIG_DEBUG_ERR, "%s: Could not set thread data\n", __func__);
+        goto handle_exit;
     }
 
-    int my_client_id = handle_data_arg->client_id;
     rigctld_client_id_set(my_client_id);
-
-    mutex_rigctld(1);
-
-    ++client_count;
-#if 0
-
-    if (!client_count++)
-    {
-        retcode = rig_open(my_rig);
-
-        if (RIG_OK == retcode && verbose > RIG_DEBUG_ERR)
-        {
-            printf("Opened rig model %d, '%s'\n",
-                   my_rig->caps->rig_model,
-                   my_rig->caps->model_name);
-        }
-    }
-
-#endif
-
-    mutex_rigctld(0);
-
-    if (my_rig->caps->get_powerstat)
-    {
-        mutex_rigctld(1);
-        rig_get_powerstat(my_rig, &rig_powerstat);
-        mutex_rigctld(0);
-        STATE(my_rig)->powerstat = rig_powerstat;
-    }
 
     elapsed_ms(&powerstat_check_time, HAMLIB_ELAPSED_SET);
 
     do
     {
-        mutex_rigctld(1);
+        rig_debug(RIG_DEBUG_TRACE, "%s: doing rigctl_parse vfo_mode=%d, secure=%d\n",
+                  __func__, handle_data_arg->vfo_mode,
+                  handle_data_arg->use_password);
+        retcode = rigctl_parse(handle_data_arg->rig, fsockin, fsockout, NULL, 0,
+                               mutex_rigctld, 1, 0,
+                               &handle_data_arg->vfo_mode, send_cmd_term,
+                               &ext_resp, &my_resp_sep,
+                               handle_data_arg->use_password);
 
-        if (!rig_opened)
+        if (retcode != 0)
         {
-            retcode = rig_open(my_rig);
-            rig_opened = retcode == RIG_OK ? 1 : 0;
-            rig_debug(RIG_DEBUG_ERR, "%s: rig_open reopened retcode=%d\n", __func__,
+            rig_debug(RIG_DEBUG_VERBOSE, "%s: rigctl_parse retcode=%d\n", __func__,
                       retcode);
         }
 
-        mutex_rigctld(0);
-
-        if (rig_opened) // only do this if rig is open
+        if (auth_timeout_active && handle_data_arg->is_passwordOK)
         {
-            rig_debug(RIG_DEBUG_TRACE, "%s: doing rigctl_parse vfo_mode=%d, secure=%d\n",
-                      __func__,
-                      handle_data_arg->vfo_mode, handle_data_arg->use_password);
-            retcode = rigctl_parse(handle_data_arg->rig, fsockin, fsockout, NULL, 0,
-                                   mutex_rigctld, 1, 0, &handle_data_arg->vfo_mode,
-                                   send_cmd_term, &ext_resp, &my_resp_sep,
-                                   handle_data_arg->use_password);
-
-            if (retcode != 0) { rig_debug(RIG_DEBUG_VERBOSE, "%s: rigctl_parse retcode=%d\n", __func__, retcode); }
-
-            // If we get a timeout, the rig might be powered off
-            // Update our power status in case power gets turned off
-            // Check power status if rig is powered off, but not more often than once per second
-            if (my_rig->caps->get_powerstat && (retcode == -RIG_ETIMEOUT ||
-                                                (retcode == -RIG_EPOWER
-                                                 && elapsed_ms(&powerstat_check_time, HAMLIB_ELAPSED_GET) >= 1000)))
+            if (rigctld_socket_set_timeout(handle_data_arg->sock, 0) != RIG_OK)
             {
-                powerstat_t powerstat;
-                rig_get_powerstat(my_rig, &powerstat);
-                rig_powerstat = powerstat;
-
-                if (powerstat == RIG_POWER_OFF || powerstat == RIG_POWER_STANDBY)
-                {
-                    retcode = -RIG_EPOWER;
-                }
-
-                elapsed_ms(&powerstat_check_time, HAMLIB_ELAPSED_SET);
+                break;
             }
+
+            auth_timeout_active = 0;
         }
-        else
+        else if (!auth_timeout_active && handle_data_arg->use_password
+                 && !handle_data_arg->is_passwordOK)
         {
-            retcode = -RIG_EIO;
+            if (rigctld_socket_set_timeout(handle_data_arg->sock,
+                                           RIGCTLD_AUTH_TIMEOUT_SECONDS) != RIG_OK)
+            {
+                break;
+            }
+
+            auth_timeout_active = 1;
+        }
+
+        if (handle_data_arg->auth_failures >= RIGCTLD_MAX_AUTH_FAILURES)
+        {
+            rig_debug(RIG_DEBUG_WARN, "%s: authentication failure limit reached\n",
+                      __func__);
+            break;
+        }
+
+        // If we get a timeout, the rig might be powered off
+        // Update our power status in case power gets turned off
+        // Check power status if rig is powered off, but not more often than once per second
+        if ((!handle_data_arg->use_password || handle_data_arg->is_passwordOK)
+                && STATE(my_rig)->comm_state != 0
+                && my_rig->caps->get_powerstat
+                && (retcode == -RIG_ETIMEOUT
+                    || (retcode == -RIG_EPOWER
+                        && elapsed_ms(&powerstat_check_time,
+                                      HAMLIB_ELAPSED_GET) >= 1000)))
+        {
+            int powerstat_retcode;
+            powerstat_t powerstat;
+
+            mutex_rigctld(1);
+            powerstat_retcode = rigctl_refresh_powerstat(my_rig);
+            powerstat = rig_powerstat;
+            mutex_rigctld(0);
+
+            if (powerstat_retcode == RIG_OK
+                    && (powerstat == RIG_POWER_OFF
+                        || powerstat == RIG_POWER_STANDBY))
+            {
+                retcode = -RIG_EPOWER;
+            }
+
+            elapsed_ms(&powerstat_check_time, HAMLIB_ELAPSED_SET);
         }
 
         // if we get a hard error we try to reopen the rig again
         // this should cover short dropouts that can occur
-        if (retcode < 0 && !RIG_IS_SOFT_ERRCODE(retcode))
+        if ((!handle_data_arg->use_password || handle_data_arg->is_passwordOK)
+                && retcode < 0 && !RIG_IS_SOFT_ERRCODE(retcode))
         {
             int retry = 3;
             rig_debug(RIG_DEBUG_ERR, "%s: i/o error\n", __func__);
@@ -1462,7 +1517,6 @@ void *handle_socket(void *arg)
             {
                 mutex_rigctld(1);
                 retcode = rig_close(my_rig);
-                rig_opened = 0;
                 mutex_rigctld(0);
                 rig_debug(RIG_DEBUG_ERR, "%s: rig_close retcode=%d\n", __func__, retcode);
 
@@ -1470,53 +1524,26 @@ void *handle_socket(void *arg)
 
                 mutex_rigctld(1);
 
-                if (!rig_opened)
+                if (STATE(my_rig)->comm_state == 0)
                 {
                     retcode = rig_open(my_rig);
-                    rig_opened = retcode == RIG_OK ? 1 : 0;
+
+                    if (retcode == RIG_OK)
+                    {
+                        rigctl_refresh_powerstat(my_rig);
+                    }
+
                     rig_debug(RIG_DEBUG_ERR, "%s: rig_open retcode=%d, opened=%d\n", __func__,
-                              retcode, rig_opened);
+                              retcode, STATE(my_rig)->comm_state != 0);
                 }
 
                 mutex_rigctld(0);
             }
-            while (!ctrl_c && !rig_opened && retry-- > 0 && retcode != RIG_OK);
+            while (!ctrl_c && STATE(my_rig)->comm_state == 0 && retry-- > 0
+                    && retcode != RIG_OK);
         }
     }
     while (!ctrl_c && (retcode == RIG_OK || RIG_IS_SOFT_ERRCODE(retcode)));
-
-    mutex_rigctld(1);
-
-    if (rigctld_idle && client_count == 1)
-    {
-        rig_close(my_rig);
-
-        if (verbose > RIG_DEBUG_ERR) { printf("Closed rig model %s.  Will reopen for new clients\n", my_rig->caps->model_name); }
-    }
-
-    --client_count;
-    mutex_rigctld(0);
-
-    if (rigctld_idle && client_count > 0) { printf("%u client%s still connected so rig remains open\n", client_count, client_count > 1 ? "s" : ""); }
-
-#if 0
-    mutex_rigctld(1);
-
-    /* Release rig if there are no clients */
-    if (!--client_count)
-    {
-        rig_close(my_rig);
-
-        if (verbose > RIG_DEBUG_ERR)
-        {
-            printf("Closed rig model %d, '%s - no clients, will reopen for new clients'\n",
-                   my_rig->caps->rig_model,
-                   my_rig->caps->model_name);
-        }
-    }
-
-    mutex_rigctld(0);
-#endif
 
     if ((retcode = getnameinfo((struct sockaddr const *)&handle_data_arg->cli_addr,
                                handle_data_arg->clilen,
@@ -1539,6 +1566,8 @@ void *handle_socket(void *arg)
     rigctld_stream_registry_close_by_client(&g_stream_registry, my_client_id);
 
 handle_exit:
+    rigctld_client_detach_socket(&client_pool,
+                                 handle_data_arg->client_slot);
 
 // for MINGW we close the handle before fclose
 #ifdef __MINGW32__
@@ -1562,7 +1591,22 @@ handle_exit:
 
     pthread_setspecific(thread_data_key,
                         NULL);      // Tell pthreads we're done with the data
+
     free(arg);
+    clients = rigctld_client_release_last(&client_pool,
+                                          my_client_slot,
+                                          rigctld_idle ? close_idle_rig : NULL,
+                                          my_rig);
+
+    if (rigctld_idle && clients == 0 && verbose > RIG_DEBUG_ERR)
+    {
+        printf("Closed rig.  Will reopen for new clients\n");
+    }
+    else if (rigctld_idle && clients > 0)
+    {
+        printf("%u client%s still connected so rig remains open\n", clients,
+               clients > 1 ? "s" : "");
+    }
 
     pthread_exit(NULL);
     return NULL;
@@ -1597,9 +1641,7 @@ static void usage(FILE *fout)
             "  -w, --twiddle_rit=SECONDS     suppress VFOB getfreq so RIT can be twiddled\n"
             "  -x, --uplink=OPTION           set uplink get_freq ignore, option 1=Sub, 2=Main\n"
             "  -Z, --debug-time-stamps       enable time stamps for debug messages\n"
-#if RIGCTLD_PASSWORDS
-            "  -A, --password=PASSWORD       set password for rigctld access (NOT IMPLEMENTED)\n"
-#endif
+            "  -A, --password=PASSWORD       require a 1 to 64 byte password\n"
             "  -R, --rigctld-idle            make rigctld close the rig when no clients are connected\n"
             "  -b, --bind-all                make rigctld bind to first network device available\n"
             "  -M, --stream-metadata-interval=MS\n"

--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -151,7 +151,6 @@ static int volatile ctrl_c = 0;
 
 const char *portno = "4532";
 const char *src_addr = NULL; /* INADDR_ANY */
-extern char rigctld_password[65];
 char resp_sep = '\n';
 extern int lock_mode;
 extern powerstat_t rig_powerstat;
@@ -338,13 +337,20 @@ int main(int argc, char *argv[])
 #if RIGCTLD_PASSWORDS
 
         case 'A':
-            strncpy(rigctld_password, optarg, sizeof(rigctld_password) - 1);
-            //char *md5 = rig_make_m d5(rigctld_password);
-            char md5[HAMLIB_SECRET_LENGTH + 1];
-            rig_password_generate_secret(rigctld_password, md5);
-            printf("Secret key: %s\n", md5);
-            rig_settings_save("sharedkey", md5, e_CHAR);
+        {
+            char secret[HAMLIB_SECRET_LENGTH + 1];
+            int retval = rigctld_password_configure(optarg, secret);
+
+            if (retval != RIG_OK)
+            {
+                fprintf(stderr, "password must contain 1 to 64 bytes\n");
+                exit(1);
+            }
+
+            printf("Secret key: %s\n", secret);
             break;
+        }
+
 #endif
 
         case 'M':
@@ -1198,7 +1204,7 @@ int main(int argc, char *argv[])
                 exit(1);
             }
 
-            if (rigctld_password[0] != 0) { arg->use_password = 1; }
+            if (rigctld_password_is_enabled()) { arg->use_password = 1; }
 
             arg->rig = my_rig;
             arg->clilen = sizeof(arg->cli_addr);

--- a/tests/rigctld_client.c
+++ b/tests/rigctld_client.c
@@ -1,0 +1,470 @@
+/*
+ * Per-client state shared by rigctld network daemons.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "hamlib/config.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+
+#ifdef HAVE_SYS_TIME_H
+#  include <sys/time.h>
+#endif
+
+#ifdef HAVE_SYS_SOCKET_H
+#  include <sys/socket.h>
+#elif defined(HAVE_WS2TCPIP_H)
+#  include <ws2tcpip.h>
+#endif
+
+#include "hamlib/rig.h"
+#include "rigctld_client.h"
+
+static pthread_key_t client_id_key;
+
+static void client_pool_now(const struct rigctld_client_pool *pool,
+                            struct timespec *now)
+{
+#ifdef CLOCK_MONOTONIC
+    clock_gettime(pool->use_monotonic ? CLOCK_MONOTONIC : CLOCK_REALTIME, now);
+#else
+    clock_gettime(CLOCK_REALTIME, now);
+#endif
+}
+
+static void client_pool_set_deadline(struct rigctld_client_pool *pool,
+                                     struct rigctld_client_slot *slot)
+{
+    client_pool_now(pool, &slot->auth_deadline);
+    slot->auth_deadline.tv_sec += pool->auth_timeout_ms / 1000;
+    slot->auth_deadline.tv_nsec +=
+        (long)(pool->auth_timeout_ms % 1000) * 1000000L;
+
+    if (slot->auth_deadline.tv_nsec >= 1000000000L)
+    {
+        slot->auth_deadline.tv_sec++;
+        slot->auth_deadline.tv_nsec -= 1000000000L;
+    }
+
+    slot->auth_deadline_active = pool->auth_timeout_ms != 0;
+}
+
+static int timespec_compare(const struct timespec *left,
+                            const struct timespec *right)
+{
+    if (left->tv_sec != right->tv_sec)
+    {
+        return left->tv_sec < right->tv_sec ? -1 : 1;
+    }
+
+    if (left->tv_nsec != right->tv_nsec)
+    {
+        return left->tv_nsec < right->tv_nsec ? -1 : 1;
+    }
+
+    return 0;
+}
+
+static void rigctld_socket_shutdown(int socket_fd)
+{
+#ifdef _WIN32
+    shutdown((SOCKET)socket_fd, SD_BOTH);
+#else
+    shutdown(socket_fd, SHUT_RDWR);
+#endif
+}
+
+static void *client_pool_watchdog(void *data)
+{
+    struct rigctld_client_pool *pool = data;
+
+    pthread_mutex_lock(&pool->mutex);
+
+    while (!pool->stopping)
+    {
+        struct timespec earliest = { 0 };
+        struct timespec now;
+        int have_deadline = 0;
+
+        client_pool_now(pool, &now);
+
+        for (unsigned int i = 0; i < pool->limit; i++)
+        {
+            struct rigctld_client_slot *slot = &pool->slots[i];
+
+            if (!slot->active || !slot->auth_deadline_active)
+            {
+                continue;
+            }
+
+            if (timespec_compare(&slot->auth_deadline, &now) <= 0)
+            {
+                slot->auth_deadline_active = 0;
+                rigctld_socket_shutdown(slot->socket_fd);
+                continue;
+            }
+
+            if (!have_deadline
+                    || timespec_compare(&slot->auth_deadline, &earliest) < 0)
+            {
+                earliest = slot->auth_deadline;
+                have_deadline = 1;
+            }
+        }
+
+        if (pool->stopping)
+        {
+            break;
+        }
+
+        if (have_deadline)
+        {
+            pthread_cond_timedwait(&pool->condition, &pool->mutex, &earliest);
+        }
+        else
+        {
+            pthread_cond_wait(&pool->condition, &pool->mutex);
+        }
+    }
+
+    pthread_mutex_unlock(&pool->mutex);
+    return NULL;
+}
+
+int rigctld_client_pool_init(struct rigctld_client_pool *pool,
+                             unsigned int maximum,
+                             unsigned int auth_timeout_ms)
+{
+    pthread_condattr_t condition_attr;
+    int retval;
+
+    if (!pool || maximum == 0 || maximum > RIGCTLD_MAX_CLIENTS)
+    {
+        return -RIG_EINVAL;
+    }
+
+    memset(pool, 0, sizeof(*pool));
+    pool->limit = maximum;
+    pool->auth_timeout_ms = auth_timeout_ms;
+
+    retval = pthread_mutex_init(&pool->mutex, NULL);
+
+    if (retval != 0)
+    {
+        return -RIG_EIO;
+    }
+
+    retval = pthread_condattr_init(&condition_attr);
+
+    if (retval != 0)
+    {
+        pthread_mutex_destroy(&pool->mutex);
+        return -RIG_EIO;
+    }
+
+#if defined(_POSIX_CLOCK_SELECTION) && _POSIX_CLOCK_SELECTION >= 0
+    pool->use_monotonic =
+        pthread_condattr_setclock(&condition_attr, CLOCK_MONOTONIC) == 0;
+#endif
+    retval = pthread_cond_init(&pool->condition, &condition_attr);
+    pthread_condattr_destroy(&condition_attr);
+
+    if (retval != 0)
+    {
+        pthread_mutex_destroy(&pool->mutex);
+        return -RIG_EIO;
+    }
+
+    for (unsigned int i = 0; i < pool->limit; i++)
+    {
+        pool->slots[i].socket_fd = -1;
+    }
+
+    pool->initialized = 1;
+
+    if (auth_timeout_ms != 0)
+    {
+        retval = pthread_create(&pool->watchdog_thread, NULL,
+                                client_pool_watchdog, pool);
+
+        if (retval != 0)
+        {
+            rigctld_client_pool_destroy(pool);
+            return -RIG_EIO;
+        }
+
+        pool->watchdog_started = 1;
+    }
+
+    return RIG_OK;
+}
+
+int rigctld_client_reserve(struct rigctld_client_pool *pool, int socket_fd,
+                           int auth_required)
+{
+    int client_slot = 0;
+
+    pthread_mutex_lock(&pool->mutex);
+
+    while (pool->closing && !pool->stopping)
+    {
+        pthread_cond_wait(&pool->condition, &pool->mutex);
+    }
+
+    if (!pool->stopping && pool->active < pool->limit)
+    {
+        for (unsigned int i = 0; i < pool->limit; i++)
+        {
+            struct rigctld_client_slot *slot = &pool->slots[i];
+
+            if (slot->active)
+            {
+                continue;
+            }
+
+            slot->active = 1;
+            slot->socket_fd = socket_fd;
+            slot->authenticated = !auth_required;
+            slot->auth_deadline_active = 0;
+
+            if (auth_required)
+            {
+                client_pool_set_deadline(pool, slot);
+            }
+
+            pool->active++;
+            client_slot = (int)i + 1;
+            pthread_cond_broadcast(&pool->condition);
+            break;
+        }
+    }
+
+    pthread_mutex_unlock(&pool->mutex);
+    return client_slot;
+}
+
+unsigned int rigctld_client_release(struct rigctld_client_pool *pool,
+                                    int client_slot)
+{
+    return rigctld_client_release_last(pool, client_slot, NULL, NULL);
+}
+
+unsigned int rigctld_client_release_last(struct rigctld_client_pool *pool,
+        int client_slot,
+        rigctld_last_client_cb_t callback, void *data)
+{
+    unsigned int active;
+    int released = 0;
+
+    pthread_mutex_lock(&pool->mutex);
+
+    if (client_slot > 0 && (unsigned int)client_slot <= pool->limit
+            && pool->slots[client_slot - 1].active)
+    {
+        struct rigctld_client_slot *slot = &pool->slots[client_slot - 1];
+
+        slot->active = 0;
+        slot->socket_fd = -1;
+        slot->authenticated = 0;
+        slot->auth_deadline_active = 0;
+        pool->active--;
+        released = 1;
+    }
+
+    active = pool->active;
+
+    // Keep new reservations excluded while the daemon closes an idle rig.
+    if (released && active == 0 && callback != NULL && !pool->stopping)
+    {
+        pool->closing = 1;
+        pthread_mutex_unlock(&pool->mutex);
+        callback(data);
+        pthread_mutex_lock(&pool->mutex);
+        pool->closing = 0;
+        pthread_cond_broadcast(&pool->condition);
+    }
+
+    pthread_cond_broadcast(&pool->condition);
+
+    pthread_mutex_unlock(&pool->mutex);
+    return active;
+}
+
+unsigned int rigctld_client_count(struct rigctld_client_pool *pool)
+{
+    unsigned int active;
+
+    pthread_mutex_lock(&pool->mutex);
+    active = pool->active;
+    pthread_mutex_unlock(&pool->mutex);
+    return active;
+}
+
+void rigctld_client_set_authenticated(struct rigctld_client_pool *pool,
+                                      int client_slot, int authenticated)
+{
+    if (!pool || client_slot <= 0 || (unsigned int)client_slot > pool->limit)
+    {
+        return;
+    }
+
+    pthread_mutex_lock(&pool->mutex);
+
+    if (pool->slots[client_slot - 1].active && !pool->stopping)
+    {
+        if (authenticated)
+        {
+            pool->slots[client_slot - 1].authenticated = 1;
+            pool->slots[client_slot - 1].auth_deadline_active = 0;
+        }
+        else if (pool->slots[client_slot - 1].authenticated)
+        {
+            pool->slots[client_slot - 1].authenticated = 0;
+            client_pool_set_deadline(pool, &pool->slots[client_slot - 1]);
+        }
+
+        pthread_cond_broadcast(&pool->condition);
+    }
+
+    pthread_mutex_unlock(&pool->mutex);
+}
+
+void rigctld_client_detach_socket(struct rigctld_client_pool *pool,
+                                  int client_slot)
+{
+    if (!pool || client_slot <= 0 || (unsigned int)client_slot > pool->limit)
+    {
+        return;
+    }
+
+    pthread_mutex_lock(&pool->mutex);
+
+    if (pool->slots[client_slot - 1].active)
+    {
+        pool->slots[client_slot - 1].socket_fd = -1;
+        pool->slots[client_slot - 1].auth_deadline_active = 0;
+        pthread_cond_broadcast(&pool->condition);
+    }
+
+    pthread_mutex_unlock(&pool->mutex);
+}
+
+void rigctld_client_pool_stop(struct rigctld_client_pool *pool)
+{
+    if (!pool || !pool->initialized)
+    {
+        return;
+    }
+
+    pthread_mutex_lock(&pool->mutex);
+    pool->stopping = 1;
+
+    for (unsigned int i = 0; i < pool->limit; i++)
+    {
+        if (pool->slots[i].active && pool->slots[i].socket_fd >= 0)
+        {
+            pool->slots[i].auth_deadline_active = 0;
+            rigctld_socket_shutdown(pool->slots[i].socket_fd);
+        }
+    }
+
+    pthread_cond_broadcast(&pool->condition);
+    pthread_mutex_unlock(&pool->mutex);
+
+    if (pool->watchdog_started)
+    {
+        pthread_join(pool->watchdog_thread, NULL);
+        pool->watchdog_started = 0;
+    }
+
+    pthread_mutex_lock(&pool->mutex);
+
+    while (pool->active != 0 || pool->closing)
+    {
+        pthread_cond_wait(&pool->condition, &pool->mutex);
+    }
+
+    pthread_mutex_unlock(&pool->mutex);
+}
+
+void rigctld_client_pool_destroy(struct rigctld_client_pool *pool)
+{
+    if (!pool || !pool->initialized)
+    {
+        return;
+    }
+
+    rigctld_client_pool_stop(pool);
+    pthread_cond_destroy(&pool->condition);
+    pthread_mutex_destroy(&pool->mutex);
+    pool->initialized = 0;
+}
+
+void rigctld_socket_close(int socket_fd)
+{
+#ifdef _WIN32
+    closesocket((SOCKET)socket_fd);
+#else
+    close(socket_fd);
+#endif
+}
+
+int rigctld_socket_set_timeout(int socket_fd, unsigned int seconds)
+{
+#ifdef _WIN32
+    DWORD timeout = seconds * 1000;
+    int retval = setsockopt((SOCKET)socket_fd, SOL_SOCKET, SO_RCVTIMEO,
+                            (const char *)&timeout, sizeof(timeout));
+
+    if (retval == 0)
+    {
+        retval = setsockopt((SOCKET)socket_fd, SOL_SOCKET, SO_SNDTIMEO,
+                            (const char *)&timeout, sizeof(timeout));
+    }
+
+#else
+    struct timeval timeout = { .tv_sec = seconds, .tv_usec = 0 };
+    int retval = setsockopt(socket_fd, SOL_SOCKET, SO_RCVTIMEO,
+                            &timeout, sizeof(timeout));
+
+    if (retval == 0)
+    {
+        retval = setsockopt(socket_fd, SOL_SOCKET, SO_SNDTIMEO,
+                            &timeout, sizeof(timeout));
+    }
+
+#endif
+
+    if (retval != 0)
+    {
+#ifdef _WIN32
+        rig_debug(RIG_DEBUG_ERR, "%s: setsockopt failed: %d\n", __func__,
+                  WSAGetLastError());
+#else
+        rig_debug(RIG_DEBUG_ERR, "%s: setsockopt failed: %s\n", __func__,
+                  strerror(errno));
+#endif
+        return -RIG_EIO;
+    }
+
+    return RIG_OK;
+}
+
+void rigctld_client_id_init(void)
+{
+    pthread_key_create(&client_id_key, NULL);
+}
+
+void rigctld_client_id_set(int client_id)
+{
+    pthread_setspecific(client_id_key, (void *)(intptr_t)client_id);
+}
+
+int rigctld_client_id_get(void)
+{
+    return (int)(intptr_t)pthread_getspecific(client_id_key);
+}

--- a/tests/rigctld_client.h
+++ b/tests/rigctld_client.h
@@ -4,8 +4,60 @@
 #ifndef RIGCTLD_CLIENT_H
 #define RIGCTLD_CLIENT_H
 
+#include <pthread.h>
+#include <time.h>
+
 /* Maximum concurrent TCP clients (reject connections beyond this). */
 #define RIGCTLD_MAX_CLIENTS 128
+#define RIGCTLD_AUTH_TIMEOUT_SECONDS 30
+#define RIGCTLD_MAX_AUTH_FAILURES 5
+
+struct rigctld_client_slot
+{
+    int socket_fd;
+    int active;
+    int authenticated;
+    int auth_deadline_active;
+    struct timespec auth_deadline;
+};
+
+struct rigctld_client_pool
+{
+    pthread_mutex_t mutex;
+    pthread_cond_t condition;
+    pthread_t watchdog_thread;
+    struct rigctld_client_slot slots[RIGCTLD_MAX_CLIENTS];
+    unsigned int active;
+    unsigned int limit;
+    unsigned int auth_timeout_ms;
+    int closing;
+    int stopping;
+    int watchdog_started;
+    int use_monotonic;
+    int initialized;
+};
+
+typedef void (*rigctld_last_client_cb_t)(void *data);
+
+int rigctld_client_pool_init(struct rigctld_client_pool *pool,
+                             unsigned int maximum,
+                             unsigned int auth_timeout_ms);
+void rigctld_client_pool_stop(struct rigctld_client_pool *pool);
+void rigctld_client_pool_destroy(struct rigctld_client_pool *pool);
+int rigctld_client_reserve(struct rigctld_client_pool *pool, int socket_fd,
+                           int auth_required);
+unsigned int rigctld_client_release(struct rigctld_client_pool *pool,
+                                    int client_slot);
+unsigned int rigctld_client_release_last(struct rigctld_client_pool *pool,
+        int client_slot,
+        rigctld_last_client_cb_t callback, void *data);
+unsigned int rigctld_client_count(struct rigctld_client_pool *pool);
+void rigctld_client_set_authenticated(struct rigctld_client_pool *pool,
+                                      int client_slot, int authenticated);
+void rigctld_client_detach_socket(struct rigctld_client_pool *pool,
+                                  int client_slot);
+void rigctld_socket_close(int socket_fd);
+int rigctld_socket_set_timeout(int socket_fd, unsigned int seconds);
 
 /* Initialize client ID subsystem.  Call once at rigctld startup. */
 void rigctld_client_id_init(void);

--- a/tests/rigctld_stream.c
+++ b/tests/rigctld_stream.c
@@ -62,25 +62,6 @@ static void __attribute__((constructor)) stream_socket_sys_init(void)
 }
 #endif
 
-/* Thread-local client ID storage. */
-static pthread_key_t client_id_key;
-
-void rigctld_client_id_init(void)
-{
-    pthread_key_create(&client_id_key, NULL);
-}
-
-void rigctld_client_id_set(int client_id)
-{
-    pthread_setspecific(client_id_key, (void *)(intptr_t)client_id);
-}
-
-int rigctld_client_id_get(void)
-{
-    return (int)(intptr_t)pthread_getspecific(client_id_key);
-}
-
-
 /* Extract the family and raw IP bytes from a sockaddr_storage, folding
  * IPv4-mapped IPv6 (::ffff:A.B.C.D) to plain IPv4 so dual-stack sockets
  * compare correctly across TCP/UDP boundaries. Returns the address length

--- a/tests/rigctltcp.c
+++ b/tests/rigctltcp.c
@@ -139,7 +139,6 @@ const char *portno = "4531";            /* -t */
 const char *src_addr = NULL;            /* -T INADDR_ANY */
 const char *multicast_addr = "0.0.0.0"; /* -M */
 int multicast_port = 4532;              /* -n */
-extern char rigctld_password[65];       /* -A */
 char resp_sep = '\n';                   /* -S */
 extern int lock_mode;
 extern powerstat_t rig_powerstat;
@@ -304,15 +303,21 @@ int main(int argc, char *argv[])
             rigctld_idle = 1;
             break;
 
-#if RIIGCTLD_PASSWORDS
+#if RIGCTLD_PASSWORDS
         case 'A':
-            strncpy(rigctld_password, optarg, sizeof(rigctld_password) - 1);
-            //char *md5 = rig_make_m d5(rigctld_password);
-            char md5[HAMLIB_SECRET_LENGTH + 1];
-            rig_password_generate_secret(rigctld_password, md5);
-            printf("Secret key: %s\n", md5);
-            rig_settings_save("sharedkey", md5, e_CHAR);
+        {
+            char secret[HAMLIB_SECRET_LENGTH + 1];
+            int retval = rigctld_password_configure(optarg, secret);
+
+            if (retval != RIG_OK)
+            {
+                fprintf(stderr, "password must contain 1 to 64 bytes\n");
+                exit(1);
+            }
+
+            printf("Secret key: %s\n", secret);
             break;
+        }
 #endif
 
         case 'm':
@@ -928,7 +933,7 @@ int main(int argc, char *argv[])
                 exit(1);
             }
 
-            if (rigctld_password[0] != 0) { arg->use_password = 1; }
+            if (rigctld_password_is_enabled()) { arg->use_password = 1; }
 
             arg->rig = my_rig;
             arg->clilen = sizeof(arg->cli_addr);

--- a/tests/rigctltcp.c
+++ b/tests/rigctltcp.c
@@ -77,6 +77,8 @@
 #include "network.h"
 #include "riglist.h"
 #include "rigctl_parse.h"
+#include "rigctld_client.h"
+#include "rig_tests.h"
 
 
 /*
@@ -84,7 +86,7 @@
  *      keep up to date SHORT_OPTIONS, usage()'s output and man page. thanks.
  * TODO: add an option to read from a file
  */
-#define SHORT_OPTIONS "m:r:p:d:P:D:s:S:c:T:t:C:W:w:x:M:n:A:lLuovhVZR:"
+#define SHORT_OPTIONS "m:r:p:d:P:D:s:S:c:T:t:C:W:w:x:M:n:lLuovhVZR:"
 static struct option long_options[] =
 {
     {"model",           1, 0, 'm'},
@@ -112,9 +114,6 @@ static struct option long_options[] =
     {"debug-time-stamps", 0, 0, 'Z'},
     {"multicast-addr",  1, 0, 'M'},
     {"multicast-port",  1, 0, 'n'},
-#if RIGCTLD_PASSWORDS
-    {"password",        1, 0, 'A'},
-#endif
     {"rigctld-idle",    0, 0, 'R'},
     {0, 0, 0, 0}
 };
@@ -123,7 +122,7 @@ static struct option long_options[] =
 void *handle_socket(void *arg);
 static void usage(FILE *fout);
 
-static unsigned client_count;
+static struct rigctld_client_pool client_pool;
 
 static RIG *my_rig;             /* handle to rig (instance) */
 static volatile int rig_opened = 0;
@@ -261,7 +260,6 @@ int main(int argc, char *argv[])
     pthread_t thread;
     pthread_attr_t attr;
     int vfo_mode = 0; /* vfo_mode=0 means target VFO is current VFO */
-    int i;
     extern int is_rigctld;
     struct rig_state *rs;
 
@@ -272,6 +270,7 @@ int main(int argc, char *argv[])
     if (err) { rig_debug(RIG_DEBUG_ERR, "%s: setvbuf err=%s\n", __func__, strerror(err)); }
 
     rig_set_debug(verbose);
+
     while (1)
     {
         int c;
@@ -302,23 +301,6 @@ int main(int argc, char *argv[])
         case 'R':
             rigctld_idle = 1;
             break;
-
-#if RIGCTLD_PASSWORDS
-        case 'A':
-        {
-            char secret[HAMLIB_SECRET_LENGTH + 1];
-            int retval = rigctld_password_configure(optarg, secret);
-
-            if (retval != RIG_OK)
-            {
-                fprintf(stderr, "password must contain 1 to 64 bytes\n");
-                exit(1);
-            }
-
-            printf("Secret key: %s\n", secret);
-            break;
-        }
-#endif
 
         case 'm':
             my_model = atoi(optarg);
@@ -539,17 +521,22 @@ int main(int argc, char *argv[])
 
 #endif
 
-    SNPRINTF(rigstartup, sizeof(rigstartup), "%s(%d) Startup:", __FILE__, __LINE__);
+    {
+        char startup_prefix[sizeof(rigstartup)];
 
-    for (i = 0; i < argc; ++i) { strcat(rigstartup, " "); strcat(rigstartup, argv[i]); }
+        SNPRINTF(startup_prefix, sizeof(startup_prefix), "%s(%d) Startup:",
+                 __FILE__, __LINE__);
+        rigctl_format_startup_args(rigstartup, sizeof(rigstartup),
+                                   startup_prefix, argc, argv);
+    }
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s\n", rigstartup);
 
     rig_debug(RIG_DEBUG_VERBOSE, "rigctltcp %s\n", hamlib_version2);
     rig_debug(RIG_DEBUG_VERBOSE, "%s",
               "Report bugs to <hamlib-developer@lists.sourceforge.net>\n\n");
-    rig_debug(RIG_DEBUG_VERBOSE, "Max# of rigctld client services=%d\n",
-              NI_MAXSERV);
+    rig_debug(RIG_DEBUG_VERBOSE, "Maximum concurrent clients=%d\n",
+              RIGCTLD_MAX_CLIENTS);
 
     my_rig = rig_init(my_model);
 
@@ -734,7 +721,7 @@ int main(int argc, char *argv[])
     enum multicast_item_e items = RIG_MULTICAST_POLL | RIG_MULTICAST_TRANSCEIVE |
                                   RIG_MULTICAST_SPECTRUM;
     retcode = network_multicast_publisher_start(my_rig, multicast_addr,
-              multicast_port, items);
+        multicast_port, items);
 
     if (retcode != RIG_OK)
     {
@@ -876,6 +863,29 @@ int main(int argc, char *argv[])
 
     rigctl_parse_init();
 
+    retcode = rigctld_client_pool_init(&client_pool, RIGCTLD_MAX_CLIENTS, 0);
+
+    if (retcode != RIG_OK)
+    {
+        fprintf(stderr, "Unable to initialize client pool\n");
+        exit(1);
+    }
+
+    retcode = pthread_attr_init(&attr);
+
+    if (retcode == 0)
+    {
+        retcode = pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    }
+
+    if (retcode != 0)
+    {
+        fprintf(stderr, "Unable to initialize client threads: %s\n",
+                strerror(retcode));
+        rigctld_client_pool_destroy(&client_pool);
+        exit(1);
+    }
+
     /*
      * main loop accepting connections
      */
@@ -933,8 +943,6 @@ int main(int argc, char *argv[])
                 exit(1);
             }
 
-            if (rigctld_password_is_enabled()) { arg->use_password = 1; }
-
             arg->rig = my_rig;
             arg->clilen = sizeof(arg->cli_addr);
             arg->vfo_mode = vfo_mode;
@@ -963,20 +971,35 @@ int main(int argc, char *argv[])
                           gai_strerror(retcode));
             }
 
+            arg->client_pool = &client_pool;
+            arg->client_slot = rigctld_client_reserve(&client_pool, arg->sock, 0);
+
+            if (!arg->client_slot)
+            {
+                rig_debug(RIG_DEBUG_ERR,
+                          "Connection from %s:%s rejected: "
+                          "max clients (%d) reached\n",
+                          host, serv, RIGCTLD_MAX_CLIENTS);
+                rigctld_socket_close(arg->sock);
+                free(arg);
+                continue;
+            }
+
             rig_debug(RIG_DEBUG_VERBOSE,
                       "Connection opened from %s:%s\n",
                       host,
                       serv);
-
-            pthread_attr_init(&attr);
-            pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
 
             retcode = pthread_create(&thread, &attr, handle_socket, arg);
 
             if (retcode != 0)
             {
                 rig_debug(RIG_DEBUG_ERR, "pthread_create: %s\n", strerror(retcode));
-                break;
+                rigctld_client_detach_socket(&client_pool, arg->client_slot);
+                rigctld_socket_close(arg->sock);
+                rigctld_client_release(&client_pool, arg->client_slot);
+                free(arg);
+                continue;
             }
 
         }
@@ -985,19 +1008,29 @@ int main(int argc, char *argv[])
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: while loop done\n", __func__);
 
-    /* allow threads to finish current action */
-    mutex_rigctld(1);
+    pthread_attr_destroy(&attr);
+    unsigned int clients = rigctld_client_count(&client_pool);
 
-    if (client_count)
+    if (clients)
     {
-        rig_debug(RIG_DEBUG_WARN, "%u outstanding client(s)\n", client_count);
+        rig_debug(RIG_DEBUG_WARN, "%u outstanding client(s)\n", clients);
     }
 
+#ifdef __MINGW__
+    closesocket(sock_listen);
+#else
+    close(sock_listen);
+#endif
+
+    rigctld_client_pool_stop(&client_pool);
+
+    mutex_rigctld(1);
     rig_close(my_rig);
     mutex_rigctld(0);
 
     network_multicast_publisher_stop(my_rig);
 
+    rigctld_client_pool_destroy(&client_pool);
     rig_cleanup(my_rig); /* if you care about memory */
 
 #ifdef __MINGW32__
@@ -1034,6 +1067,16 @@ static FILE *get_fsockin(struct handle_data *handle_data_arg)
 #endif
 }
 
+static void close_idle_rig(void *data)
+{
+    RIG *rig = data;
+
+    mutex_rigctld(1);
+    rig_close(rig);
+    rig_opened = 0;
+    mutex_rigctld(0);
+}
+
 /*
  * This is the function run by the threads
  */
@@ -1046,6 +1089,8 @@ void *handle_socket(void *arg)
     char host[NI_MAXHOST];
     char serv[NI_MAXSERV];
     rig_powerstat = RIG_POWER_ON; // defaults to power on
+    int my_client_slot = handle_data_arg->client_slot;
+    unsigned int clients;
 
     fsockin = get_fsockin(handle_data_arg);
 
@@ -1069,32 +1114,12 @@ void *handle_socket(void *arg)
     }
 
     retcode = pthread_setspecific(thread_data_key, arg);
+
     if (retcode != 0)
     {
         rig_debug(RIG_DEBUG_ERR, "%s: Could not set thread data\n", __func__);
-        // What should we do here???
+        goto handle_exit;
     }
-
-    mutex_rigctld(1);
-
-    ++client_count;
-#if 0
-
-    if (!client_count++)
-    {
-        retcode = rig_open(my_rig);
-
-        if (RIG_OK == retcode && verbose > RIG_DEBUG_ERR)
-        {
-            printf("Opened rig model %d, '%s'\n",
-                   my_rig->caps->rig_model,
-                   my_rig->caps->model_name);
-        }
-    }
-
-#endif
-
-    mutex_rigctld(0);
 
     if (my_rig->caps->get_powerstat)
     {
@@ -1126,14 +1151,14 @@ void *handle_socket(void *arg)
             unsigned char cmd[64];
             unsigned char reply[64];
             unsigned char term[2] = ";";
-            rig_debug(RIG_DEBUG_TRACE, "%s: doing rigctl_parse vfo_mode=%d, secure=%d\n",
+            rig_debug(RIG_DEBUG_TRACE, "%s: doing rigctl_parse vfo_mode=%d\n",
                       __func__,
-                      handle_data_arg->vfo_mode, handle_data_arg->use_password);
+                      handle_data_arg->vfo_mode);
 #if 0
             retcode = rigctl_parse(handle_data_arg->rig, fsockin, fsockout, NULL, 0,
                                    mutex_rigctld,
                                    1, 0, &handle_data_arg->vfo_mode, send_cmd_term, &ext_resp, &resp_sep,
-                                   handle_data_arg->use_password);
+                                   0);
 #else
             memset(cmd, 0, sizeof(cmd));
             nbytes = -1;
@@ -1289,38 +1314,6 @@ void *handle_socket(void *arg)
 
 client_done:
 
-    if (rigctld_idle && client_count == 1)
-    {
-        rig_close(my_rig);
-
-        if (verbose > RIG_DEBUG_ERR) { printf("Closed rig model %s.  Will reopen for new clients\n", my_rig->caps->model_name); }
-    }
-
-    mutex_rigctld(1);
-    --client_count;
-
-    if (rigctld_idle && client_count > 0) { printf("%u client%s still connected so rig remains open\n", client_count, client_count > 1 ? "s" : ""); }
-    mutex_rigctld(0);
-
-#if 0
-    mutex_rigctld(1);
-
-    /* Release rig if there are no clients */
-    if (!--client_count)
-    {
-        rig_close(my_rig);
-
-        if (verbose > RIG_DEBUG_ERR)
-        {
-            printf("Closed rig model %d, '%s - no clients, will reopen for new clients'\n",
-                   my_rig->caps->rig_model,
-                   my_rig->caps->model_name);
-        }
-    }
-
-    mutex_rigctld(0);
-#endif
-
     if ((retcode = getnameinfo((struct sockaddr const *)&handle_data_arg->cli_addr,
                                handle_data_arg->clilen,
                                host,
@@ -1340,6 +1333,8 @@ client_done:
               serv);
 
 handle_exit:
+    rigctld_client_detach_socket(&client_pool,
+                                 handle_data_arg->client_slot);
 
 // for MINGW we close the handle before fclose
 #ifdef __MINGW32__
@@ -1362,7 +1357,22 @@ handle_exit:
 #endif
 
     pthread_setspecific(thread_data_key, NULL);
+
     free(arg);
+    clients = rigctld_client_release_last(&client_pool,
+                                          my_client_slot,
+                                          rigctld_idle ? close_idle_rig : NULL,
+                                          my_rig);
+
+    if (rigctld_idle && clients == 0 && verbose > RIG_DEBUG_ERR)
+    {
+        printf("Closed rig.  Will reopen for new clients\n");
+    }
+    else if (rigctld_idle && clients > 0)
+    {
+        printf("%u client%s still connected so rig remains open\n", clients,
+               clients > 1 ? "s" : "");
+    }
 
     pthread_exit(NULL);
     return NULL;
@@ -1372,41 +1382,38 @@ handle_exit:
 static void usage(FILE *fout)
 {
     fprintf(fout, "Usage: rigctltcp [OPTION]...\n"
-           "Daemon serving COMMANDs to a connected radio transceiver or receiver.\n\n");
+                  "Daemon serving COMMANDs to a connected radio transceiver or receiver.\n\n");
 
     fprintf(fout,
-        "  -m, --model=ID                select radio model number. See model list (-l)\n"
-        "  -r, --rig-file=DEVICE         set device of the radio to operate on\n"
-        "  -p, --ptt-file=DEVICE         set device of the PTT device to operate on\n"
-        "  -d, --dcd-file=DEVICE         set device of the DCD device to operate on\n"
-        "  -P, --ptt-type=TYPE           set type of the PTT device to operate on\n"
-        "  -D, --dcd-type=TYPE           set type of the DCD device to operate on\n"
-        "  -s, --serial-speed=BAUD       set serial speed of the serial port\n"
-        "  -c, --civaddr=ID              set CI-V address, decimal (for Icom rigs only)\n"
-        "  -S, --separator=CHAR          set char as rigctld response separator, default is \\n\n"
-        "  -L, --show-conf               list all config parameters\n"
-        "  -C, --set-conf=PARM=VAL[,...] set config parameters\n"
-        "  -l, --list                    list all model numbers and exit\n"
-        "  -u, --dump-caps               dump capabilities and exit\n"
-        "  -o, --vfo                     do not default to VFO_CURR, require extra vfo arg\n"
-        "  -v, --verbose                 set verbose mode, cumulative (-v to -vvvvv)\n"
-        "  -T, --listen-addr=IPADDR      set listening IP address, default ANY\n"
-        "  -t, --port=NUM                set TCP listening port, default %s\n"
-        "  -M, --multicast-addr=ADDR     set multicast UDP address, default %s (off), recommend 224.0.1.1\n"
-        "  -n, --multicast-port=PORT     set multicast UDP port, default %d\n"
-        "  -W, --twiddle_timeout=SECONDS timeout after detecting vfo manual change\n"
-        "  -w, --twiddle_rit=SECONDS     suppress VFOB getfreq so RIT can be twiddled\n"
-        "  -x, --uplink=OPTION           set uplink get_freq ignore, option 1=Sub, 2=Main\n"
-        "  -Z, --debug-time-stamps       enable time stamps for debug messages\n"
-#if RIGCTLD_PASSWORDS
-        "  -A, --password=PASSWORD       set password for rigctld access (64 chars max), default none\n"
-#endif
-        "  -R, --rigctltcp-idle          make rigctltcp close the rig when no clients are connected\n"
-        "  -h, --help                    display this help and exit\n"
-        "  -V, --version                 output version information and exit\n\n",
-        portno,
-        multicast_addr,
-        multicast_port);
+            "  -m, --model=ID                select radio model number. See model list (-l)\n"
+            "  -r, --rig-file=DEVICE         set device of the radio to operate on\n"
+            "  -p, --ptt-file=DEVICE         set device of the PTT device to operate on\n"
+            "  -d, --dcd-file=DEVICE         set device of the DCD device to operate on\n"
+            "  -P, --ptt-type=TYPE           set type of the PTT device to operate on\n"
+            "  -D, --dcd-type=TYPE           set type of the DCD device to operate on\n"
+            "  -s, --serial-speed=BAUD       set serial speed of the serial port\n"
+            "  -c, --civaddr=ID              set CI-V address, decimal (for Icom rigs only)\n"
+            "  -S, --separator=CHAR          set char as rigctld response separator, default is \\n\n"
+            "  -L, --show-conf               list all config parameters\n"
+            "  -C, --set-conf=PARM=VAL[,...] set config parameters\n"
+            "  -l, --list                    list all model numbers and exit\n"
+            "  -u, --dump-caps               dump capabilities and exit\n"
+            "  -o, --vfo                     do not default to VFO_CURR, require extra vfo arg\n"
+            "  -v, --verbose                 set verbose mode, cumulative (-v to -vvvvv)\n"
+            "  -T, --listen-addr=IPADDR      set listening IP address, default ANY\n"
+            "  -t, --port=NUM                set TCP listening port, default %s\n"
+            "  -M, --multicast-addr=ADDR     set multicast UDP address, default %s (off), recommend 224.0.1.1\n"
+            "  -n, --multicast-port=PORT     set multicast UDP port, default %d\n"
+            "  -W, --twiddle_timeout=SECONDS timeout after detecting vfo manual change\n"
+            "  -w, --twiddle_rit=SECONDS     suppress VFOB getfreq so RIT can be twiddled\n"
+            "  -x, --uplink=OPTION           set uplink get_freq ignore, option 1=Sub, 2=Main\n"
+            "  -Z, --debug-time-stamps       enable time stamps for debug messages\n"
+            "  -R, --rigctltcp-idle          make rigctltcp close the rig when no clients are connected\n"
+            "  -h, --help                    display this help and exit\n"
+            "  -V, --version                 output version information and exit\n\n",
+            portno,
+            multicast_addr,
+            multicast_port);
 
     usage_rig(fout);
 }

--- a/tests/testctlparser.c
+++ b/tests/testctlparser.c
@@ -21,6 +21,8 @@
 
 int lock_mode;
 powerstat_t rig_powerstat = RIG_POWER_ON;
+extern char rigctld_password[65];
+extern int is_rigctld;
 
 static char captured_description[sizeof(((channel_t *)0)->channel_desc)];
 static freq_t captured_freq;
@@ -89,6 +91,16 @@ static int capture_mw_to_power(RIG *rig, float *power, unsigned int mwpower,
     return RIG_OK;
 }
 
+static int checking_halt_authorization;
+
+static void fail_if_halt_exits(void)
+{
+    if (checking_halt_authorization)
+    {
+        abort();
+    }
+}
+
 static int capture_channel(RIG *rig, vfo_t vfo, const channel_t *chan)
 {
     (void)rig;
@@ -141,6 +153,136 @@ static int parse_command_output(RIG *rig, FILE *input, char *argv[], int argc,
     *output_length = fread(output, 1, output_size, stream);
     fclose(stream);
     return ret;
+}
+
+static int parse_secure_network_command(RIG *rig, const char *command,
+                                        struct handle_data *connection)
+{
+    FILE *input = tmpfile();
+    FILE *output = tmpfile();
+    char *argv[] = { "testctlparser" };
+    int vfo_mode = 0;
+    int ext_resp = 0;
+    char resp_sep = '\n';
+    int ret;
+
+    if (input == NULL || output == NULL)
+    {
+        if (input != NULL) { fclose(input); }
+
+        if (output != NULL) { fclose(output); }
+
+        return -RIG_EINTERNAL;
+    }
+
+    fputs(command, input);
+    rewind(input);
+    pthread_setspecific(thread_data_key, connection);
+    ret = rigctl_parse(rig, input, output, argv, 1, NULL, 1, 0,
+                       &vfo_mode, 0, &ext_resp, &resp_sep, 1);
+    pthread_setspecific(thread_data_key, NULL);
+    fclose(input);
+    fclose(output);
+    return ret;
+}
+
+static int check_password_authorization(RIG *rig)
+{
+    static const char *protected_commands[] =
+    {
+        "\\halt\n",
+        "\\set_vfo VFOA\n",
+        "\\hamlib_version\n"
+    };
+    static const char *protected_names[] =
+    {
+        "halt",
+        "set_vfo",
+        "hamlib_version"
+    };
+    static const char *preauth_commands[] =
+    {
+        "\\chk_vfo\n",
+        "\\dump_state\n"
+    };
+    static const char *preauth_names[] =
+    {
+        "chk_vfo",
+        "dump_state"
+    };
+    struct handle_data connection = { .rig = rig };
+    char password[] = "test-password";
+    char *secret;
+    char command[64];
+    int ret;
+
+    for (size_t i = 0;
+            i < sizeof(protected_commands) / sizeof(protected_commands[0]); i++)
+    {
+        checking_halt_authorization = i == 0;
+        ret = parse_secure_network_command(rig, protected_commands[i],
+                                           &connection);
+        checking_halt_authorization = 0;
+
+        if (ret != -RIG_ESECURITY)
+        {
+            fprintf(stderr, "unauthenticated %s: expected %d, got %d\n",
+                    protected_names[i], -RIG_ESECURITY, ret);
+            return 1;
+        }
+    }
+
+    if (HAMLIB_STATE(rig)->comm_state != 0)
+    {
+        fprintf(stderr, "unauthenticated commands opened the rig\n");
+        return 1;
+    }
+
+    for (size_t i = 0;
+            i < sizeof(preauth_commands) / sizeof(preauth_commands[0]); i++)
+    {
+        ret = parse_secure_network_command(rig, preauth_commands[i], &connection);
+
+        if (ret != RIG_OK)
+        {
+            fprintf(stderr, "unauthenticated %s: expected success, got %d\n",
+                    preauth_names[i], ret);
+            return 1;
+        }
+    }
+
+    strcpy(rigctld_password, password);
+    secret = rig_make_md5(password);
+
+    if (secret == NULL)
+    {
+        fprintf(stderr, "unable to create password secret\n");
+        return 1;
+    }
+
+    snprintf(command, sizeof(command), "\\password %s\n", secret);
+    is_rigctld = 1;
+    ret = parse_secure_network_command(rig, command, &connection);
+    is_rigctld = 0;
+    free(secret);
+
+    if (ret != RIG_OK || !connection.is_passwordOK)
+    {
+        fprintf(stderr, "password authentication failed: ret=%d authenticated=%d\n",
+                ret, connection.is_passwordOK);
+        return 1;
+    }
+
+    ret = parse_secure_network_command(rig, "\\hamlib_version\n", &connection);
+
+    if (ret != RIG_OK)
+    {
+        fprintf(stderr, "authenticated hamlib_version: expected success, got %d\n",
+                ret);
+        return 1;
+    }
+
+    return 0;
 }
 
 static int check_send_command(RIG *rig, const char *command,
@@ -413,6 +555,13 @@ int main(void)
     state = HAMLIB_STATE(rig);
     memcpy(state->chan_list, caps.chan_list, sizeof(state->chan_list));
     rigctl_parse_init();
+    atexit(fail_if_halt_exits);
+
+    if (check_password_authorization(rig) != 0)
+    {
+        rig_cleanup(rig);
+        return 1;
+    }
 
     if (check_description(rig, maximum, maximum) != 0
             || check_description(rig, thirty, maximum) != 0

--- a/tests/testctlparser.c
+++ b/tests/testctlparser.c
@@ -21,7 +21,6 @@
 
 int lock_mode;
 powerstat_t rig_powerstat = RIG_POWER_ON;
-extern char rigctld_password[65];
 extern int is_rigctld;
 
 static char captured_description[sizeof(((channel_t *)0)->channel_desc)];
@@ -212,7 +211,9 @@ static int check_password_authorization(RIG *rig)
     };
     struct handle_data connection = { .rig = rig };
     char password[] = "test-password";
-    char *secret;
+    char overlong_password[66];
+    char secret[HAMLIB_SECRET_LENGTH + 1];
+    char repeated_secret[HAMLIB_SECRET_LENGTH + 1];
     char command[64];
     int ret;
 
@@ -251,20 +252,41 @@ static int check_password_authorization(RIG *rig)
         }
     }
 
-    strcpy(rigctld_password, password);
-    secret = rig_make_md5(password);
+    memset(overlong_password, 'x', sizeof(overlong_password) - 1);
+    overlong_password[sizeof(overlong_password) - 1] = '\0';
 
-    if (secret == NULL)
+    if (rigctld_password_configure("", secret) != -RIG_EINVAL
+            || rigctld_password_configure(overlong_password, secret)
+            != -RIG_EINVAL || rigctld_password_is_enabled())
     {
-        fprintf(stderr, "unable to create password secret\n");
+        fprintf(stderr, "invalid password was configured\n");
+        return 1;
+    }
+
+    ret = rigctld_password_configure(password, secret);
+    rig_password_generate_secret(password, repeated_secret);
+
+    if (ret != RIG_OK || !rigctld_password_is_enabled()
+            || strcmp(secret, repeated_secret) != 0)
+    {
+        fprintf(stderr, "unable to configure a stable password secret\n");
+        return 1;
+    }
+
+    snprintf(command, sizeof(command), "\\password %sx\n", secret);
+    is_rigctld = 1;
+    ret = parse_secure_network_command(rig, command, &connection);
+
+    if (ret != -RIG_EPROTO || connection.is_passwordOK)
+    {
+        fprintf(stderr, "password with trailing data was accepted\n");
+        is_rigctld = 0;
         return 1;
     }
 
     snprintf(command, sizeof(command), "\\password %s\n", secret);
-    is_rigctld = 1;
     ret = parse_secure_network_command(rig, command, &connection);
     is_rigctld = 0;
-    free(secret);
 
     if (ret != RIG_OK || !connection.is_passwordOK)
     {

--- a/tests/testctlparser.c
+++ b/tests/testctlparser.c
@@ -511,20 +511,26 @@ done:
 static int check_sensitive_write(void)
 {
     static const unsigned char secret[] = "unique-write-secret";
+    FILE *sink = tmpfile();
     hamlib_port_t port = { 0 };
-    int descriptors[2];
     int ret;
 
-    if (pipe(descriptors) != 0)
+    if (sink == NULL)
     {
         return 1;
     }
 
-    port.fd = descriptors[1];
+    port.fd = fileno(sink);
+
+    if (port.fd < 0)
+    {
+        fclose(sink);
+        return 1;
+    }
+
     rig_debug_clear();
     ret = write_block_sensitive(&port, secret, sizeof(secret) - 1);
-    close(descriptors[0]);
-    close(descriptors[1]);
+    fclose(sink);
 
     if (ret != RIG_OK || strstr(debugmsgsave, (const char *)secret) != NULL)
     {

--- a/tests/testctlparser.c
+++ b/tests/testctlparser.c
@@ -14,10 +14,21 @@
 #include <string.h>
 #include <unistd.h>
 
+#ifdef HAVE_SYS_SOCKET_H
+#  include <sys/socket.h>
+#endif
+#ifdef HAVE_SYS_TIME_H
+#  include <sys/time.h>
+#endif
+
 #include "hamlib/rig.h"
 #include "hamlib/rig_state.h"
+#include "hamlib/port.h"
 
+#include "iofunc.h"
 #include "rigctl_parse.h"
+#include "rigctld_client.h"
+#include "rig_tests.h"
 
 int lock_mode;
 powerstat_t rig_powerstat = RIG_POWER_ON;
@@ -91,6 +102,9 @@ static int capture_mw_to_power(RIG *rig, float *power, unsigned int mwpower,
 }
 
 static int checking_halt_authorization;
+static int powerstat_calls;
+static int powerstat_retcode = RIG_OK;
+static powerstat_t reported_powerstat = RIG_POWER_ON;
 
 static void fail_if_halt_exits(void)
 {
@@ -108,6 +122,73 @@ static int capture_channel(RIG *rig, vfo_t vfo, const channel_t *chan)
            sizeof(captured_description));
     return RIG_OK;
 }
+
+static int fail_rig_open(RIG *rig)
+{
+    (void)rig;
+    return -RIG_EIO;
+}
+
+static int test_get_powerstat(RIG *rig, powerstat_t *powerstat)
+{
+    (void)rig;
+    powerstat_calls++;
+
+    if (powerstat_retcode == RIG_OK)
+    {
+        *powerstat = reported_powerstat;
+    }
+
+    return powerstat_retcode;
+}
+
+static void count_last_client(void *data)
+{
+    int *count = data;
+
+    (*count)++;
+}
+
+#ifdef HAVE_SOCKETPAIR
+struct pool_stop_context
+{
+    struct rigctld_client_pool *pool;
+    pthread_mutex_t mutex;
+    int finished;
+};
+
+static void *stop_client_pool(void *data)
+{
+    struct pool_stop_context *context = data;
+
+    rigctld_client_pool_stop(context->pool);
+    pthread_mutex_lock(&context->mutex);
+    context->finished = 1;
+    pthread_mutex_unlock(&context->mutex);
+    return NULL;
+}
+
+static int wait_for_socket_shutdown(int socket_fd, unsigned int timeout_ms)
+{
+    fd_set read_set;
+    struct timeval timeout =
+    {
+        .tv_sec = timeout_ms / 1000,
+        .tv_usec = (int)(timeout_ms % 1000) * 1000
+    };
+    char byte;
+
+    FD_ZERO(&read_set);
+    FD_SET(socket_fd, &read_set);
+
+    if (select(socket_fd + 1, &read_set, NULL, NULL, &timeout) != 1)
+    {
+        return 0;
+    }
+
+    return recv(socket_fd, &byte, 1, MSG_DONTWAIT) == 0;
+}
+#endif
 
 static int parse_command(RIG *rig, FILE *input, char *argv[], int argc,
                          char send_cmd_term)
@@ -154,8 +235,8 @@ static int parse_command_output(RIG *rig, FILE *input, char *argv[], int argc,
     return ret;
 }
 
-static int parse_secure_network_command(RIG *rig, const char *command,
-                                        struct handle_data *connection)
+static int parse_secure_network_command_output(RIG *rig, const char *command,
+        struct handle_data *connection, char *response, size_t response_size)
 {
     FILE *input = tmpfile();
     FILE *output = tmpfile();
@@ -179,10 +260,389 @@ static int parse_secure_network_command(RIG *rig, const char *command,
     pthread_setspecific(thread_data_key, connection);
     ret = rigctl_parse(rig, input, output, argv, 1, NULL, 1, 0,
                        &vfo_mode, 0, &ext_resp, &resp_sep, 1);
+
+    if (response != NULL && response_size > 0)
+    {
+        size_t length;
+
+        rewind(output);
+        length = fread(response, 1, response_size - 1, output);
+        response[length] = '\0';
+    }
+
     pthread_setspecific(thread_data_key, NULL);
     fclose(input);
     fclose(output);
     return ret;
+}
+
+static int parse_secure_network_command(RIG *rig, const char *command,
+                                        struct handle_data *connection)
+{
+    return parse_secure_network_command_output(rig, command, connection,
+            NULL, 0);
+}
+
+static int check_client_pool(void)
+{
+    struct rigctld_client_pool pool;
+    int last_client_count = 0;
+    int first_slot;
+    int second_slot;
+    int failed = 0;
+
+    if (rigctld_client_pool_init(&pool, 2, 0) != RIG_OK)
+    {
+        return 1;
+    }
+
+    first_slot = rigctld_client_reserve(&pool, -1, 0);
+    second_slot = rigctld_client_reserve(&pool, -1, 0);
+    failed = !first_slot || !second_slot
+             || rigctld_client_reserve(&pool, -1, 0)
+             || rigctld_client_count(&pool) != 2
+             || rigctld_client_release(&pool, first_slot) != 1
+             || rigctld_client_release_last(&pool, second_slot,
+                                            count_last_client,
+                                            &last_client_count) != 0
+             || rigctld_client_release_last(&pool, second_slot,
+                                            count_last_client,
+                                            &last_client_count) != 0
+             || last_client_count != 1;
+
+    rigctld_client_pool_stop(&pool);
+    failed = failed || rigctld_client_reserve(&pool, -1, 0) != 0;
+    rigctld_client_pool_destroy(&pool);
+
+    if (failed)
+    {
+        fprintf(stderr, "client pool limit or accounting failed\n");
+    }
+
+    return failed;
+}
+
+static int check_authentication_deadline(void)
+{
+#ifdef HAVE_SOCKETPAIR
+    struct rigctld_client_pool pool;
+    int protected_pair[2];
+    int expiring_pair[2];
+    int protected_slot;
+    int expiring_slot;
+    char byte = 'x';
+    int failed = 0;
+
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, protected_pair) != 0)
+    {
+        return 1;
+    }
+
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, expiring_pair) != 0)
+    {
+        rigctld_socket_close(protected_pair[0]);
+        rigctld_socket_close(protected_pair[1]);
+        return 1;
+    }
+
+    if (rigctld_client_pool_init(&pool, 2, 500) != RIG_OK)
+    {
+        rigctld_socket_close(protected_pair[0]);
+        rigctld_socket_close(protected_pair[1]);
+        rigctld_socket_close(expiring_pair[0]);
+        rigctld_socket_close(expiring_pair[1]);
+        return 1;
+    }
+
+    protected_slot = rigctld_client_reserve(&pool, protected_pair[0], 1);
+    expiring_slot = rigctld_client_reserve(&pool, expiring_pair[0], 1);
+    rigctld_client_set_authenticated(&pool, protected_slot, 1);
+
+    for (int i = 0; i < 3; i++)
+    {
+        usleep(30000);
+        rigctld_client_set_authenticated(&pool, expiring_slot, 0);
+        send(expiring_pair[1], &byte, 1, 0);
+    }
+
+    if (!wait_for_socket_shutdown(expiring_pair[1], 2000)
+            || wait_for_socket_shutdown(protected_pair[1], 0))
+    {
+        failed = 1;
+    }
+
+    rigctld_client_set_authenticated(&pool, protected_slot, 0);
+
+    if (!wait_for_socket_shutdown(protected_pair[1], 2000))
+    {
+        failed = 1;
+    }
+
+    rigctld_client_detach_socket(&pool, protected_slot);
+    rigctld_client_detach_socket(&pool, expiring_slot);
+    rigctld_socket_close(protected_pair[0]);
+    rigctld_socket_close(protected_pair[1]);
+    rigctld_socket_close(expiring_pair[0]);
+    rigctld_socket_close(expiring_pair[1]);
+    rigctld_client_release(&pool, protected_slot);
+    rigctld_client_release(&pool, expiring_slot);
+    rigctld_client_pool_destroy(&pool);
+
+    if (failed)
+    {
+        fprintf(stderr, "absolute authentication deadline failed\n");
+    }
+
+    return failed;
+#else
+    return 0;
+#endif
+}
+
+static int check_client_pool_shutdown(void)
+{
+#ifdef HAVE_SOCKETPAIR
+    struct rigctld_client_pool pool;
+    struct pool_stop_context context = { .pool = &pool };
+    pthread_t stop_thread;
+    int sockets[2];
+    int client_slot = 0;
+    int callback_count = 0;
+    int stopped_early;
+    int client_released = 0;
+    int failed = 0;
+
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) != 0)
+    {
+        return 1;
+    }
+
+    if (rigctld_client_pool_init(&pool, 1, 0) != RIG_OK)
+    {
+        rigctld_socket_close(sockets[0]);
+        rigctld_socket_close(sockets[1]);
+        return 1;
+    }
+
+    if (pthread_mutex_init(&context.mutex, NULL) != 0)
+    {
+        rigctld_client_pool_destroy(&pool);
+        rigctld_socket_close(sockets[0]);
+        rigctld_socket_close(sockets[1]);
+        return 1;
+    }
+
+    client_slot = rigctld_client_reserve(&pool, sockets[0], 0);
+
+    if (!client_slot
+            || pthread_create(&stop_thread, NULL, stop_client_pool,
+                              &context) != 0)
+    {
+        failed = 1;
+        goto done;
+    }
+
+    int stop_started = 0;
+
+    for (int i = 0; i < 1000; i++)
+    {
+        pthread_mutex_lock(&pool.mutex);
+        stop_started = pool.stopping;
+        pthread_mutex_unlock(&pool.mutex);
+
+        if (stop_started)
+        {
+            break;
+        }
+
+        usleep(1000);
+    }
+
+    pthread_mutex_lock(&context.mutex);
+    stopped_early = context.finished;
+    pthread_mutex_unlock(&context.mutex);
+
+    rigctld_client_detach_socket(&pool, client_slot);
+    rigctld_socket_close(sockets[0]);
+    rigctld_socket_close(sockets[1]);
+    rigctld_client_release_last(&pool, client_slot, count_last_client,
+                                &callback_count);
+    client_released = 1;
+    pthread_join(stop_thread, NULL);
+
+    if (!stop_started || stopped_early || !context.finished
+            || callback_count != 0)
+    {
+        failed = 1;
+    }
+
+done:
+
+    if (!client_released)
+    {
+        if (client_slot)
+        {
+            rigctld_client_detach_socket(&pool, client_slot);
+        }
+
+        rigctld_socket_close(sockets[0]);
+        rigctld_socket_close(sockets[1]);
+
+        if (client_slot)
+        {
+            rigctld_client_release(&pool, client_slot);
+        }
+    }
+
+    rigctld_client_pool_destroy(&pool);
+    pthread_mutex_destroy(&context.mutex);
+
+    if (failed)
+    {
+        fprintf(stderr, "client pool shutdown synchronization failed\n");
+    }
+
+    return failed;
+#else
+    return 0;
+#endif
+}
+
+static int check_sensitive_write(void)
+{
+    static const unsigned char secret[] = "unique-write-secret";
+    hamlib_port_t port = { 0 };
+    int descriptors[2];
+    int ret;
+
+    if (pipe(descriptors) != 0)
+    {
+        return 1;
+    }
+
+    port.fd = descriptors[1];
+    rig_debug_clear();
+    ret = write_block_sensitive(&port, secret, sizeof(secret) - 1);
+    close(descriptors[0]);
+    close(descriptors[1]);
+
+    if (ret != RIG_OK || strstr(debugmsgsave, (const char *)secret) != NULL)
+    {
+        fprintf(stderr, "sensitive write exposed its payload in debug history\n");
+        return 1;
+    }
+
+    return 0;
+}
+
+static int check_startup_argument_redaction(void)
+{
+    static const char secret[] = "startup-secret-value";
+    static const char expected[] =
+        "test: rigctl -m 1 -A <redacted> -A<redacted> "
+        "--password <redacted> --password=<redacted> password <redacted> "
+        "\\password <redacted> +\\password <redacted> "
+        "\x98 <redacted> ordinary";
+    char separate_secret[] = "startup-secret-value";
+    char inline_short[] = "-Astartup-secret-value";
+    char inline_long[] = "--password=startup-secret-value";
+    char command_secret[] = "startup-secret-value";
+    char slash_secret[] = "startup-secret-value";
+    char extended_secret[] = "startup-secret-value";
+    char opcode_password[] = { (char)0x98, '\0' };
+    char opcode_secret[] = "startup-secret-value";
+    char *arguments[] =
+    {
+        "rigctl", "-m", "1", "-A", separate_secret, inline_short,
+        "--password", separate_secret, inline_long, "password",
+        command_secret, "\\password", slash_secret, "+\\password",
+        extended_secret, opcode_password, opcode_secret, "ordinary"
+    };
+    char formatted[512];
+    char small[12];
+    char wiped[] = "erase-me";
+    int ret;
+
+    rigctl_wipe_password(separate_secret);
+    rigctl_wipe_password(inline_short + 2);
+    rigctl_wipe_password(inline_long + 11);
+    ret = rigctl_format_startup_args(formatted, sizeof(formatted), "test:",
+                                     sizeof(arguments) / sizeof(arguments[0]),
+                                     arguments);
+
+    if (ret != RIG_OK || strcmp(formatted, expected) != 0
+            || strstr(formatted, secret) != NULL)
+    {
+        fprintf(stderr, "startup argument redaction failed: '%s'\n", formatted);
+        return 1;
+    }
+
+    rig_debug_clear();
+    rig_debug(RIG_DEBUG_VERBOSE, "%s\n", formatted);
+
+    if (strstr(debugmsgsave, secret) != NULL)
+    {
+        fprintf(stderr, "startup credential reached debug history\n");
+        return 1;
+    }
+
+    memset(small, 0xa5, sizeof(small));
+    ret = rigctl_format_startup_args(small, sizeof(small), "test:",
+                                     sizeof(arguments) / sizeof(arguments[0]),
+                                     arguments);
+
+    if (ret != -RIG_ETRUNC || small[sizeof(small) - 1] != '\0')
+    {
+        fprintf(stderr, "bounded startup formatting failed\n");
+        return 1;
+    }
+
+    rigctl_wipe_password(wiped);
+
+    if (strcmp(wiped, "********") != 0)
+    {
+        fprintf(stderr, "password argument was not wiped\n");
+        return 1;
+    }
+
+    return 0;
+}
+
+static int check_socket_timeouts(void)
+{
+#ifdef HAVE_SOCKETPAIR
+    struct timeval receive_timeout;
+    struct timeval send_timeout;
+    socklen_t receive_length = sizeof(receive_timeout);
+    socklen_t send_length = sizeof(send_timeout);
+    int sockets[2];
+    int failed;
+
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) != 0)
+    {
+        return 1;
+    }
+
+    failed = rigctld_socket_set_timeout(sockets[0], 1) != RIG_OK
+             || getsockopt(sockets[0], SOL_SOCKET, SO_RCVTIMEO,
+                           &receive_timeout, &receive_length) != 0
+             || getsockopt(sockets[0], SOL_SOCKET, SO_SNDTIMEO,
+                           &send_timeout, &send_length) != 0
+             || (receive_timeout.tv_sec == 0 && receive_timeout.tv_usec == 0)
+             || (send_timeout.tv_sec == 0 && send_timeout.tv_usec == 0)
+             || rigctld_socket_set_timeout(sockets[0], 0) != RIG_OK;
+    rigctld_socket_close(sockets[0]);
+    rigctld_socket_close(sockets[1]);
+
+    if (failed)
+    {
+        fprintf(stderr, "socket timeout configuration failed\n");
+        return 1;
+    }
+
+#endif
+
+    return 0;
 }
 
 static int check_password_authorization(RIG *rig)
@@ -210,12 +670,24 @@ static int check_password_authorization(RIG *rig)
         "dump_state"
     };
     struct handle_data connection = { .rig = rig };
+    struct handle_data other_connection = { .rig = rig };
+    struct handle_data failure_connection = { .rig = rig };
     char password[] = "test-password";
+    char maximum_password[65];
     char overlong_password[66];
     char secret[HAMLIB_SECRET_LENGTH + 1];
     char repeated_secret[HAMLIB_SECRET_LENGTH + 1];
+    char wrong_secret[HAMLIB_SECRET_LENGTH + 1];
     char command[64];
+    char expected_response[64];
+    char response[256];
+    int (*saved_rig_open)(RIG *) = rig->caps->rig_open;
+    int (*saved_get_powerstat)(RIG *, powerstat_t *) =
+        rig->caps->get_powerstat;
+    int result = 1;
     int ret;
+
+    is_rigctld = 1;
 
     for (size_t i = 0;
             i < sizeof(protected_commands) / sizeof(protected_commands[0]); i++)
@@ -229,15 +701,17 @@ static int check_password_authorization(RIG *rig)
         {
             fprintf(stderr, "unauthenticated %s: expected %d, got %d\n",
                     protected_names[i], -RIG_ESECURITY, ret);
-            return 1;
+            goto done;
         }
     }
 
     if (HAMLIB_STATE(rig)->comm_state != 0)
     {
         fprintf(stderr, "unauthenticated commands opened the rig\n");
-        return 1;
+        goto done;
     }
+
+    connection.auth_failures = 0;
 
     for (size_t i = 0;
             i < sizeof(preauth_commands) / sizeof(preauth_commands[0]); i++)
@@ -248,10 +722,29 @@ static int check_password_authorization(RIG *rig)
         {
             fprintf(stderr, "unauthenticated %s: expected success, got %d\n",
                     preauth_names[i], ret);
-            return 1;
+            goto done;
         }
     }
 
+    if (HAMLIB_STATE(rig)->comm_state != 0)
+    {
+        fprintf(stderr, "pre-authentication commands opened the rig\n");
+        goto done;
+    }
+
+    ret = parse_secure_network_command_output(rig,
+        "+\\set_vfo VFOA\n", &connection, response, sizeof(response));
+
+    if (ret != -RIG_ESECURITY
+            || strcmp(response, "set_vfo: VFOA\nRPRT -19\n") != 0)
+    {
+        fprintf(stderr, "protected extended response was incompatible: '%s'\n",
+                response);
+        goto done;
+    }
+
+    memset(maximum_password, 'm', sizeof(maximum_password) - 1);
+    maximum_password[sizeof(maximum_password) - 1] = '\0';
     memset(overlong_password, 'x', sizeof(overlong_password) - 1);
     overlong_password[sizeof(overlong_password) - 1] = '\0';
 
@@ -260,7 +753,14 @@ static int check_password_authorization(RIG *rig)
             != -RIG_EINVAL || rigctld_password_is_enabled())
     {
         fprintf(stderr, "invalid password was configured\n");
-        return 1;
+        goto done;
+    }
+
+    if (rigctld_password_configure("x", secret) != RIG_OK
+            || rigctld_password_configure(maximum_password, secret) != RIG_OK)
+    {
+        fprintf(stderr, "valid password boundary was rejected\n");
+        goto done;
     }
 
     ret = rigctld_password_configure(password, secret);
@@ -270,30 +770,231 @@ static int check_password_authorization(RIG *rig)
             || strcmp(secret, repeated_secret) != 0)
     {
         fprintf(stderr, "unable to configure a stable password secret\n");
-        return 1;
+        goto done;
+    }
+
+    memset(wrong_secret, '0', HAMLIB_SECRET_LENGTH);
+    wrong_secret[HAMLIB_SECRET_LENGTH] = '\0';
+
+    if (strcmp(wrong_secret, secret) == 0)
+    {
+        wrong_secret[0] = '1';
+    }
+
+    snprintf(command, sizeof(command), "\\password %.31s\n", secret);
+    ret = parse_secure_network_command(rig, command, &connection);
+
+    if (ret != -RIG_ESECURITY || connection.is_passwordOK)
+    {
+        fprintf(stderr, "short password secret was accepted\n");
+        goto done;
+    }
+
+    snprintf(command, sizeof(command), "\\password %s\n", wrong_secret);
+    ret = parse_secure_network_command(rig, command, &connection);
+
+    if (ret != -RIG_ESECURITY || connection.is_passwordOK)
+    {
+        fprintf(stderr, "wrong password secret was accepted\n");
+        goto done;
     }
 
     snprintf(command, sizeof(command), "\\password %sx\n", secret);
-    is_rigctld = 1;
     ret = parse_secure_network_command(rig, command, &connection);
 
-    if (ret != -RIG_EPROTO || connection.is_passwordOK)
+    if (ret != -RIG_ESECURITY || connection.is_passwordOK)
     {
-        fprintf(stderr, "password with trailing data was accepted\n");
-        is_rigctld = 0;
-        return 1;
+        fprintf(stderr, "password secret with trailing data was accepted\n");
+        goto done;
+    }
+
+    rig_debug_clear();
+    snprintf(command, sizeof(command), "+\\password %s\n", secret);
+    ret = parse_secure_network_command_output(rig, command, &connection,
+        response, sizeof(response));
+
+    if (ret != RIG_OK || !connection.is_passwordOK
+            || connection.auth_failures != 0
+            || strcmp(response, "password:\nRPRT 0\n") != 0
+            || strstr(response, secret) != NULL
+            || strstr(debugmsgsave, secret) != NULL)
+    {
+        fprintf(stderr,
+                "password authentication response or redaction failed: "
+                "ret=%d response='%s'\n", ret, response);
+        goto done;
+    }
+
+    ret = parse_secure_network_command(rig, "\\hamlib_version\n",
+                                       &other_connection);
+
+    if (ret != -RIG_ESECURITY || other_connection.is_passwordOK)
+    {
+        fprintf(stderr, "password authentication leaked between connections\n");
+        goto done;
+    }
+
+    snprintf(command, sizeof(command), "\\password %s\n", wrong_secret);
+    ret = parse_secure_network_command(rig, command, &connection);
+
+    if (ret != -RIG_ESECURITY || connection.is_passwordOK
+            || connection.auth_failures != 1)
+    {
+        fprintf(stderr, "wrong password did not revoke authentication\n");
+        goto done;
+    }
+
+    ret = parse_secure_network_command(rig, "\\hamlib_version\n", &connection);
+
+    if (ret != -RIG_ESECURITY)
+    {
+        fprintf(stderr, "protected command ran after authentication revocation\n");
+        goto done;
+    }
+
+    for (unsigned int i = 0; i < RIGCTLD_MAX_AUTH_FAILURES; i++)
+    {
+        ret = parse_secure_network_command(rig, "\\hamlib_version\n",
+                                           &failure_connection);
+
+        if (ret != -RIG_ESECURITY)
+        {
+            fprintf(stderr, "authentication failure limit setup failed\n");
+            goto done;
+        }
+    }
+
+    if (failure_connection.auth_failures != RIGCTLD_MAX_AUTH_FAILURES)
+    {
+        fprintf(stderr, "authentication failures were not counted\n");
+        goto done;
     }
 
     snprintf(command, sizeof(command), "\\password %s\n", secret);
+    HAMLIB_STATE(rig)->powerstat = RIG_POWER_OFF;
+    rig_powerstat = RIG_POWER_OFF;
     ret = parse_secure_network_command(rig, command, &connection);
-    is_rigctld = 0;
+    HAMLIB_STATE(rig)->powerstat = RIG_POWER_ON;
+    rig_powerstat = RIG_POWER_ON;
 
-    if (ret != RIG_OK || !connection.is_passwordOK)
+    if (ret != RIG_OK || !connection.is_passwordOK
+            || HAMLIB_STATE(rig)->comm_state != 0)
     {
-        fprintf(stderr, "password authentication failed: ret=%d authenticated=%d\n",
-                ret, connection.is_passwordOK);
-        return 1;
+        fprintf(stderr, "password authentication required an open powered rig\n");
+        goto done;
     }
+
+    ((struct rig_caps *)rig->caps)->rig_open = fail_rig_open;
+    ret = parse_secure_network_command_output(rig, "\\hamlib_version\n",
+        &connection, response, sizeof(response));
+    ((struct rig_caps *)rig->caps)->rig_open = saved_rig_open;
+    snprintf(expected_response, sizeof(expected_response), "RPRT %d\n",
+             -RIG_EIO);
+
+    if (ret != -RIG_EIO || strcmp(response, expected_response) != 0)
+    {
+        fprintf(stderr, "lazy-open failure did not return an error: '%s'\n",
+                response);
+        goto done;
+    }
+
+    {
+        FILE *input = tmpfile();
+        char *local_command[] = { "testctlparser", "hamlib_version" };
+
+        if (input == NULL)
+        {
+            goto done;
+        }
+
+        is_rigctld = 0;
+        ((struct rig_caps *)rig->caps)->rig_open = fail_rig_open;
+        ret = parse_command(rig, input, local_command, 2, 0);
+        ((struct rig_caps *)rig->caps)->rig_open = saved_rig_open;
+        is_rigctld = 1;
+        fclose(input);
+
+        if (ret != RIG_OK)
+        {
+            fprintf(stderr,
+                    "local command did not preserve ignored open error: %d\n",
+                    ret);
+            goto done;
+        }
+    }
+
+    ((struct rig_caps *)rig->caps)->rig_open = saved_rig_open;
+    ((struct rig_caps *)rig->caps)->get_powerstat = test_get_powerstat;
+    powerstat_calls = 0;
+    powerstat_retcode = RIG_OK;
+    reported_powerstat = RIG_POWER_OFF;
+    int powerstat_calls_before = powerstat_calls;
+    HAMLIB_STATE(rig)->powerstat = RIG_POWER_ON;
+    rig_powerstat = RIG_POWER_ON;
+    ret = parse_secure_network_command(rig, "\\hamlib_version\n", &connection);
+
+    if (ret != -RIG_EPOWER || powerstat_calls <= powerstat_calls_before
+            || HAMLIB_STATE(rig)->powerstat != RIG_POWER_OFF
+            || rig_powerstat != RIG_POWER_OFF)
+    {
+        fprintf(stderr,
+                "lazy open did not refresh power before dispatch: ret=%d calls=%d\n",
+                ret, powerstat_calls);
+        goto done;
+    }
+
+    rig_close(rig);
+    reported_powerstat = RIG_POWER_STANDBY;
+    powerstat_calls_before = powerstat_calls;
+    HAMLIB_STATE(rig)->powerstat = RIG_POWER_ON;
+    rig_powerstat = RIG_POWER_ON;
+    ret = parse_secure_network_command(rig, "\\hamlib_version\n", &connection);
+
+    if (ret != -RIG_EPOWER || powerstat_calls <= powerstat_calls_before
+            || HAMLIB_STATE(rig)->powerstat != RIG_POWER_STANDBY
+            || rig_powerstat != RIG_POWER_STANDBY)
+    {
+        fprintf(stderr,
+                "standby power refresh did not block dispatch: ret=%d calls=%d\n",
+                ret, powerstat_calls);
+        goto done;
+    }
+
+    rig_close(rig);
+    reported_powerstat = RIG_POWER_ON;
+    powerstat_calls_before = powerstat_calls;
+    ret = parse_secure_network_command(rig, "\\hamlib_version\n", &connection);
+
+    if (ret != RIG_OK || powerstat_calls <= powerstat_calls_before
+            || HAMLIB_STATE(rig)->powerstat != RIG_POWER_ON
+            || rig_powerstat != RIG_POWER_ON)
+    {
+        fprintf(stderr,
+                "successful power refresh did not permit dispatch: ret=%d calls=%d\n",
+                ret, powerstat_calls);
+        goto done;
+    }
+
+    rig_close(rig);
+    powerstat_retcode = -RIG_EIO;
+    reported_powerstat = RIG_POWER_OFF;
+    powerstat_calls_before = powerstat_calls;
+    HAMLIB_STATE(rig)->powerstat = RIG_POWER_ON;
+    rig_powerstat = RIG_POWER_ON;
+    ret = parse_secure_network_command(rig, "\\hamlib_version\n", &connection);
+
+    if (ret != RIG_OK || powerstat_calls <= powerstat_calls_before
+            || HAMLIB_STATE(rig)->powerstat != RIG_POWER_ON
+            || rig_powerstat != RIG_POWER_ON)
+    {
+        fprintf(stderr,
+                "failed power refresh changed cached state: ret=%d calls=%d\n",
+                ret, powerstat_calls);
+        goto done;
+    }
+
+    powerstat_retcode = RIG_OK;
+    ((struct rig_caps *)rig->caps)->get_powerstat = saved_get_powerstat;
 
     ret = parse_secure_network_command(rig, "\\hamlib_version\n", &connection);
 
@@ -301,10 +1002,24 @@ static int check_password_authorization(RIG *rig)
     {
         fprintf(stderr, "authenticated hamlib_version: expected success, got %d\n",
                 ret);
-        return 1;
+        goto done;
     }
 
-    return 0;
+    if (HAMLIB_STATE(rig)->comm_state == 0)
+    {
+        fprintf(stderr, "authenticated protected command did not open the rig\n");
+        goto done;
+    }
+
+    result = 0;
+
+done:
+    ((struct rig_caps *)rig->caps)->rig_open = saved_rig_open;
+    ((struct rig_caps *)rig->caps)->get_powerstat = saved_get_powerstat;
+    powerstat_retcode = RIG_OK;
+    checking_halt_authorization = 0;
+    is_rigctld = 0;
+    return result;
 }
 
 static int check_send_command(RIG *rig, const char *command,
@@ -579,7 +1294,13 @@ int main(void)
     rigctl_parse_init();
     atexit(fail_if_halt_exits);
 
-    if (check_password_authorization(rig) != 0)
+    if (check_client_pool() != 0 || check_authentication_deadline() != 0
+            || check_client_pool_shutdown() != 0
+            || check_sensitive_write() != 0
+            || check_startup_argument_redaction() != 0
+            || check_socket_timeouts() != 0
+            || check_password_authorization(rig) != 0
+       )
     {
         rig_cleanup(rig);
         return 1;


### PR DESCRIPTION
The password feature was re-enabled with authorization inferred from command argument labels. Commands with no first argument, including `halt`, and VFO-labelled commands could therefore run before authentication. The 32-character secret printed at startup also did not match what the verifier accepted, so the displayed credential could not authenticate.

Use an explicit pre-authentication flag for `password`, `chk_vfo`, and `dump_state`, which existing netrigctl clients need during the opening handshake. Every other command is rejected before it can open, recover, or operate the rig.

Derive one stable 32-character bearer secret at startup, retain that exact value, require an exact-length submission, and compare it without content-dependent early exit. Authentication remains isolated per connection, and the generated credential is no longer written to settings automatically.

Unauthenticated connections now have an absolute 30-second authentication deadline and are closed after five failed password or unauthorized command attempts. Client slots are bounded, socket ownership is coordinated with the authentication watchdog, and daemon shutdown waits for connection workers before releasing shared rig state.

Credential-bearing arguments are redacted from normal diagnostics and startup logging. `rigctltcp` no longer exposes its incomplete `-A` path. The rigctld documentation now describes the supported handshake and makes clear that the reusable bearer secret is sent over plaintext TCP and should be used only on a trusted network or through a secure tunnel.

Validated with a full build, ten repeated focused parser and lifecycle test runs, and `make check` (1/1 C++ tests, 22/22 main tests, and 11/11 streaming tests passed).

Closes #2065.
