### PR TITLE
fix(ftx1): prevent monitor control from keying transmitter

### DIFF
--- a/rigs/yaesu/ftx1/ftx1.h
+++ b/rigs/yaesu/ftx1/ftx1.h
@@ -274,6 +274,8 @@ extern int ftx1_parse_clar_offset(const char *response, char vfo,
                                   shortfreq_t *offset);
 extern int ftx1_parse_ex_menu_response(const char *response, int group,
                                        int section, int item, int *value);
+extern int ftx1_parse_monitor_response(const char *response, int selector,
+                                       int *level);
 extern int ftx1_parse_smeter_response(const char *response, int p1, int *value);
 
 #endif /* _FTX1_H */

--- a/rigs/yaesu/ftx1/ftx1_audio.c
+++ b/rigs/yaesu/ftx1/ftx1_audio.c
@@ -9,7 +9,7 @@
  *   RG P1 P2P3P4;    - RF Gain (P1=VFO 0/1, P2-P4=000-255)
  *   MG P1P2P3;       - Mic Gain (000-100)
  *   GT P1P2P3P4;     - AGC Time Constant (0000-6000ms or code)
- *   ML P1P2P3;       - Monitor Level (000-100)
+ *   ML P1P2P3;       - Monitor on/off or level (selector-dependent)
  *   SM P1;           - S-Meter Read (P1=0 main, returns 0000-0255)
  *   RM P1;           - Meter Read (1=Main S, 2=Sub S, 3=COMP, 4=ALC, 5=PO, 6=SWR, 7=ID, 8=VDD)
  *   PC P1 P2P2P2;    - Power Control (P1=1 field head, P1=2 SPA-1)
@@ -174,6 +174,33 @@ int ftx1_get_mic_gain(RIG *rig, float *val)
     }
 
     *val = (float)level / FTX1_MIC_GAIN_MAX;
+    return RIG_OK;
+}
+
+int ftx1_parse_monitor_response(const char *response, int selector, int *level)
+{
+    int parsed_level;
+
+    if (selector < 0 || selector > 1 || strlen(response) != 7
+            || response[0] != 'M' || response[1] != 'L'
+            || response[2] != '0' + selector
+            || response[3] < '0' || response[3] > '9'
+            || response[4] < '0' || response[4] > '9'
+            || response[5] < '0' || response[5] > '9'
+            || response[6] != ';')
+    {
+        return -RIG_EPROTO;
+    }
+
+    parsed_level = (response[3] - '0') * 100 + (response[4] - '0') * 10
+                   + response[5] - '0';
+
+    if ((selector == 0 && parsed_level > 1) || parsed_level > 100)
+    {
+        return -RIG_EPROTO;
+    }
+
+    *level = parsed_level;
     return RIG_OK;
 }
 
