### PR TITLE
Enable choosing which stream conversions to allow

### DIFF
--- a/HAMLIB_STREAMING.md
+++ b/HAMLIB_STREAMING.md
@@ -359,9 +359,15 @@ installed between that source and the stream. Requests beyond the rules
 more channels than the mapping allows) fail with `-RIG_EINVAL`.
 
 `rig_stream_get_conversions()` reports the installed stages
-(`RIG_STREAM_CONV_FORMAT/RATE/CHANNELS`, 0 = native stream). A config
-with `require_native = 1` refuses conversion with `-RIG_ENAVAIL`
-(distinct from `-RIG_EINVAL` for the impossible). One exception to the
+(`RIG_STREAM_CONV_FORMAT/RATE/CHANNELS`, 0 = native stream). The same
+constants go the other way in `require_native`, a bitmask of the stages
+the open must NOT install: any stage both required and needed refuses the
+open with `-RIG_ENAVAIL` (distinct from `-RIG_EINVAL` for the
+impossible), while stages left out of the mask still convert. So
+`require_native = RIG_STREAM_CONV_RATE` demands the hardware's own sample
+rate — the stage that costs latency — and accepts the frontend's format
+conversion, and `RIG_STREAM_CONV_ALL` demands a fully native stream.
+One exception to the
 authoring rule: a relaying backend (netrigctl) fills the `native_*`
 fields too, declaring both views pre-derived; the frontend then serves
 the entry verbatim and delegates conversion to the far side (see §6.1).
@@ -383,8 +389,12 @@ struct rig_stream_config {
     unsigned int        mtu;                /* sender path MTU, 0 = default 1500 (see 6.8) */
     unsigned int        transport_buffer_ms;         /* UDP socket buffer as ms of stream data; 0 = rig token / built-in 250 ms */
     unsigned int        transport_buffer_bytes;      /* explicit UDP socket buffer bytes; 0 = derive from transport_buffer_ms/rate */
-    int                 require_native;     /* 1 = open only as a native stream:
-                                             * -RIG_ENAVAIL rather than convert */
+    uint32_t            require_native;     /* RIG_STREAM_CONV_* stages that must
+                                             * be native: -RIG_ENAVAIL rather
+                                             * than install a listed stage.
+                                             * 0 = convert as needed,
+                                             * RIG_STREAM_CONV_ALL = fully
+                                             * native (see 3.3) */
 };
 ```
 
@@ -509,8 +519,10 @@ rejects a stack-declared one (see "Object ownership & lifetimes"). Ask for a
 format and rate from the effective caps; `rig_stream_caps_count()` and
 `rig_stream_caps_at()` enumerate them (§3.3). After a successful open,
 `rig_stream_get_conversions()` tells you whether the stream is served
-natively or through conversion; set `cfg->require_native = 1` to demand
-hardware-native service. Pass a `struct rig_stream_read_info *` as the last
+natively or through conversion; set `cfg->require_native` to the
+`RIG_STREAM_CONV_*` stages that must not run (`RIG_STREAM_CONV_ALL` for a
+fully hardware-native stream) to have the open refused instead of
+converted. Pass a `struct rig_stream_read_info *` as the last
 argument instead of `NULL` when you need the producer sample index, drop
 counts and capture time.
 
@@ -552,7 +564,8 @@ Semantics:
   `sample_rate` or `channels`, an unknown stream type, a `struct_size` of 0,
   and exhaustion of either the caps `max_streams` limit or the
   `HAMLIB_MAX_STREAMS` slots for that type — all with `-RIG_EINVAL`. A
-  convertible request with `require_native = 1` fails with `-RIG_ENAVAIL`.
+  request whose conversion stages intersect `require_native` fails with
+  `-RIG_ENAVAIL`.
 - **close** unregisters the stream, wakes any blocked reader or
   write-status waiter, then waits for every `rig_stream_*` call already in
   flight on that stream to return before the handle is torn down. A
@@ -838,9 +851,17 @@ exceed the signed-char range used by the short-form parser:
      channels=<1..255>        stream channel count (default 1; validated
                               against the caps entry — coherent I/Q may
                               exceed stereo)
-     require_native=<0|1>     1 = open only as a hardware-native stream;
-                              a convertible request is refused with
-                              RPRT -RIG_ENAVAIL (default 0 = convert)
+     require_native=<stages>  conversion stages that must NOT run, as a
+                              comma-separated list of FORMAT, RATE and
+                              CHANNELS, or ALL (every stage, i.e. a fully
+                              hardware-native stream) or NONE (default).
+                              A request needing a listed stage is refused
+                              with RPRT -RIG_ENAVAIL; stages left out still
+                              convert, so require_native=RATE demands the
+                              native sample rate but accepts a format
+                              conversion. An unknown stage name fails the
+                              open with RPRT -RIG_EINVAL rather than being
+                              ignored
      time_stale_coarse=<ms>   staleness → COARSE threshold (see details below)
      time_stale_invalidate=<ms> staleness → time-invalid threshold (see details below)
      keepalive_timeout=<s>    silence before the client is dropped, clamped
@@ -861,7 +882,7 @@ max_payload: <bytes>         effective frame-aligned payload budget (see 6.8)
 conversions: <C1,C2,...>     server-side conversion stages, comma-
                              separated RIG_STREAM_CONV_* names with the
                              prefix stripped (FORMAT, RATE, CHANNELS);
-                             empty = native stream
+                             NONE = native stream
 [multicast: <addr>]          (only for multicast streams)
 ```
 
@@ -890,20 +911,30 @@ defined field of `struct rig_stream_caps`, and the same format (minus
 the `native_*` keys, which a bare declaration does not have) is what
 `dump_caps` prints in its streaming section, so one parser serves both.
 A parser MUST skip unknown keys and unknown flag names: future
-capability flags extend the `flags=` list without a new key.
+capability flags extend the `flags=` list without a new key. Every
+list-valued key here carries `NONE` when its list is empty (see the
+value syntaxes below).
 
 Every key uses one of
 three value syntaxes, and each key always uses the same one:
 
 - **name list** — comma-separated symbolic names, no spaces
-  (`formats=PCM_S16,PCM_F32`). One name is a one-element list; a list
-  may be empty (`flags=` on an entry with no capability flags, like
-  `conversions:` on a native stream).
+  (`formats=PCM_S16,PCM_F32`). One name is a one-element list.
 - **integer list** — comma-separated decimal integers, ascending, no
   spaces (`rates=24000,48000`, `channels=1,2`). Ranges are **not** part of
   the grammar — a contiguous set is spelled out (`channels=1,2,3,4`).
 - **scalar** — a single decimal integer (`max_streams=4`,
   `tx_horizon_ms=30000`).
+
+**An empty list is spelled `NONE`**, in every list-valued key of the
+streaming protocol and whichever of the two list syntaxes it uses:
+`flags=NONE` on an entry with no capability flags, `channels=NONE` on one
+that declares no channel counts, `conversions: NONE` on a native stream,
+`require_native=NONE` for a demand of nothing. Nothing this
+implementation writes carries an empty value, so a reader never has to
+tell "the empty list" apart from "the field is missing". A parser SHOULD
+still accept an empty value as the empty list: earlier drafts wrote one,
+and an absent key means the same thing.
 
 The effective sets are
 what `\stream_open` serves — through server-side conversion where they
@@ -955,7 +986,7 @@ udp_port: <port>
 paused: <0|1>
 muted: <0|1>
 conversions: <C1,C2,...>     server-side conversion stages (see
-                             stream_open; empty = native stream)
+                             stream_open; NONE = native stream)
 codec_frames: <n>            whole codec frames produced (0 = raw stream)
 packet_count: <n>            UDP datagrams sent (RX) / accepted (TX)
 gap_count: <n>               inbound datagrams missing by sequence
@@ -1005,7 +1036,7 @@ udp_port: <port>             0 unless the caller owns the stream
 paused: <0|1>
 muted: <0|1>
 owner: <0|1>                 1 = opened by this TCP connection
-conversions: <C1,C2,...>     (empty = native stream)
+conversions: <C1,C2,...>     (NONE = native stream)
 codec_frames: <n>
 ```
 
@@ -1013,7 +1044,7 @@ codec_frames: <n>
 verbatim (`>` marks client input). The dummy's native audio format is
 PCM_F32, so this PCM_S16 open is served through server-side format
 conversion — visible as `conversions: FORMAT` in the open response and
-everywhere after (a native stream shows an empty value):
+everywhere after (a native stream shows `conversions: NONE`):
 
 ```
 > +\stream_open AUDIO_RX PCM_S16 48000 channels=2

--- a/HAMLIB_STREAMING_BACKEND_GUIDE.md
+++ b/HAMLIB_STREAMING_BACKEND_GUIDE.md
@@ -49,8 +49,10 @@ converted request — it always runs at a native configuration you declared
 (see Section 3, "What the frontend handles for you"; the full derivation
 and acceptance rules are in `HAMLIB_STREAMING.md` §3.3). Do **not**
 advertise combinations you would have to convert to serve: the frontend
-serves those through conversion, and `require_native` relies on your
-declaration being hardware truth.
+serves those through conversion, and `require_native` — with which an
+application demands specific stages (format, rate, channels) be served
+natively or the open refused — relies on your declaration being hardware
+truth.
 
 `rig_caps.stream_caps` is a **pointer** to a 0-terminated
 `struct rig_stream_caps` array (not an embedded array — so the descriptor
@@ -149,7 +151,9 @@ For I/Q formats, one "sample" is one complex pair (I + Q components).
 3. **List only what the hardware supports.** The frontend serves anything
    reachable from your native set through conversion and rejects the rest
    (`-RIG_EINVAL`); listing conversions yourself only mislabels them as
-   hardware-native and breaks `require_native` for your users.
+   hardware-native and breaks `require_native` for your users: an
+   application that demands a native sample rate would get a resampled
+   stream and no error.
 4. **List every native rate the hardware genuinely offers.** Format and
    channel conversion are always built into the frontend, but rate
    conversion depends on libsamplerate (optional at build time) — on a

--- a/README.developer
+++ b/README.developer
@@ -397,7 +397,9 @@ capability model and format conversion) and HAMLIB_STREAMING_BACKEND_GUIDE.md
 its hardware-native formats, sample rates and channel counts in stream_caps;
 the frontend derives the wider effective set it advertises to applications
 and installs any needed conversion at stream open
