### PR TITLE
Fix building Python bindings with SWIG 4.5

### DIFF
--- a/bindings/hamlib.swg
+++ b/bindings/hamlib.swg
@@ -69,7 +69,7 @@
   len = $1_dim0;
   $result = PyList_New(len);
   for (i = 0; i < len; i++) {
-    PyList_SetItem($result,i,PyInt_FromLong((long)$1[i]));
+    PyList_SetItem($result,i,PyLong_FromLong((long)$1[i]));
   }
 }
 
@@ -78,7 +78,7 @@
   len = $1_dim0;
   $result = PyList_New(len);
   for (i = 0; i < len; i++) {
-    PyList_SetItem($result,i,PyInt_FromLong((long)$1[i]));
+    PyList_SetItem($result,i,PyLong_FromLong((long)$1[i]));
   }
 }
 


### PR DESCRIPTION
This change is compatible with SWIG 4.4.

Fixes:
 error: implicit declaration of function 'PyInt_FromLong'

SWIG commit that dropped the macros used for compatibility with Python 2:
 https://github.com/swig/swig/commit/79f7a2b7cb7ddc256eba09c8770133148025171d

Debian bug report:
 https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1145352