### PR TITLE
fix(usrp): initialize backend state safely

### DIFF
--- a/rigs/kit/usrp_impl.cc
+++ b/rigs/kit/usrp_impl.cc
@@ -27,63 +27,55 @@
 #if defined(HAVE_USRP)
 
 
-#include <stdlib.h>
 #include <stdio.h>
-#include <errno.h>
+#include <new>
 #include <usrp/usrp_standard.h>
 
 #include "usrp_impl.h"
 #include "token.h"
 
 
-struct usrp_priv_data {
-	usrp_standard_rx *urx;
-	usrp_standard_tx *utx;
-	freq_t if_mix_freq;
+struct usrp_priv_data
+{
+    usrp_standard_rx_sptr urx;
+    usrp_standard_tx *utx = nullptr;
+    freq_t if_mix_freq = MHz(45);
 };
 
 
 int usrp_init(RIG *rig)
 {
-    // cppcheck-suppress leakReturnValNotUsed
-	STATE(rig)->priv = static_cast<struct usrp_priv_data*>(malloc(sizeof(struct usrp_priv_data)));
-	if (!STATE(rig)->priv) {
-		/* whoops! memory shortage! */
-		return -RIG_ENOMEM;
-	}
+    struct usrp_priv_data *priv = new (std::nothrow) usrp_priv_data {};
+    STATE(rig)->priv = priv;
 
-	return RIG_OK;
+    if (!priv)
+    {
+        return -RIG_ENOMEM;
+    }
+
+    return RIG_OK;
 }
 
 int usrp_cleanup(RIG *rig)
 {
-	if (!rig)
-		return -RIG_EINVAL;
+    if (!rig)
+    {
+        return -RIG_EINVAL;
+    }
 
-	if (STATE(rig)->priv)
-		free(STATE(rig)->priv);
-	STATE(rig)->priv = NULL;
+    delete static_cast<struct usrp_priv_data *>(STATE(rig)->priv);
+    STATE(rig)->priv = NULL;
 
-	return RIG_OK;
+    return RIG_OK;
 }
 
 int usrp_open(RIG *rig)
 {
-	struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>(STATE(rig)->priv);
+    struct usrp_priv_data *priv = static_cast<struct usrp_priv_data *>(STATE(
+            rig)->priv);
 
-	int which_board = 0;
-	int decim = 125;
-
-	priv->urx = usrp_standard_rx::make (which_board, decim, 1, -1, usrp_standard_rx::FPGA_MODE_NORMAL).get();
-	if (priv->urx == 0)
-		return -RIG_EIO;
-
-	return RIG_OK;
-}
-
-int usrp_close(RIG *rig)
-{
-	struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>(STATE(rig)->priv);
+    int which_board = 0;
+    int decim = 125;
 
     if (!priv)
     {
@@ -91,9 +83,31 @@ int usrp_close(RIG *rig)
         return -RIG_EARG;
     }
 
-	delete priv->urx;
+    priv->urx = usrp_standard_rx::make(which_board, decim, 1, -1,
+                                       usrp_standard_rx::FPGA_MODE_NORMAL);
 
-	return RIG_OK;
+    if (!priv->urx)
+    {
+        return -RIG_EIO;
+    }
+
+    return RIG_OK;
+}
+
+int usrp_close(RIG *rig)
+{
+    struct usrp_priv_data *priv = static_cast<struct usrp_priv_data *>(STATE(
+            rig)->priv);
+
+    if (!priv)
+    {
+        rig_debug(RIG_DEBUG_ERR, "%s: priv == NULL?\n", __func__);
+        return -RIG_EARG;
+    }
+
+    priv->urx.reset();
+
+    return RIG_OK;
 }
 
 /*
@@ -101,7 +115,8 @@ int usrp_close(RIG *rig)
  */
 int usrp_set_conf(RIG *rig, hamlib_token_t token, const char *val)
 {
-	struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>(STATE(rig)->priv);
+    struct usrp_priv_data *priv = static_cast<struct usrp_priv_data *>(STATE(
+            rig)->priv);
 
     if (!priv)
     {
@@ -109,14 +124,17 @@ int usrp_set_conf(RIG *rig, hamlib_token_t token, const char *val)
         return -RIG_EARG;
     }
 
-	switch(token) {
-		case TOK_IFMIXFREQ:
-			sscanf(val, "%" SCNfreq, &priv->if_mix_freq);
-			break;
-		default:
-			return -RIG_EINVAL;
-	}
-	return RIG_OK;
+    switch (token)
+    {
+    case TOK_IFMIXFREQ:
+        sscanf(val, "%" SCNfreq, &priv->if_mix_freq);
+        break;
+
+    default:
+        return -RIG_EINVAL;
+    }
+
+    return RIG_OK;
 }
 
 /*
@@ -126,7 +144,8 @@ int usrp_set_conf(RIG *rig, hamlib_token_t token, const char *val)
  */
 int usrp_get_conf(RIG *rig, hamlib_token_t token, char *val)
 {
-	const struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>(STATE(rig)->priv);
+    const struct usrp_priv_data *priv = static_cast<struct usrp_priv_data *>(STATE(
+            rig)->priv);
 
     if (!priv)
     {
@@ -134,22 +153,26 @@ int usrp_get_conf(RIG *rig, hamlib_token_t token, char *val)
         return -RIG_EARG;
     }
 
-	switch(token) {
-		case TOK_IFMIXFREQ:
-			sprintf(val, "%" PRIfreq, priv->if_mix_freq);
-			break;
-		default:
-			return -RIG_EINVAL;
-	}
-	return RIG_OK;
+    switch (token)
+    {
+    case TOK_IFMIXFREQ:
+        sprintf(val, "%" PRIfreq, priv->if_mix_freq);
+        break;
+
+    default:
+        return -RIG_EINVAL;
+    }
+
+    return RIG_OK;
 }
 
 
 
 int usrp_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
 {
-	const struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>(STATE(rig)->priv);
-	int chan = 0;
+    const struct usrp_priv_data *priv = static_cast<struct usrp_priv_data *>(STATE(
+            rig)->priv);
+    int chan = 0;
 
     if (!priv)
     {
@@ -157,17 +180,25 @@ int usrp_set_freq(RIG *rig, vfo_t vfo, freq_t freq)
         return -RIG_EARG;
     }
 
-	if (!priv->urx->set_rx_freq (chan, freq))
-		return -RIG_EPROTO;
+    if (!priv->urx)
+    {
+        return -RIG_EIO;
+    }
 
-	return RIG_OK;
+    if (!priv->urx->set_rx_freq(chan, freq))
+    {
+        return -RIG_EPROTO;
+    }
+
+    return RIG_OK;
 }
 
 
 int usrp_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
 {
-	const struct usrp_priv_data *priv = static_cast<struct usrp_priv_data*>(STATE(rig)->priv);
-	int chan = 0;
+    const struct usrp_priv_data *priv = static_cast<struct usrp_priv_data *>(STATE(
+            rig)->priv);
+    int chan = 0;
 
     if (!priv)
     {
@@ -175,14 +206,19 @@ int usrp_get_freq(RIG *rig, vfo_t vfo, freq_t *freq)
         return -RIG_EARG;
     }
 
-	*freq = priv->urx->rx_freq (chan);
+    if (!priv->urx)
+    {
+        return -RIG_EIO;
+    }
 
-	return RIG_OK;
+    *freq = priv->urx->rx_freq(chan);
+
+    return RIG_OK;
 }
 
-const char * usrp_get_info(RIG *rig)
+const char *usrp_get_info(RIG *rig)
 {
-	return NULL;
+    return NULL;
 }
 
-#endif	/* HAVE_USRP */
+#endif  /* HAVE_USRP */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -204,6 +204,13 @@ check_SCRIPTS = \
 
 TESTS = $(check_SCRIPTS) $(DIRECT_TESTS)
 
+if HAVE_USRP
+check_PROGRAMS += testusrp
+TESTS += testusrp
+testusrp_SOURCES = testusrp.cc
+testusrp_LDADD = $(top_builddir)/rigs/kit/libhamlib-kit.la $(LDADD)
+endif
+
 $(top_builddir)/src/libhamlib.la:
 	$(MAKE) -C $(top_builddir)/src/ libhamlib.la
 

--- a/tests/testusrp.cc
+++ b/tests/testusrp.cc
@@ -1,0 +1,86 @@
+/*
+ * Hamlib USRP backend state tests
+ * Copyright (c) 2026 by Hamlib Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "hamlib/rig.h"
+#include "hamlib/riglist.h"
+
+extern "C"
+{
+    extern struct rig_caps usrp_caps;
+}
+
+static int check_conf(RIG *rig, hamlib_token_t token, const char *expected)
+{
+    char value[64] = {};
+    int retval = rig_get_conf2(rig, token, value, sizeof(value));
+
+    if (retval != RIG_OK || strcmp(value, expected) != 0)
+    {
+        fprintf(stderr, "expected USRP if_mix_freq %s, got %s (%d)\n",
+                expected, value, retval);
+        return 1;
+    }
+
+    return 0;
+}
+
+int main(void)
+{
+    RIG *rig;
+    hamlib_token_t token;
+    freq_t freq = 0;
+
+    rig_register(&usrp_caps);
+    rig = rig_init(RIG_MODEL_USRP);
+
+    if (rig == NULL)
+    {
+        fprintf(stderr, "failed to initialize USRP rig\n");
+        return 1;
+    }
+
+    token = rig_token_lookup(rig, "if_mix_freq");
+
+    if (token == RIG_CONF_END)
+    {
+        fprintf(stderr, "USRP if_mix_freq token was not registered\n");
+        rig_cleanup(rig);
+        return 1;
+    }
+
+    if (check_conf(rig, token, "45000000") != 0)
+    {
+        rig_cleanup(rig);
+        return 1;
+    }
+
+    if (rig_set_conf(rig, token, "12345678") != RIG_OK
+            || check_conf(rig, token, "12345678") != 0)
+    {
+        fprintf(stderr, "USRP if_mix_freq did not retain an override\n");
+        rig_cleanup(rig);
+        return 1;
+    }
+
+    if (rig->caps->rig_close(rig) != RIG_OK
+            || rig->caps->set_freq(rig, RIG_VFO_A, 145000000) != -RIG_EIO
+            || rig->caps->get_freq(rig, RIG_VFO_A, &freq) != -RIG_EIO)
+    {
+        fprintf(stderr, "USRP callbacks were not safe without a receiver\n");
+        rig_cleanup(rig);
+        return 1;
+    }
+
+    rig_cleanup(rig);
+    return 0;
+}


### PR DESCRIPTION
`usrp_init()` left `if_mix_freq` uninitialized and discarded the receiver smart pointer returned by `make()`.

Initialize the backend state with the 45 MHz default, retain receiver ownership through cleanup, and add focused regression coverage.

Tested with a non-USRP build and the existing C/C++ test suites.
