### PR TITLE
ftx1: assume tuner status on when using ATAS antenna

### DIFF
--- a/rigs/yaesu/ftx1/ftx1_tx.c
+++ b/rigs/yaesu/ftx1/ftx1_tx.c
@@ -251,6 +251,16 @@ int ftx1_get_tuner(RIG *rig, int *mode)
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s\n", __func__);
 
+    int type;
+    if (ftx1_get_effective_tuner_type(rig, &type) == RIG_OK &&
+        type == FTX1_TUNER_TYPE_ATAS)
+    {
+        rig_debug(RIG_DEBUG_VERBOSE, "%s: ATAS tuner type detected, always "
+                                     "reporting tuner active\n", __func__);
+        *mode = 1;
+        return RIG_OK;
+    }
+
     SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "AC;");
 
     ret = newcat_get_cmd(rig);


### PR DESCRIPTION
When using ATAS antenna, there is no such concept of enabling or disabling the tuner. We can assume that the tuner is always on when using ATAS antenna. The user will see the tuner status as "on" and is thus able to trigger the tune process.