### PR TITLE
fix(stream): bound resampler ratios and memory use

### DIFF
--- a/HAMLIB_STREAMING.md
+++ b/HAMLIB_STREAMING.md
@@ -303,10 +303,12 @@ Limits: `HAMLIB_MAX_STREAM_RATES = 32`,
   effective rates equal the native rates): the native rates, plus the
   curated standard rates {8000, 11025, 16000, 22050, 24000, 44100,
   48000, 96000, 192000}, plus every exact integer division (factors
-  2…10) of each native rate. Deduplicated, ascending, bounded by the
-  largest native rate: audio up to and including it, I/Q strictly below
-  it (an I/Q stream's sample rate is its represented bandwidth, so
-  upsampling past the hardware cannot create information).
+  2…10) of each native rate. Candidates outside libsamplerate's
+  single-stage 1/256…256 conversion-ratio range are omitted. The result
+  is deduplicated, ascending, and bounded by the largest native rate:
+  audio up to and including it, I/Q strictly below it (an I/Q stream's
+  sample rate is its represented bandwidth, so upsampling past the
+  hardware cannot create information).
 - **Channels:** the declared list is exact — the effective list equals
   the native list, and unlisted counts are never invented (a device may
   genuinely support only very specific counts, which is exactly what the
@@ -349,14 +351,16 @@ the server advertises already reflects whether its resampler is present.
 
 **Acceptance at `rig_stream_open()` is by rule, not by list membership** —
 the advertised effective list is for discoverability. Any rate at or
-below the largest native rate is accepted when the resampler is built,
-listed or not (e.g. an arbitrary 22 222 Hz). The frontend resolves the
-request to a native source: format prefers the float format (lossless
-staging), then S16, then the lowest declared bit; the rate source is the
-smallest native rate ≥ the request; and a conversion pipeline is
-installed between that source and the stream. Requests beyond the rules
-(a rate above the largest native rate, an I/Q format on an audio stream,
-more channels than the mapping allows) fail with `-RIG_EINVAL`.
+below the largest native rate is accepted when the resampler is built and
+the selected native/requested pair is within libsamplerate's single-stage
+1/256…256 ratio range, listed or not (e.g. an arbitrary 22 222 Hz). The
+frontend resolves the request to a native source: format prefers the float
+format (lossless staging), then S16, then the lowest declared bit; the rate
+source is the smallest native rate ≥ the request; and a conversion pipeline
+is installed between that source and the stream. Requests beyond the rules
+(an unsupported conversion ratio, a rate above the largest native rate, an
+I/Q format on an audio stream, or more channels than the mapping allows)
+fail with `-RIG_EINVAL`.
 
 `rig_stream_get_conversions()` reports the installed stages
 (`RIG_STREAM_CONV_FORMAT/RATE/CHANNELS`, 0 = native stream). A config
@@ -550,9 +554,10 @@ Semantics:
   (§3.3), resolves the native source the backend will run at, and installs
   any conversion pipeline. It additionally rejects a non-positive
   `sample_rate` or `channels`, an unknown stream type, a `struct_size` of 0,
-  and exhaustion of either the caps `max_streams` limit or the
-  `HAMLIB_MAX_STREAMS` slots for that type — all with `-RIG_EINVAL`. A
-  convertible request with `require_native = 1` fails with `-RIG_ENAVAIL`.
+  a rate conversion outside libsamplerate's supported ratio, and exhaustion
+  of either the caps `max_streams` limit or the `HAMLIB_MAX_STREAMS` slots for
+  that type — all with `-RIG_EINVAL`. A convertible request with
+  `require_native = 1` fails with `-RIG_ENAVAIL`.
 - **close** unregisters the stream, wakes any blocked reader or
   write-status waiter, then waits for every `rig_stream_*` call already in
   flight on that stream to return before the handle is torn down. A

--- a/src/stream.c
+++ b/src/stream.c
@@ -331,11 +331,6 @@ static const int stream_curated_rates[] =
 #define STREAM_MAX_DECIM_FACTOR 10
 #endif
 
-static int stream_type_is_iq_type(rig_stream_type_t type)
-{
-    return type == RIG_STREAM_TYPE_IQ_RX || type == RIG_STREAM_TYPE_IQ_TX;
-}
-
 #ifdef HAVE_SAMPLERATE
 /* Append rate to a 0-terminated list if absent and there is room; the
  * caller adds in priority order, so on overflow the least useful entries
@@ -373,6 +368,8 @@ static int stream_rate_list_max(const int *rates)
 
     return max;
 }
+
+static int stream_rate_source(const int *native_rates, int requested_rate);
 
 #endif /* HAVE_SAMPLERATE */
 
@@ -425,7 +422,7 @@ static void chan_list_add(int *list, int count)
 static void stream_derive_caps(struct rig_stream_caps *dst,
                                const struct rig_stream_caps *src)
 {
-    int is_iq = stream_type_is_iq_type(src->type);
+    int is_iq = stream_type_is_iq(src->type);
 
     *dst = *src;
 
@@ -493,11 +490,11 @@ static void stream_derive_caps(struct rig_stream_caps *dst,
     }
 
 #ifdef HAVE_SAMPLERATE
-    /* Rates (resampler built): native, then curated standards, then
-     * integer divisions of each native rate (factors 2..10, exact results
-     * only) — in that priority order, deduplicated, ascending. This list
-     * is discoverability; acceptance at open is rule-based. Audio may go
-     * up to the largest native rate, I/Q only strictly below it
+    /* Rates (resampler built): native, then reachable curated standards,
+     * then integer divisions of each native rate (factors 2..10, exact
+     * results only) — in that priority order, deduplicated, ascending. This
+     * list is discoverability; acceptance at open is rule-based. Audio may
+     * go up to the largest native rate, I/Q only strictly below it
      * (downward-only: the I/Q sample rate is the represented bandwidth).
      * Without the resampler the effective rates equal the native rates. */
     {
@@ -507,8 +504,11 @@ static void stream_derive_caps(struct rig_stream_caps *dst,
         for (int i = 0; stream_curated_rates[i] != 0; i++)
         {
             int r = stream_curated_rates[i];
+            int native_rate = stream_rate_source(src->sample_rates, r);
 
-            if ((is_iq && r < native_max) || (!is_iq && r <= native_max))
+            if (((is_iq && r < native_max) || (!is_iq && r <= native_max))
+                    && native_rate > 0
+                    && stream_conv_rate_supported(native_rate, r))
             {
                 stream_rate_list_add(dst->sample_rates, r);
             }
@@ -815,29 +815,27 @@ static int caps_rate_native(const struct rig_stream_caps *caps, int rate)
     return rate_in_list(caps->sample_rates, rate);
 }
 
-
 #ifdef HAVE_SAMPLERATE
-/* Smallest native rate >= rate (the cheapest downconversion source), or 0
- * when the request exceeds every native rate — the effective set is
- * bounded by the largest native rate for audio and I/Q alike. */
-static int caps_rate_source(const struct rig_stream_caps *caps, int rate)
+/* Smallest native rate at or above the requested rate, or zero. */
+static int stream_rate_source(const int *native_rates, int requested_rate)
 {
     int best = 0;
 
     for (int i = 0; i < HAMLIB_MAX_STREAM_RATES
-            && caps->sample_rates[i] != 0; i++)
+            && native_rates[i] != 0; i++)
     {
-        int r = caps->sample_rates[i];
+        int rate = native_rates[i];
 
-        if (r >= rate && (best == 0 || r < best))
+        if (rate >= requested_rate && (best == 0 || rate < best))
         {
-            best = r;
+            best = rate;
         }
     }
 
     return best;
 }
 #endif
+
 
 /* Resolution for a pre-derived caps entry (native_formats set — a relaying
  * backend such as netrigctl): conversion happens on the far side of the
@@ -938,8 +936,7 @@ static int resolve_stream_source(const struct rig_stream_config *config,
                                  struct rig_stream_config *backend_cfg,
                                  int *conversions)
 {
-    int is_iq = config->type == RIG_STREAM_TYPE_IQ_RX
-                || config->type == RIG_STREAM_TYPE_IQ_TX;
+    int is_iq = stream_type_is_iq(config->type);
     rig_stream_format_t family = is_iq ? STREAM_IQ_FORMAT_MASK
                                  : STREAM_PCM_FORMAT_MASK;
     int conv = RIG_STREAM_CONV_NONE;
@@ -1046,19 +1043,29 @@ static int resolve_stream_source(const struct rig_stream_config *config,
         return RIG_OK;    /* conv stays RIG_STREAM_CONV_NONE */
     }
 
-    /* Rate: native, or (resampler built) any rate up to the largest
-     * native rate — audio and I/Q alike; I/Q upsampling beyond the
-     * hardware is impossible by this bound (sample rate = bandwidth). */
+    /* Rate: native, or any rate that a single resampler stage can convert
+     * against the smallest suitable native source. I/Q remains bounded by
+     * the native bandwidth just like audio is bounded by its largest rate. */
     if (!caps_rate_native(caps, config->sample_rate))
     {
 #ifdef HAVE_SAMPLERATE
-        int src_rate = caps_rate_source(caps, config->sample_rate);
+        int src_rate = stream_rate_source(caps->sample_rates,
+                                          config->sample_rate);
 
         if (src_rate <= 0)
         {
             rig_debug(RIG_DEBUG_ERR,
                       "%s: rate %d exceeds the largest native rate\n",
                       __func__, config->sample_rate);
+            return -RIG_EINVAL;
+        }
+
+        if (!stream_conv_rate_supported(src_rate, config->sample_rate))
+        {
+            rig_debug(RIG_DEBUG_ERR,
+                      "%s: rate conversion %d <-> %d exceeds the "
+                      "resampler ratio limit\n",
+                      __func__, config->sample_rate, src_rate);
             return -RIG_EINVAL;
         }
 
@@ -1292,10 +1299,9 @@ int HAMLIB_API rig_stream_open(RIG *rig,
     s->backend_config = backend_cfg;
     s->conversions = conversions;
 
-    /* The ring buffer holds the CONSUMER's format: the client's request on
+    /* The ring buffer holds the consumer's format: the client's request on
      * RX, the backend-native side on TX. */
-    int is_rx = config->type == RIG_STREAM_TYPE_AUDIO_RX
-                || config->type == RIG_STREAM_TYPE_IQ_RX;
+    int is_rx = stream_type_is_rx(config->type);
     const struct rig_stream_config *ring_cfg = is_rx ? config
                                                : &s->backend_config;
 
@@ -1324,40 +1330,28 @@ int HAMLIB_API rig_stream_open(RIG *rig,
      * reported), so no local pipeline is installed for it. */
     if (conversions != RIG_STREAM_CONV_NONE && found_caps->native_formats == 0)
     {
-        int is_iq = config->type == RIG_STREAM_TYPE_IQ_RX
-                    || config->type == RIG_STREAM_TYPE_IQ_TX;
+        int is_iq = stream_type_is_iq(config->type);
         int quality = stream_resample_quality(rig);
-        int conv_ret;
+        const struct rig_stream_config *src_cfg = is_rx ? &backend_cfg
+                : config;
+        const struct rig_stream_config *dst_cfg = is_rx ? config
+                : &backend_cfg;
+        int conv_ret = stream_conv_init(&s->conv,
+                                        src_cfg->format,
+                                        src_cfg->sample_rate,
+                                        src_cfg->channels,
+                                        dst_cfg->format,
+                                        dst_cfg->sample_rate,
+                                        dst_cfg->channels, is_iq, quality);
 
-        if (is_rx)
-        {
-            conv_ret = stream_conv_init(&s->conv,
-                                        backend_cfg.format,
-                                        backend_cfg.sample_rate,
-                                        backend_cfg.channels,
-                                        config->format,
-                                        config->sample_rate,
-                                        config->channels, is_iq, quality);
-        }
-        else
-        {
-            conv_ret = stream_conv_init(&s->conv,
-                                        config->format,
-                                        config->sample_rate,
-                                        config->channels,
-                                        backend_cfg.format,
-                                        backend_cfg.sample_rate,
-                                        backend_cfg.channels, is_iq, quality);
-        }
-
-        if (conv_ret != 0)
+        if (conv_ret != RIG_OK)
         {
             rig_debug(RIG_DEBUG_ERR,
                       "%s: conversion pipeline init failed (0x%x)\n",
                       __func__, conversions);
             free(s);
             pthread_mutex_unlock(&ss->stream_mutex);
-            return -RIG_ENOMEM;
+            return conv_ret;
         }
     }
 
@@ -1444,7 +1438,11 @@ static size_t conv_ring_sink(void *ctx, const void *buf, size_t len)
 {
     struct rig_stream *s = ctx;
 
-    return stream_ringbuf_write(&s->ringbuf, buf, len);
+    stream_ringbuf_write(&s->ringbuf, buf, len);
+
+    /* The overwrite ring consumes the full producer span even when only its
+     * last capacity bytes remain readable. */
+    return len;
 }
 
 size_t stream_backend_write(struct rig_stream *stream, const void *buf,

--- a/src/stream_convert.c
+++ b/src/stream_convert.c
@@ -31,10 +31,15 @@
 #endif
 
 #include "stream_convert.h"
+#include <limits.h>
 #include <math.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef HAVE_SAMPLERATE
+#include <samplerate.h>
+#endif
 
 /* The sample converters dereference multi-byte samples in host byte order and
  * perform no byte swapping, so the little-endian wire payload is only correct
@@ -734,8 +739,26 @@ int rig_stream_convert_channels(const void *src, int src_channels,
 /* rig_stream_resample — sample rate conversion (requires libsamplerate) */
 /* ------------------------------------------------------------------ */
 
+int stream_conv_rate_supported(int src_rate, int dst_rate)
+{
+    if (src_rate <= 0 || dst_rate <= 0)
+    {
+        return 0;
+    }
+
+    if (src_rate == dst_rate)
+    {
+        return 1;
+    }
+
 #ifdef HAVE_SAMPLERATE
-#include <samplerate.h>
+    return src_is_valid_ratio((double)dst_rate / (double)src_rate);
+#else
+    return 0;
+#endif
+}
+
+#ifdef HAVE_SAMPLERATE
 
 /* Map Hamlib quality constants to libsamplerate converter types. */
 static int resample_converter_type(int quality)
@@ -803,9 +826,9 @@ int rig_stream_resample(const float *src, int src_rate,
 /* Persistent per-stream conversion context (stream_conv)              */
 /* ------------------------------------------------------------------ */
 
-/* Frames processed per pipeline pass; bounds the scratch buffers while
- * arbitrarily large writes stream through in slices. */
+/* Frames processed per pipeline pass; bounds scratch working-set growth. */
 #define STREAM_CONV_CHUNK_FRAMES 1024
+#define STREAM_CONV_MAX_SCRATCH_BYTES (16U * 1024U * 1024U)
 
 struct stream_conv
 {
@@ -875,9 +898,16 @@ int stream_conv_init(struct stream_conv **out,
                      rig_stream_format_t dst_fmt, int dst_rate, int dst_ch,
                      int is_iq, int quality)
 {
-    if (!out || src_rate <= 0 || dst_rate <= 0 || src_ch <= 0 || dst_ch <= 0)
+    if (!out)
     {
-        return -1;
+        return -RIG_EINVAL;
+    }
+
+    *out = NULL;
+
+    if (src_rate <= 0 || dst_rate <= 0 || src_ch <= 0 || dst_ch <= 0)
+    {
+        return -RIG_EINVAL;
     }
 
     int src_ss = rig_stream_format_sample_size(src_fmt);
@@ -885,23 +915,25 @@ int stream_conv_init(struct stream_conv **out,
 
     if (src_ss <= 0 || dst_ss <= 0)
     {
-        return -1;  /* compressed/unknown formats are not convertible */
+        return -RIG_EINVAL;
     }
 
-#ifndef HAVE_SAMPLERATE
-
-    if (src_rate != dst_rate)
+    if (!stream_conv_rate_supported(src_rate, dst_rate))
     {
-        return -1;  /* rate conversion requires libsamplerate */
+        return -RIG_EINVAL;
     }
 
-#endif
+    if (src_ch > INT_MAX / src_ss || dst_ch > INT_MAX / dst_ss
+            || (is_iq && src_rate != dst_rate && dst_ch > INT_MAX / 2))
+    {
+        return -RIG_EINVAL;
+    }
 
     struct stream_conv *c = calloc(1, sizeof(*c));
 
     if (!c)
     {
-        return -1;
+        return -RIG_ENOMEM;
     }
 
     c->src_fmt = src_fmt;
@@ -916,14 +948,10 @@ int stream_conv_init(struct stream_conv **out,
     c->pivot_fmt = is_iq ? RIG_STREAM_FORMAT_IQ_CF32
                    : RIG_STREAM_FORMAT_PCM_F32;
 
-    /* Output frames a full input chunk can produce (+margin for the
-     * resampler's internal state). Source selection keeps dst <= src rate,
-     * but size for either direction to stay safe. */
     double ratio = (double)dst_rate / (double)src_rate;
     c->out_cap_frames = (size_t)((double)STREAM_CONV_CHUNK_FRAMES
                                  * (ratio > 1.0 ? ratio : 1.0)) + 64;
 
-    /* Scratch sized for the widest stage across the whole pipeline. */
     int pivot_ss = rig_stream_format_sample_size(c->pivot_fmt);
     size_t worst_frame = (size_t)src_ch * src_ss;
 
@@ -942,16 +970,23 @@ int stream_conv_init(struct stream_conv **out,
         worst_frame = c->dst_frame_bytes;
     }
 
-    size_t worst_frames = STREAM_CONV_CHUNK_FRAMES > c->out_cap_frames
-                          ? STREAM_CONV_CHUNK_FRAMES : c->out_cap_frames;
-    c->buf_bytes = worst_frames * worst_frame;
+    size_t scratch_frames = STREAM_CONV_CHUNK_FRAMES > c->out_cap_frames
+                            ? STREAM_CONV_CHUNK_FRAMES : c->out_cap_frames;
+
+    if (worst_frame > STREAM_CONV_MAX_SCRATCH_BYTES / scratch_frames)
+    {
+        free(c);
+        return -RIG_EINVAL;
+    }
+
+    c->buf_bytes = scratch_frames * worst_frame;
     c->buf_a = malloc(c->buf_bytes);
     c->buf_b = malloc(c->buf_bytes);
 
     if (!c->buf_a || !c->buf_b)
     {
         stream_conv_free(c);
-        return -1;
+        return -RIG_ENOMEM;
     }
 
 #ifdef HAVE_SAMPLERATE
@@ -970,14 +1005,14 @@ int stream_conv_init(struct stream_conv **out,
         if (!c->src_state)
         {
             stream_conv_free(c);
-            return -1;
+            return -RIG_EINVAL;
         }
     }
 
 #endif
 
     *out = c;
-    return 0;
+    return RIG_OK;
 }
 
 void stream_conv_free(struct stream_conv *c)
@@ -1143,5 +1178,3 @@ ssize_t stream_conv_process(struct stream_conv *c, const void *buf,
 
     return (ssize_t)(consumed_frames * c->src_frame_bytes);
 }
-
-

--- a/src/stream_convert.h
+++ b/src/stream_convert.h
@@ -73,6 +73,9 @@ int rig_stream_resample(const float *src, int src_rate,
                         size_t src_samples, size_t *dst_samples,
                         int channels, int quality);
 
+/* Return non-zero when one conversion stage can serve the rate pair. */
+int stream_conv_rate_supported(int src_rate, int dst_rate);
+
 /* --- Persistent per-stream conversion context (frontend data path) --- */
 
 /* Opaque context carrying the stream's conversion pipeline state: scratch
@@ -92,8 +95,9 @@ typedef size_t (*stream_conv_sink_fn)(void *ctx, const void *buf,
  * channels when narrowing from more; I/Q only selects a subset. Rate
  * conversion requires libsamplerate (fails otherwise) and resamples I/Q
  * as interleaved I/Q float pairs; quality is the RIG_RESAMPLE_* sinc
- * converter to use (ignored without rate conversion). Returns 0 and
- * sets *out, or -1. */
+ * converter to use (ignored without rate conversion). Returns RIG_OK and
+ * sets *out, -RIG_EINVAL for unsupported geometry or resampler setup, or
+ * -RIG_ENOMEM when Hamlib scratch allocation fails. */
 int stream_conv_init(struct stream_conv **out,
                      rig_stream_format_t src_fmt, int src_rate, int src_ch,
                      rig_stream_format_t dst_fmt, int dst_rate, int dst_ch,

--- a/test/test_stream_api.c
+++ b/test/test_stream_api.c
@@ -315,6 +315,47 @@ static struct rig_caps stub_caps_codec_stream =
     .stream_close = stub_stream_close,
 };
 
+/* A native rate chosen so 8000 Hz is just outside libsamplerate's
+ * single-stage ratio range while nearby standard and arbitrary rates remain
+ * reachable. Both directions exercise RX downsampling and TX upsampling. */
+static const struct rig_stream_caps stub_ratio_stream_caps[] =
+{
+    {
+        .type = RIG_STREAM_TYPE_AUDIO_RX,
+        .formats = RIG_STREAM_FORMAT_PCM_F32,
+        .sample_rates = { 2056000, 0 },
+        .channels = { 1, 0 },
+        .max_streams = 1,
+    },
+    {
+        .type = RIG_STREAM_TYPE_AUDIO_TX,
+        .formats = RIG_STREAM_FORMAT_PCM_F32,
+        .sample_rates = { 2056000, 0 },
+        .channels = { 1, 0 },
+        .max_streams = 1,
+    },
+    { 0 }
+};
+
+static struct rig_caps stub_caps_ratio_stream =
+{
+    .rig_model = 7,
+    .model_name = "Stub Ratio Stream",
+    .mfg_name = "Test",
+    .version = "1.0",
+    .status = RIG_STATUS_STABLE,
+    .rig_type = RIG_TYPE_TRANSCEIVER,
+    .port_type = RIG_PORT_NONE,
+    .timeout = 1000,
+    .retry = 0,
+    .stream_caps = stub_ratio_stream_caps,
+    .rig_init = stub_rig_init,
+    .rig_cleanup = stub_rig_cleanup,
+    .rig_open = stub_rig_open,
+    .rig_close = stub_rig_close,
+    .stream_open = stub_stream_open,
+    .stream_close = stub_stream_close,
+};
 
 /* Helper: set up a RIG with the given caps, call rig_open-equivalent init. */
 static RIG *setup_rig(struct rig_caps *caps)
@@ -494,6 +535,87 @@ void test_caps_derived_rates(void)
     TEST_CHECK(iq->sample_rates[2] == 0);
 #endif
 
+    teardown_rig(rig);
+}
+
+void test_rate_ratio_limits(void)
+{
+    RIG *rig = setup_rig(&stub_caps_ratio_stream);
+    TEST_ASSERT(rig != NULL);
+
+    const struct rig_stream_caps *rx = rig_stream_caps_at(rig, 0);
+    const struct rig_stream_caps *tx = rig_stream_caps_at(rig, 1);
+    TEST_ASSERT(rx != NULL && tx != NULL);
+
+#ifdef HAVE_SAMPLERATE
+    TEST_CHECK(!rate_in_list(rx->sample_rates, 8000));
+    TEST_CHECK(!rate_in_list(tx->sample_rates, 8000));
+    TEST_CHECK(rate_in_list(rx->sample_rates, 11025));
+    TEST_CHECK(rate_in_list(tx->sample_rates, 11025));
+#endif
+
+    struct rig_stream_config *cfg = rig_stream_config_alloc();
+    TEST_ASSERT(cfg != NULL);
+    cfg->format = RIG_STREAM_FORMAT_PCM_F32;
+    cfg->channels = 1;
+    cfg->buffer_bytes = 64;
+
+    static const rig_stream_type_t types[] =
+    {
+        RIG_STREAM_TYPE_AUDIO_RX,
+        RIG_STREAM_TYPE_AUDIO_TX,
+    };
+    static const struct
+    {
+        int rate;
+        int expected;
+    } cases[] =
+    {
+        { 8000, -RIG_EINVAL },
+#ifdef HAVE_SAMPLERATE
+        { 22222, RIG_OK },
+#else
+        { 22222, -RIG_EINVAL },
+#endif
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++)
+    {
+        cfg->sample_rate = cases[i].rate;
+
+        for (size_t j = 0; j < sizeof(types) / sizeof(types[0]); j++)
+        {
+            rig_stream_t *stream = NULL;
+            cfg->type = types[j];
+            int ret = rig_stream_open(rig, cfg, &stream);
+            TEST_CHECK(ret == cases[i].expected);
+
+            if (ret == RIG_OK)
+            {
+                TEST_ASSERT(stream != NULL);
+                TEST_CHECK(rig_stream_get_conversions(stream)
+                           == RIG_STREAM_CONV_RATE);
+
+                if (types[j] == RIG_STREAM_TYPE_AUDIO_TX)
+                {
+                    float input[1024] = { 0 };
+                    size_t written = 0;
+                    TEST_CHECK(rig_stream_write(rig, stream, input,
+                                                sizeof(input), &written,
+                                                0, NULL) == RIG_OK);
+                    TEST_CHECK(written == sizeof(input));
+                }
+
+                rig_stream_close(rig, stream);
+            }
+            else
+            {
+                TEST_CHECK(stream == NULL);
+            }
+        }
+    }
+
+    rig_stream_config_free(cfg);
     teardown_rig(rig);
 }
 
@@ -2387,6 +2509,7 @@ TEST_LIST =
     { "get_stream_caps",          test_get_stream_caps },
     { "caps_derived_formats",     test_caps_derived_formats },
     { "caps_derived_rates",       test_caps_derived_rates },
+    { "rate_ratio_limits",        test_rate_ratio_limits },
     { "caps_derived_channels",    test_caps_derived_channels },
     { "channel_list_exact",       test_channel_list_exact },
     { "codec_format_native_only", test_codec_format_native_only },

--- a/test/test_stream_convert.c
+++ b/test/test_stream_convert.c
@@ -29,6 +29,7 @@
 #include "acutest.h"
 #include "test_debug.h"
 #include "stream_convert.h"
+#include <stdint.h>
 #include <string.h>
 #include <math.h>
 
@@ -698,6 +699,104 @@ void test_resample_quality_levels(void)
     }
 }
 
+#ifdef HAVE_SAMPLERATE
+struct counting_sink
+{
+    size_t bytes;
+};
+
+static size_t count_converted_bytes(void *ctx, const void *buf, size_t len)
+{
+    struct counting_sink *sink = ctx;
+    (void)buf;
+    sink->bytes += len;
+    return len;
+}
+#endif
+
+void test_conversion_context_rate_bounds(void)
+{
+    struct stream_conv *conv = NULL;
+
+    TEST_CHECK(stream_conv_rate_supported(48000, 48000));
+    TEST_CHECK(!stream_conv_rate_supported(0, 48000));
+    TEST_CHECK(!stream_conv_rate_supported(48000, 0));
+
+#ifdef HAVE_SAMPLERATE
+    TEST_CHECK(stream_conv_rate_supported(1, 256));
+    TEST_CHECK(stream_conv_rate_supported(256, 1));
+    TEST_CHECK(!stream_conv_rate_supported(1, 257));
+    TEST_CHECK(!stream_conv_rate_supported(257, 1));
+    TEST_CHECK(!stream_conv_rate_supported(1, 24000));
+
+    TEST_CHECK(stream_conv_init(&conv,
+                                RIG_STREAM_FORMAT_PCM_F32, 1, 1,
+                                RIG_STREAM_FORMAT_PCM_F32, 256, 1,
+                                0, RIG_RESAMPLE_FAST) == RIG_OK);
+    TEST_ASSERT(conv != NULL);
+
+    float upsample_input[1024] = { 0 };
+    struct counting_sink sink = { 0 };
+    TEST_CHECK(stream_conv_process(conv, upsample_input,
+                                   sizeof(upsample_input),
+                                   count_converted_bytes, &sink)
+               == (ssize_t)sizeof(upsample_input));
+    TEST_CHECK(sink.bytes > 0);
+    stream_conv_free(conv);
+    conv = NULL;
+
+    TEST_CHECK(stream_conv_init(&conv,
+                                RIG_STREAM_FORMAT_PCM_F32, 256, 1,
+                                RIG_STREAM_FORMAT_PCM_F32, 1, 1,
+                                0, RIG_RESAMPLE_FAST) == RIG_OK);
+    TEST_ASSERT(conv != NULL);
+
+    float downsample_input[4096] = { 0 };
+    sink.bytes = 0;
+    TEST_CHECK(stream_conv_process(conv, downsample_input,
+                                   sizeof(downsample_input),
+                                   count_converted_bytes, &sink)
+               == (ssize_t)sizeof(downsample_input));
+    stream_conv_free(conv);
+    conv = NULL;
+
+    /* The exact ratio limit remains available for current four-channel IQ. */
+    TEST_CHECK(stream_conv_init(&conv,
+                                RIG_STREAM_FORMAT_IQ_CF32, 1, 4,
+                                RIG_STREAM_FORMAT_IQ_CF32, 256, 4,
+                                1, RIG_RESAMPLE_FAST) == RIG_OK);
+    TEST_ASSERT(conv != NULL);
+    stream_conv_free(conv);
+    conv = NULL;
+
+    /* Supported ratios still have to fit the scratch working-set limit. */
+    TEST_CHECK(stream_conv_init(&conv,
+                                RIG_STREAM_FORMAT_IQ_CF32, 1, 64,
+                                RIG_STREAM_FORMAT_IQ_CF32, 256, 64,
+                                1, RIG_RESAMPLE_FAST) == -RIG_EINVAL);
+    TEST_CHECK(conv == NULL);
+#else
+    TEST_CHECK(!stream_conv_rate_supported(1, 256));
+    TEST_CHECK(!stream_conv_rate_supported(256, 1));
+#endif
+
+    TEST_CHECK(stream_conv_init(&conv,
+                                RIG_STREAM_FORMAT_PCM_F32, 1, 1,
+                                RIG_STREAM_FORMAT_PCM_F32, 257, 1,
+                                0, RIG_RESAMPLE_FAST) == -RIG_EINVAL);
+    TEST_CHECK(conv == NULL);
+    TEST_CHECK(stream_conv_init(&conv,
+                                RIG_STREAM_FORMAT_PCM_F32, 257, 1,
+                                RIG_STREAM_FORMAT_PCM_F32, 1, 1,
+                                0, RIG_RESAMPLE_FAST) == -RIG_EINVAL);
+    TEST_CHECK(conv == NULL);
+    TEST_CHECK(stream_conv_init(&conv,
+                                RIG_STREAM_FORMAT_IQ_CF32, 1, 4,
+                                RIG_STREAM_FORMAT_IQ_CF32, 24000, 4,
+                                1, RIG_RESAMPLE_FAST) == -RIG_EINVAL);
+    TEST_CHECK(conv == NULL);
+}
+
 
 TEST_LIST =
 {
@@ -747,5 +846,9 @@ TEST_LIST =
     { "resample_downsample",      test_resample_downsample },
     { "resample_identity",        test_resample_identity },
     { "resample_quality_levels",  test_resample_quality_levels },
+    {
+        "conversion_context_rate_bounds",
+        test_conversion_context_rate_bounds
+    },
     { NULL, NULL }
 };


### PR DESCRIPTION
Very low requested stream rates can create a large upsampling ratio when Hamlib converts a stream to a backend's native rate. The persistent converter sized its scratch buffers from that ratio, allowing disproportionately large memory allocations.

This change rejects rate pairs outside libsamplerate's supported ratio range, caps each resampler scratch buffer at 16 MiB, omits unsupported effective rates from advertised stream capabilities, and validates the limits before allocating conversion state. It also reports overwrite-ring delivery as fully consumed by the producer. The one-shot resampling API remains unchanged.

The affected streaming allocation path was introduced with the initial streaming subsystem in [#2116](https://github.com/Hamlib/Hamlib/pull/2116). Without these bounds, a client able to request a sufficiently low rate could cause excessive memory use, creating a potential resource-exhaustion or denial-of-service risk for an exposed `rigctld` service.

Tested with the complete test suite both with and without libsamplerate support.
