### PR TITLE
Execute the CI actions for pushes and pull requests on all branches

### DIFF
--- a/.github/codeql-analysis.yml
+++ b/.github/codeql-analysis.yml
@@ -2,10 +2,8 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master, ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
   schedule:
     - cron: '0 5 * * 2'
 

--- a/.github/workflows/android-ndk.yml
+++ b/.github/workflows/android-ndk.yml
@@ -2,9 +2,7 @@ name: Android NDK cross-compile
 
 on:
   push:
-    branches: [ master, feature/* ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -2,9 +2,7 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [ master, feature/* ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/c-cpp32.yml
+++ b/.github/workflows/c-cpp32.yml
@@ -2,9 +2,7 @@ name: C/C++ CI 32-bit
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,8 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
   schedule:
     - cron: '39 20 * * 6'
 

--- a/.github/workflows/macos-latest-features.yml
+++ b/.github/workflows/macos-latest-features.yml
@@ -2,9 +2,7 @@ name: MacOS latest C/C++ (features)
 
 on:
   push:
-    branches: [ master, feature/* ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/macos-latest-no-features.yml
+++ b/.github/workflows/macos-latest-no-features.yml
@@ -2,9 +2,7 @@ name: MacOS latest C/C++ (no features)
 
 on:
   push:
-    branches: [ master, feature/* ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/ubuntu-latest-features.yml
+++ b/.github/workflows/ubuntu-latest-features.yml
@@ -2,9 +2,7 @@ name: Ubuntu latest C/C++ (features)
 
 on:
   push:
-    branches: [ master, feature/* ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/ubuntu-latest-no-features.yml
+++ b/.github/workflows/ubuntu-latest-no-features.yml
@@ -2,9 +2,7 @@ name: Ubuntu latest C/C++ (no features)
 
 on:
   push:
-    branches: [ master, feature/* ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/windows-cross-features.yml
+++ b/.github/workflows/windows-cross-features.yml
@@ -2,9 +2,7 @@ name: Windows mingw-w64 cross C/C++ (features)
 
 on:
   push:
-    branches: [ master, feature/* ]
   pull_request:
-    branches: [ master ]
 
 env:
   # Same libusb Windows binary release the official build scripts use

--- a/.github/workflows/windows-cross-no-features.yml
+++ b/.github/workflows/windows-cross-no-features.yml
@@ -2,9 +2,7 @@ name: Windows mingw-w64 cross C/C++ (no features)
 
 on:
   push:
-    branches: [ master, feature/* ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/windows-latest-features.yml
+++ b/.github/workflows/windows-latest-features.yml
@@ -2,9 +2,7 @@ name: Windows latest C/C++ (features)
 
 on:
   push:
-    branches: [ master, feature/* ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/windows-latest-no-features.yml
+++ b/.github/workflows/windows-latest-no-features.yml
@@ -2,9 +2,7 @@ name: Windows latest C/C++ (no features)
 
 on:
   push:
-    branches: [ master, feature/* ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
Drop the filtering of branch names so that actions are always executed. Now we have 2 active branches (`master` and `Hamlib-4.7`) and without filtering this will still work if we have more branches or with different names (e.g. `Hamlib-5.0`) in the future.

Currently, actions aren't executed for PRs on the `Hamlib-4.7` branch because the original workflows were executed only for the `master` branch (possibly the only active branch at that time), then I added `feature/*` for a `git-flow` style that isn't used in the official, I use it in my repository from which I create my PRs.

