### PR TITLE
fix(tests): make rigctld client lifecycle deterministic

### DIFF
--- a/test/test_netrigctl_stream.c
+++ b/test/test_netrigctl_stream.c
@@ -110,41 +110,6 @@ static int find_free_port(void)
 }
 
 
-/* Wait until rigctld is accepting TCP connections. */
-static int wait_for_rigctld(int port, int timeout_ms)
-{
-    int elapsed = 0;
-
-    while (elapsed < timeout_ms)
-    {
-        int sock = socket(AF_INET, SOCK_STREAM, 0);
-        struct sockaddr_in addr;
-
-        if (sock < 0)
-        {
-            return -1;
-        }
-
-        memset(&addr, 0, sizeof(addr));
-        addr.sin_family = AF_INET;
-        addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-        addr.sin_port = htons(port);
-
-        if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) == 0)
-        {
-            close(sock);
-            return 0;
-        }
-
-        close(sock);
-        usleep(50000);  /* 50ms */
-        elapsed += 50;
-    }
-
-    return -1;
-}
-
-
 /* Find the rigctld binary — check build tree first, then PATH. */
 static const char *find_rigctld(void)
 {
@@ -314,14 +279,6 @@ static int start_rigctld_once(struct rigctld_proc *proc,
         _exit(127);
     }
 
-    /* Parent: wait for rigctld to start */
-    if (wait_for_rigctld(proc->port, 5000) < 0)
-    {
-        kill(proc->pid, SIGTERM);
-        waitpid(proc->pid, NULL, 0);
-        return -1;
-    }
-
     return 0;
 }
 
@@ -399,14 +356,48 @@ static void stop_rigctld(struct rigctld_proc *proc)
 }
 
 
