### PR TITLE
Fix wrong define used

### DIFF
--- a/simulators/simts890.c
+++ b/simulators/simts890.c
@@ -1185,7 +1185,7 @@ int main(int argc, char *argv[])
                     const struct tm *localtm;
                     t = time(NULL);
                     localtm = localtime(&t);
-                    strftime(&buf[3], BUFSIZ - 3, "%y%m%d%H%M%S;", localtm);
+                    strftime(&buf[3], BUFSIZE - 3, "%y%m%d%H%M%S;", localtm);
                     OUTPUT(buf);
                 }
                 else


### PR DESCRIPTION
BUFSIZ is defined in stdio.h as 8192, while BUFSIZE is defined in our sim.h as 256.

Found by https://sonarcloud.io/