### PR TITLE
Add information on master and Hamlib-4.7 differences

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,16 @@ applications.
 The master repository is https://github.com/Hamlib/Hamlib  
 The backup repository is https://sourceforge.net/projects/hamlib/  
 
-Daily snapshots are available at https://hamlib.sourceforge.net/snapshots/
+Daily snapshots of the *master branch* are available at
+https://hamlib.sourceforge.net/snapshots/
+
+Daily snapshots of the *Hamlib-4.7 branch* are available at
+https://github.com/Hamlib/Hamlib/tree/Hamlib-4.7
+
+> **Note:** Major changes are planned for Hamlib 5 (current *master branch*)
+> which will introduce incompatibilities with existing software that uses
+> Hamlib.  Until a given software application announces support for Hamlib 5,
+> use the snapshots and releases from the *Hamlib-4.7* branch.
 
 Development happens on the GitHub master (often by merging feature branches)
 and each release has a release branch.


### PR DESCRIPTION
(cherry picked from commit d7e94b5d0f07164901f503a102e4b790ec0f366a)