### PR TITLE
Fix rigctld double-close crash on Windows (MinGW)

### DIFF
--- a/tests/rigctl_parse.h
+++ b/tests/rigctl_parse.h
@@ -53,6 +53,15 @@ struct handle_data
     int use_password;
     int is_passwordOK;
     int client_id;      /* Identifies the connection owning a stream */
+#ifdef __MINGW32__
+    int sock_osfhandle; /* CRT fd from _open_osfhandle(sock, ...), opened once by
+                          * get_fsockin() in rigctld.c and reused by get_fsockout() --
+                          * opening a second one there used to let handle_exit's two
+                          * fclose() calls each independently close the same
+                          * underlying Windows handle, fatal on the second call
+                          * (CloseHandle() on an already-closed handle, unlike
+                          * POSIX's harmless EBADF on a redundant close()). */
+#endif
 };
 
 extern pthread_key_t thread_data_key;

--- a/tests/rigctld.c
+++ b/tests/rigctld.c
@@ -1291,8 +1291,14 @@ int main(int argc, char *argv[])
 static FILE *get_fsockout(struct handle_data *handle_data_arg)
 {
 #ifdef __MINGW32__
-    int sock_osfhandle = _open_osfhandle(handle_data_arg->sock, _O_RDONLY);
-    return _fdopen(sock_osfhandle, "wb");
+    /* Reuse the osfhandle get_fsockin() already opened on this socket instead of
+     * opening a second one -- see struct handle_data's own sock_osfhandle comment
+     * for why (this used to double-open, and handle_exit's fclose() calls on the
+     * two independently-wrapped handles then double-closed the same underlying
+     * Windows handle). get_fsockin() is always called before get_fsockout() in
+     * handle_socket(), so sock_osfhandle is already set by the time we get here.
+     */
+    return _fdopen(handle_data_arg->sock_osfhandle, "wb");
 #else
     return fdopen(handle_data_arg->sock, "wb");
 #endif
@@ -1301,15 +1307,15 @@ static FILE *get_fsockout(struct handle_data *handle_data_arg)
 static FILE *get_fsockin(struct handle_data *handle_data_arg)
 {
 #ifdef __MINGW32__
-    int sock_osfhandle = _open_osfhandle(handle_data_arg->sock, _O_RDONLY);
+    handle_data_arg->sock_osfhandle = _open_osfhandle(handle_data_arg->sock, _O_RDONLY);
 
-    if (sock_osfhandle == -1)
+    if (handle_data_arg->sock_osfhandle == -1)
     {
         rig_debug(RIG_DEBUG_ERR, "_open_osfhandle error: %s\n", strerror(errno));
         return NULL;
     }
 
-    return _fdopen(sock_osfhandle,  "rb");
+    return _fdopen(handle_data_arg->sock_osfhandle,  "rb");
 #else
     return fdopen(handle_data_arg->sock, "rb");
 #endif
@@ -1534,17 +1540,23 @@ void *handle_socket(void *arg)
 
 handle_exit:
 
-// for MINGW we close the handle before fclose
 #ifdef __MINGW32__
-    retcode = closesocket(handle_data_arg->sock);
-
-    if (retcode != 0) { rig_debug(RIG_DEBUG_ERR, "%s: fclose(fsockin) %s\n", __func__, strerror(retcode)); }
-
-#endif
-
+    /* fsockin/fsockout share one CRT fd wrapping handle_data_arg->sock (see
+     * get_fsockin()/get_fsockout()) -- closing it via either FILE*'s fclose()
+     * already releases the underlying Windows handle. A prior closesocket() call
+     * here, plus fclose()-ing BOTH streams, each independently closed the same
+     * handle again, fatal on Windows (CloseHandle() on an already-closed handle,
+     * unlike POSIX's harmless EBADF on a redundant close()). fclose() only the
+     * one that's actually set; the other's now-detached FILE* is simply
+     * abandoned rather than closed a second time.
+     */
+    if (fsockin) { fclose(fsockin); }
+    else if (fsockout) { fclose(fsockout); }
+#else
     if (fsockin) { fclose(fsockin); }
 
     if (fsockout) { fclose(fsockout); }
+#endif
 
 // for everybody else we close the handle after fclose
 #ifndef __MINGW32__


### PR DESCRIPTION
rigctld could crash intermittently on Windows (MinGW builds only) — most reliably on \dump_caps for a rig with a large capability set, e.g. an IC-7610.

Root cause: get_fsockout() called _open_osfhandle() a second time on the same raw client socket handle get_fsockin() had already wrapped, giving handle_exit two independently-wrapped FILE* streams over one underlying Windows handle. Both got fclose()'d there (plus a closesocket() call before that), so the second (and third) close each operated on an already-closed handle — CloseHandle() is fatal on an already-closed handle on Windows, unlike POSIX where a redundant close() just returns a harmless EBADF. Root-caused via a crash-dump/debugger session against a real IC-7610 — gdb backtraces show fclose() → _close() → CloseHandle() faulting inside handle_socket.

Fix: get_fsockin() now stores the osfhandle it opens on struct handle_data (new sock_osfhandle field, MinGW-only), and get_fsockout() reuses it instead of opening a second one. handle_exit drops the redundant closesocket() call and fclose()s only one of the two streams, since they now share a single underlying fd.

Windows/MinGW only — the bug is entirely inside #ifdef __MINGW32__ code, so POSIX builds were never affected.

Testing: Built via MSYS2/mingw64 and verified against a real IC-7610 through downstream consumers (EpicLog, a logging application, and WSJT-X) — their connection sequence calls \dump_caps as part of establishing a rig session, previously the most reliable way to trigger this crash on that rig, and now completes without issue.

