### PR TITLE
fix(ftx1): keep clarifier state scoped to its VFO

### DIFF
--- a/rigs/yaesu/ftx1/ftx1_clarifier.c
+++ b/rigs/yaesu/ftx1/ftx1_clarifier.c
@@ -35,18 +35,34 @@
 #define FTX1_CF_SETTING_RESP_LEN  11
 #define FTX1_CF_FREQ_RESP_LEN     11
 
-/*
- * Cache RX/TX CLAR enable states from a CF setting response.
- * Eliminates the read-then-write race in set functions (Bug 3.1):
- * without caching, set_rx_clar must read TX state before writing both,
- * creating a window where the TX state could change between read and write.
- */
-static void ftx1_cache_clar_state(struct newcat_priv_data *priv,
-                                  const char *resp)
+static struct ftx1_clarifier_cache *
+ftx1_get_clar_cache(struct newcat_priv_data *priv, char vfo_param)
 {
-    priv->ftx1_rx_clar_on = resp[5];
-    priv->ftx1_tx_clar_on = resp[6];
-    priv->ftx1_clar_cached = 1;
+    return &priv->ftx1_clar_cache[vfo_param - '0'];
+}
+
+void ftx1_cache_clar_state(struct newcat_priv_data *priv, char vfo_param,
+                           char rx_enabled, char tx_enabled)
+{
+    if (vfo_param < '0' || vfo_param > '1')
+    {
+        return;
+    }
+
+    struct ftx1_clarifier_cache *cache = ftx1_get_clar_cache(priv, vfo_param);
+    cache->rx_on = rx_enabled;
+    cache->tx_on = tx_enabled;
+    cache->valid = true;
+}
+
+void ftx1_invalidate_clar_state(struct newcat_priv_data *priv, char vfo_param)
+{
+    if (vfo_param < '0' || vfo_param > '1')
+    {
+        return;
+    }
+
+    ftx1_get_clar_cache(priv, vfo_param)->valid = false;
 }
 
 int ftx1_parse_clar_state(const char *resp, char vfo,
@@ -152,7 +168,7 @@ int ftx1_get_rx_clar(RIG *rig, vfo_t vfo, shortfreq_t *offset)
     }
 
     /* Cache both RX and TX CLAR states for use by set functions */
-    ftx1_cache_clar_state(priv, priv->ret_data);
+    ftx1_cache_clar_state(priv, vfo_param, rx_clar_enabled, tx_clar_enabled);
 
     rig_debug(RIG_DEBUG_TRACE, "%s: CF setting response='%s', rx_clar_enabled=%c\n",
               __func__, priv->ret_data, rx_clar_enabled);
@@ -199,6 +215,7 @@ int ftx1_set_rx_clar(RIG *rig, vfo_t vfo, shortfreq_t offset)
     int err;
     char vfo_param;
     char tx_clar_enabled;
+    struct ftx1_clarifier_cache *cache;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called with offset=%ld\n", __func__, (long)offset);
 
@@ -211,16 +228,12 @@ int ftx1_set_rx_clar(RIG *rig, vfo_t vfo, shortfreq_t offset)
     }
 
     vfo_param = ftx1_get_cf_vfo_param(rig, vfo);
+    cache = ftx1_get_clar_cache(priv, vfo_param);
 
-    /*
-     * Get TX CLAR state from cache if available, otherwise read from radio.
-     * Using the cache eliminates the read-then-write race (Bug 3.1):
-     * without it, an external actor could change TX CLAR between our
-     * read and write, and we'd overwrite their change with a stale value.
-     */
-    if (priv->ftx1_clar_cached)
+    /* Preserve the TX CLAR state cached for this VFO. */
+    if (cache->valid)
     {
-        tx_clar_enabled = priv->ftx1_tx_clar_on;
+        tx_clar_enabled = cache->tx_on;
     }
     else
     {
@@ -241,7 +254,9 @@ int ftx1_set_rx_clar(RIG *rig, vfo_t vfo, shortfreq_t offset)
             return -RIG_EPROTO;
         }
 
