### PR TITLE
fix(tests): avoid duplicate parser state definitions

### DIFF
--- a/tests/testctlparser.c
+++ b/tests/testctlparser.c
@@ -19,9 +19,6 @@
 
 #include "rigctl_parse.h"
 
-int lock_mode;
-powerstat_t rig_powerstat = RIG_POWER_ON;
-
 static char captured_description[sizeof(((channel_t *)0)->channel_desc)];
 static freq_t captured_freq;
 static double captured_msec;


### PR DESCRIPTION
This PR removes duplicate definitions of `lock_mode` and `rig_powerstat` from `testctlparser`. These variables are already provided by core `rig.c`; defining them again causes GCC 16/Linux static links to fail with multiple-definition errors.

Tested with the focused static build and `testctlparser`.
