### PR TITLE
Ignore a global symbol added by SWIG 4.5

### DIFF
--- a/bindings/python/test_Hamlib_class.py
+++ b/bindings/python/test_Hamlib_class.py
@@ -1282,6 +1282,8 @@ class TestClass:
 'cvar',
 'hamlib_copyright',
 'hamlib_version']
+        if 'typing' in self.actual_properties:
+            self.actual_properties.remove('typing')  # remove symbol added by SWIG 4.5
         assert expected_properties == self.actual_properties
 
     @classmethod


### PR DESCRIPTION
(cherry picked from commit 7535d0c126adf27caab736527603584e50525409)