+/* Connect and disconnect without sending a command. This exercises the
+ * daemon's client-thread setup and teardown path. */
+static int connect_and_close_rigctld(int port)
+{
+    for (int attempt = 0; attempt < 100; attempt++)
+    {
+        int sock = socket(AF_INET, SOCK_STREAM, 0);
+        struct sockaddr_in addr;
+
+        if (sock < 0)
+        {
+            return -1;
+        }
+
+        memset(&addr, 0, sizeof(addr));
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        addr.sin_port = htons(port);
+
+        if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) == 0)
+        {
+            shutdown(sock, SHUT_RDWR);
+            close(sock);
+            return 0;
+        }
+
+        close(sock);
+        usleep(50000);
+    }
+
+    return -1;
+}
+
+
 /* Open a netrigctl RIG connected to the subprocess rigctld. */
 static RIG *open_netrigctl(int port)
 {
     /* A freshly spawned rigctld can stall for hundreds of ms on a loaded
      * CI runner between accepting the TCP connection and serving it, which
      * makes a single rig_open attempt time out and fail the whole test.
-     * Retry a few times before declaring the daemon unusable. */
-    for (int attempt = 0; attempt < 3; attempt++)
+     * Retry for several seconds before declaring the daemon unusable. */
+    for (int attempt = 0; attempt < 20; attempt++)
     {
         RIG *rig;
         char pathname[64];
@@ -491,6 +482,48 @@ static int has_rate(const int *rates, int rate)
 
 
 /* --- Tests --- */
+
+
+/* A client that disconnects during setup must not poison the daemon for the
+ * next client. */
+void test_immediate_disconnect_preserves_daemon(void)
+{
+    struct rigctld_proc proc = {0};
+
+    if (start_rigctld(&proc) < 0)
+    {
+        TEST_CHECK_(0, "could not start rigctld");
+        return;
+    }
+
+    for (int attempt = 0; attempt < 16; attempt++)
+    {
+        if (!TEST_CHECK_(connect_and_close_rigctld(proc.port) == 0,
+                         "could not connect to rigctld"))
+        {
+            break;
+        }
+
+        if (!TEST_CHECK_(rigctld_alive(&proc),
+                         "rigctld exited after disconnect"))
+        {
+            break;
+        }
+    }
+
+    RIG *rig = open_netrigctl(proc.port);
+    TEST_ASSERT(rig != NULL);
+
+    if (rig)
+    {
+        TEST_CHECK_(rig_stream_caps_count(rig) > 0,
+                    "next client did not receive stream capabilities");
+        rig_close(rig);
+        rig_cleanup(rig);
+    }
+
+    stop_rigctld(&proc);
+}
 
 
 /* Verify all 4 stream types are discovered with correct format bitmasks,
@@ -2639,13 +2672,13 @@ static int query_source_id_once(int port)
 
 
 /* A daemon that has only just begun listening may leave the first connection
- * unanswered on a busy machine, so allow the query a few attempts before
+ * unanswered on a busy machine, so allow the query several seconds before
  * reporting the ID as unavailable. */
 static int query_source_id_raw(int port)
 {
     int attempt;
 
-    for (attempt = 0; attempt < 3; attempt++)
+    for (attempt = 0; attempt < 20; attempt++)
     {
         int source_id = query_source_id_once(port);
 
@@ -2654,7 +2687,7 @@ static int query_source_id_raw(int port)
             return source_id;
         }
 
-        usleep(100000);  /* 100ms */
+        usleep(250000);
     }
 
     return -1;
@@ -2695,6 +2728,8 @@ void test_stream_source_id_cli_and_derived(void)
 
 TEST_LIST =
 {
+    { "immediate_disconnect_preserves_daemon",
+      test_immediate_disconnect_preserves_daemon },
     { "rx_overlong_payload_len_rejected", test_rx_overlong_payload_len_rejected },
     { "rx_metadata_no_false_link_loss", test_rx_metadata_no_false_link_loss },
     { "source_ip_equal_decision",       test_source_ip_equal_decision },

--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -56,6 +56,9 @@
 #elif HAVE_WS2TCPIP_H
 #  include <ws2tcpip.h>
 #  include <fcntl.h>
+#  ifdef __MINGW32__
+#    include <io.h>
+#  endif
 #  if defined(HAVE_WSPIAPI_H)
 #    include <wspiapi.h>
 #  endif
@@ -1288,20 +1291,51 @@ int main(int argc, char *argv[])
     return 0;
 }
 
-static FILE *get_fsockout(struct handle_data *handle_data_arg)
+static FILE *get_fsockout(FILE *fsockin)
 {
 #ifdef __MINGW32__
-    int sock_osfhandle = _open_osfhandle(handle_data_arg->sock, _O_RDONLY);
-    return _fdopen(sock_osfhandle, "wb");
+    int sock_osfhandle = _dup(_fileno(fsockin));
+    FILE *stream;
+
+    if (sock_osfhandle == -1)
+    {
+        return NULL;
+    }
+
+    stream = _fdopen(sock_osfhandle, "wb");
+
+    if (!stream)
+    {
+        _close(sock_osfhandle);
+    }
+
+    return stream;
 #else
-    return fdopen(handle_data_arg->sock, "wb");
+    int sock_fd = dup(fileno(fsockin));
+    FILE *stream;
+
+    if (sock_fd < 0)
+    {
+        return NULL;
+    }
+
+    stream = fdopen(sock_fd, "wb");
+
+    if (!stream)
+    {
+        close(sock_fd);
+    }
+
+    return stream;
 #endif
 }
 
-static FILE *get_fsockin(struct handle_data *handle_data_arg)
+static FILE *get_fsockin(struct handle_data *handle_data_arg,
+                         int *socket_fd_owned)
 {
 #ifdef __MINGW32__
-    int sock_osfhandle = _open_osfhandle(handle_data_arg->sock, _O_RDONLY);
+    int sock_osfhandle = _open_osfhandle(handle_data_arg->sock, _O_RDWR);
+    FILE *stream;
 
     if (sock_osfhandle == -1)
     {
@@ -1309,9 +1343,24 @@ static FILE *get_fsockin(struct handle_data *handle_data_arg)
         return NULL;
     }
 
-    return _fdopen(sock_osfhandle,  "rb");
+    *socket_fd_owned = 0;
+    stream = _fdopen(sock_osfhandle, "rb");
+
+    if (!stream)
+    {
+        _close(sock_osfhandle);
+    }
+
+    return stream;
 #else
-    return fdopen(handle_data_arg->sock, "rb");
+    FILE *stream = fdopen(handle_data_arg->sock, "rb");
+
+    if (stream)
+    {
+        *socket_fd_owned = 0;
+    }
+
+    return stream;
 #endif
 }
 
@@ -1323,6 +1372,7 @@ void *handle_socket(void *arg)
     struct handle_data *handle_data_arg = (struct handle_data *)arg;
     FILE *fsockin = NULL;
     FILE *fsockout = NULL;
+    int socket_fd_owned = 1;
     int retcode = RIG_OK;
     char host[NI_MAXHOST];
     char serv[NI_MAXSERV];
@@ -1332,7 +1382,7 @@ void *handle_socket(void *arg)
     rig_powerstat = RIG_POWER_ON; // defaults to power on
     struct timespec powerstat_check_time;
 
-    fsockin = get_fsockin(handle_data_arg);
+    fsockin = get_fsockin(handle_data_arg, &socket_fd_owned);
 
     if (!fsockin)
     {
@@ -1342,14 +1392,11 @@ void *handle_socket(void *arg)
         goto handle_exit;
     }
 
-    fsockout = get_fsockout(handle_data_arg);
+    fsockout = get_fsockout(fsockin);
 
     if (!fsockout)
     {
         rig_debug(RIG_DEBUG_ERR, "%s: fdopen out: %s\n", __func__, strerror(errno));
-        fclose(fsockin);
-        fsockin = NULL;
-
         goto handle_exit;
     }
 
@@ -1536,9 +1583,12 @@ handle_exit:
 
 // for MINGW we close the handle before fclose
 #ifdef __MINGW32__
-    retcode = closesocket(handle_data_arg->sock);
+    if (socket_fd_owned)
+    {
+        retcode = closesocket(handle_data_arg->sock);
 
-    if (retcode != 0) { rig_debug(RIG_DEBUG_ERR, "%s: fclose(fsockin) %s\n", __func__, strerror(retcode)); }
+        if (retcode != 0) { rig_debug(RIG_DEBUG_ERR, "%s: fclose(fsockin) %s\n", __func__, strerror(retcode)); }
+    }
 
 #endif
 
@@ -1548,9 +1598,12 @@ handle_exit:
 
 // for everybody else we close the handle after fclose
 #ifndef __MINGW32__
-    retcode = close(handle_data_arg->sock);
+    if (socket_fd_owned)
+    {
+        retcode = close(handle_data_arg->sock);
 
-    if (retcode != 0 && errno != EBADF) { rig_debug(RIG_DEBUG_ERR, "%s: close(handle_data_arg->sock) %s\n", __func__, strerror(errno)); }
+        if (retcode != 0 && errno != EBADF) { rig_debug(RIG_DEBUG_ERR, "%s: close(handle_data_arg->sock) %s\n", __func__, strerror(errno)); }
+    }
 
 #endif
 
@@ -1558,7 +1611,6 @@ handle_exit:
                         NULL);      // Tell pthreads we're done with the data
     free(arg);
 
-    pthread_exit(NULL);
     return NULL;
 }
 


### PR DESCRIPTION
The netrigctl streaming test harness used an extra short-lived TCP connection to detect rigctld readiness. That connection could race with client-thread setup and socket cleanup, producing invalid descriptors and intermittent daemon failures.

Remove the synthetic readiness connection and let real clients retry while rigctld starts. Give the input and output streams independent descriptors, track socket ownership explicitly, and return normally from the worker thread.

Add a regression test covering repeated immediate client disconnects followed by a real streaming client connection.

The readiness behavior was introduced by [#2116](https://github.com/Hamlib/Hamlib/pull/2116), specifically commit [2ef1e1d](https://github.com/Hamlib/Hamlib/commit/2ef1e1dade5ce8336ee724bf274952ed93940dd). This surfaced as an unrelated failure while testing [#2124](https://github.com/Hamlib/Hamlib/pull/2124).

No production Hamlib API or wire protocol changes.

Validation:
- Focused regression: `./test_netrigctl_stream -t immediate_disconnect_preserves_daemon`
- Complete netrigctl streaming suite: all 31 tests passed
