### PR TITLE
build(tests): backport testnetrigctl build fix to 4.7

### DIFF
--- a/rigs/dummy/dummy_common.c
+++ b/rigs/dummy/dummy_common.c
@@ -20,10 +20,12 @@
  *
  */
 
-// cppcheck-suppress *
+#include <errno.h>
+#include <limits.h>
 #include <stdlib.h>
+#include <string.h>
 
-#include "hamlib/rig.h"
+#include "dummy_common.h"
 
 struct ext_list *alloc_init_ext(const struct confparams *cfp)
 {
@@ -74,4 +76,80 @@ struct ext_list *find_ext(struct ext_list *elp, hamlib_token_t token)
     }
 
     return NULL;
+}
+
+void dummy_reset_agc_levels(
+    enum agc_level_e agc_levels[HAMLIB_MAX_AGC_LEVELS],
+    int *agc_level_count)
+{
+    for (int i = 0; i < HAMLIB_MAX_AGC_LEVELS; i++)
+    {
+        agc_levels[i] = RIG_AGC_NONE;
+    }
+
+    *agc_level_count = 0;
+}
+
+int dummy_parse_agc_levels(char *value,
+                           enum agc_level_e agc_levels[HAMLIB_MAX_AGC_LEVELS],
+                           int *agc_level_count)
+{
+    enum agc_level_e parsed_levels[HAMLIB_MAX_AGC_LEVELS];
+    char *saveptr = NULL;
+    char *token;
+    int count = 0;
+
+    if (value == NULL || value[0] == '\0' || agc_levels == NULL
+            || agc_level_count == NULL)
+    {
+        return -RIG_EPROTO;
+    }
+
+    for (int i = 0; i < HAMLIB_MAX_AGC_LEVELS; i++)
+    {
+        parsed_levels[i] = RIG_AGC_NONE;
+    }
+
+    for (token = strtok_r(value, " ", &saveptr); token != NULL;
+            token = strtok_r(NULL, " ", &saveptr))
+    {
+        char *separator;
+        char *endptr;
+        long code;
+
+        if (count == HAMLIB_MAX_AGC_LEVELS)
+        {
+            // Truncate a longer peer list to the array capacity
+            break;
+        }
+
+        separator = strchr(token, '=');
+
+        if (separator == NULL || separator == token || separator[1] == '\0'
+                || strchr(separator + 1, '=') != NULL)
+        {
+            return -RIG_EPROTO;
+        }
+
+        errno = 0;
+        code = strtol(token, &endptr, 10);
+
+        if (errno == ERANGE || code < INT_MIN || code > INT_MAX
+                || endptr != separator)
+        {
+            return -RIG_EPROTO;
+        }
+
+        parsed_levels[count++] = (enum agc_level_e)code;
+    }
+
+    if (count == 0)
+    {
+        return -RIG_EPROTO;
+    }
+
+    memcpy(agc_levels, parsed_levels, sizeof(parsed_levels));
+    *agc_level_count = count;
+
+    return RIG_OK;
 }

--- a/rigs/dummy/dummy_common.h
+++ b/rigs/dummy/dummy_common.h
@@ -26,5 +26,11 @@
 
 struct ext_list *alloc_init_ext(const struct confparams *cfp);
 struct ext_list *find_ext(struct ext_list *elp, hamlib_token_t token);
+void dummy_reset_agc_levels(
+    enum agc_level_e agc_levels[HAMLIB_MAX_AGC_LEVELS],
+    int *agc_level_count);
+int dummy_parse_agc_levels(char *value,
+                           enum agc_level_e agc_levels[HAMLIB_MAX_AGC_LEVELS],
+                           int *agc_level_count);
 
 #endif /* _DUMMY_H */

--- a/rigs/dummy/netrigctl.c
+++ b/rigs/dummy/netrigctl.c
@@ -31,6 +31,7 @@
 #include "num_stdio.h"
 
 #include "dummy.h"
+#include "dummy_common.h"
 
 #define CMD_MAX 64
 #define BUF_MAX 1024
@@ -623,6 +624,10 @@ static int netrigctl_open(RIG *rig)
         rs->vfo_list = RIG_VFO_A | RIG_VFO_B;
     }
 
+    dummy_reset_agc_levels(rig->caps->agc_levels,
+                           &rig->caps->agc_level_count);
+    dummy_reset_agc_levels(rs->agc_levels, &rs->agc_level_count);
+
     if (prot_ver == 0) { RETURNFUNC(RIG_OK); }
 
     // otherwise we continue reading protocol 1 fields