-        ftx1_cache_clar_state(priv, priv->ret_data);
+        ftx1_cache_clar_state(priv, vfo_param, rx_clar_enabled,
+                              tx_clar_enabled);
+        tx_clar_enabled = cache->tx_on;
     }
 
     if (offset == 0)
@@ -249,21 +264,22 @@ int ftx1_set_rx_clar(RIG *rig, vfo_t vfo, shortfreq_t offset)
         /* Disable RX CLAR, preserve TX CLAR state */
         SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CF%c000%c000;",
                  vfo_param, tx_clar_enabled);
-        priv->ftx1_rx_clar_on = '0';
     }
     else
     {
         /* Enable RX CLAR, preserve TX CLAR state, then set frequency */
         SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CF%c001%c000;",
                  vfo_param, tx_clar_enabled);
-        priv->ftx1_rx_clar_on = '1';
 
         rig_debug(RIG_DEBUG_TRACE, "%s: enable cmd=%s\n", __func__, priv->cmd_str);
 
         if (RIG_OK != (err = newcat_set_cmd(rig)))
         {
+            ftx1_invalidate_clar_state(priv, vfo_param);
             return err;
         }
+
+        cache->rx_on = '1';
 
         /* Now set the frequency */
         if (offset > 0)
@@ -282,7 +298,13 @@ int ftx1_set_rx_clar(RIG *rig, vfo_t vfo, shortfreq_t offset)
 
     if (RIG_OK != (err = newcat_set_cmd(rig)))
     {
+        ftx1_invalidate_clar_state(priv, vfo_param);
         return err;
+    }
+
+    if (offset == 0)
+    {
+        cache->rx_on = '0';
     }
 
     return RIG_OK;
@@ -329,7 +351,7 @@ int ftx1_get_tx_clar(RIG *rig, vfo_t vfo, shortfreq_t *offset)
     }
 
     /* Cache both RX and TX CLAR states for use by set functions */
-    ftx1_cache_clar_state(priv, priv->ret_data);
+    ftx1_cache_clar_state(priv, vfo_param, rx_clar_enabled, tx_clar_enabled);
 
     rig_debug(RIG_DEBUG_TRACE, "%s: CF setting response='%s', tx_clar_enabled=%c\n",
               __func__, priv->ret_data, tx_clar_enabled);
@@ -376,6 +398,7 @@ int ftx1_set_tx_clar(RIG *rig, vfo_t vfo, shortfreq_t offset)
     int err;
     char vfo_param;
     char rx_clar_enabled;
+    struct ftx1_clarifier_cache *cache;
 
     rig_debug(RIG_DEBUG_VERBOSE, "%s called with offset=%ld\n", __func__, (long)offset);
 
@@ -388,14 +411,12 @@ int ftx1_set_tx_clar(RIG *rig, vfo_t vfo, shortfreq_t offset)
     }
 
     vfo_param = ftx1_get_cf_vfo_param(rig, vfo);
+    cache = ftx1_get_clar_cache(priv, vfo_param);
 
-    /*
-     * Get RX CLAR state from cache if available, otherwise read from radio.
-     * Using the cache eliminates the read-then-write race (Bug 3.1).
-     */
-    if (priv->ftx1_clar_cached)
+    /* Preserve the RX CLAR state cached for this VFO. */
+    if (cache->valid)
     {
-        rx_clar_enabled = priv->ftx1_rx_clar_on;
+        rx_clar_enabled = cache->rx_on;
     }
     else
     {
@@ -416,7 +437,9 @@ int ftx1_set_tx_clar(RIG *rig, vfo_t vfo, shortfreq_t offset)
             return -RIG_EPROTO;
         }
 
-        ftx1_cache_clar_state(priv, priv->ret_data);
+        ftx1_cache_clar_state(priv, vfo_param, rx_clar_enabled,
+                              tx_clar_enabled);
+        rx_clar_enabled = cache->rx_on;
     }
 
     if (offset == 0)
