### PR TITLE
fix(yaesu): preserve legacy NewCAT bandwidth handling

### DIFF
--- a/rigs/yaesu/newcat.c
+++ b/rigs/yaesu/newcat.c
@@ -717,6 +717,41 @@ static int newcat_get_index_from_width(pbwidth_t width, const struct newcat_widt
     return info->count - 1; // Not found, use the maximum
 }
 
+static const struct newcat_width_info *newcat_width_info_for_mode(
+    const struct newcat_priv_caps *priv_caps, rmode_t mode)
+{
+    if (priv_caps == NULL)
+    {
+        return NULL;
+    }
+
+    switch (mode)
+    {
+    case RIG_MODE_RTTY:
+    case RIG_MODE_RTTYR:
+        if (priv_caps->rtty_widths != NULL)
+        {
+            return priv_caps->rtty_widths;
+        }
+
+        HL_FALLTHROUGH
+
+    case RIG_MODE_PKTUSB:
+    case RIG_MODE_PKTLSB:
+    case RIG_MODE_CW:
+    case RIG_MODE_CWR:
+    case RIG_MODE_PSK:
+        return priv_caps->cw_widths;
+
+    case RIG_MODE_LSB:
+    case RIG_MODE_USB:
+        return priv_caps->ssb_widths;
+
+    default:
+        return &dummy_widths;
+    }
+}
+
 /*
  * ************************************
  *
@@ -8712,41 +8747,7 @@ int newcat_set_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t width)
 
     // NOTE: RIG_PASSBAND_NORMAL (0) should select the default filter width (SH00)
 
-    // Preselect set of possible widths
-    switch (mode)
-    {
-    case RIG_MODE_RTTY:
-    case RIG_MODE_RTTYR:
-        width_info = priv_caps->rtty_widths;  // Set RTTY data if different
-        HL_FALLTHROUGH                        // Fall into CW
-    case RIG_MODE_PKTUSB:
-    case RIG_MODE_PKTLSB:
-    case RIG_MODE_CW:
-    case RIG_MODE_CWR:
-    case RIG_MODE_PSK:     // For FTX-1
-        if (width_info == NULL)
-        {
-            width_info = priv_caps->cw_widths;
-        }
-        break;
-
-    case RIG_MODE_LSB:
-    case RIG_MODE_USB:
-        width_info = priv_caps->ssb_widths;
-        break;
-
-#if 0
-    case RIG_MODE_AM:
-    case RIG_MODE_FM:
-    case RIG_MODE_PKTFM:
-    case RIG_MODE_FMN:
-        //????
-        break;
-#endif
-    default:
-        width_info = &dummy_widths;  // Just in case...
-
-    }
+    width_info = newcat_width_info_for_mode(priv_caps, mode);
 
     if (is_ft950)
     {
@@ -9449,40 +9450,7 @@ int newcat_get_rx_bandwidth(RIG *rig, vfo_t vfo, rmode_t mode, pbwidth_t *width)
         main_sub_vfo = (RIG_VFO_B == vfo || RIG_VFO_SUB == vfo) ? '1' : '0';
     }
 
-    // Preselect set of possible widths
-    switch (mode)
-    {
-    case RIG_MODE_RTTY:
-    case RIG_MODE_RTTYR:
-        width_info = priv_caps->rtty_widths;  // Set RTTY data if different
-        HL_FALLTHROUGH                        // Fall into CW
-    case RIG_MODE_PKTUSB:
-    case RIG_MODE_PKTLSB:
-    case RIG_MODE_CW:
-    case RIG_MODE_CWR:
-    case RIG_MODE_PSK:     // For FTX-1
-        if (width_info == NULL)
-        {
-            width_info = priv_caps->cw_widths;
-        }
-        break;
-
-    case RIG_MODE_LSB:
-    case RIG_MODE_USB:
-        width_info = priv_caps->ssb_widths;
-        break;
-
-#if 0
-    case RIG_MODE_AM:
-    case RIG_MODE_FM:
-    case RIG_MODE_PKTFM:
-    case RIG_MODE_FMN:
-        //????
-        break;
-#endif
-    default:
-        width_info = &dummy_widths;  // Just in case...
-    }
+    width_info = newcat_width_info_for_mode(priv_caps, mode);
 
     if (sh_command_valid)
     {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -29,6 +29,7 @@ DIRECT_TESTS = \
 	testguohetec \
 	testicomfallback \
 	testicomts \
+	testnewcatwidth \
 	testnewcatset \
 	testrigctlprotocol \
 	testthd7x \
@@ -124,6 +125,7 @@ testid5100_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
 testnewcatset_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
 testicomfallback_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
 testelecraftvfo_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
+testnewcatwidth_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
 testicomts_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/rigs/icom
 testid5100_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/rigs/icom
 testicomfallback_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/rigs/icom
@@ -168,6 +170,7 @@ testftx1parsers_LDADD = $(top_builddir)/rigs/yaesu/libhamlib-yaesu.la $(LDADD)
 testft991idmeter_LDADD = $(top_builddir)/rigs/yaesu/libhamlib-yaesu.la $(LDADD)
 testguohetec_LDADD = $(PTHREAD_LIBS) $(top_builddir)/rigs/guohetec/libhamlib-guohetec.la $(LDADD)
 testnewcatset_LDADD = $(NET_LIBS) $(PTHREAD_LIBS) $(top_builddir)/rigs/yaesu/libhamlib-yaesu.la $(LDADD)
+testnewcatwidth_LDADD = $(PTHREAD_LIBS) $(top_builddir)/rigs/yaesu/libhamlib-yaesu.la $(LDADD)
 if TESTS_HAVE_LIBUSB
     rigtestlibusb_LDADD = $(LIBUSB_LIBS)
 endif

--- a/tests/testnewcatwidth.c
+++ b/tests/testnewcatwidth.c
@@ -1,0 +1,286 @@
+/*
+ * Hamlib Yaesu NewCAT legacy bandwidth tests
+ * Copyright (c) 2026 by Hamlib Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+#ifdef _WIN32
+
+#include <stdio.h>
+
+int main(void)
+{
+    printf("testnewcatwidth: skipped, requires socketpair()\n");
+    return 77;
+}
+
+#else
+
+#include <poll.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "hamlib/rig.h"
+#include "hamlib/port.h"
+#include "hamlib/rig_state.h"
+
+extern struct rig_caps ft450_caps;
+extern struct rig_caps ft9000_caps;
+
+enum test_operation
+{
+    TEST_SET_MODE,
+    TEST_GET_MODE
+};
+
+struct peer_case
+{
+    int fd;
+    const char *mode_command;
+    const char *mode_response;
+    const char *width_command;
+    const char *width_response;
+    int status;
+};
+
+struct width_case
+{
+    const char *name;
+    rig_model_t model;
+    enum test_operation operation;
+    rmode_t mode;
+    pbwidth_t width;
+    const char *mode_command;
+    const char *mode_response;
+    const char *width_command;
+    const char *width_response;
+};
+
+static int read_frame(int fd, char *buffer, size_t capacity)
+{
+    size_t used = 0;
+
+    while (used + 1 < capacity)
+    {
+        struct pollfd descriptor = { .fd = fd, .events = POLLIN };
+        ssize_t count;
+
+        if (poll(&descriptor, 1, 2000) != 1)
+        {
+            return -1;
+        }
+
+        count = read(fd, buffer + used, 1);
+
+        if (count != 1)
+        {
+            return -1;
+        }
+
+        if (buffer[used++] == ';')
+        {
+            buffer[used] = '\0';
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
+static int write_all(int fd, const char *buffer)
+{
+    size_t length = strlen(buffer);
+    size_t written = 0;
+
+    while (written < length)
+    {
+        ssize_t count = write(fd, buffer + written, length - written);
+
+        if (count <= 0)
+        {
+            return -1;
+        }
+
+        written += (size_t)count;
+    }
+
+    return 0;
+}
+
+static int exchange(int fd, const char *expected, const char *response)
+{
+    char command[32];
+
+    if (read_frame(fd, command, sizeof(command)) != 0
+            || strcmp(command, expected) != 0)
+    {
+        return -1;
+    }
+
+    if (response != NULL && write_all(fd, response) != 0)
+    {
+        return -1;
+    }
+
+    return 0;
+}
+
+static void *run_peer(void *arg)
+{
+    struct peer_case *test = arg;
+
+    test->status = -1;
+
+    if (exchange(test->fd, test->mode_command,
+                 test->mode_response) != 0
+            || exchange(test->fd, test->width_command,
+                        test->width_response) != 0)
+    {
+        return NULL;
+    }
+
+    test->status = 0;
+    return NULL;
+}
+
+static int run_case(const struct width_case *test_case)
+{
+    int sockets[2];
+    pthread_t thread;
+    struct peer_case peer =
+    {
+        .fd = -1,
+        .mode_command = test_case->mode_command,
+        .mode_response = test_case->mode_response,
+        .width_command = test_case->width_command,
+        .width_response = test_case->width_response,
+        .status = -1
+    };
+    RIG *rig;
+    rmode_t mode = test_case->mode;
+    pbwidth_t width = test_case->width;
+    int retval;
+
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) != 0)
+    {
+        perror("socketpair");
+        return 1;
+    }
+
+    rig = rig_init(test_case->model);
+
+    if (rig == NULL)
+    {
+        close(sockets[0]);
+        close(sockets[1]);
+        return 1;
+    }
+
+    RIGPORT(rig)->fd = sockets[0];
+    RIGPORT(rig)->timeout = 100;
+    RIGPORT(rig)->retry = 0;
+    STATE(rig)->powerstat = RIG_POWER_ON;
+    peer.fd = sockets[1];
+
+    if (pthread_create(&thread, NULL, run_peer, &peer) != 0)
+    {
+        RIGPORT(rig)->fd = -1;
+        rig_cleanup(rig);
+        close(sockets[0]);
+        close(sockets[1]);
+        return 1;
+    }
+
+    if (test_case->operation == TEST_SET_MODE)
+    {
+        retval = rig->caps->set_mode(rig, RIG_VFO_A, mode, width);
+    }
+    else
+    {
+        mode = RIG_MODE_NONE;
+        width = RIG_PASSBAND_NORMAL;
+        retval = rig->caps->get_mode(rig, RIG_VFO_A, &mode, &width);
+    }
+
+    pthread_join(thread, NULL);
+    RIGPORT(rig)->fd = -1;
+    rig_cleanup(rig);
+    close(sockets[0]);
+    close(sockets[1]);
+
+    if (peer.status != 0 || retval != RIG_OK
+            || mode != test_case->mode || width != test_case->width)
+    {
+        fprintf(stderr,
+                "%s: expected %d/%s/%d, got %d/%s/%d (peer %d)\n",
+                test_case->name, RIG_OK, rig_strrmode(test_case->mode),
+                (int)test_case->width, retval, rig_strrmode(mode),
+                (int)width, peer.status);
+        return 1;
+    }
+
+    return 0;
+}
+
+int main(void)
+{
+    static const struct width_case cases[] =
+    {
+        {
+            "FT-450 set USB", RIG_MODEL_FT450, TEST_SET_MODE,
+            RIG_MODE_USB, 2400, "MD02;", NULL, "SH016;", NULL
+        },
+        {
+            "FT-450 get USB", RIG_MODEL_FT450, TEST_GET_MODE,
+            RIG_MODE_USB, 2400, "MD0;", "MD02;", "SH0;", "SH016;"
+        },
+        {
+            "FT-450 set CW", RIG_MODEL_FT450, TEST_SET_MODE,
+            RIG_MODE_CW, 500, "MD03;", NULL, "SH006;", NULL
+        },
+        {
+            "FT-450 get CW", RIG_MODEL_FT450, TEST_GET_MODE,
+            RIG_MODE_CW, 500, "MD0;", "MD03;", "SH0;", "SH006;"
+        },
+        {
+            "FTDX-9000 set USB", RIG_MODEL_FT9000, TEST_SET_MODE,
+            RIG_MODE_USB, 2400, "MD02;", NULL, "SH016;", NULL
+        },
+        {
+            "FTDX-9000 get USB", RIG_MODEL_FT9000, TEST_GET_MODE,
+            RIG_MODE_USB, 2400, "MD0;", "MD02;", "SH0;", "SH016;"
+        },
+        {
+            "FTDX-9000 set CW", RIG_MODEL_FT9000, TEST_SET_MODE,
+            RIG_MODE_CW, 500, "MD03;", NULL, "SH006;", NULL
+        },
+        {
+            "FTDX-9000 get CW", RIG_MODEL_FT9000, TEST_GET_MODE,
+            RIG_MODE_CW, 500, "MD0;", "MD03;", "SH0;", "SH006;"
+        }
+    };
+    size_t i;
+
+    rig_set_debug(RIG_DEBUG_NONE);
+    rig_register(&ft450_caps);
+    rig_register(&ft9000_caps);
+
+    for (i = 0; i < sizeof(cases) / sizeof(cases[0]); i++)
+    {
+        if (run_case(&cases[i]) != 0)
+        {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+#endif /* !_WIN32 */


### PR DESCRIPTION
FT-450, FT-450D, and FTDX9000 do not provide private width tables. NewCAT mode set/get operations dereferenced those missing tables before reaching the existing legacy bandwidth mapping, causing a crash.

Use a shared null-safe selector to preserve the legacy mapping and add socket-backed USB/CW set/get coverage for FT-450 and FTDX9000.

Testing:

- Full build
- `make check TESTS=testnewcatwidth`
- ASan/UBSan focused test