@@ -584,46 +611,46 @@ int ftx1_get_vox_delay(RIG *rig, int *tenths)
 }
 
 /*
- * ftx1_set_monitor_level - Set Monitor Level (ML P1 P2P3P4;)
- * CAT command: ML P1 P2P3P4; (P1=VFO 0/1, P2-P4=000-100)
+ * ftx1_set_monitor_level - Set Monitor Level (ML 1 P2P3P4;)
+ * The FTX-1's ML selector 1 controls the global monitor level; it is not a
+ * VFO selector.
  */
 int ftx1_set_monitor_level(RIG *rig, vfo_t vfo, float val)
 {
     struct newcat_priv_data *priv = STATE(rig)->priv;
-    int p1 = ftx1_vfo_to_p1(rig, vfo);
     int level = (int)(val * 100);
 
-    rig_debug(RIG_DEBUG_VERBOSE, "%s: vfo=%s p1=%d val=%f\n", __func__,
-              rig_strvfo(vfo), p1, val);
+    (void)vfo;
+
+    rig_debug(RIG_DEBUG_VERBOSE, "%s: val=%f\n", __func__, val);
 
     if (level < 0) level = 0;
     if (level > 100) level = 100;
 
-    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "ML%d%03d;", p1, level);
+    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "ML1%03d;", level);
     return newcat_set_cmd(rig);
 }
 
 /*
  * ftx1_get_monitor_level - Get Monitor Level
- * Response: ML P1 P2P3P4; (P1=VFO, P2-P4=level)
+ * Response: ML P1 P2P3P4; (P1=1, P2-P4=level)
  */
 int ftx1_get_monitor_level(RIG *rig, vfo_t vfo, float *val)
 {
     struct newcat_priv_data *priv = STATE(rig)->priv;
     int ret;
-    int p1 = ftx1_vfo_to_p1(rig, vfo);
-    int p1_resp, level;
+    int level;
 
-    rig_debug(RIG_DEBUG_VERBOSE, "%s: vfo=%s p1=%d\n", __func__,
-              rig_strvfo(vfo), p1);
+    (void)vfo;
 
-    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "ML%d;", p1);
+    rig_debug(RIG_DEBUG_VERBOSE, "%s\n", __func__);
+
+    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "ML1;");
 
     ret = newcat_get_cmd(rig);
     if (ret != RIG_OK) return ret;
 
-    /* Response: ML0100 (P1=0, level=100) */
-    if (sscanf(priv->ret_data + 2, "%1d%3d", &p1_resp, &level) != 2)
+    if (ftx1_parse_monitor_response(priv->ret_data, 1, &level) != RIG_OK)
     {
         rig_debug(RIG_DEBUG_ERR, "%s: failed to parse '%s'\n", __func__,
                   priv->ret_data);

--- a/rigs/yaesu/ftx1/ftx1_tx.c
+++ b/rigs/yaesu/ftx1/ftx1_tx.c
@@ -7,7 +7,7 @@
  * CAT Commands in this file:
  *   TX P1;           - Transmit (P1: 0=RX, 1=TX CAT, 2=TX Data)
  *   PC P1P2P3;       - Power Control (005-100 watts) [also in ftx1_audio.c]
- *   MX P1;           - Monitor TX Audio (0=off, 1=on)
+ *   MX P1;           - MOX transmit control
  *   VX P1;           - VOX on/off (0=off, 1=on)
  *   AC P1P2P3;       - Antenna Tuner Control (P1: 0=off, 1=on, 2=tune)
  *   BI P1;           - Break-In on/off (0=off, 1=on) - type via EX020115
@@ -142,39 +142,39 @@ int ftx1_get_vox(RIG *rig, int *status)
     return RIG_OK;
 }
 
-/* Set TX Monitor (MX P1;) */
+/* Set TX Monitor using ML selector 0 (000=off, 001=on). */
 int ftx1_set_monitor(RIG *rig, int status)
 {
     struct newcat_priv_data *priv = STATE(rig)->priv;
-    int p1 = status ? 1 : 0;
+    int level = status ? 1 : 0;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: status=%d\n", __func__, status);
 
-    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "MX%d;", p1);
+    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "ML0%03d;", level);
     return newcat_set_cmd(rig);
 }
 
-/* Get TX Monitor status (MX P1;) */
+/* Get TX Monitor using ML selector 0 (000=off, 001=on). */
 int ftx1_get_monitor(RIG *rig, int *status)
 {
     struct newcat_priv_data *priv = STATE(rig)->priv;
-    int ret, p1;
+    int ret, level;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s\n", __func__);
 
-    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "MX;");
+    SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "ML0;");
 
     ret = newcat_get_cmd(rig);
     if (ret != RIG_OK) return ret;
 
-    if (sscanf(priv->ret_data + 2, "%1d", &p1) != 1)
+    if (ftx1_parse_monitor_response(priv->ret_data, 0, &level) != RIG_OK)
     {
         rig_debug(RIG_DEBUG_ERR, "%s: failed to parse '%s'\n", __func__,
                   priv->ret_data);
         return -RIG_EPROTO;
     }
 