@@ -424,21 +447,22 @@ int ftx1_set_tx_clar(RIG *rig, vfo_t vfo, shortfreq_t offset)
         /* Disable TX CLAR, preserve RX CLAR state */
         SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CF%c00%c0000;",
                  vfo_param, rx_clar_enabled);
-        priv->ftx1_tx_clar_on = '0';
     }
     else
     {
         /* Enable TX CLAR, preserve RX CLAR state, then set frequency */
         SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CF%c00%c1000;",
                  vfo_param, rx_clar_enabled);
-        priv->ftx1_tx_clar_on = '1';
 
         rig_debug(RIG_DEBUG_TRACE, "%s: enable cmd=%s\n", __func__, priv->cmd_str);
 
         if (RIG_OK != (err = newcat_set_cmd(rig)))
         {
+            ftx1_invalidate_clar_state(priv, vfo_param);
             return err;
         }
+
+        cache->tx_on = '1';
 
         /* Now set the frequency */
         if (offset > 0)
@@ -457,7 +481,13 @@ int ftx1_set_tx_clar(RIG *rig, vfo_t vfo, shortfreq_t offset)
 
     if (RIG_OK != (err = newcat_set_cmd(rig)))
     {
+        ftx1_invalidate_clar_state(priv, vfo_param);
         return err;
+    }
+
+    if (offset == 0)
+    {
+        cache->tx_on = '0';
     }
 
     return RIG_OK;

--- a/rigs/yaesu/ftx1/ftx1_mem.c
+++ b/rigs/yaesu/ftx1/ftx1_mem.c
@@ -364,14 +364,17 @@ int ftx1_set_channel(RIG *rig, vfo_t vfo, const channel_t *chan)
         SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str),
                  "CF100%d0000;", (chan->rit != 0) ? 1 : 0);
         (void)newcat_set_cmd(rig);
+        ftx1_invalidate_clar_state(priv, '1');
 
         SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str),
                  "CF100%d0000;", (chan->xit != 0) ? 3 : 2);
         (void)newcat_set_cmd(rig);
+        ftx1_invalidate_clar_state(priv, '1');
 
         SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str),
                  "CF101%c%04d;", dir, off);
         (void)newcat_set_cmd(rig);
+        ftx1_invalidate_clar_state(priv, '1');
     }
     else
     {
@@ -379,8 +382,10 @@ int ftx1_set_channel(RIG *rig, vfo_t vfo, const channel_t *chan)
          * from a previous write or the operator's prior VFO-B. */
         SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CF10000000;");
         (void)newcat_set_cmd(rig);
+        ftx1_invalidate_clar_state(priv, '1');
         SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CF10020000;");
         (void)newcat_set_cmd(rig);
+        ftx1_invalidate_clar_state(priv, '1');
     }
 
     /* 4. Commit VFO-B to the last-selected memory channel. */
@@ -396,8 +401,10 @@ restore:
      * side-effect cleanup. */
     SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CF10000000;");
     (void)newcat_set_cmd(rig);
+    ftx1_invalidate_clar_state(priv, '1');
     SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CF10020000;");
     (void)newcat_set_cmd(rig);
+    ftx1_invalidate_clar_state(priv, '1');
     if (is_fm_family)
     {
         SNPRINTF(priv->cmd_str, sizeof(priv->cmd_str), "CT10;");

--- a/rigs/yaesu/newcat.h
+++ b/rigs/yaesu/newcat.h
@@ -125,6 +125,16 @@ struct newcat_priv_caps
     const struct newcat_width_info *rtty_widths;  // If NULL, use CW widths
 };
 
+#define FTX1_CLARIFIER_VFO_COUNT 2
+
+/* FTX-1 CF P1 selects independent Main (0) and Sub (1) state. */
+struct ftx1_clarifier_cache
+{
+    bool valid;
+    char rx_on;
+    char tx_on;
+};
+
 /*
  * Private state for newcat rigs
  */
@@ -152,11 +162,13 @@ struct newcat_priv_data
     vfo_t ftx1_tx_vfo;           /* TX VFO for virtual split */
     int ftx1_cache_fix_needed;   /* 1 if Main cache needs restoration */
     freq_t ftx1_cache_fix_freq;  /* Saved Main freq for cache restoration */
