### PR TITLE
Update CI workflows to checkout version 6

### DIFF
--- a/.github/workflows/android-ndk.yml
+++ b/.github/workflows/android-ndk.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up NDK toolchain
       run: |

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -52,7 +52,7 @@ jobs:
             --with-xml-support=yes
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Raise kernel socket buffer ceiling for network test suites
       if: runner.os == 'Linux'
       run: sudo sysctl -w net.core.wmem_max=8388608 net.core.rmem_max=8388608

--- a/.github/workflows/c-cpp32.yml
+++ b/.github/workflows/c-cpp32.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: fedora:32
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: bootstrap
       run: |
         sudo apt install libusb-1.0-0-dev

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/macos-latest-features.yml
+++ b/.github/workflows/macos-latest-features.yml
@@ -34,7 +34,7 @@ jobs:
             --with-xml-support=yes
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install dependencies on MacOS
       run: |
         brew install autoconf

--- a/.github/workflows/macos-latest-no-features.yml
+++ b/.github/workflows/macos-latest-no-features.yml
@@ -34,7 +34,7 @@ jobs:
             --with-xml-support=no
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install dependencies on MacOS
       run: |
         brew install autoconf

--- a/.github/workflows/ubuntu-latest-features.yml
+++ b/.github/workflows/ubuntu-latest-features.yml
@@ -34,7 +34,7 @@ jobs:
             --with-xml-support=yes
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Raise kernel socket buffer ceiling for network test suites
       run: sudo sysctl -w net.core.wmem_max=8388608 net.core.rmem_max=8388608
     - name: Install dependencies on Ubuntu latest

--- a/.github/workflows/ubuntu-latest-no-features.yml
+++ b/.github/workflows/ubuntu-latest-no-features.yml
@@ -34,7 +34,7 @@ jobs:
             --with-xml-support=no
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Raise kernel socket buffer ceiling for network test suites
       run: sudo sysctl -w net.core.wmem_max=8388608 net.core.rmem_max=8388608
     - name: Install dependencies on Ubuntu latest

--- a/.github/workflows/windows-cross-features.yml
+++ b/.github/workflows/windows-cross-features.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 40
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install cross toolchain and Wine
       run: |
         sudo apt update

--- a/.github/workflows/windows-cross-no-features.yml
+++ b/.github/workflows/windows-cross-no-features.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 40
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install cross toolchain and Wine
       run: |
         sudo apt update

--- a/.github/workflows/windows-latest-features.yml
+++ b/.github/workflows/windows-latest-features.yml
@@ -39,7 +39,7 @@ jobs:
         shell: msys2 {0}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up MSYS2 (MINGW64)
       uses: msys2/setup-msys2@v2
       with:

--- a/.github/workflows/windows-latest-no-features.yml
+++ b/.github/workflows/windows-latest-no-features.yml
@@ -39,7 +39,7 @@ jobs:
         shell: msys2 {0}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up MSYS2 (MINGW64)
       uses: msys2/setup-msys2@v2
       with:


### PR DESCRIPTION
Turns out version 4 is using a deprecated version of node.js which was generating warning emails.  Jump to version 6 for a bit of future proofing.  Even though version 7 is available, it didn't seem to work well in my limited testing.