-(rig_stream_get_conversions() reports what runs on a stream).
+(rig_stream_get_conversions() reports what runs on a stream, and an
+application that needs a stage served natively lists it in
+rig_stream_config.require_native to have the open refused instead).
 
 Likewise, a complete test of the build system is accomplished with 'make
 distcheck' which exercises a complete build sequence from creating a

--- a/doc/man1/rigctld.1
+++ b/doc/man1/rigctld.1
@@ -1862,17 +1862,28 @@ under
 .IP
 Each key uses one of three value syntaxes, always the same one:
 .IR formats ", " native_formats " and " flags
-are comma-separated symbolic name lists (a list may be empty \(em
-.I flags
-on an entry with no capability flags);
+are comma-separated symbolic name lists;
 .IR rates ", " channels ", " native_rates " and " native_channels
 are comma-separated ascending decimal integer lists (ranges are not part
 of the grammar \(em a contiguous set is spelled out, e.g.
 \(aqchannels=1,2,3,4\(aq); and
 .IR max_streams " (the concurrent-stream limit) and " tx_horizon_ms
 (the timed-TX lead-time limit, 0 = not schedulable) are single
-integers.  The line carries every defined capability field; clients
-must skip unknown keys and unknown flag names.
+integers.  An empty list is spelled
+.BR NONE ,
+whichever of the two list syntaxes the key uses \(em
+\(aqflags=NONE\(aq on an entry with no capability flags,
+\(aqchannels=NONE\(aq on one that declares no channel counts \(em so no
+key is ever written with an empty value; the same token spells the empty
+list in
+.I conversions
+and
+.I require_native
+under
+.BR stream_open .
+A parser should nonetheless accept an empty value as the empty list, as
+an absent key already means.  The line carries every defined capability
+field; clients must skip unknown keys and unknown flag names.
 .
 .TP
 .BR stream_open " \(aq" \fIType\fP "\(aq \(aq" \fIFormat\fP "\(aq \(aq" \fIRate\fP "\(aq [\fIkey=value\fP ...]"
@@ -1903,8 +1914,13 @@ arguments:
 (1\(en255, validated against the capability entry \(em coherent I/Q may
 exceed stereo),
 .I require_native
-(0\(en1; 1 opens only a hardware-native stream, refusing a request that
-would need conversion with \-RIG_ENAVAIL),
+(comma-separated conversion stage names \(em FORMAT, RATE, CHANNELS \(em or
+ALL for every stage, or NONE; a request that would need a listed stage is
+refused with \-RIG_ENAVAIL instead of converted, while stages left out are
+still converted, so \(aqrequire_native=RATE\(aq demands a hardware-native
+sample rate but accepts a format conversion.  An unknown stage name is
+rejected with \-RIG_EINVAL rather than ignored, so a demand this server
+cannot honour never passes silently),
 .I time_stale_coarse
 (ms), and
 .I time_stale_invalidate
@@ -1918,7 +1934,7 @@ The response reports
 .IR max_payload ,
 .I conversions
 (the active server-side conversion stages as a comma-separated name
-list \(em FORMAT, RATE and/or CHANNELS \(em empty for a native stream),
+list \(em FORMAT, RATE and/or CHANNELS \(em NONE for a native stream),
 and, for multicast streams,
 .IR multicast .
 Codec formats (e.g. OPUS) open native-only \(em no conversion stage ever

--- a/include/hamlib/rig.h
+++ b/include/hamlib/rig.h
@@ -1998,14 +1998,22 @@ typedef enum {
 /* caps_flags is a single 64-bit namespace: future flags extend it with
  * (1ULL<<n) — the wire carries flag NAMES, so no key ever changes. */
 
-/* Active conversion stages between the hardware and an open stream, reported
- * by rig_stream_get_conversions(). 0 means a native stream: the bytes pass
- * untouched between the hardware and the application. Anything else marks a
- * converted stream and names exactly which stages the frontend runs. */
-#define RIG_STREAM_CONV_NONE      0       /* native stream */
+/* Conversion stages between the hardware and an open stream: the stages
+ * rig_stream_get_conversions() reports as running, and the stages
+ * rig_stream_config.require_native demands NOT run. RIG_STREAM_CONV_NONE
+ * means a native stream — the bytes pass untouched between the hardware and
+ * the application, and as a require_native value it demands nothing.
+ * Anything else names exactly which stages are meant. */
+#define RIG_STREAM_CONV_NONE      0       /* native stream / no demand */
 #define RIG_STREAM_CONV_FORMAT   (1<<0)   /* sample format converted */
 #define RIG_STREAM_CONV_RATE     (1<<1)   /* resampled */
 #define RIG_STREAM_CONV_CHANNELS (1<<2)   /* channel count mapped */
+/* Every stage, present and future — the value rig_stream_config.require_native
+ * takes to demand a fully native stream. Deliberately every bit rather than the
+ * OR of the three above: a stage added by a later release is then forbidden
+ * too, without the caller recompiling. Never test a REPORTED bitmask against
+ * it; test the individual stage bits. */
+#define RIG_STREAM_CONV_ALL       0xffffffffU
 
 /* Streaming capability descriptor. Two views share this struct:
  *
@@ -2088,11 +2096,20 @@ struct rig_stream_config {
                                              * 250 ms). Overridden by transport_buffer_bytes. */
     uint32_t transport_buffer_bytes;        /* Explicit transport buffer bytes
                                              * (0 = derive from transport_buffer_ms/rate) */
-    int32_t require_native;                 /* 1 = open only as a native stream:
-                                             * fail with -RIG_ENAVAIL rather than
-                                             * install a conversion. 0 (default) =
-                                             * convert when the request is in the
-                                             * effective but not the native set. */
+    uint32_t require_native;                /* Stages that MUST be served
+                                             * natively, as a bitmask of
+                                             * RIG_STREAM_CONV_*: the open fails
+                                             * with -RIG_ENAVAIL rather than
+                                             * install any stage listed here.
+                                             * RIG_STREAM_CONV_NONE (0, the
+                                             * default) = convert whatever the
+                                             * request needs; RIG_STREAM_CONV_ALL
+                                             * = a fully native stream. Stages
+                                             * left out are still converted as
+                                             * needed, so RIG_STREAM_CONV_RATE
+                                             * alone demands a native sample rate
+                                             * while allowing format and channel
+                                             * conversion. */
 };
 
 typedef struct rig_stream rig_stream_t;     /* Opaque — defined in src/stream.h */
@@ -3656,8 +3673,17 @@ rig_stream_config_free(struct rig_stream_config *config);
  * the opaque handle; free it with rig_stream_close(). \a config may be freed
  * immediately after this call returns.
  *
+ * A request that the backend cannot serve natively but the frontend can
+ * convert to is opened through conversion (see RIG_STREAM_CONV_* and
+ * rig_stream_get_conversions()), unless \a config->require_native lists the
+ * stage in question: any stage both required native and needed by the request
+ * refuses the open with -RIG_ENAVAIL, which is why that code is distinct from
+ * the -RIG_EINVAL of an outright unservable request.
+ *
  * \return RIG_OK, or a negative error (-RIG_EINVAL for a bad config/format,
- *         -RIG_ENIMPL if the backend has no streaming, and backend errors).
+ *         -RIG_ENAVAIL if serving the request would install a conversion
+ *         stage listed in \a config->require_native, -RIG_ENIMPL if the
+ *         backend has no streaming, and backend errors).
  */
 extern HAMLIB_EXPORT(int)
 rig_stream_open(RIG *rig,

--- a/rigs/dummy/netrigctl.c
+++ b/rigs/dummy/netrigctl.c
@@ -2907,7 +2907,8 @@ static int netrigctl_stream_open(RIG *rig, struct rig_stream *stream)
 {
     int ret;
     /* Larger than CMD_MAX: type + format + rate + key=value options. */
-    char cmd[128];
+    char cmd[160];
+    char native_req[64] = "";
     char buf[BUF_MAX];
     hamlib_port_t *rp = RIGPORT(rig);
     struct rig_stream_net_session *sess;
@@ -2925,13 +2926,31 @@ static int netrigctl_stream_open(RIG *rig, struct rig_stream *stream)
     /* Streaming commands require '+' ext_resp prefix. The server performs
      * any format conversion, so the full requested shape is forwarded:
      * channels (the server would otherwise default to 1 and serve
-     * mislabeled data) and a native-only demand for it to enforce too. */
+     * mislabeled data) and the native-only demand for it to enforce too —
+     * by stage name, so the server refuses exactly the stages this client
+     * required and converts the rest. */
+    if (stream->config.require_native != RIG_STREAM_CONV_NONE)
+    {
+        char stages[48];
+
+        if (stream_native_req_str(stream->config.require_native, stages,
+                                  sizeof(stages)) < 0)
+        {
+            rig_debug(RIG_DEBUG_ERR,
+                      "%s: cannot render require_native 0x%x\n",
+                      __func__, (unsigned)stream->config.require_native);
+            return -RIG_EINVAL;
+        }
+
+        SNPRINTF(native_req, sizeof(native_req), " require_native=%s", stages);
+    }
+
     SNPRINTF(cmd, sizeof(cmd), "+\\stream_open %s %s %d channels=%d%s\n",
              stream_type_name(stream->type),
              stream_format_name(stream->config.format),
              stream->config.sample_rate,
              stream->config.channels,
-             stream->config.require_native ? " require_native=1" : "");
+             native_req);
 
     ret = netrigctl_transaction(rig, cmd, strlen(cmd), buf);
 
@@ -2991,9 +3010,10 @@ static int netrigctl_stream_open(RIG *rig, struct rig_stream *stream)
         }
         else if (strncmp(buf, "conversions:", 12) == 0)
         {
-            /* Comma-separated stage names; empty value = native stream.
-             * Unknown names are skipped by the shared parser so a future
-             * server may add stages without breaking this client. */
+            /* Comma-separated stage names; NONE (or, from an older
+             * server, an empty value) = native stream. Unknown names are
+             * skipped by the shared parser so a future server may add
+             * stages without breaking this client. */
             conversions = stream_conversions_parse(buf + 12);
             rig_debug(RIG_DEBUG_VERBOSE, "%s: conversions=0x%x\n",
                       __func__, conversions);

--- a/src/stream.c
+++ b/src/stream.c
@@ -1197,13 +1197,25 @@ int HAMLIB_API rig_stream_open(RIG *rig,
 
     /* The request is servable, but only through conversion: a client that
      * demanded a native stream gets a distinct refusal (-RIG_ENAVAIL, vs
-     * -RIG_EINVAL for the outright impossible). */
-    if (conversions != RIG_STREAM_CONV_NONE && config->require_native)
+     * -RIG_EINVAL for the outright impossible). Only the stages listed in
+     * require_native are refused; the rest are converted as usual, so a
+     * client can demand a native sample rate and still take a format
+     * conversion. */
     {
-        rig_debug(RIG_DEBUG_ERR,
-                  "%s: config requires conversions 0x%x but require_native "
-                  "is set\n", __func__, conversions);
-        return -RIG_ENAVAIL;
+        uint32_t refused = (uint32_t)conversions & config->require_native;
+
+        if (refused != RIG_STREAM_CONV_NONE)
+        {
+            char convbuf[64];
+
+            stream_conversions_str((int)refused, convbuf, sizeof(convbuf));
+            rig_debug(RIG_DEBUG_ERR,
+                      "%s: request needs conversion stage(s) %s (0x%x), which "
+                      "require_native (0x%x) demands natively\n",
+                      __func__, convbuf, (unsigned)refused,
+                      (unsigned)config->require_native);
+            return -RIG_ENAVAIL;
+        }
     }
 
     struct rig_stream_state *ss = get_stream_state(rig);

--- a/src/stream_net.c
+++ b/src/stream_net.c
@@ -1009,10 +1009,10 @@ int rig_stream_net_parse_caps_line(const char *line,
         }
     }
 
-    /* Parse formats= (comma-separated format names) */
+    /* Parse formats= (comma-separated format names, or STREAM_LIST_NONE) */
     val = find_kv(line, "formats", &vlen);
 
-    if (val != NULL && vlen > 0)
+    if (val != NULL && vlen > 0 && !stream_list_none(val, (size_t)vlen))
     {
         char fbuf[256];
         copy_kv_value(val, vlen, fbuf, sizeof(fbuf));
@@ -1037,7 +1037,7 @@ int rig_stream_net_parse_caps_line(const char *line,
      * HAMLIB_MAX_STREAM_RATES effective list. */
     val = find_kv(line, "rates", &vlen);
 
-    if (val != NULL && vlen > 0)
+    if (val != NULL && vlen > 0 && !stream_list_none(val, (size_t)vlen))
     {
         char rbuf[256];
         copy_kv_value(val, vlen, rbuf, sizeof(rbuf));
@@ -1062,11 +1062,12 @@ int rig_stream_net_parse_caps_line(const char *line,
     }
 
     /* Parse flags= (comma-separated RIG_STREAM_CAP_* names, prefix
-     * stripped; optional — absent or empty means none; unknown names are
-     * skipped for forward compatibility) */
+     * stripped; optional — absent, STREAM_LIST_NONE, or empty from an
+     * older peer all mean none; unknown names are skipped for forward
+     * compatibility) */
     val = find_kv(line, "flags", &vlen);
 
-    if (val != NULL && vlen > 0)
+    if (val != NULL && vlen > 0 && !stream_list_none(val, (size_t)vlen))
     {
         char flbuf[128];
         copy_kv_value(val, vlen, flbuf, sizeof(flbuf));
@@ -1100,7 +1101,7 @@ int rig_stream_net_parse_caps_line(const char *line,
     /* Parse native_formats= (comma-separated format names) */
     val = find_kv(line, "native_formats", &vlen);
 
-    if (val != NULL && vlen > 0)
+    if (val != NULL && vlen > 0 && !stream_list_none(val, (size_t)vlen))
     {
         char fbuf[256];
         copy_kv_value(val, vlen, fbuf, sizeof(fbuf));
@@ -1124,7 +1125,7 @@ int rig_stream_net_parse_caps_line(const char *line,
     /* Parse native_rates= (comma-separated integers) */
     val = find_kv(line, "native_rates", &vlen);
 
-    if (val != NULL && vlen > 0)
+    if (val != NULL && vlen > 0 && !stream_list_none(val, (size_t)vlen))
     {
         char rbuf[256];
         copy_kv_value(val, vlen, rbuf, sizeof(rbuf));
@@ -1151,7 +1152,7 @@ int rig_stream_net_parse_caps_line(const char *line,
     /* Parse native_channels= (comma-separated allowed counts) */
     val = find_kv(line, "native_channels", &vlen);
 
-    if (val != NULL && vlen > 0)
+    if (val != NULL && vlen > 0 && !stream_list_none(val, (size_t)vlen))
     {
         char cbuf[128];
         copy_kv_value(val, vlen, cbuf, sizeof(cbuf));
@@ -1161,7 +1162,7 @@ int rig_stream_net_parse_caps_line(const char *line,
     /* Parse channels= (comma-separated allowed counts) */
     val = find_kv(line, "channels", &vlen);
 
-    if (val != NULL && vlen > 0)
+    if (val != NULL && vlen > 0 && !stream_list_none(val, (size_t)vlen))
     {
         char cbuf[128];
         copy_kv_value(val, vlen, cbuf, sizeof(cbuf));

--- a/src/stream_proto.c
+++ b/src/stream_proto.c
@@ -668,6 +668,15 @@ int stream_format_bitmask_str(rig_stream_format_t formats,
 
     buf[0] = '\0';
 
+    /* Every list-valued key of the protocol spells the empty list NONE
+     * (see stream_list_none()) — never an empty value. */
+    if (formats == 0)
+    {
+        int n = snprintf(buf, buflen, "%s", STREAM_LIST_NONE);
+
+        return (n < 0 || (size_t)n >= buflen) ? -1 : n;
+    }
+
     for (i = 0; i < FORMAT_TABLE_SIZE; i++)
     {
         if (formats & format_table[i].format)
@@ -723,6 +732,13 @@ int stream_caps_flags_str(uint64_t caps_flags, char *buf, size_t buflen)
 
     buf[0] = '\0';
 
+    if (caps_flags == 0)
+    {
+        int n = snprintf(buf, buflen, "%s", STREAM_LIST_NONE);
+
+        return (n < 0 || (size_t)n >= buflen) ? -1 : n;
+    }
+
     for (i = 0; i < sizeof(caps_flag_table) / sizeof(caps_flag_table[0]); i++)
     {
         if (!(caps_flags & caps_flag_table[i].flag))
@@ -761,9 +777,34 @@ uint64_t stream_caps_flag_parse(const char *name)
 
 /* Append an ascending 0-terminated int list as comma-separated decimals.
  * Returns 0, or -1 on overflow. */
+/* One token spells the empty list in EVERY list-valued key of the streaming
+ * protocol — caps name lists and integer lists, the conversions: stage list,
+ * and require_native. A key whose value is missing entirely, or empty as an
+ * older peer wrote it, means the same thing. */
+const char *const STREAM_LIST_NONE = "NONE";
+
+int stream_list_none(const char *value, size_t len)
+{
+    return len == 4 && strncmp(value, STREAM_LIST_NONE, 4) == 0;
+}
+
+
 static int append_int_list(char *buf, size_t buflen, size_t *pos,
                            const int *list, int max_entries)
 {
+    if (max_entries <= 0 || list[0] == 0)
+    {
+        int n = snprintf(buf + *pos, buflen - *pos, "%s", STREAM_LIST_NONE);
+
+        if (n < 0 || (size_t)n >= buflen - *pos)
+        {
+            return -1;
+        }
+
+        *pos += (size_t)n;
+        return 0;
+    }
+
     for (int i = 0; i < max_entries && list[i] != 0; i++)
     {
         int n = snprintf(buf + *pos, buflen - *pos, "%s%d",
@@ -913,6 +954,16 @@ int stream_conversions_str(int conv, char *buf, size_t buflen)
 
     buf[0] = '\0';
 
+    /* A native stream is spelled NONE, not an empty value: the same token
+     * a client writes in require_native, and one an eye or a log filter
+     * cannot mistake for a missing field. */
+    if (conv == RIG_STREAM_CONV_NONE)
+    {
+        int n = snprintf(buf, buflen, "%s", STREAM_LIST_NONE);
+
+        return (n < 0 || (size_t)n >= buflen) ? -1 : n;
+    }
+
     for (i = 0; i < sizeof(conv_table) / sizeof(conv_table[0]); i++)
     {
         if (!(conv & conv_table[i].flag))
@@ -960,7 +1011,15 @@ int stream_conversions_parse(const char *text)
 
         size_t i;
 
-        /* Unknown names are skipped so future servers may add stages. */
+        /* NONE contributes no stage; an empty value means the same thing
+         * (older servers wrote one). Other unknown names are skipped so
+         * future servers may add stages. */
+        if (stream_list_none(tok, len))
+        {
+            tok += len;
+            continue;
+        }
+
         for (i = 0; i < sizeof(conv_table) / sizeof(conv_table[0]); i++)
         {
             if (len == strlen(conv_table[i].name)
@@ -975,4 +1034,101 @@ int stream_conversions_parse(const char *text)
     }
 
     return conv;
+}
+
+
+/* --- require_native stage list --- */
+
+/* The wire spells a rig_stream_config.require_native mask with the same stage
+ * names as the conversions: line, plus ALL (every stage, present and future)
+ * and NONE (the empty list). */
+int stream_native_req_str(uint32_t mask, char *buf, size_t buflen)
+{
+    static const uint32_t known = (uint32_t)(RIG_STREAM_CONV_FORMAT
+                                  | RIG_STREAM_CONV_RATE
+                                  | RIG_STREAM_CONV_CHANNELS);
+
+    if (buflen == 0)
+    {
+        return -1;
+    }
+
+    /* Only RIG_STREAM_CONV_ALL sets bits outside the named stages, and it
+     * must survive the round trip as ALL: an older peer that rendered it as
+     * the stages it happens to know would quietly narrow the demand. */
+    if (mask & ~known)
+    {
+        int n = snprintf(buf, buflen, "ALL");
+
+        return (n < 0 || (size_t)n >= buflen) ? -1 : n;
+    }
+
+    /* RIG_STREAM_CONV_NONE renders as NONE through the shared formatter. */
+    return stream_conversions_str((int)mask, buf, buflen);
+}
+
+/* Strict counterpart of stream_conversions_parse(): an unknown stage name is
+ * an error rather than a skip. A requirement the peer cannot honour must
+ * never be silently dropped — the client would hold a guarantee that nothing
+ * enforces. Returns 0 with *mask set, or -1 (nothing written). */
+int stream_native_req_parse(const char *text, uint32_t *mask)
+{
+    uint32_t out = RIG_STREAM_CONV_NONE;
+    const char *tok = text;
+
+    if (!text || !mask)
+    {
+        return -1;
+    }
+
+    while (*tok != '\0')
+    {
+        while (*tok == ' ' || *tok == ',')
+        {
+            tok++;
+        }
+
+        size_t len = strcspn(tok, ", \r\n");
+
+        if (len == 0)
+        {
+            break;
+        }
+
+        size_t i;
+        int found = 0;
+
+        if (len == 3 && strncmp(tok, "ALL", len) == 0)
+        {
+            out |= RIG_STREAM_CONV_ALL;
+            found = 1;
+        }
+        else if (stream_list_none(tok, len))
+        {
+            found = 1;                /* RIG_STREAM_CONV_NONE: no stage */
+        }
+
+        for (i = 0; !found && i < sizeof(conv_table) / sizeof(conv_table[0]);
+                i++)
+        {
+            if (len == strlen(conv_table[i].name)
+                    && strncmp(tok, conv_table[i].name, len) == 0)
+            {
+                out |= (uint32_t)conv_table[i].flag;
+                found = 1;
+            }
+        }
+
+        if (!found)
+        {
+            rig_debug(RIG_DEBUG_ERR, "%s: unknown conversion stage '%.*s'\n",
+                      __func__, (int)len, tok);
+            return -1;
+        }
+
+        tok += len;
+    }
+
+    *mask = out;
+    return 0;
 }

--- a/src/stream_proto.h
+++ b/src/stream_proto.h
@@ -293,7 +293,8 @@ static inline int stream_ctrl_time_valid(uint16_t control)
                         | RIG_STREAM_CTRL_PONG));
 }
 
-/* Write comma-separated format names for all bits set in the bitmask.
+/* Write comma-separated format names for all bits set in the bitmask;
+ * STREAM_LIST_NONE for an empty bitmask.
  * Returns number of characters written (excluding NUL), or -1 if buf too small. */
 int stream_format_bitmask_str(rig_stream_format_t formats,
                               char *buf, size_t buflen);
@@ -315,7 +316,7 @@ const char *stream_format_name(rig_stream_format_t format);
 rig_stream_format_t stream_format_parse(const char *name);
 
 /* Write comma-separated RIG_STREAM_CAP_* flag names (prefix stripped);
- * empty string when no flag is set. Returns characters written or -1. */
+ * STREAM_LIST_NONE when no flag is set. Returns characters written or -1. */
 int stream_caps_flags_str(uint64_t caps_flags, char *buf, size_t buflen);
 
 /* Parse one flag name to its RIG_STREAM_CAP_* bit; 0 for unknown names. */
@@ -330,13 +331,35 @@ uint64_t stream_caps_flag_parse(const char *name);
 int stream_caps_format_line(const struct rig_stream_caps *e,
                             int include_native, char *buf, size_t buflen);
 
+/* The token every list-valued key of the streaming protocol uses for an
+ * empty list — caps name lists and integer lists, the conversions: stage
+ * list and require_native alike. A missing key, or an empty value from an
+ * older peer, means the same thing; nothing this library writes is empty. */
+extern const char *const STREAM_LIST_NONE;
+
+/* 1 if the first len bytes of value are exactly that token. */
+int stream_list_none(const char *value, size_t len);
+
 /* Write comma-separated RIG_STREAM_CONV_* stage names (prefix stripped);
- * empty string when no conversion is active. Returns chars written or -1. */
+ * "NONE" for RIG_STREAM_CONV_NONE. Returns chars written or -1. */
 int stream_conversions_str(int conv, char *buf, size_t buflen);
 
-/* Parse a comma-separated stage-name list back to the bitmask; unknown
- * names are skipped (forward compatibility), empty text is CONV_NONE. */
+/* Parse a comma-separated stage-name list back to the bitmask; "NONE" and
+ * empty text are both RIG_STREAM_CONV_NONE, and unknown names are skipped
+ * (forward compatibility). */
 int stream_conversions_parse(const char *text);
+
+/* Render a rig_stream_config.require_native mask as the stage-name list the
+ * \stream_open require_native= key carries: "ALL" for RIG_STREAM_CONV_ALL,
+ * else the names stream_conversions_str() writes ("NONE" for
+ * RIG_STREAM_CONV_NONE). Returns chars written or -1. */
+int stream_native_req_str(uint32_t mask, char *buf, size_t buflen);
+
+/* Parse that list back to a mask. STRICT, unlike stream_conversions_parse():
+ * an unknown stage name fails (-1) rather than being skipped, so a demand the
+ * peer cannot honour is refused instead of silently dropped. Returns 0 and
+ * sets *mask on success. */
+int stream_native_req_parse(const char *text, uint32_t *mask);
 
 
 /* Stream type classification helpers */

--- a/test/test_dummy_stream.c
+++ b/test/test_dummy_stream.c
@@ -2969,7 +2969,7 @@ void test_timed_tx_horizon_rejected(void)
 /* Helper: open an AUDIO_RX stream with the given format/rate, returning
  * the stream (or NULL) and the open return code in *ret_out. */
 static rig_stream_t *open_audio_rx(RIG *rig, rig_stream_format_t fmt,
-                                   int rate, int require_native,
+                                   int rate, uint32_t require_native,
                                    int *ret_out)
 {
     struct rig_stream_config *config = rig_stream_config_alloc();
@@ -3025,8 +3025,9 @@ void test_conversions_bitmask(void)
     close_dummy(rig);
 }
 
-/* require_native: native requests open with a hard guarantee, convertible
- * ones are refused with the distinct -RIG_ENAVAIL. */
+/* require_native, whole-mask form: RIG_STREAM_CONV_ALL demands a fully
+ * native stream, so native requests open with a hard guarantee while any
+ * convertible one is refused with the distinct -RIG_ENAVAIL. */
 void test_require_native(void)
 {
     RIG *rig = open_dummy();
@@ -3034,18 +3035,84 @@ void test_require_native(void)
 
     int ret;
     rig_stream_t *st = open_audio_rx(rig, RIG_STREAM_FORMAT_PCM_F32, 48000,
-                                     1, &ret);
+                                     RIG_STREAM_CONV_ALL, &ret);
     TEST_ASSERT(ret == RIG_OK && st != NULL);
     TEST_CHECK(rig_stream_get_conversions(st) == RIG_STREAM_CONV_NONE);
     rig_stream_close(rig, st);
 
-    st = open_audio_rx(rig, RIG_STREAM_FORMAT_PCM_S16, 48000, 1, &ret);
+    st = open_audio_rx(rig, RIG_STREAM_FORMAT_PCM_S16, 48000,
+                       RIG_STREAM_CONV_ALL, &ret);
     TEST_CHECK(ret == -RIG_ENAVAIL && st == NULL);
     TEST_MSG("expected -RIG_ENAVAIL, got %d", ret);
 
 #ifdef HAVE_SAMPLERATE
-    st = open_audio_rx(rig, RIG_STREAM_FORMAT_PCM_F32, 44100, 1, &ret);
+    st = open_audio_rx(rig, RIG_STREAM_FORMAT_PCM_F32, 44100,
+                       RIG_STREAM_CONV_ALL, &ret);
     TEST_CHECK(ret == -RIG_ENAVAIL && st == NULL);
+#endif
+
+    /* An empty mask is the default: convert whatever the request needs. */
+    st = open_audio_rx(rig, RIG_STREAM_FORMAT_PCM_S16, 48000, 0, &ret);
+    TEST_ASSERT(ret == RIG_OK && st != NULL);
+    TEST_CHECK(rig_stream_get_conversions(st) == RIG_STREAM_CONV_FORMAT);
+    rig_stream_close(rig, st);
+
+    close_dummy(rig);
+}
+
+/* require_native, per-stage form: only the stages listed are refused, and
+ * the rest still convert. Against the F32-native dummy at its native rates,
+ * that is the relay case — demand the sample rate, take the frontend's
+ * format conversion. */
+void test_require_native_per_stage(void)
+{
+    RIG *rig = open_dummy();
+    TEST_ASSERT(rig != NULL);
+
+    int ret;
+
+    /* S16 at a native rate needs the format stage only. Demanding it
+     * natively refuses... */
+    rig_stream_t *st = open_audio_rx(rig, RIG_STREAM_FORMAT_PCM_S16, 48000,
+                                     RIG_STREAM_CONV_FORMAT, &ret);
+    TEST_CHECK(ret == -RIG_ENAVAIL && st == NULL);
+    TEST_MSG("format demand on a format-converted open: got %d", ret);
+
+    /* ...while demanding the other two stages lets the same open through. */
+    st = open_audio_rx(rig, RIG_STREAM_FORMAT_PCM_S16, 48000,
+                       RIG_STREAM_CONV_RATE | RIG_STREAM_CONV_CHANNELS, &ret);
+    TEST_ASSERT(ret == RIG_OK && st != NULL);
+    TEST_CHECK(rig_stream_get_conversions(st) == RIG_STREAM_CONV_FORMAT);
+    rig_stream_close(rig, st);
+
+#ifdef HAVE_SAMPLERATE
+    /* Resampling is the stage the split exists for: forbidding it alone
+     * refuses an off-rate open... */
+    st = open_audio_rx(rig, RIG_STREAM_FORMAT_PCM_S16, 44100,
+                       RIG_STREAM_CONV_RATE, &ret);
+    TEST_CHECK(ret == -RIG_ENAVAIL && st == NULL);
+    TEST_MSG("rate demand on a resampled open: got %d", ret);
+
+    /* ...and so does forbidding the format stage, since both run here. */
+    st = open_audio_rx(rig, RIG_STREAM_FORMAT_PCM_S16, 44100,
+                       RIG_STREAM_CONV_FORMAT, &ret);
+    TEST_CHECK(ret == -RIG_ENAVAIL && st == NULL);
+
+    /* Forbidding a stage the request never needed is not a refusal. */
+    st = open_audio_rx(rig, RIG_STREAM_FORMAT_PCM_S16, 44100,
+                       RIG_STREAM_CONV_CHANNELS, &ret);
+    TEST_ASSERT(ret == RIG_OK && st != NULL);
+    TEST_CHECK(rig_stream_get_conversions(st)
+               == (RIG_STREAM_CONV_FORMAT | RIG_STREAM_CONV_RATE));
+    rig_stream_close(rig, st);
+
+    /* Native format at a non-native rate: only the rate stage runs, so a
+     * format demand is satisfied by a resampled stream. */
+    st = open_audio_rx(rig, RIG_STREAM_FORMAT_PCM_F32, 44100,
+                       RIG_STREAM_CONV_FORMAT, &ret);
+    TEST_ASSERT(ret == RIG_OK && st != NULL);
+    TEST_CHECK(rig_stream_get_conversions(st) == RIG_STREAM_CONV_RATE);
+    rig_stream_close(rig, st);
 #endif
 
     close_dummy(rig);
@@ -3332,6 +3399,7 @@ TEST_LIST =
     { "audio_rx_tone_s8",             test_audio_rx_tone_s8 },
     { "conversions_bitmask",          test_conversions_bitmask },
     { "require_native",               test_require_native },
+    { "require_native_per_stage",     test_require_native_per_stage },
     { "codec_rx_frame_sequence",      test_codec_rx_frame_sequence },
     { "codec_loopback_roundtrip",     test_codec_loopback_roundtrip },
 #ifdef HAVE_SAMPLERATE

--- a/test/test_netrigctl_stream.c
+++ b/test/test_netrigctl_stream.c
@@ -1184,14 +1184,40 @@ void test_rx_converted_stream_e2e(void)
     TEST_CHECK(ret == RIG_OK);
 
     /* require_native on the convertible config is refused... */
-    cfg.require_native = 1;
+    cfg.require_native = RIG_STREAM_CONV_ALL;
     stream = NULL;
     ret = rig_stream_open(rig, &cfg, &stream);
     TEST_CHECK(ret == -RIG_ENAVAIL);
     TEST_MSG("require_native open: got %d, expected %d", ret, -RIG_ENAVAIL);
     TEST_CHECK(stream == NULL);
 
+    /* ...and so is naming just the stage this request needs, which crosses
+     * the wire by name for the server to enforce. */
+    cfg.require_native = RIG_STREAM_CONV_FORMAT;
+    stream = NULL;
+    ret = rig_stream_open(rig, &cfg, &stream);
+    TEST_CHECK(ret == -RIG_ENAVAIL);
+    TEST_MSG("FORMAT demand: got %d, expected %d", ret, -RIG_ENAVAIL);
+    TEST_CHECK(stream == NULL);
+
+    /* Demanding only the stages it does not need serves the conversion:
+     * the relay case — native rate, frontend format conversion. */
+    cfg.require_native = RIG_STREAM_CONV_RATE | RIG_STREAM_CONV_CHANNELS;
+    stream = NULL;
+    ret = rig_stream_open(rig, &cfg, &stream);
+    TEST_CHECK(ret == RIG_OK);
+    TEST_MSG("rate+channels demand returned %d", ret);
+
+    if (stream)
+    {
+        TEST_CHECK(rig_stream_get_conversions(stream)
+                   == RIG_STREAM_CONV_FORMAT);
+        rig_stream_close(rig, stream);
+        stream = NULL;
+    }
+
     /* ...while its native form succeeds and reports a native stream. */
+    cfg.require_native = RIG_STREAM_CONV_ALL;
     cfg.format = RIG_STREAM_FORMAT_PCM_F32;
     ret = rig_stream_open(rig, &cfg, &stream);
     TEST_CHECK(ret == RIG_OK);

--- a/test/test_rigctld_commands.c
+++ b/test/test_rigctld_commands.c
@@ -118,7 +118,7 @@ extern int is_rigctld;
 #define EXPECTED_AUDIO_RX_LINE \
     "type=AUDIO_RX formats=PCM_S8,PCM_U8,PCM_S16,PCM_F32,OPUS " \
     "rates=" EXPECTED_AUDIO_RATES " channels=1,2 max_streams=4 " \
-    "flags= tx_horizon_ms=0 " \
+    "flags=NONE tx_horizon_ms=0 " \
     "native_formats=PCM_F32,OPUS " \
     "native_rates=" EXPECTED_AUDIO_NATIVE_RATES " native_channels=1,2"
 #define EXPECTED_AUDIO_TX_LINE \
@@ -130,7 +130,7 @@ extern int is_rigctld;
 #define EXPECTED_IQ_RX_LINE \
     "type=IQ_RX formats=IQ_CS8,IQ_CU8,IQ_CS16,IQ_CF32 " \
     "rates=" EXPECTED_IQ_RATES " channels=1,2,3,4 max_streams=4 " \
-    "flags= tx_horizon_ms=0 " \
+    "flags=NONE tx_horizon_ms=0 " \
     "native_formats=IQ_CF32 " \
     "native_rates=" EXPECTED_IQ_NATIVE_RATES " native_channels=1,2,3,4"
 #define EXPECTED_IQ_TX_LINE \
@@ -669,7 +669,7 @@ void test_cmd_dump_caps_streaming(void)
     TEST_CHECK(strstr(buf,
                       "\ttype=AUDIO_RX formats=PCM_F32,OPUS "
                       "rates=8000,16000,24000,48000,96000 channels=1,2 "
-                      "max_streams=4 flags= tx_horizon_ms=0\n") != NULL);
+                      "max_streams=4 flags=NONE tx_horizon_ms=0\n") != NULL);
     TEST_CHECK(strstr(buf,
                       "\ttype=AUDIO_TX formats=PCM_F32,OPUS "
                       "rates=8000,16000,24000,48000,96000 channels=1,2 "
@@ -678,7 +678,7 @@ void test_cmd_dump_caps_streaming(void)
     TEST_CHECK(strstr(buf,
                       "\ttype=IQ_RX formats=IQ_CF32 "
                       "rates=24000,48000,96000,192000 channels=1,2,3,4 "
-                      "max_streams=4 flags= tx_horizon_ms=0\n") != NULL);
+                      "max_streams=4 flags=NONE tx_horizon_ms=0\n") != NULL);
     TEST_CHECK(strstr(buf, "native_formats=") == NULL);
     TEST_MSG("declaration form must not carry native_* keys");
 
@@ -1040,8 +1040,8 @@ void test_cmd_stream_open_iq_multichannel(void)
     /* Native format, rate and channel count: a native stream. */
     char conv[64] = "x";
     TEST_CHECK(parse_ext_str(buf, "conversions", conv, sizeof(conv)) == 0);
-    TEST_CHECK(conv[0] == '\0');
-    TEST_MSG("conversions: got '%s', expected empty", conv);
+    TEST_CHECK(strcmp(conv, "NONE") == 0);
+    TEST_MSG("conversions: got '%s', expected NONE", conv);
 
     struct rigctld_stream *s = rigctld_stream_registry_find_by_id(
                                    &g_stream_registry, stream_id);
@@ -1099,14 +1099,14 @@ void test_cmd_stream_open_reports_conversions(void)
 
     conv[0] = 'x'; conv[1] = '\0';
     TEST_CHECK(parse_ext_str(buf, "conversions", conv, sizeof(conv)) == 0);
-    TEST_CHECK(conv[0] == '\0');
-    TEST_MSG("native open conversions: got '%s', expected empty", conv);
+    TEST_CHECK(strcmp(conv, "NONE") == 0);
+    TEST_MSG("native open conversions: got '%s', expected NONE", conv);
 
     stream_test_end(rig);
 }
 
 
-/* require_native=1 refuses a convertible-but-not-native request
+/* require_native=ALL refuses a convertible-but-not-native request
  * with -RIG_ENAVAIL (distinct from -RIG_EINVAL for the impossible), and
  * accepts the native form of the same request. */
 void test_cmd_stream_open_require_native(void)
@@ -1115,7 +1115,7 @@ void test_cmd_stream_open_require_native(void)
     TEST_CHECK(rig != NULL);
     char buf[1024];
 
-    run_cmd(rig, "\\stream_open AUDIO_RX PCM_S16 48000 require_native=1",
+    run_cmd(rig, "\\stream_open AUDIO_RX PCM_S16 48000 require_native=ALL",
             buf, sizeof(buf));
 
     int rprt_code = 0;
@@ -1126,14 +1126,104 @@ void test_cmd_stream_open_require_native(void)
     TEST_CHECK(rigctld_stream_registry_count(&g_stream_registry) == 0);
 
     int ret = run_cmd(rig,
-                      "\\stream_open AUDIO_RX PCM_F32 48000 require_native=1",
+                      "\\stream_open AUDIO_RX PCM_F32 48000 require_native=ALL",
                       buf, sizeof(buf));
     TEST_CHECK(ret == 0);
     TEST_MSG("native require_native open failed: '%s'", buf);
 
     char conv[64] = "x";
     TEST_CHECK(parse_ext_str(buf, "conversions", conv, sizeof(conv)) == 0);
-    TEST_CHECK(conv[0] == '\0');
+    TEST_CHECK(strcmp(conv, "NONE") == 0);
+    TEST_MSG("native require_native open conversions: got '%s'", conv);
+
+    stream_test_end(rig);
+}
+
+
+/* The wire carries the require_native mask as stage names, from the same
+ * vocabulary the conversions: line answers in: a demand that names only
+ * stages the request does not need serves the converted stream, one that
+ * names a needed stage refuses it. */
+void test_cmd_stream_open_require_native_stages(void)
+{
+    RIG *rig = stream_test_begin();
+    TEST_CHECK(rig != NULL);
+    char buf[1024];
+    char cmd[64];
+
+    /* S16 against the F32-native dummy resolves to a format conversion at
+     * a native rate — exactly what a relay wants to allow. */
+    int ret = run_cmd(rig,
+                      "\\stream_open AUDIO_RX PCM_S16 48000 "
+                      "require_native=RATE,CHANNELS",
+                      buf, sizeof(buf));
+    TEST_CHECK(ret == 0);
+    TEST_MSG("rate+channels demand on a format-converted open failed: '%s'",
+             buf);
+
+    char conv[64] = "";
+    TEST_CHECK(parse_ext_str(buf, "conversions", conv, sizeof(conv)) == 0);
+    TEST_CHECK(strcmp(conv, "FORMAT") == 0);
+    TEST_MSG("conversions: got '%s', expected FORMAT", conv);
+
+    int stream_id = -1, udp_port = -1;
+    parse_open_response(buf, &stream_id, &udp_port);
+    snprintf(cmd, sizeof(cmd), "\\stream_close %d", stream_id);
+    run_cmd(rig, cmd, buf, sizeof(buf));
+    TEST_CHECK(rigctld_stream_registry_count(&g_stream_registry) == 0);
+
+    /* Naming the stage the request does need refuses it. */
+    run_cmd(rig, "\\stream_open AUDIO_RX PCM_S16 48000 require_native=FORMAT",
+            buf, sizeof(buf));
+
+    int rprt_code = 0;
+    TEST_CHECK(parse_rprt_code(buf, &rprt_code) == 0);
+    TEST_CHECK(rprt_code == -RIG_ENAVAIL);
+    TEST_MSG("FORMAT demand: got RPRT %d, expected %d",
+             rprt_code, -RIG_ENAVAIL);
+    TEST_CHECK(rigctld_stream_registry_count(&g_stream_registry) == 0);
+
+    /* NONE is the empty demand, i.e. the default. */
+    ret = run_cmd(rig, "\\stream_open AUDIO_RX PCM_S16 48000 "
+                       "require_native=NONE", buf, sizeof(buf));
+    TEST_CHECK(ret == 0);
+    TEST_MSG("require_native=NONE open failed: '%s'", buf);
+    parse_open_response(buf, &stream_id, &udp_port);
+    snprintf(cmd, sizeof(cmd), "\\stream_close %d", stream_id);
+    run_cmd(rig, cmd, buf, sizeof(buf));
+
+    stream_test_end(rig);
+}
+
+
+/* A stage name the server does not know fails the open with -RIG_EINVAL.
+ * Skipping it (as the conversions: parser does for forward compatibility)
+ * would hand the client a stream with none of the guarantee it asked for. */
+void test_cmd_stream_open_require_native_unknown(void)
+{
+    RIG *rig = stream_test_begin();
+    TEST_CHECK(rig != NULL);
+    char buf[1024];
+
+    run_cmd(rig, "\\stream_open AUDIO_RX PCM_F32 48000 require_native=CODEC",
+            buf, sizeof(buf));
+
+    int rprt_code = 0;
+    TEST_CHECK(parse_rprt_code(buf, &rprt_code) == 0);
+    TEST_MSG("could not parse RPRT from: '%s'", buf);
+    TEST_CHECK(rprt_code == -RIG_EINVAL);
+    TEST_MSG("unknown stage: got RPRT %d, expected %d",
+             rprt_code, -RIG_EINVAL);
+    TEST_CHECK(rigctld_stream_registry_count(&g_stream_registry) == 0);
+
+    /* An unknown name among known ones is just as fatal — the demand is
+     * refused whole, never partially honoured. */
+    run_cmd(rig, "\\stream_open AUDIO_RX PCM_F32 48000 "
+                 "require_native=RATE,CODEC", buf, sizeof(buf));
+    rprt_code = 0;
+    TEST_CHECK(parse_rprt_code(buf, &rprt_code) == 0);
+    TEST_CHECK(rprt_code == -RIG_EINVAL);
+    TEST_CHECK(rigctld_stream_registry_count(&g_stream_registry) == 0);
 
     stream_test_end(rig);
 }
@@ -2121,8 +2211,8 @@ void test_rx_codec_passthrough_audio(void)
     /* A codec stream is native by definition. */
     char conv[64] = "x";
     TEST_CHECK(parse_ext_str(buf, "conversions", conv, sizeof(conv)) == 0);
-    TEST_CHECK(conv[0] == '\0');
-    TEST_MSG("codec conversions: got '%s', expected empty", conv);
+    TEST_CHECK(strcmp(conv, "NONE") == 0);
+    TEST_MSG("codec conversions: got '%s', expected NONE", conv);
 
     int client_sock = create_client_udp_socket();
     TEST_CHECK(client_sock >= 0);
@@ -5987,6 +6077,8 @@ TEST_LIST =
     { "cmd_stream_open_iq_multichannel",    test_cmd_stream_open_iq_multichannel },
     { "cmd_stream_open_reports_conversions", test_cmd_stream_open_reports_conversions },
     { "cmd_stream_open_require_native",     test_cmd_stream_open_require_native },
+    { "cmd_stream_open_require_native_stages", test_cmd_stream_open_require_native_stages },
+    { "cmd_stream_open_require_native_unknown", test_cmd_stream_open_require_native_unknown },
 
     /* stream_open — happy paths with backend verification */
     { "cmd_stream_open_kv_config_params",   test_cmd_stream_open_kv_config_params },

--- a/test/test_rigctld_stream.c
+++ b/test/test_rigctld_stream.c
@@ -675,10 +675,15 @@ void test_format_bitmask_str(void)
     TEST_CHECK(strcmp(buf, "IQ_CS16,IQ_CF32") == 0);
     TEST_MSG("got '%s'", buf);
 
-    /* Empty bitmask */
+    /* Empty bitmask: the shared empty-list token, never an empty value */
     ret = stream_format_bitmask_str(0, buf, sizeof(buf));
-    TEST_CHECK(ret == 0);
-    TEST_CHECK(buf[0] == '\0');
+    TEST_CHECK(ret == 4);
+    TEST_CHECK(strcmp(buf, "NONE") == 0);
+    TEST_MSG("empty bitmask rendered '%s'", buf);
+
+    /* Too short for the token: refused, not truncated */
+    ret = stream_format_bitmask_str(0, buf, 4);
+    TEST_CHECK(ret == -1);
 
     /* Buffer too small */
     ret = stream_format_bitmask_str(RIG_STREAM_FORMAT_PCM_S16, buf, 5);
@@ -2106,7 +2111,8 @@ void test_caps_line_roundtrip(void)
              (unsigned long long)in.caps_flags);
     TEST_CHECK(out.tx_schedule_horizon_ms == in.tx_schedule_horizon_ms);
 
-    /* Served form: native view appended; empty flags stay empty. */
+    /* Served form: native view appended; empty flags render as the
+     * empty-list token and parse back to no flags. */
     in.caps_flags = 0;
     in.tx_schedule_horizon_ms = 0;
     in.native_formats = RIG_STREAM_FORMAT_PCM_F32;
@@ -2117,6 +2123,9 @@ void test_caps_line_roundtrip(void)
     TEST_CHECK(stream_caps_format_line(&in, 1, line, sizeof(line)) > 0);
     TEST_MSG("line: '%s'", line);
 
+    TEST_CHECK(strstr(line, "flags=NONE") != NULL);
+    TEST_MSG("empty flags not rendered as NONE: '%s'", line);
+
     memset(&out, 0, sizeof(out));
     TEST_CHECK(rig_stream_net_parse_caps_line(line, &out) == 0);
     TEST_CHECK(out.caps_flags == 0);
@@ -2126,6 +2135,57 @@ void test_caps_line_roundtrip(void)
                       sizeof(in.native_sample_rates)) == 0);
     TEST_CHECK(memcmp(out.native_channels, in.native_channels,
                       sizeof(in.native_channels)) == 0);
+}
+
+/* Every list-valued caps key spells an empty list NONE — name lists and
+ * integer lists alike — so no key is ever written with an empty value.
+ * Each spelling parses back to the empty list, including the empty value
+ * an older peer would have written. */
+void test_caps_line_empty_lists_none(void)
+{
+    struct rig_stream_caps in;
+    struct rig_stream_caps out;
+    char line[1024];
+
+    memset(&in, 0, sizeof(in));
+    in.type = RIG_STREAM_TYPE_AUDIO_RX;
+    in.formats = RIG_STREAM_FORMAT_PCM_S16;
+    in.sample_rates[0] = 48000;
+    in.max_streams = 1;
+    /* channels, flags and the whole native view left empty. */
+
+    TEST_CHECK(stream_caps_format_line(&in, 1, line, sizeof(line)) > 0);
+    TEST_MSG("line: '%s'", line);
+
+    TEST_CHECK(strstr(line, "channels=NONE") != NULL);
+    TEST_CHECK(strstr(line, "flags=NONE") != NULL);
+    TEST_CHECK(strstr(line, "native_formats=NONE") != NULL);
+    TEST_CHECK(strstr(line, "native_rates=NONE") != NULL);
+    TEST_CHECK(strstr(line, "native_channels=NONE") != NULL);
+    TEST_CHECK_(strstr(line, "= ") == NULL && line[strlen(line) - 1] != '=',
+                "a key was written with an empty value: '%s'", line);
+
+    memset(&out, 0, sizeof(out));
+    TEST_CHECK(rig_stream_net_parse_caps_line(line, &out) == 0);
+    TEST_CHECK(out.formats == in.formats);
+    TEST_CHECK(out.sample_rates[0] == 48000);
+    TEST_CHECK(out.channels[0] == 0);
+    TEST_CHECK(out.caps_flags == 0);
+    TEST_CHECK(out.native_formats == 0);
+    TEST_CHECK(out.native_sample_rates[0] == 0);
+    TEST_CHECK(out.native_channels[0] == 0);
+
+    /* The empty values an older peer wrote still mean the empty list. */
+    const char *legacy =
+        "type=AUDIO_RX formats=PCM_S16 rates=48000 channels= "
+        "max_streams=1 flags= tx_horizon_ms=0";
+
+    memset(&out, 0, sizeof(out));
+    TEST_CHECK(rig_stream_net_parse_caps_line(legacy, &out) == 0);
+    TEST_CHECK(out.formats == RIG_STREAM_FORMAT_PCM_S16);
+    TEST_CHECK(out.sample_rates[0] == 48000);
+    TEST_CHECK(out.channels[0] == 0);
+    TEST_CHECK(out.caps_flags == 0);
 }
 
 /* Unknown flag names on the wire are skipped, known ones kept — a
@@ -2631,6 +2691,114 @@ void test_write_status_emit(void)
 }
 
 
+/* --- require_native stage list on the wire --- */
+
+/* The mask renders to the stage names the \stream_open require_native= key
+ * carries, and parses back to the same mask. ALL must survive as ALL: a peer
+ * that re-rendered it as the stages it happens to know would silently narrow
+ * the demand for the next hop. */
+void test_native_req_round_trip(void)
+{
+    static const struct
+    {
+        uint32_t mask;
+        const char *text;
+    } cases[] =
+    {
+        { 0,                                            "NONE" },
+        { RIG_STREAM_CONV_FORMAT,                       "FORMAT" },
+        { RIG_STREAM_CONV_RATE,                         "RATE" },
+        { RIG_STREAM_CONV_CHANNELS,                     "CHANNELS" },
+        {
+            RIG_STREAM_CONV_FORMAT | RIG_STREAM_CONV_RATE,
+            "FORMAT,RATE"
+        },
+        {
+            RIG_STREAM_CONV_FORMAT | RIG_STREAM_CONV_RATE
+            | RIG_STREAM_CONV_CHANNELS,
+            "FORMAT,RATE,CHANNELS"
+        },
+        { RIG_STREAM_CONV_ALL,                          "ALL" },
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++)
+    {
+        char buf[64] = "";
+        TEST_CHECK(stream_native_req_str(cases[i].mask, buf, sizeof(buf)) > 0);
+        TEST_CHECK_(strcmp(buf, cases[i].text) == 0,
+                    "0x%x rendered '%s', expected '%s'",
+                    (unsigned)cases[i].mask, buf, cases[i].text);
+
+        uint32_t back = 0xdeadbeef;
+        TEST_CHECK(stream_native_req_parse(cases[i].text, &back) == 0);
+        TEST_CHECK_(back == cases[i].mask, "'%s' parsed to 0x%x, expected 0x%x",
+                    cases[i].text, (unsigned)back, (unsigned)cases[i].mask);
+    }
+
+    /* Spaces, empty text and repeats are all accepted. */
+    uint32_t mask = 0xdeadbeef;
+    TEST_CHECK(stream_native_req_parse("", &mask) == 0);
+    TEST_CHECK(mask == 0);
+
+    TEST_CHECK(stream_native_req_parse("RATE, FORMAT RATE", &mask) == 0);
+    TEST_CHECK(mask == (uint32_t)(RIG_STREAM_CONV_RATE
+                                  | RIG_STREAM_CONV_FORMAT));
+
+    /* ALL is a superset of every named stage, so it absorbs them. */
+    TEST_CHECK(stream_native_req_parse("FORMAT,ALL", &mask) == 0);
+    TEST_CHECK(mask == RIG_STREAM_CONV_ALL);
+
+    /* A short buffer fails rather than truncating a demand. */
+    char tiny[4];
+    TEST_CHECK(stream_native_req_str(RIG_STREAM_CONV_FORMAT
+                                     | RIG_STREAM_CONV_RATE,
+                                     tiny, sizeof(tiny)) < 0);
+}
+
+/* The reported side speaks the same NONE: a native stream renders as the
+ * token, not as an empty value, and the token parses back to
+ * RIG_STREAM_CONV_NONE from either spelling. */
+void test_conversions_str_none(void)
+{
+    char buf[64] = "x";
+
+    TEST_CHECK(stream_conversions_str(RIG_STREAM_CONV_NONE, buf,
+                                      sizeof(buf)) == 4);
+    TEST_CHECK_(strcmp(buf, "NONE") == 0, "CONV_NONE rendered '%s'", buf);
+
+    TEST_CHECK(stream_conversions_parse("NONE") == RIG_STREAM_CONV_NONE);
+    TEST_CHECK(stream_conversions_parse("") == RIG_STREAM_CONV_NONE);
+
+    /* NONE contributes no stage when it turns up beside one. */
+    TEST_CHECK(stream_conversions_parse("NONE,RATE") == RIG_STREAM_CONV_RATE);
+
+    /* Too short for the token: refused, not truncated to "NON". */
+    char tiny[4];
+    TEST_CHECK(stream_conversions_str(RIG_STREAM_CONV_NONE, tiny,
+                                      sizeof(tiny)) < 0);
+}
+
+/* Parsing is strict where stream_conversions_parse() is forgiving: an
+ * unknown stage name is an error, and nothing is written to the mask. */
+void test_native_req_unknown_name(void)
+{
+    uint32_t mask = 0x5a5a5a5a;
+
+    TEST_CHECK(stream_native_req_parse("CODEC", &mask) < 0);
+    TEST_CHECK(stream_native_req_parse("RATE,CODEC", &mask) < 0);
+    TEST_CHECK(stream_native_req_parse("format", &mask) < 0);   /* case */
+    TEST_CHECK_(mask == 0x5a5a5a5a, "mask was written on failure: 0x%x",
+                (unsigned)mask);
+
+    TEST_CHECK(stream_native_req_parse(NULL, &mask) < 0);
+    TEST_CHECK(stream_native_req_parse("RATE", NULL) < 0);
+
+    /* The reported-conversions parser keeps its skip-unknown behaviour:
+     * a stage a future server names must not break a client reading it. */
+    TEST_CHECK(stream_conversions_parse("RATE,CODEC") == RIG_STREAM_CONV_RATE);
+}
+
+
 TEST_LIST =
 {
     /* Subscribe token */
@@ -2638,6 +2806,12 @@ TEST_LIST =
 
     /* Packet header */
     { "header_pack_unpack_roundtrip", test_header_pack_unpack_roundtrip },
+
+    /* require_native stage list */
+    { "native_req_round_trip",        test_native_req_round_trip },
+    { "native_req_unknown_name",      test_native_req_unknown_name },
+    { "conversions_str_none",         test_conversions_str_none },
+
     { "time_block_round_trip", test_time_block_round_trip },
     { "time_block_negative_seconds", test_time_block_negative_seconds },
     { "time_block_short_buffer", test_time_block_short_buffer },
@@ -2762,6 +2936,7 @@ TEST_LIST =
     { "net_parse_caps_line_audio_rx",  test_net_parse_caps_line_audio_rx },
     { "net_parse_caps_line_iq_tx",     test_net_parse_caps_line_iq_tx },
     { "caps_line_roundtrip",           test_caps_line_roundtrip },
+    { "caps_line_empty_lists_none",    test_caps_line_empty_lists_none },
     { "caps_line_unknown_flag_skipped", test_caps_line_unknown_flag_skipped },
     { "net_parse_caps_line_native_keys", test_net_parse_caps_line_native_keys },
     { "net_parse_caps_line_missing_type", test_net_parse_caps_line_missing_type },

--- a/test/test_stream_api.c
+++ b/test/test_stream_api.c
@@ -578,7 +578,7 @@ void test_channel_list_exact(void)
 
     /* Listed counts still open under require_native. */
     cfg->channels = 1;
-    cfg->require_native = 1;
+    cfg->require_native = RIG_STREAM_CONV_ALL;
     stream = NULL;
     ret = rig_stream_open(rig, cfg, &stream);
     TEST_CHECK(ret == RIG_OK);
@@ -926,13 +926,52 @@ void test_conversions_getter(void)
     cfg->format = RIG_STREAM_FORMAT_PCM_S16;
     cfg->sample_rate = 48000;
     cfg->channels = 1;
-    cfg->require_native = 1;
+    cfg->require_native = RIG_STREAM_CONV_ALL;
 
     rig_stream_t *stream = NULL;
     TEST_ASSERT(rig_stream_open(rig, cfg, &stream) == RIG_OK);
     TEST_CHECK(rig_stream_get_conversions(stream) == RIG_STREAM_CONV_NONE);
 
     rig_stream_close(rig, stream);
+    rig_stream_config_free(cfg);
+    teardown_rig(rig);
+}
+
+/* The channel map is a stage like the others: against a mono-only backend
+ * a stereo request is refused when CHANNELS is required native, and served
+ * when the demand names a different stage. */
+void test_require_native_channels_stage(void)
+{
+    RIG *rig = setup_rig(&stub_caps_mono_stream);
+    TEST_ASSERT(rig != NULL);
+
+    struct rig_stream_config *cfg = rig_stream_config_alloc();
+    TEST_ASSERT(cfg != NULL);
+    cfg->type = RIG_STREAM_TYPE_AUDIO_RX;
+    cfg->format = RIG_STREAM_FORMAT_PCM_F32;
+    cfg->sample_rate = 48000;
+    cfg->channels = 2;                  /* mono backend -> upmix */
+
+    rig_stream_t *stream = NULL;
+    cfg->require_native = RIG_STREAM_CONV_CHANNELS;
+    int ret = rig_stream_open(rig, cfg, &stream);
+    TEST_CHECK(ret == -RIG_ENAVAIL && stream == NULL);
+    TEST_MSG("channels demand on an upmixed open: got %d, expected %d",
+             ret, -RIG_ENAVAIL);
+
+    cfg->require_native = RIG_STREAM_CONV_FORMAT | RIG_STREAM_CONV_RATE;
+    stream = NULL;
+    ret = rig_stream_open(rig, cfg, &stream);
+    TEST_CHECK(ret == RIG_OK);
+    TEST_MSG("format+rate demand on an upmixed open returned %d", ret);
+
+    if (ret == RIG_OK)
+    {
+        TEST_CHECK(rig_stream_get_conversions(stream)
+                   == RIG_STREAM_CONV_CHANNELS);
+        rig_stream_close(rig, stream);
+    }
+
     rig_stream_config_free(cfg);
     teardown_rig(rig);
 }
@@ -2395,6 +2434,7 @@ TEST_LIST =
     { "caps_codec_only_not_widened", test_caps_codec_only_not_widened },
     { "caps_pre_open_raw",        test_caps_pre_open_raw },
     { "conversions_getter",       test_conversions_getter },
+    { "require_native_channels_stage", test_require_native_channels_stage },
     { "config_alloc_free",        test_config_alloc_free },
     { "get_max_payload",          test_get_max_payload },
     { "open_null_config",         test_open_null_config },

--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -6387,11 +6387,15 @@ struct stream_open_opts
     int keepalive_timeout;
 };
 
-static void stream_open_parse_opts(FILE *fin, struct rig_stream_config *cfg,
-                                   struct stream_open_opts *opts)
+/* Returns 0, or -1 if a parameter was rejected outright (only require_native
+ * is that strict — see below); the whole argument line is consumed either
+ * way, so the caller can simply fail the command. */
+static int stream_open_parse_opts(FILE *fin, struct rig_stream_config *cfg,
+                                  struct stream_open_opts *opts)
 {
     struct hamlib_kv_pair kv[12];
     int nkv = hamlib_parse_kv_args(fin, kv, 12);
+    int err = 0;
     int i;
 
     for (i = 0; i < nkv; i++)
@@ -6402,11 +6406,22 @@ static void stream_open_parse_opts(FILE *fin, struct rig_stream_config *cfg,
         }
         else if (strcmp(kv[i].key, "require_native") == 0)
         {
-            long val;
+            uint32_t mask;
 
-            if (stream_open_kv_long(&kv[i], 0, 1, &val) == 0)
+            /* Comma-separated stage names (FORMAT, RATE, CHANNELS), ALL or
+             * NONE. Unlike every other key here, a bad value fails the open
+             * instead of falling back to the default: silently ignoring it
+             * would serve a converted stream to a client that asked for a
+             * guarantee. */
+            if (stream_native_req_parse(kv[i].value, &mask) < 0)
             {
-                cfg->require_native = (int)val;
+                rig_debug(RIG_DEBUG_ERR, "%s: invalid require_native '%s'\n",
+                          __func__, kv[i].value);
+                err = -1;
+            }
+            else
+            {
+                cfg->require_native = mask;
             }
         }
         else if (strcmp(kv[i].key, "ttl") == 0)
@@ -6511,6 +6526,8 @@ static void stream_open_parse_opts(FILE *fin, struct rig_stream_config *cfg,
                       __func__, kv[i].key);
         }
     }
+
+    return err;
 }
 
 
@@ -6541,7 +6558,11 @@ declare_proto_rig(stream_open)
     /* Optional key=value parameters follow the positional arguments */
     if (interactive)
     {
-        stream_open_parse_opts(fin, &cfg, &opts);
+        if (stream_open_parse_opts(fin, &cfg, &opts) < 0)
+        {
+            free(opts.multicast_spec);
+            RETURNFUNC2(-RIG_EINVAL);
+        }
     }
 
     /* TX multicast not supported */

--- a/tests/rigstreamtest.c
+++ b/tests/rigstreamtest.c
@@ -41,20 +41,24 @@
 #include "token.h"
 #include "misc.h"
 #include "rigstreamtest_util.h"
+#include "stream_proto.h"
 
 
 static volatile sig_atomic_t running = 1;
-static int g_require_native = 0;  /* --require-native: fail instead of
-                                   * accepting a converted stream */
+/* --require-native[=LIST]: conversion stages the open must not install */
+static uint32_t g_require_native = RIG_STREAM_CONV_NONE;
 
 /* Report the frontend conversion stages of a freshly opened stream:
  * CONV_NONE marks a native stream (bytes untouched). */
 static void report_conversions(rig_stream_t *st, const char *tag)
 {
     int c = rig_stream_get_conversions(st);
+    char stages[64];
+
+    stream_conversions_str(c, stages, sizeof(stages));
 
     printf("Stream %s: conversions=0x%x (%s)\n", tag, c,
-           c == RIG_STREAM_CONV_NONE ? "native stream" : "converted stream");
+           c == RIG_STREAM_CONV_NONE ? "native stream" : stages);
 }
 
 static void sighandler(int sig)
@@ -122,8 +126,14 @@ static void usage(const char *prog)
             "  --iq                   Use I/Q streams for the phases (default: audio)\n"
             "  --stats-secs <sec>     Interim stats interval (default 5)\n"
             "  --buffer-ms <ms>       Ring buffer size as ms of stream data\n"
-            "  --require-native       Fail instead of accepting a converted stream\n"
-            "                         (0 = backend default)\n"
+            "  --require-native[=LIST] Conversion stages the stream must NOT\n"
+            "                         use: comma-separated FORMAT, RATE,\n"
+            "                         CHANNELS, or ALL (the default when the\n"
+            "                         flag is given bare). An open needing a\n"
+            "                         listed stage fails instead of converting;\n"
+            "                         stages left out are still converted, so\n"
+            "                         --require-native=RATE demands a native\n"
+            "                         sample rate but accepts a format change\n"
             "\n"
             "Full-duplex soak (--full-duplex): RX and TX streams run concurrently\n"
             "the whole run; PTT is cycled ON for --tx-secs / OFF for --rx-secs\n"
@@ -1588,7 +1598,7 @@ int main(int argc, char *argv[])
         { "iq",          no_argument,       NULL, OPT_IQ },
         { "stats-secs",  required_argument, NULL, OPT_STATS_SECS },
         { "buffer-ms",   required_argument, NULL, OPT_BUFFER_MS },
-        { "require-native", no_argument,    NULL, OPT_REQUIRE_NATIVE },
+        { "require-native", optional_argument, NULL, OPT_REQUIRE_NATIVE },
         { "full-duplex", no_argument,       NULL, OPT_FULL_DUPLEX },
         { "tone-on-ms",     required_argument, NULL, OPT_TONE_ON },
         { "tone-off-ms",    required_argument, NULL, OPT_TONE_OFF },
@@ -1694,7 +1704,21 @@ int main(int argc, char *argv[])
             break;
 
         case OPT_REQUIRE_NATIVE:
-            g_require_native = 1;
+
+            /* Bare flag = every stage, i.e. a fully native stream. */
+            if (!optarg)
+            {
+                g_require_native = RIG_STREAM_CONV_ALL;
+            }
+            else if (stream_native_req_parse(optarg, &g_require_native) < 0)
+            {
+                fprintf(stderr,
+                        "Error: --require-native: unknown stage in '%s' "
+                        "(expected FORMAT, RATE, CHANNELS, ALL or NONE)\n",
+                        optarg);
+                return 1;
+            }
+
             break;
 
         case OPT_FULL_DUPLEX:


### PR DESCRIPTION
This PR allows choosing which stream conversions are allowed/disallowed (require_native).
The work is based on feedback from @KJ5HST in https://github.com/Hamlib/Hamlib/pull/2116#issuecomment-5376715109

LLM summary of the changes:

## Summary

Two related changes to the streaming subsystem, both driven by feedback, 
using the format-conversion work in production:

1. `rig_stream_config.require_native` becomes a **per-stage bitmask** instead of
   an all-or-nothing flag, so an application can demand a hardware-native sample
   rate while still accepting the frontend's format conversion.
2. `NONE` becomes the **single empty-list token** across the rigctld protocol —
   conversion-stage lists and capability lines alike — so no key is ever written
   with an empty value.

Nothing has shipped with `require_native` yet, so no compatibility shims are
carried for it.

### 1. `require_native` as a conversion-stage mask

The old boolean covered sample format, rate and channel count together, but those
stages have very different costs to a relay. Resampling is the latency stage, and
demanding a native rate is cheap: read `native_sample_rates` and open at one of
them. Format is the opposite — demanding a native format means taking whatever
each backend happens to offer or `-RIG_ENAVAIL`, and for a relay it is
self-defeating, since doing the conversion itself moves quantization out of the
frontend's routines and into worse ones. The guarantee was only available
all-or-nothing, so consumers negotiated the rate and read
`rig_stream_get_conversions()` afterwards — which lands in the right place but
enforces nothing.

`require_native` now takes the same `RIG_STREAM_CONV_*` constants that
`rig_stream_get_conversions()` reports. Any stage that is both required and
needed refuses the open with `-RIG_ENAVAIL`; stages left out still convert:

```c
cfg->require_native = RIG_STREAM_CONV_RATE;   /* resample = fail, format = fine */
cfg->require_native = RIG_STREAM_CONV_ALL;    /* fully native stream */
cfg->require_native = RIG_STREAM_CONV_NONE;   /* default: convert as needed */
```

`RIG_STREAM_CONV_ALL` is deliberately every bit (`0xffffffffU`), not the OR of
the three defined stages: a stage added in a later release is then forbidden for
a caller that asked for `ALL` without recompiling. The field changed from
`int32_t` to `uint32_t` (layout-neutral) so the value assigns cleanly.

On the wire and command line, `require_native=` takes stage names from the same
vocabulary the `conversions:` response line already speaks:

```
\stream_open AUDIO_RX PCM_S16 48000 require_native=RATE
\stream_open AUDIO_RX PCM_S16 48000 require_native=FORMAT,RATE
\stream_open AUDIO_RX PCM_F32 48000 require_native=ALL
```

Parsing is **strict** here — an unknown stage name fails the open with
`-RIG_EINVAL` rather than being skipped. This is intentionally asymmetric with
the reported-conversions parser, which keeps skipping unknown names for forward
compatibility: a reported stage a client does not know is informational, but a
required stage a server does not know is a guarantee it cannot honour, and
silently dropping it recreates exactly the false assurance this change fixes.

netrigctl forwards the mask by name so the far side enforces the same stages.
`rigstreamtest` gained `--require-native[=LIST]` (bare flag = `ALL`) and now
prints stage names in its conversion report.

### 2. `NONE` as the empty-list token

`stream_conversions_str()` wrote an empty string for a native stream, and the
capability lines wrote empty values for empty lists (`flags=` on an entry with no
capability flags). Both now write `NONE`, from one shared definition:

```
conversions: NONE                                  (was: conversions: )
type=AUDIO_RX ... max_streams=4 flags=NONE ...     (was: flags= )
```

This covers every list-valued key in both list syntaxes — `formats`, `flags`,
`rates`, `channels` and the `native_*` set — so a reader never has to tell "the
empty list" apart from "the field is missing". Applied to the integer lists too:
a rule with an exception for `rates=`/`channels=` would have kept the
inconsistency this change removes. Parsers still accept an empty value as the
empty list (as an absent key already means), so tolerance is read-only.

Wire-visible: `\stream_open`, `\stream_status` and `\stream_list` now report
`conversions: NONE` for native streams, and `\stream_caps`, `dump_caps` and
`dumpstate` write `flags=NONE` where `flags= ` used to appear.

### Documentation

`HAMLIB_STREAMING.md` (conversion model, config struct, open semantics,
`\stream_open` key list, value-syntax grammar), `HAMLIB_STREAMING_BACKEND_GUIDE.md`
(what a mis-declared capability costs a user demanding a native rate),
`README.developer`, and the `rigctld(1)` `require_native`, `conversions` and
`stream_caps` grammar paragraphs.

### Testing

`make check` passes; all 11 streaming suites green. New coverage:

- `test_rigctld_stream`: mask↔text round trip (`ALL` surviving as `ALL`, spaces,
  repeats, short-buffer refusal), strict unknown-name rejection with the mask
  left untouched, `NONE` on the reported side, and a caps line whose every empty
  list renders `NONE` and parses back — including the legacy empty-value form.
- `test_dummy_stream`: per-stage refusals against the F32-native dummy — a format
  demand refuses a format-converted open, a rate+channels demand serves it, and
  with libsamplerate a rate demand refuses a resampled open while a channels
  demand lets it through reporting `FORMAT|RATE`.
- `test_stream_api`: the channel-map stage isolated against a mono-only backend.
- `test_rigctld_commands`: stage names over TCP, `NONE`, and unknown names
  (`CODEC`, `RATE,CODEC`) rejected with the registry left untouched.
- `test_netrigctl_stream`: a per-stage demand crossing the wire end to end —
  `FORMAT` refused, `RATE|CHANNELS` served with `conversions: FORMAT`.

Also verified live against `rigctld -m 1` for every combination above, and the
man page renders clean under groff.