-    int ftx1_clar_cached;        /* 1 if RX/TX CLAR states have been cached */
-    char ftx1_rx_clar_on;        /* Cached RX CLAR enable: '0' or '1' */
-    char ftx1_tx_clar_on;        /* Cached TX CLAR enable: '0' or '1' */
+    struct ftx1_clarifier_cache ftx1_clar_cache[FTX1_CLARIFIER_VFO_COUNT];
     int ftx1_in_memory_mode;     /* 1 if driver knows the Main-side is in Memory mode (VM011) */
 };
+
+void ftx1_cache_clar_state(struct newcat_priv_data *priv, char vfo_param,
+                           char rx_enabled, char tx_enabled);
+void ftx1_invalidate_clar_state(struct newcat_priv_data *priv, char vfo_param);
 
 /*
  * Functions considered to be Stable:

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -128,7 +128,8 @@ testicomts_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/rigs/icom
 testid5100_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/rigs/icom
 testicomfallback_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/rigs/icom
 testgeministatus_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/amplifiers/gemini
-testftx1parsers_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/rigs/yaesu/ftx1
+testftx1parsers_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/rigs/yaesu \
+	-I$(top_srcdir)/rigs/yaesu/ftx1
 testft991idmeter_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/rigs/yaesu
 testguohetec_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/rigs/guohetec
 if TESTS_HAVE_LIBUSB

--- a/tests/testftx1parsers.c
+++ b/tests/testftx1parsers.c
@@ -13,6 +13,36 @@
 #include <string.h>
 
 #include "ftx1.h"
+#include "newcat.h"
+
+static int expect_clar_cache_isolated(void)
+{
+    struct newcat_priv_data priv = { 0 };
+
+    ftx1_cache_clar_state(&priv, '0', '1', '0');
+    ftx1_cache_clar_state(&priv, '1', '0', '1');
+
+    if (!priv.ftx1_clar_cache[0].valid
+            || priv.ftx1_clar_cache[0].rx_on != '1'
+            || priv.ftx1_clar_cache[0].tx_on != '0'
+            || !priv.ftx1_clar_cache[1].valid
+            || priv.ftx1_clar_cache[1].rx_on != '0'
+            || priv.ftx1_clar_cache[1].tx_on != '1')
+    {
+        fprintf(stderr, "CF cache state was not isolated by VFO\n");
+        return 1;
+    }
+
+    ftx1_invalidate_clar_state(&priv, '1');
+
+    if (!priv.ftx1_clar_cache[0].valid || priv.ftx1_clar_cache[1].valid)
+    {
+        fprintf(stderr, "CF cache invalidation affected the wrong VFO\n");
+        return 1;
+    }
+
+    return 0;
+}
 
 static int expect_clar_state(const char *response, char vfo, int expected,
                              char expected_rx, char expected_tx)
@@ -146,7 +176,8 @@ int main(void)
         "EX0301042147483648;"
     };
 
-    if (expect_clar_state("CF00000000;", '0', RIG_OK, '0', '0') != 0
+    if (expect_clar_cache_isolated() != 0
+            || expect_clar_state("CF00000000;", '0', RIG_OK, '0', '0') != 0
             || expect_clar_state("CF00010000;", '0', RIG_OK, '1', '0') != 0
             || expect_clar_state("CF10010000;", '1', RIG_OK, '1', '0') != 0
             || expect_clar_offset("CF001+1234;", '0', RIG_OK, 1234) != 0


### PR DESCRIPTION
The FTX-1 backend cached one RX/TX clarifier state for the entire radio, even though the CAT protocol addresses Main and Sub independently. A state read on one VFO could therefore supply the wrong sibling state when updating the other.

The cache now maintains separate Main and Sub entries, updates them only after successful CAT writes, and invalidates uncertain state. Direct CF writes from memory operations also invalidate the affected entry.

The CAT protocol already distinguishes Main and Sub; the cache now does too.

Validation:

- FTX-1 Yaesu backend build passed.
- `testftx1parsers` passed.