-    *status = p1;
+    *status = level;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s: status=%d\n", __func__, *status);
 

--- a/tests/testftx1parsers.c
+++ b/tests/testftx1parsers.c
@@ -130,6 +130,36 @@ static int expect_smeter(const char *response, int p1, int expected,
     return 0;
 }
 
+static int expect_monitor(const char *response, int selector, int expected,
+                          int expected_level)
+{
+    int level = 42;
+    int ret = ftx1_parse_monitor_response(response, selector, &level);
+
+    if (ret != expected)
+    {
+        fprintf(stderr, "ML response '%s': expected %d, got %d\n",
+                response, expected, ret);
+        return 1;
+    }
+
+    if (ret == RIG_OK && level != expected_level)
+    {
+        fprintf(stderr, "ML response '%s': expected %d, got %d\n",
+                response, expected_level, level);
+        return 1;
+    }
+
+    if (ret != RIG_OK && level != 42)
+    {
+        fprintf(stderr, "ML response '%s' changed output on failure\n",
+                response);
+        return 1;
+    }
+
+    return 0;
+}
+
 int main(void)
 {
     static const char *invalid_states[] =
@@ -144,6 +174,10 @@ int main(void)
     {
         "EX0301051;", "EX030104;", "EX0301041junk;",
         "EX0301042147483648;"
+    };
+    static const char *invalid_monitor[] =
+    {
+        "ML0002;", "ML2000;", "ML0000"
     };
 
     if (expect_clar_state("CF00000000;", '0', RIG_OK, '0', '0') != 0
@@ -182,6 +216,24 @@ int main(void)
     for (size_t i = 0; i < sizeof(invalid_ex) / sizeof(invalid_ex[0]); i++)
     {
         if (expect_ex(invalid_ex[i], -RIG_EPROTO, 0) != 0)
+        {
+            return 1;
+        }
+    }
+
+    if (expect_monitor("ML0000;", 0, RIG_OK, 0) != 0
+            || expect_monitor("ML0001;", 0, RIG_OK, 1) != 0
+            || expect_monitor("ML1000;", 1, RIG_OK, 0) != 0
+            || expect_monitor("ML1100;", 1, RIG_OK, 100) != 0
+            || expect_monitor("ML1101;", 1, -RIG_EPROTO, 0) != 0)
+    {
+        return 1;
+    }
+
+    for (size_t i = 0; i < sizeof(invalid_monitor)
+            / sizeof(invalid_monitor[0]); i++)
+    {
+        if (expect_monitor(invalid_monitor[i], 0, -RIG_EPROTO, 0) != 0)
         {
             return 1;
         }


### PR DESCRIPTION
The FTX-1 backend currently implements "Enable monitor" by sending `MX`, the CAT command for MOX/transmit. In other words, enabling a receive-side monitor function can key the transmitter.

This is a serious safety boundary since a control that should only enable monitor audio can cause unintended RF transmission. The FTX-1 CAT manual defines `ML0` as monitor on/off and `ML1` as monitor level; `MX` is explicitly MOX. 

The code comment also claims the `ML` first digit 0/1 is a VFO selector, which is wrong. The first digit is selecting the monitor operation (on vs off), while the remaining digits set the monitor level.

See: [Yaesu FTX-1 CAT Manual](https://www.yaesu.com/Files/4CB1CAF6-1018-01AF-FABABCA11697FC7F/FTX-1_CAT_OM_ENG_2507-B.pdf)

This change:

- Maps Hamlib monitor control to `ML0`.
- Keeps monitor gain on the separate global `ML1` selector.
- Validates monitor responses before accepting them.
- Adds parser regression tests for valid and malformed responses.

A request to enable monitor audio should not be capable of starting a transmission.