### PR TITLE
ftx1: align TONE/TSQL/CSQL functions with Hamlib semantics

### DIFF
--- a/rigs/yaesu/ftx1/ftx1_func.c
+++ b/rigs/yaesu/ftx1/ftx1_func.c
@@ -228,11 +228,47 @@ int ftx1_set_func(RIG *rig, vfo_t vfo, setting_t func, int status)
             }
             return ftx1_set_breakin(rig, 0);
         case RIG_FUNC_TONE:
-            return ftx1_set_ctcss_mode(rig, status ? FTX1_CTCSS_MODE_ENC : FTX1_CTCSS_MODE_OFF);
+            {
+                tone_t ctcss_mode;
+                int ret = ftx1_get_ctcss_mode(rig, &ctcss_mode);
+                if (ret != RIG_OK) return ret;
+                if (status == 0) {
+                    if (ctcss_mode == FTX1_CTCSS_MODE_ENC || ctcss_mode == FTX1_CTCSS_MODE_TSQ)
+                        return ftx1_set_ctcss_mode(rig, FTX1_CTCSS_MODE_OFF);
+                } else {
+                    if (ctcss_mode != FTX1_CTCSS_MODE_ENC && ctcss_mode != FTX1_CTCSS_MODE_TSQ)
+                        return ftx1_set_ctcss_mode(rig, FTX1_CTCSS_MODE_ENC);
+                }
+                return RIG_OK;  /* No change needed */
+            }
         case RIG_FUNC_TSQL:
-            return ftx1_set_ctcss_mode(rig, status ? FTX1_CTCSS_MODE_TSQ : FTX1_CTCSS_MODE_OFF);
+            {
+                tone_t ctcss_mode;
+                int ret = ftx1_get_ctcss_mode(rig, &ctcss_mode);
+                if (ret != RIG_OK) return ret;
+                if (status == 0) {
+                    if (ctcss_mode == FTX1_CTCSS_MODE_TSQ)
+                        return ftx1_set_ctcss_mode(rig, FTX1_CTCSS_MODE_ENC);
+                } else {
+                    if (ctcss_mode != FTX1_CTCSS_MODE_TSQ)
+                        return ftx1_set_ctcss_mode(rig, FTX1_CTCSS_MODE_TSQ);
+                }
+                return RIG_OK;  /* No change needed */
+            }
         case RIG_FUNC_CSQL:
-            return ftx1_set_ctcss_mode(rig, status ? FTX1_CTCSS_MODE_DCS : FTX1_CTCSS_MODE_OFF);
+            {
+                tone_t ctcss_mode;
+                int ret = ftx1_get_ctcss_mode(rig, &ctcss_mode);
+                if (ret != RIG_OK) return ret;
+                if (status == 0) {
+                    if (ctcss_mode == FTX1_CTCSS_MODE_DCS)
+                        return ftx1_set_ctcss_mode(rig, FTX1_CTCSS_MODE_OFF);
+                } else {
+                    if (ctcss_mode != FTX1_CTCSS_MODE_DCS)
+                        return ftx1_set_ctcss_mode(rig, FTX1_CTCSS_MODE_DCS);
+                }
+                return RIG_OK;  /* No change needed */
+            }
         case RIG_FUNC_RIT:
             /* FTX-1: Setting RX CLAR to 0 disables it; to enable, use set_rit with offset */
             if (!status) return ftx1_set_rx_clar(rig, vfo, 0);
@@ -305,7 +341,7 @@ int ftx1_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status)
             {
                 tone_t ctcss_mode;
                 ret = ftx1_get_ctcss_mode(rig, &ctcss_mode);
-                if (ret == RIG_OK) *status = (ctcss_mode == FTX1_CTCSS_MODE_ENC) ? 1 : 0;
+                if (ret == RIG_OK) *status = (ctcss_mode == FTX1_CTCSS_MODE_ENC || ctcss_mode == FTX1_CTCSS_MODE_TSQ) ? 1 : 0;
                 return ret;
             }
         case RIG_FUNC_TSQL:


### PR DESCRIPTION
In Hamlib, the TONE, TSQL, and CSQL functions are independent of each other, where TONE is used to set the tx of CTCSS tone, TSQL is used to set the rx of CTCSS tone, and CSQL is used to set the tx/rx of DCS tone. In ftx1, however, there are only 4 choices for TONE/TSQL/CSQL, which are totally disabled, TONE only, TONE+TSQL, and CSQL only.

To match the Hamlib semantics, this commit changes the getter and the setter of TONE/TSQL/CSQL functions.

When CSQL is enabled, ftx1 will be set to CSQL only, and TONE/TSQL will be disabled. When CSQL is disabled, and ftx1 is currently set to CSQL only, the rig will be set to disabling all of TONE/TSQL/CSQL.

When TSQL is enabled, ftx1 will be set to TONE+TSQL, and CSQL will be disabled. When TSQL is disabled, and ftx1 is currently set to TONE+TSQL, the rig will be set to TONE only.

When TONE is enabled, and ftx1 is currently not in TONE only or TONE+TSQL, the rig will be set to TONE only. When TONE is disabled, and ftx1 is currently in TONE only or TONE+TSQL, the rig will be set to disabling all of TONE/TSQL/CSQL.

With the above changes, disabling one of TONE/TSQL/CSQL when the function being disabled is currently not enabled will not change the rig's state, which is consistent with Hamlib semantics.