### PR TITLE
rigs: yaesu: ft2000: declare AGC level support in rig_caps

### DIFF
--- a/rigs/yaesu/ft2000.c
+++ b/rigs/yaesu/ft2000.c
@@ -202,6 +202,16 @@ struct rig_caps ft2000_caps =
     .max_rit =            Hz(9999),
     .max_xit =            Hz(9999),
     .max_ifshift =        Hz(1000),
+    /* dump_caps prints "AGC levels: 9=NONE" (RIG_AGC_NONE, hamlib's
+     * empty-caps placeholder) without this -- FT-2000's newcat.c AGC
+     * switch only has cases for OFF/FAST/MEDIUM/SLOW/AUTO, confirmed
+     * against the FT-2000 CAT operation manual, same vocabulary
+     * already declared by sibling newcat-family rigs (e.g. ft950.c).
+     * Descriptive only -- newcat.c's RIG_LEVEL_AGC case doesn't
+     * consult this array, so it doesn't add runtime validation, just
+     * makes dump_caps/rig_caps introspection truthful for this rig. */
+    .agc_level_count =    5,
+    .agc_levels =         { RIG_AGC_OFF, RIG_AGC_FAST, RIG_AGC_MEDIUM, RIG_AGC_SLOW, RIG_AGC_AUTO },
     .vfo_ops =            FT2000_VFO_OPS,
     .scan_ops =           RIG_SCAN_VFO,
     .targetable_vfo =     RIG_TARGETABLE_FREQ | RIG_TARGETABLE_MODE | RIG_TARGETABLE_LEVEL | RIG_TARGETABLE_FUNC | RIG_TARGETABLE_TONE,


### PR DESCRIPTION
## Problem

`ft2000_caps` leaves `.agc_level_count`/`.agc_levels` unset, so
`dump_caps` reports `AGC levels: 9=NONE` (`RIG_AGC_NONE`, hamlib's
empty-caps placeholder) even though `newcat_set_level()` /
`newcat_get_level()`'s `RIG_LEVEL_AGC` case for this rig already
handles OFF/FAST/MEDIUM/SLOW/AUTO, confirmed against the FT-2000 CAT
operation manual.

## Fix

Declare the same five levels in `ft2000_caps`, matching the
vocabulary already used by sibling newcat-family rigs such as
`ft950.c`. This is descriptive only — the runtime switch in
`newcat.c` doesn't consult this array for validation — but it makes
`dump_caps`/`rig_caps` introspection accurate for this rig, which
matters for any tooling that queries `rig_caps` to build a UI or
capability manifest rather than hardcoding per-rig level lists.

## Testing

- `patch` applies cleanly and builds against current master.
- Live-verified: `dump_caps` against a physical FT-2000 over rigctld
  now correctly reports the 5 AGC levels instead of `9=NONE`.