@@ -800,31 +805,26 @@ static int netrigctl_open(RIG *rig)
             }
             else if (strcmp(setting, "agc_levels") == 0)
             {
-                char *p = strtok(value, " ");
-                rig->caps->agc_levels[0] = RIG_AGC_NONE; // default value gets overwritten
-                rig->caps->agc_level_count = 0;
+                enum agc_level_e agc_levels[HAMLIB_MAX_AGC_LEVELS];
+                int agc_level_count;
 
-                while (p)
+                ret = dummy_parse_agc_levels(value, agc_levels, &agc_level_count);
+
+                if (ret != RIG_OK)
                 {
-                    int agc_code;
-                    char agc_string[32];
-                    int n = sscanf(p, "%d=%31s\n", &agc_code, agc_string);
-
-                    if (n == 2)
-                    {
-                        rig->caps->agc_levels[i++] = agc_code;
-                        rig->caps->agc_level_count++;
-                        rig_debug(RIG_DEBUG_VERBOSE, "%s: rig has agc code=%d, level=%s\n", __func__,
-                                  agc_code, agc_string);
-                    }
-                    else
-                    {
-                        rig_debug(RIG_DEBUG_ERR, "%s did not parse code=agc from '%s'\n", __func__, p);
-                    }
-
-                    rig_debug(RIG_DEBUG_VERBOSE, "%d=%s\n", agc_code, agc_string);
-                    p = strtok(NULL, " ");
+                    rig_debug(RIG_DEBUG_ERR,
+                              "%s: ignoring invalid agc_levels field '%s'\n",
+                              __func__, buf);
+                    dummy_reset_agc_levels(rig->caps->agc_levels,
+                                           &rig->caps->agc_level_count);
+                    dummy_reset_agc_levels(rs->agc_levels,
+                                           &rs->agc_level_count);
+                    continue;
                 }
+
+                memcpy(rig->caps->agc_levels, agc_levels, sizeof(agc_levels));
+                memcpy(rs->agc_levels, agc_levels, sizeof(agc_levels));
+                rig->caps->agc_level_count = rs->agc_level_count = agc_level_count;
             }
             else if (strcmp(setting, "level_gran") == 0)
             {

--- a/rigs/dummy/quisk.c
+++ b/rigs/dummy/quisk.c
@@ -31,6 +31,7 @@
 #include "num_stdio.h"
 
 #include "dummy.h"
+#include "dummy_common.h"
 
 #define CMD_MAX 64
 #define BUF_MAX 1024
@@ -573,6 +574,10 @@ static int quisk_open(RIG *rig)
     HAMLIB_TRACE;
 #endif
 
+    dummy_reset_agc_levels(rig->caps->agc_levels,
+                           &rig->caps->agc_level_count);
+    dummy_reset_agc_levels(rs->agc_levels, &rs->agc_level_count);
+
     if (prot_ver == 0) { RETURNFUNC(RIG_OK); }
 
     HAMLIB_TRACE;
@@ -738,31 +743,26 @@ static int quisk_open(RIG *rig)
             }
             else if (strcmp(setting, "agc_levels") == 0)
             {
-                char *p = strtok(value, " ");
-                rig->caps->agc_levels[0] = RIG_AGC_NONE; // default value gets overwritten
-                rig->caps->agc_level_count = 0;
+                enum agc_level_e agc_levels[HAMLIB_MAX_AGC_LEVELS];
+                int agc_level_count;
 
-                while (p)
+                ret = dummy_parse_agc_levels(value, agc_levels, &agc_level_count);
+
+                if (ret != RIG_OK)
                 {
-                    int agc_code;
-                    char agc_string[32];
-                    int n = sscanf(p, "%d=%31s\n", &agc_code, agc_string);
-
-                    if (n == 2)
-                    {
-                        rig->caps->agc_levels[i++] = agc_code;
-                        rig->caps->agc_level_count++;
-                        rig_debug(RIG_DEBUG_VERBOSE, "%s: rig has agc code=%d, level=%s\n", __func__,
-                                  agc_code, agc_string);
-                    }
-                    else
-                    {
-                        rig_debug(RIG_DEBUG_ERR, "%s did not parse code=agc from '%s'\n", __func__, p);
-                    }
-
-                    rig_debug(RIG_DEBUG_VERBOSE, "%d=%s\n", agc_code, agc_string);
-                    p = strtok(NULL, " ");
+                    rig_debug(RIG_DEBUG_ERR,
+                              "%s: ignoring invalid agc_levels field '%s'\n",
+                              __func__, buf);
+                    dummy_reset_agc_levels(rig->caps->agc_levels,
+                                           &rig->caps->agc_level_count);
+                    dummy_reset_agc_levels(rs->agc_levels,
+                                           &rs->agc_level_count);
+                    continue;
                 }
+
+                memcpy(rig->caps->agc_levels, agc_levels, sizeof(agc_levels));
+                memcpy(rs->agc_levels, agc_levels, sizeof(agc_levels));
+                rig->caps->agc_level_count = rs->agc_level_count = agc_level_count;
             }
             else if (strcmp(setting, "level_gran") == 0)
             {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -40,6 +40,7 @@ GENERATED_TEST_WRAPPERS = \
 	testfreq.sh \
 	testgrid.sh \
 	testloc.sh \
+	testnetrigctl.sh \
 	testrig.sh \
 	testrigcaps.sh
 
@@ -58,6 +59,7 @@ check_PROGRAMS = \
 	testgrid \
 	testloc \
 	testmW2power \
+	testnetrigctl \
 	testrig \
 	testrigcaps \
 	testrigopen \
@@ -144,6 +146,7 @@ testelecraftvfo_LDADD = $(NET_LIBS) $(PTHREAD_LIBS) $(top_builddir)/rigs/kenwood
 testftx1parsers_LDADD = $(top_builddir)/rigs/yaesu/libhamlib-yaesu.la $(LDADD)
 testft991idmeter_LDADD = $(top_builddir)/rigs/yaesu/libhamlib-yaesu.la $(LDADD)
 testnewcatset_LDADD = $(NET_LIBS) $(PTHREAD_LIBS) $(top_builddir)/rigs/yaesu/libhamlib-yaesu.la $(LDADD)
+testnetrigctl_LDADD = $(top_builddir)/rigs/dummy/libhamlib-dummy.la
 if TESTS_HAVE_LIBUSB
     rigtestlibusb_LDADD = $(LIBUSB_LIBS)
 endif
@@ -231,6 +234,10 @@ $(top_builddir)/rigs/yaesu/libhamlib-yaesu.la:
 testrig.sh:
 	echo 'LD_LIBRARY_PATH=$(top_builddir)/src/.libs:$(top_builddir)/dummy/.libs ./testrig 1' > testrig.sh
 	chmod +x ./testrig.sh
+
+testnetrigctl.sh:
+	echo './testnetrigctl' > testnetrigctl.sh
+	chmod +x ./testnetrigctl.sh
 
 testfreq.sh:
 	echo './testfreq' > testfreq.sh

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -146,7 +146,7 @@ testelecraftvfo_LDADD = $(NET_LIBS) $(PTHREAD_LIBS) $(top_builddir)/rigs/kenwood
 testftx1parsers_LDADD = $(top_builddir)/rigs/yaesu/libhamlib-yaesu.la $(LDADD)
 testft991idmeter_LDADD = $(top_builddir)/rigs/yaesu/libhamlib-yaesu.la $(LDADD)
 testnewcatset_LDADD = $(NET_LIBS) $(PTHREAD_LIBS) $(top_builddir)/rigs/yaesu/libhamlib-yaesu.la $(LDADD)
-testnetrigctl_LDADD = $(top_builddir)/rigs/dummy/libhamlib-dummy.la
+testnetrigctl_SOURCES = testnetrigctl.c $(top_srcdir)/rigs/dummy/dummy_common.c
 if TESTS_HAVE_LIBUSB
     rigtestlibusb_LDADD = $(LIBUSB_LIBS)
 endif

--- a/tests/testnetrigctl.c
+++ b/tests/testnetrigctl.c
@@ -1,0 +1,120 @@
+/*
+ * Hamlib NET rigctl parser tests
+ * Copyright (c) 2026 by Hamlib Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+#include <stdio.h>
+
+#include "../rigs/dummy/dummy_common.h"
+
+struct parse_case
+{
+    const char *name;
+    char *value;
+    int expected_ret;
+    int expected_count;
+    const enum agc_level_e *expected_levels;
+};
+
+static void fill_levels(enum agc_level_e *levels, enum agc_level_e value)
+{
+    for (int i = 0; i < HAMLIB_MAX_AGC_LEVELS; i++)
+    {
+        levels[i] = value;
+    }
+}
+
+static int expect_state(const char *name, const enum agc_level_e *levels,
+                        const enum agc_level_e *expected, int count,
+                        int expected_count)
+{
+    if (count != expected_count)
+    {
+        fprintf(stderr, "%s: expected count %d, got %d\n", name,
+                expected_count, count);
+        return 1;
+    }
+
+    for (int i = 0; i < HAMLIB_MAX_AGC_LEVELS; i++)
+    {
+        if (levels[i] != expected[i])
+        {
+            fprintf(stderr, "%s: level %d expected %d, got %d\n", name, i,
+                    expected[i], levels[i]);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+int main(void)
+{
+    char short_value[] = "2=FAST 3=SLOW";
+    char maximum_value[] =
+        "0=OFF 1=SUPERFAST 2=FAST 3=SLOW 4=USER 5=MEDIUM 6=AUTO 7=LONG";
+    char ninth_value[] =
+        "0=OFF 1=SUPERFAST 2=FAST 3=SLOW 4=USER 5=MEDIUM 6=AUTO 7=LONG 8=ON";
+    char malformed_value[] = "0=OFF invalid 2=FAST";
+    const enum agc_level_e none[HAMLIB_MAX_AGC_LEVELS] = {
+        RIG_AGC_NONE, RIG_AGC_NONE, RIG_AGC_NONE, RIG_AGC_NONE,
+        RIG_AGC_NONE, RIG_AGC_NONE, RIG_AGC_NONE, RIG_AGC_NONE
+    };
+    const enum agc_level_e user[HAMLIB_MAX_AGC_LEVELS] = {
+        RIG_AGC_USER, RIG_AGC_USER, RIG_AGC_USER, RIG_AGC_USER,
+        RIG_AGC_USER, RIG_AGC_USER, RIG_AGC_USER, RIG_AGC_USER
+    };
+    const enum agc_level_e short_levels[HAMLIB_MAX_AGC_LEVELS] = {
+        RIG_AGC_FAST, RIG_AGC_SLOW, RIG_AGC_NONE, RIG_AGC_NONE,
+        RIG_AGC_NONE, RIG_AGC_NONE, RIG_AGC_NONE, RIG_AGC_NONE
+    };
+    const enum agc_level_e maximum_levels[HAMLIB_MAX_AGC_LEVELS] = {
+        RIG_AGC_OFF, RIG_AGC_SUPERFAST, RIG_AGC_FAST, RIG_AGC_SLOW,
+        RIG_AGC_USER, RIG_AGC_MEDIUM, RIG_AGC_AUTO, RIG_AGC_LONG
+    };
+    struct parse_case cases[] = {
+        { "short list", short_value, RIG_OK, 2, short_levels },
+        { "maximum list", maximum_value, RIG_OK, HAMLIB_MAX_AGC_LEVELS,
+          maximum_levels },
+        { "ninth entry truncated", ninth_value, RIG_OK, HAMLIB_MAX_AGC_LEVELS,
+          maximum_levels },
+        { "malformed token", malformed_value, -RIG_EPROTO, 42, user }
+    };
+    enum agc_level_e levels[HAMLIB_MAX_AGC_LEVELS];
+    int count = 42;
+
+    fill_levels(levels, RIG_AGC_USER);
+    dummy_reset_agc_levels(levels, &count);
+
+    if (expect_state("reset", levels, none, count, 0) != 0)
+    {
+        return 1;
+    }
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++)
+    {
+        fill_levels(levels, RIG_AGC_USER);
+        count = 42;
+        int ret = dummy_parse_agc_levels(cases[i].value, levels, &count);
+
+        if (ret != cases[i].expected_ret)
+        {
+            fprintf(stderr, "%s: expected return %d, got %d\n", cases[i].name,
+                    cases[i].expected_ret, ret);
+            return 1;
+        }
+
+        if (expect_state(cases[i].name, levels, cases[i].expected_levels,
+                         count, cases[i].expected_count) != 0)
+        {
+            return 1;
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Backport PR #2123 to Hamlib-4.7. The 4.7 branch predates PR #2106, so this includes its bounded AGC parser and testnetrigctl regression test as prerequisites. It then applies the build fix from #2123, compiling dummy_common.c directly into testnetrigctl instead of relying on a potentially stale dummy backend archive. The existing 4.7 test-registration layout is preserved, with only the necessary test entries added.